### PR TITLE
Renders imported metadata for ScannedResources

### DIFF
--- a/app/decorators/scanned_resource_decorator.rb
+++ b/app/decorators/scanned_resource_decorator.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 class ScannedResourceDecorator < Valkyrie::ResourceDecorator
-  self.display_attributes += Schema::Common.attributes + [:member_of_collections, :rendered_holding_location]
+  self.display_attributes += Schema::Common.attributes + Schema::Common.attributes.map { |attrib| ('imported_' + attrib.to_s).to_sym } + [:member_of_collections, :rendered_holding_location]
   delegate :query_service, to: :metadata_adapter
-  delegate :author, to: :primary_imported_metadata, prefix: :imported
+  delegate(*Schema::Common.attributes, to: :primary_imported_metadata, prefix: :imported)
 
   def member_of_collections
     @member_of_collections ||=

--- a/app/decorators/valkyrie/resource_decorator.rb
+++ b/app/decorators/valkyrie/resource_decorator.rb
@@ -1,20 +1,21 @@
 # frozen_string_literal: true
 class Valkyrie::ResourceDecorator < ApplicationDecorator
   self.suppressed_attributes = [
-    :description,
-    :rights_statement,
-    :holding_location,
-    :title,
     :depositor,
-    :source_metadata_identifier,
-    :source_metadata,
-    :nav_date,
-    :pdf_type,
-    :ocr_language,
+    :description,
+    :holding_location,
     :keyword,
+    :nav_date,
+    :ocr_language,
+    :pdf_type,
+    :rights_statement,
+    :sort_title,
     :source_jsonld,
-    :sort_title
+    :source_metadata,
+    :source_metadata_identifier,
+    :title
   ]
+  self.suppressed_attributes += self.suppressed_attributes.map { |attrib| ('imported_' + attrib.to_s).to_sym }
   self.display_attributes = [:internal_resource, :created_at, :updated_at]
 
   def created_at

--- a/app/models/imported_metadata.rb
+++ b/app/models/imported_metadata.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class ImportedMetadata < Valkyrie::Resource
-  include Schema::Plum
+  include Schema::Common
 end

--- a/app/models/schema/dublin_core.rb
+++ b/app/models/schema/dublin_core.rb
@@ -7,34 +7,36 @@ module Schema
 
     def self.attributes
       [
-        :title, # http://purl.org/dc/terms/title
-        :part_of, # http://purl.org/dc/terms/isPartOf
-        :resource_type, # http://purl.org/dc/terms/type
-        :creator, # http://purl.org/dc/elements/1.1/creator
-        :contributor, # http://purl.org/dc/elements/1.1/contributor
-        :description, # http://purl.org/dc/elements/1.1/description
-        :keyword, # http://purl.org/dc/elements/1.1/relation
-        :coverage, # http://purl.org/dc/elements/1.1/coverage
-        :created, # http://purl.org/dc/terms/created
-        :date, # http://purl.org/dc/elements/1.1/date
-        :source, # http://purl.org/dc/elements/1.1/source
-        :extent, # http://purl.org/dc/terms/extent
-        :license, # http://purl.org/dc/terms/rights
-        :publisher, # http://purl.org/dc/elements/1.1/publisher
-        :date_created, # http://purl.org/dc/terms/created
-        :subject, # http://purl.org/dc/elements/1.1/subject
-        :language, # http://purl.org/dc/elements/1.1/language
-        :bibliographic_citation, # http://purl.org/dc/terms/bibliographicCitation
         :abstract, # http://purl.org/dc/terms/abstract
         :alternative, # http://purl.org/dc/terms/alternative
-        :identifier, # http://purl.org/dc/terms/identifier
-        :local_identifier, # http://purl.org/dc/elements/1.1/identifier
-        :replaces, # http://purl.org/dc/terms/replaces
+        :alternative_title, # http://purl.org/dc/terms/alternative
+        :bibliographic_citation, # http://purl.org/dc/terms/bibliographicCitation
         :contents, # http://purl.org/dc/terms/tableOfContents
-        :rights_note, # http://purl.org/dc/elements/1.1/rights
-        :geo_subject, # http://purl.org/dc/terms/coverage
+        :created, # http://purl.org/dc/terms/created
+        :date_created, # http://purl.org/dc/terms/created
+        :extent, # http://purl.org/dc/terms/extent
         :genre, # http://purl.org/dc/terms/type
-        :alternative_title # http://purl.org/dc/terms/alternative
+        :geo_subject, # http://purl.org/dc/terms/coverage
+        :identifier, # http://purl.org/dc/terms/identifier
+        :license, # http://purl.org/dc/terms/rights
+        :part_of, # http://purl.org/dc/terms/isPartOf
+        :replaces, # http://purl.org/dc/terms/replaces
+        :resource_type, # http://purl.org/dc/terms/type
+        :title, # http://purl.org/dc/terms/title
+        :type, # http://purl.org/dc/terms/type
+
+        :contributor, # http://purl.org/dc/elements/1.1/contributor
+        :coverage, # http://purl.org/dc/elements/1.1/coverage
+        :creator, # http://purl.org/dc/elements/1.1/creator
+        :date, # http://purl.org/dc/elements/1.1/date
+        :description, # http://purl.org/dc/elements/1.1/description
+        :keyword, # http://purl.org/dc/elements/1.1/relation
+        :language, # http://purl.org/dc/elements/1.1/language
+        :local_identifier, # http://purl.org/dc/elements/1.1/identifier
+        :publisher, # http://purl.org/dc/elements/1.1/publisher
+        :rights_note, # http://purl.org/dc/elements/1.1/rights
+        :source, # http://purl.org/dc/elements/1.1/source
+        :subject # http://purl.org/dc/elements/1.1/subject
       ]
     end
 

--- a/spec/views/catalog/show.html.erb_spec.rb
+++ b/spec/views/catalog/show.html.erb_spec.rb
@@ -2,9 +2,10 @@
 require 'rails_helper'
 
 RSpec.describe "catalog/show.html.erb" do
-  context "when given a ScannedResource solr document" do
+  context 'when given a new ScannedResource instance' do
     let(:scanned_resource) do
       FactoryGirl.create_for_repository(:scanned_resource,
+                                        title: 'test title1',
                                         label: 'test label',
                                         actor: 'test person',
                                         sort_title: 'test title2',
@@ -12,15 +13,7 @@ RSpec.describe "catalog/show.html.erb" do
                                         rights_statement: 'test statement',
                                         call_number: 'test value2',
                                         edition: 'test edition',
-                                        nav_date: 'test date',
-                                        imported_metadata: [
-                                          {
-                                            author: "Shakespeare",
-                                            title: "Imported Title"
-                                          }
-                                        ],
-                                        member_of_collection_ids: [collection.id],
-                                        holding_location: RDF::URI('https://bibdata.princeton.edu/locations/delivery_locations/1'))
+                                        nav_date: 'test date')
     end
     let(:document) { Valkyrie::MetadataAdapter.find(:index_solr).resource_factory.from_resource(scanned_resource) }
     let(:collection) { FactoryGirl.create_for_repository(:collection) }
@@ -33,14 +26,10 @@ RSpec.describe "catalog/show.html.erb" do
       render
     end
     it "renders all available attributes" do
-      expect(rendered).to have_content scanned_resource.primary_imported_metadata.title.to_sentence
-      expect(rendered).to have_content "Imported Title"
+      # Title
+      expect(rendered).to have_content "test title1"
 
       expect(rendered).to have_selector "#attributes h2", text: "Attributes"
-
-      # Author
-      expect(rendered).to have_selector "th", text: "Author"
-      expect(rendered).to have_content "Shakespeare"
 
       # Label
       expect(rendered).to have_selector "th", text: "Label"
@@ -69,6 +58,126 @@ RSpec.describe "catalog/show.html.erb" do
       # Nav Date
       expect(rendered).not_to have_selector "th", text: "Nav Date"
       expect(rendered).not_to have_content "test date"
+
+      # Model name
+      expect(rendered).to have_selector "th", text: "Model"
+      expect(rendered).to have_content "ScannedResource"
+
+      # Date Uploaded
+      expect(rendered).to have_selector "th", text: "Date Uploaded"
+      expect(rendered).to have_selector ".created_at", text: "01/01/90 12:00:00 AM UTC"
+
+      # Date Modified
+      expect(rendered).to have_selector "th", text: "Date Modified"
+      expect(rendered).to have_selector ".updated_at", text: "01/01/90 12:00:00 AM UTC"
+    end
+  end
+
+  context "when given a ScannedResource solr document" do
+    let(:scanned_resource) do
+      FactoryGirl.create_for_repository(:scanned_resource,
+                                        imported_metadata: [
+                                          {
+                                            title: "Ars minor [fragment].",
+                                            language: "lat",
+                                            creator: "Donatus, Aelius",
+                                            call_number: "114.14",
+                                            extent: "2 partial leaves ; 20 x 14.8 cm.",
+                                            format: "Book",
+                                            type: "Early works to 1500",
+                                            description: "WHS fragment is parts of 2 leaves (ff. 2.7, Schwenke 6,1-9,6; 10,2-12,5; 22,1-23,21; 24,2-36) of a 27-line edition; vellum; Type 5.",
+                                            publisher: "[Netherlands : Prototypography, about 1465-1480].",
+                                            subject: [
+                                              "Latin language—Grammar—Early works to 1500",
+                                              "Type and type-founding—Specimens"
+                                            ],
+                                            sort_title: "Ars minor [fragment].",
+                                            former_owner: [
+                                              "Hodgkin, John Eliot"
+                                            ],
+                                            bookseller: [
+                                              "Maggs Bros"
+                                            ],
+                                            author: "Donatus, Aelius",
+                                            created: ['1465-01-01T00:00:00Z', '1480-12-31T23:59:59Z'],
+                                            date: "1465-1480",
+                                            identifier: "http://arks.princeton.edu/ark:/88435/5m60qr98h"
+                                          }
+                                        ],
+                                        member_of_collection_ids: [collection.id],
+                                        holding_location: RDF::URI('https://bibdata.princeton.edu/locations/delivery_locations/1'))
+    end
+    let(:document) { Valkyrie::MetadataAdapter.find(:index_solr).resource_factory.from_resource(scanned_resource) }
+    let(:collection) { FactoryGirl.create_for_repository(:collection) }
+    let(:solr_document) { SolrDocument.new(document) }
+    before do
+      Timecop.freeze(Time.zone.local(1990))
+      assign :document, solr_document
+      allow(view).to receive(:has_search_parameters?).and_return(false)
+      stub_blacklight_views
+      render
+    end
+    it "renders all available attributes" do
+      expect(rendered).to have_content scanned_resource.primary_imported_metadata.title.to_sentence
+      expect(rendered).to have_content "Ars minor [fragment]."
+
+      expect(rendered).to have_selector "#attributes h2", text: "Attributes"
+
+      # Language
+      expect(rendered).to have_selector "th", text: "Language"
+      expect(rendered).to have_content "lat"
+
+      # Creator
+      expect(rendered).to have_selector "th", text: "Creator"
+      expect(rendered).to have_content "Donatus, Aelius"
+
+      # Call Number
+      expect(rendered).to have_selector "th", text: "Call Number"
+      expect(rendered).to have_content "114.14"
+
+      # Extent
+      expect(rendered).to have_selector "th", text: "Extent"
+      expect(rendered).to have_content "2 partial leaves ; 20 x 14.8 cm."
+
+      # Type
+      expect(rendered).to have_selector "th", text: "Type"
+      expect(rendered).to have_content "Early works to 1500"
+
+      # Description
+      expect(rendered).not_to have_selector "th", text: "Description"
+      expect(rendered).not_to have_content "WHS fragment is parts of 2 leaves (ff. 2.7, Schwenke 6,1-9,6; 10,2-12,5; 22,1-23,21; 24,2-36) of a 27-line edition; vellum; Type 5."
+
+      # Publisher
+      expect(rendered).to have_selector "th", text: "Publisher"
+      expect(rendered).to have_content "[Netherlands : Prototypography, about 1465-1480]."
+
+      # Subject
+      expect(rendered).to have_selector "th", text: "Subject"
+      expect(rendered).to have_content "Latin language—Grammar—Early works to 1500"
+      expect(rendered).to have_content "Type and type-founding—Specimens"
+
+      # Sort Title
+      expect(rendered).not_to have_selector "th", text: "Sort Title"
+
+      # Former Owner
+      expect(rendered).to have_selector "th", text: "Former Owner"
+      expect(rendered).to have_content "Hodgkin, John Eliot"
+
+      # Bookseller
+      expect(rendered).to have_selector "th", text: "Bookseller"
+      expect(rendered).to have_content "Maggs Bros"
+
+      # Author
+      expect(rendered).to have_selector "th", text: "Author"
+      expect(rendered).to have_content "Donatus, Aelius"
+
+      # Date
+      expect(rendered).to have_selector "th", text: "Date"
+      expect(rendered).to have_content "1465-1480"
+
+      # Identifier
+      expect(rendered).to have_selector "th", text: "Identifier"
+      expect(rendered).to have_content "http://arks.princeton.edu/ark:/88435/5m60qr98h"
 
       # Model name
       expect(rendered).to have_selector "th", text: "Model"


### PR DESCRIPTION
Resolves #20 and #93 by delegating ScannedResourceDecorator accessor methods to primary_imported_metadata (with the prefix "imported_") and explicitly exposing these prefixed values within "display_attributes".