### PR TITLE
Extending IIIF Manifest Support for Resource Metadata

### DIFF
--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -1,21 +1,36 @@
 # frozen_string_literal: true
 class ApplicationDecorator < Draper::Decorator
-  class_attribute :suppressed_attributes, :display_attributes
+  class_attribute :suppressed_attributes, :display_attributes, :iiif_manifest_attributes
   self.suppressed_attributes = []
   self.display_attributes = []
+  self.iiif_manifest_attributes = []
   delegate_all
 
+  def self.imported_attributes(attribute_names)
+    attribute_names.map { |attrib| ('imported_' + attrib.to_s).to_sym }
+  end
+
   def display_attributes
-    Hash[
-      (self.class.display_attributes - self.class.suppressed_attributes).map do |attribute|
-        [attribute, Array.wrap(self.[](attribute))]
-      end
-    ]
+    attributes(self.class.display_attributes - self.class.suppressed_attributes)
+  end
+
+  def iiif_manifest_attributes
+    attributes(self.class.iiif_manifest_attributes)
   end
 
   def [](attribute)
     __send__(attribute)
   end
 
-  delegate :model_name, to: :object
+  delegate :model_name, :attributes, to: :object
+
+  private
+
+    def attributes(attribute_names)
+      Hash[
+        attribute_names.map do |attribute|
+          [attribute, Array.wrap(self.[](attribute))]
+        end
+      ]
+    end
 end

--- a/app/decorators/valkyrie/resource_decorator.rb
+++ b/app/decorators/valkyrie/resource_decorator.rb
@@ -15,7 +15,7 @@ class Valkyrie::ResourceDecorator < ApplicationDecorator
     :source_metadata_identifier,
     :title
   ]
-  self.suppressed_attributes += self.suppressed_attributes.map { |attrib| ('imported_' + attrib.to_s).to_sym }
+  self.suppressed_attributes += imported_attributes(suppressed_attributes)
   self.display_attributes = [:internal_resource, :created_at, :updated_at]
 
   def created_at

--- a/app/models/remote_record.rb
+++ b/app/models/remote_record.rb
@@ -8,6 +8,15 @@ class RemoteRecord
     end
   end
 
+  def self.bibdata?(source_metadata_identifier)
+    PulMetadataServices::Client.bibdata?(source_metadata_identifier)
+  end
+
+  def self.source_metadata_url(id)
+    return "https://bibdata.princeton.edu/bibliographic/#{id}" if bibdata?(id)
+    "https://findingaids.princeton.edu/collections/#{id.tr('_', '/')}.xml?scope=record"
+  end
+
   class PulfaRecord
     attr_reader :source_metadata_identifier
     def initialize(source_metadata_identifier)

--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -1,92 +1,150 @@
 # frozen_string_literal: true
 class ManifestBuilder
-  attr_reader :resource
+  attr_reader :resource, :services
+
+  ##
+  # @param [Resource] resource the Resource subject
   def initialize(resource)
     @resource = RootNode.new(resource)
   end
 
+  ##
+  # Build the JSON-serialized Manifest instance
+  # @return [JSON]
   def build
-    JSON.parse(IIIFManifest::ManifestFactory.new(resource).to_h.to_json, symbolize_keys: true)
+    JSON.parse(manifest.to_json, symbolize_keys: true)
   end
 
+  ##
+  # Presenter modeling the Resource subjects as root nodes
   class RootNode
     attr_reader :resource
     delegate :query_service, to: :metadata_adapter
+    delegate :decorate, :source_metadata_identifier, :to_model, to: :resource
+
+    ##
+    # @param [Resource] resource the Resource being modeled as the root
     def initialize(resource)
       @resource = resource
     end
 
     delegate :description, to: :resource
 
+    ##
+    # Stringify the Resource by delegating to the header within the Decorator
+    # @return [String]
     def to_s
       resource.decorate.header
     end
 
+    ##
+    # Retrieves the presenters for each member Work as a separate root
+    # @return [RootNode]
     def work_presenters
       @work_presenters ||= (members - leaf_nodes).map do |node|
         RootNode.new(node)
       end
     end
 
+    ##
+    # Retrieves the presenters for each member FileSet as a leaf
+    # @return [LeafNode]
     def file_set_presenters
       @file_set_presenters ||= leaf_nodes.map do |node|
         LeafNode.new(node, self)
       end
     end
 
+    ##
+    # Retrieves the presenter for each Range (sc:Range) instance
+    # @return [TopStructure]
     def ranges
       logical_structure.map do |top_structure|
         TopStructure.new(top_structure)
       end
     end
 
+    ##
+    # Helper method for generating the URL to the resource manifest
+    # @return [String]
     def manifest_url
       helper.polymorphic_url([:manifest, resource])
     end
 
+    ##
+    # Retrieves the first viewing hint from the resource metadata
+    # @return [String]
     def viewing_hint
       Array(resource.viewing_hint).first
     end
 
     private
 
+      ##
+      # Retrieve an instance of the ManifestHelper
+      # @return [ManifestHelper]
       def helper
         @helper ||= ManifestHelper.new
       end
 
+      ##
+      # Retrieve the child members for the subject resource of the Manifest
+      # @return [Resource]
       def members
         @members ||= query_service.find_members(resource: resource).to_a
       end
 
+      ##
+      # Retrieve the leaf nodes for the Manifest
+      # @return [FileSet]
       def leaf_nodes
         @leaf_nodes ||= members.select { |x| x.instance_of?(FileSet) }
       end
 
+      ##
+      # Retrieve the metadata adapter instance for the Valkyrie engine
+      # @return [String]
       def metadata_adapter
         Valkyrie.config.metadata_adapter
       end
 
+      ##
+      # Retrieve the TopStructure for the resource manifest
+      # @param [TopStructure]
       def logical_structure
         resource.logical_structure || []
       end
   end
 
+  ##
+  # Presenter modeling the top node of nested structure resource trees
   class TopStructure
     attr_reader :structure
+
+    ##
+    # @param [Hash] structure the top structure node
     def initialize(structure)
       @structure = structure
     end
 
+    ##
+    # Retrieve the label for the Structure
+    # @return [String]
     def label
       structure.label.to_sentence
     end
 
+    ##
+    # Retrieve the ranges (sc:Range) for this structure
+    # @return [TopStructure]
     def ranges
       @ranges ||= structure.nodes.select { |x| x.proxy.blank? }.map do |node|
         TopStructure.new(node)
       end
     end
 
+    # Retrieve the IIIF Manifest nodes for FileSet resources
+    # @return [LeafStructureNode]
     def file_set_presenters
       @file_set_presenters ||= structure.nodes.select { |x| x.proxy.present? }.map do |node|
         LeafStructureNode.new(node)
@@ -94,20 +152,32 @@ class ManifestBuilder
     end
   end
 
+  ##
+  # Class modeling the terminal nodes of IIIF Manifest structures
   class LeafStructureNode
     attr_reader :structure
+    ##
+    # @param [Hash] structure the structure terminal node
     def initialize(structure)
       @structure = structure
     end
 
+    ##
+    # Retrieve the ID for the node from the first proxy in the structure
+    # @return [String]
     def id
       structure.proxy.first.to_s
     end
   end
 
+  ##
+  # Presenter for Resource instances (usually FileSets) modeled as leaf nodes
   class LeafNode
     attr_reader :resource, :parent_node
     delegate :query_service, to: :metadata_adapter
+    ##
+    # @param [Resource] resource a FileSet resource featured in the IIIF Manifest
+    # @param [RootNode] parent_node the node for the parent Work for the FileSet
     def initialize(resource, parent_node)
       @resource = resource
       @parent_node = parent_node
@@ -115,14 +185,23 @@ class ManifestBuilder
 
     delegate :id, to: :resource
 
+    ##
+    # Stringify the image using the decorator
+    # @return [String]
     def to_s
       resource.decorate.header
     end
 
+    ##
+    # Retrieve the ID for the resource
+    # @return [String]
     def derivative_id
       resource.id
     end
 
+    ##
+    # Retrieve an instance of the IIIFManifest::DisplayImage for the image
+    # @return [IIIFManifest::DisplayImage]
     def display_image
       IIIFManifest::DisplayImage.new(id,
                                      width: width,
@@ -133,51 +212,93 @@ class ManifestBuilder
 
     private
 
+      ##
+      # Retrieve the width for the image resource
+      # @return [String]
       def width
         file.width.first
       end
 
+      ##
+      # Retrieve the height for the image resource
+      # @return [String]
       def height
         file.height.first
       end
 
+      ##
+      # Retrieve the File related to the image resource
+      # @return [File]
       def file
         resource.original_file
       end
 
+      ##
+      # Retrieve an instance of the IIIFManifest::IIIFEndpoint for the service endpoint
+      # @return [IIIFManifest::IIIFEndpoint]
       def endpoint
         IIIFManifest::IIIFEndpoint.new(helper.manifest_image_path(derivative_id),
                                        profile: "http://iiif.io/api/image/2/level2.json")
       end
 
+      ##
+      # Retrieve an instance of the ManifestHelper
+      # @return [ManifestHelper]
       def helper
         @helper ||= ManifestHelper.new
       end
   end
 
+  ##
+  # Class providing helper methods for the IIIF::Presentation::Manifest
   class ManifestHelper
     include ActionDispatch::Routing::PolymorphicRoutes
     include Rails.application.routes.url_helpers
 
+    ##
+    # Retrieve the default options for URL's
+    # @return [Hash]
     def default_url_options
       Figgy.default_url_options
     end
 
+    ##
+    # Retrieve the base URL for Riiif
+    # @param [String] id identifier for the image resource
+    # @return [String]
     def manifest_image_path(id)
       RiiifHelper.new.base_url(id)
     end
 
+    ##
+    # Retrieve the URL path for an image served over the Riiif
+    # @param [String] id identifier for the image resource
+    # @return [String]
     def manifest_image_thumbnail_path(id)
       "#{manifest_image_path(id)}/full/!200,150/0/default.jpg"
     end
   end
 
+  ##
+  # Class providing helper methods for the Riiif Gem
   class RiiifHelper
     include ActionDispatch::Routing::PolymorphicRoutes
     include Riiif::Engine.routes.url_helpers
 
+    ##
+    # Retrieve the default options for URL's
+    # @return [Hash]
     def default_url_options
       Figgy.default_url_options
     end
   end
+
+  private
+
+    ##
+    # Instantiate the Manifest
+    # @return [IIIFManifest]
+    def manifest
+      @manifest || @manifest = IIIFManifest::ManifestFactory.new(@resource, manifest_service_locator: ManifestServiceLocator).to_h
+    end
 end

--- a/app/services/manifest_builder/license_builder.rb
+++ b/app/services/manifest_builder/license_builder.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+class ManifestBuilder
+  class LicenseBuilder
+    attr_reader :resource
+
+    ##
+    # @param [Valhalla::Resource] resource the Resource being viewed
+    def initialize(resource)
+      @resource = RootNode.new(resource)
+    end
+
+    ##
+    # Append the metadata to the IIIF Manifest
+    # @param [IIIF::Presentation::Manifest] manifest the IIIF manifest being
+    # @return [IIIF::Presentation::Manifest]
+    def apply(manifest)
+      manifest.license = license
+      manifest
+    end
+
+    private
+
+      def license
+        statements = @resource.decorate.rights_statement.map(&:value)
+        statements.empty? ? nil : statements.first
+      rescue
+        nil
+      end
+  end
+end

--- a/app/services/manifest_builder/manifest_service_locator.rb
+++ b/app/services/manifest_builder/manifest_service_locator.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+class ManifestBuilder
+  ##
+  # Class for the IIIF Manifest Service Locator
+  class ManifestServiceLocator < IIIFManifest::ManifestServiceLocator
+    class << self
+      ##
+      # Class accessor for the metadata builder
+      # @return [Class]
+      def metadata_manifest_builder
+        ManifestBuilder::MetadataBuilder
+      end
+
+      ##
+      # Class accessor for the "see also" builder
+      # @return [Class]
+      def see_also_builder
+        ManifestBuilder::SeeAlsoBuilder
+      end
+
+      ##
+      # Class accessor for the license builder
+      # @return [Class]
+      def license_builder
+        ManifestBuilder::LicenseBuilder
+      end
+
+      ##
+      # Override the Class method for instantiating a CompositeBuilder
+      # Insert the metadata manifest builder
+      # @return [IIIFManifest::ManifestBuilder::CompositeBuilder]
+      def manifest_builders
+        composite_builder_factory.new(
+          record_property_builder,
+          sequence_builder,
+          structure_builder,
+          metadata_manifest_builder,
+          see_also_builder,
+          license_builder,
+          composite_builder: composite_builder
+        )
+      end
+    end
+  end
+end

--- a/app/services/manifest_builder/metadata_builder.rb
+++ b/app/services/manifest_builder/metadata_builder.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+class ManifestBuilder
+  class MetadataBuilder
+    attr_reader :resource
+
+    ##
+    # @param [Valhalla::Resource] resource the Resource being viewed
+    def initialize(resource, metadata_object_class: MetadataObject)
+      @resource = RootNode.new(resource)
+      @metadata_object_class = metadata_object_class
+    end
+
+    ##
+    # Append the metadata to the IIIF Manifest
+    # @param [IIIF::Presentation::Manifest] manifest the IIIF manifest being
+    # @return [IIIF::Presentation::Manifest]
+    def apply(manifest)
+      manifest.metadata = transformed_metadata
+      manifest
+    end
+
+    class MetadataObject
+      def initialize(attribute, value)
+        @attribute = attribute
+        @value = value
+      end
+
+      def pdf_type_label
+        'PDF Type'
+      end
+
+      def label
+        if respond_to?("#{@attribute}_label".to_sym)
+          send("#{@attribute}_label".to_sym)
+        else
+          @attribute.to_s.titleize
+        end
+      end
+
+      def date_value
+        @value.map do |date|
+          date.split("/").map do |d|
+            if year_only(date.split("/"))
+              Date.parse(d).strftime("%Y")
+            else
+              Date.parse(d).strftime("%m/%d/%Y")
+            end
+          end.join("-")
+        end
+      rescue => e
+        Rails.logger.warn e.message
+        @value
+      end
+
+      alias created_value date_value
+      alias imported_created_value created_value
+      alias updated_value date_value
+      alias imported_updated_value updated_value
+      private :date_value
+
+      def identifier_value
+        @value.map do |id|
+          if id =~ /^https?\:\/\//
+            "<a href='#{id}' alt='#{label}'>#{id}</a>"
+          else
+            id
+          end
+        end
+      end
+
+      alias imported_identifier_value identifier_value
+
+      def value
+        if respond_to?("#{@attribute}_value".to_sym)
+          send("#{@attribute}_value".to_sym)
+        else
+          @value
+        end
+      end
+
+      def to_h
+        { label: label, value: value }
+      end
+
+      private
+
+        def year_only(dates)
+          dates.length == 2 && dates.first.end_with?("-01-01T00:00:00Z") && dates.last.end_with?("-12-31T23:59:59Z")
+        end
+    end
+
+    private
+
+      def transformed_metadata
+        @resource.decorate.iiif_manifest_attributes.select { |_, value| value.present? }.map do |u, v|
+          @metadata_object_class.new(u, v).to_h
+        end
+      end
+  end
+end

--- a/app/services/manifest_builder/see_also_builder.rb
+++ b/app/services/manifest_builder/see_also_builder.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+class ManifestBuilder
+  class SeeAlsoBuilder
+    attr_reader :resource
+
+    ##
+    # @param [Valhalla::Resource] resource the Resource being viewed
+    def initialize(resource)
+      @resource = RootNode.new(resource)
+    end
+
+    def apply(manifest)
+      manifest.see_also = see_also
+      manifest
+    end
+
+    private
+
+      def see_also
+        source_metadata_hash.blank? ? figgy_rdf_hash : [figgy_rdf_hash, source_metadata_hash]
+      end
+
+      def source_metadata_hash
+        return if resource.source_metadata_identifier.blank?
+        {
+          "@id" => RemoteRecord.source_metadata_url(resource.source_metadata_identifier.first),
+          "format" => "text/xml"
+        }
+      end
+
+      def helper
+        @helper ||= ManifestHelper.new
+      end
+
+      def figgy_rdf_hash
+        {
+          "@id" => helper.polymorphic_url(resource, format: :jsonld),
+          "format" => "application/ld+json"
+        }
+      end
+  end
+end

--- a/spec/decorators/application_decorator_spec.rb
+++ b/spec/decorators/application_decorator_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ApplicationDecorator do
+  subject(:decorator) { described_class.new(resource) }
+  let(:resource) { FactoryGirl.build(:scanned_resource) }
+
+  describe '#iiif_manifest_attributes' do
+    it 'defaults to no attributes for the IIIF Manifest' do
+      expect(decorator.iiif_manifest_attributes).to be_empty
+    end
+  end
+end

--- a/spec/decorators/scanned_resource_decorator_spec.rb
+++ b/spec/decorators/scanned_resource_decorator_spec.rb
@@ -13,4 +13,24 @@ RSpec.describe ScannedResourceDecorator do
       expect(decorator.rendered_rights_statement.first).to include '<a href="http://rightsstatements.org/vocab/NKC/1.0/">No Known Copyright</a>'
     end
   end
+
+  context 'with imported metadata' do
+    let(:resource) do
+      FactoryGirl.build(:scanned_resource,
+                        title: 'test title',
+                        author: 'test author',
+                        imported_metadata: [{
+                          creator: 'test creator',
+                          subject: 'test subject'
+                        }])
+    end
+    describe "#iiif_manifest_attributes" do
+      it "returns attributes merged with the imported metadata for the IIIF Manifest" do
+        expect(decorator.iiif_manifest_attributes).to include title: ['test title']
+        expect(decorator.iiif_manifest_attributes).to include author: ['test author']
+        expect(decorator.iiif_manifest_attributes).to include creator: ['test creator']
+        expect(decorator.iiif_manifest_attributes).to include subject: ['test subject']
+      end
+    end
+  end
 end

--- a/spec/models/remote_record_spec.rb
+++ b/spec/models/remote_record_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe RemoteRecord, type: :model do
+  describe '.retrieve' do
+    context 'with a Voyager record ID' do
+      it 'constructs a RemoteRecord instance' do
+        expect(described_class.retrieve('4609321')).to be_a RemoteRecord
+      end
+    end
+
+    context 'with a PULFA record ID' do
+      it 'constructs a PulfaRecord instance' do
+        expect(described_class.retrieve('AC044_c0003')).to be_a RemoteRecord::PulfaRecord
+      end
+    end
+  end
+
+  describe '.bibdata?' do
+    context 'with a Voyager record ID' do
+      it 'validates that this is a bib. ID' do
+        expect(described_class.bibdata?('4609321')).to be_truthy
+      end
+    end
+
+    context 'with a PULFA record ID' do
+      it 'validates that this is a not a bib. ID' do
+        expect(described_class.bibdata?('AC044_c0003')).to be_falsy
+      end
+    end
+  end
+
+  describe '.source_metadata_url' do
+    context 'with a Voyager record ID' do
+      it 'validates that this is not a bib. ID' do
+        expect(described_class.source_metadata_url('4609321')).to eq 'https://bibdata.princeton.edu/bibliographic/4609321'
+      end
+    end
+
+    context 'with a PULFA record ID' do
+      it 'validates that this is a bib. ID' do
+        expect(described_class.source_metadata_url('AC044_c0003')).to eq 'https://findingaids.princeton.edu/collections/AC044/c0003.xml?scope=record'
+      end
+    end
+  end
+end

--- a/spec/services/manifest_builder/license_builder_spec.rb
+++ b/spec/services/manifest_builder/license_builder_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ManifestBuilder::LicenseBuilder do
+  describe '#apply' do
+    let(:builder) { described_class.new(scanned_resource) }
+    let(:manifest) { IIIF::Presentation::Manifest.new }
+    let(:decorated) { ScannedResourceDecorator.new(scanned_resource) }
+    let(:scanned_resource) do
+      FactoryGirl.create_for_repository(:scanned_resource,
+                                        rights_statement: RDF::URI("https://creativecommons.org/licenses/by-nc/4.0/"))
+    end
+
+    context 'when viewing a new Scanned Resource' do
+      before do
+        builder.apply(manifest)
+      end
+
+      it 'appends the transformed metadata to the Manifest' do
+        expect(manifest.license).to eq "https://creativecommons.org/licenses/by-nc/4.0/"
+      end
+    end
+
+    context 'when viewing a new Scanned Resource with an invalid rights statement' do
+      let(:scanned_resource) do
+        FactoryGirl.create_for_repository(:scanned_resource,
+                                          rights_statement: 1234)
+      end
+
+      before do
+        builder.apply(manifest)
+      end
+
+      it 'appends the transformed metadata to the Manifest' do
+        expect(manifest.license).to be nil
+      end
+    end
+  end
+end

--- a/spec/services/manifest_builder/manifest_service_locator_spec.rb
+++ b/spec/services/manifest_builder/manifest_service_locator_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ManifestBuilder::ManifestServiceLocator do
+  describe '.metadata_manifest_builder' do
+    it 'returns the class for building manifest metadata' do
+      expect(described_class.metadata_manifest_builder).to eq ManifestBuilder::MetadataBuilder
+    end
+  end
+
+  describe '.see_also_builder' do
+    it 'returns the class for building manifest see also links' do
+      expect(described_class.see_also_builder).to eq ManifestBuilder::SeeAlsoBuilder
+    end
+  end
+
+  describe '.license_builder' do
+    it 'returns the class for building manifest license' do
+      expect(described_class.license_builder).to eq ManifestBuilder::LicenseBuilder
+    end
+  end
+
+  describe '.manifest_builders' do
+    it 'returns a composite builder factory' do
+      expect(described_class.manifest_builders).to be_a IIIFManifest::ManifestBuilder::CompositeBuilderFactory
+    end
+  end
+end

--- a/spec/services/manifest_builder/metadata_builder/metadata_object_spec.rb
+++ b/spec/services/manifest_builder/metadata_builder/metadata_object_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ManifestBuilder::MetadataBuilder::MetadataObject do
+  subject(:metadata_object) { described_class.new('test attribute', ['test value']) }
+
+  describe '#pdf_type_label' do
+    subject(:metadata_object) { described_class.new('pdf_type', ['test value']) }
+
+    it 'returns the overridden label for the pdf_type attribute' do
+      expect(metadata_object.label).to eq 'PDF Type'
+    end
+  end
+
+  describe '#label' do
+    it 'returns the label for the attribute' do
+      expect(metadata_object.label).to eq 'Test Attribute'
+    end
+  end
+
+  describe '#value' do
+    it 'returns the value for the attribute' do
+      expect(metadata_object.value).to eq ['test value']
+    end
+  end
+
+  describe '#to_h' do
+    it 'returns a hash for the label and value for the attribute' do
+      expect(metadata_object.to_h).to eq label: 'Test Attribute', value: ['test value']
+    end
+  end
+
+  describe '#created_value' do
+    context 'with a year-only range' do
+      subject(:metadata_object) { described_class.new('created', ['1970-01-01T00:00:00Z/1971-12-31T23:59:59Z']) }
+
+      it 'returns the year for the value' do
+        expect(metadata_object.value).to eq ['1970-1971']
+      end
+    end
+
+    context 'with range' do
+      subject(:metadata_object) { described_class.new('created', ['1970-01-02T00:00:00Z/1971-02-03T00:00:00Z']) }
+
+      it 'returns the formatted range for the dates' do
+        expect(metadata_object.value).to eq ['01/02/1970-02/03/1971']
+      end
+    end
+
+    context 'with a single date' do
+      subject(:metadata_object) { described_class.new('created', ['1970-03-04T00:00:00Z']) }
+
+      it 'returns the formatted range for the dates' do
+        expect(metadata_object.value).to eq ['03/04/1970']
+      end
+    end
+
+    context 'with an invalid date' do
+      subject(:metadata_object) { described_class.new('created', ['1970-13-05T00:00:00Z']) }
+
+      it 'returns the initial value' do
+        expect(metadata_object.value).to eq ['1970-13-05T00:00:00Z']
+      end
+    end
+  end
+
+  describe '#identifier_value' do
+    context 'with a URL' do
+      subject(:metadata_object) { described_class.new('identifier', ['https://example.com/resource']) }
+
+      it 'generates a formatted link' do
+        expect(metadata_object.value).to eq ["<a href='https://example.com/resource' alt='Identifier'>https://example.com/resource</a>"]
+      end
+    end
+
+    context 'with a string' do
+      subject(:metadata_object) { described_class.new('identifier', ['doi:10.3390/systems4040037']) }
+
+      it 'generates a formatted link' do
+        expect(metadata_object.value).to eq ["doi:10.3390/systems4040037"]
+      end
+    end
+  end
+end

--- a/spec/services/manifest_builder/metadata_builder_spec.rb
+++ b/spec/services/manifest_builder/metadata_builder_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ManifestBuilder::MetadataBuilder do
+  describe '#apply' do
+    let(:builder) { described_class.new(scanned_resource) }
+    let(:manifest) { IIIF::Presentation::Manifest.new }
+    let(:decorated) { instance_double(ScannedResourceDecorator) }
+    let(:scanned_resource) { instance_double(ScannedResource) }
+
+    before do
+      allow(scanned_resource).to receive(:decorate).and_return(decorated)
+    end
+
+    context 'when viewing a new Scanned Resource' do
+      before do
+        allow(decorated).to receive(:iiif_manifest_attributes).and_return(
+          title: ['test title'],
+          identifier: ['http://arks.princeton.edu/ark:/88435/5m60qr98h'],
+          pdf_type: ['Gray'],
+          created: ['1465-01-01T00:00:00Z/1480-12-31T23:59:59Z'],
+          updated: ['1470-06-07T01:02:03Z']
+        )
+        builder.apply(manifest)
+      end
+
+      it 'appends the transformed metadata to the Manifest' do
+        expect(manifest.metadata).to be_an Array
+        expect(manifest.metadata).to include label: "Title", value: ["test title"]
+        expect(manifest.metadata).to include label: "Identifier", value: \
+          ["<a href='http://arks.princeton.edu/ark:/88435/5m60qr98h' alt='Identifier'>http://arks.princeton.edu/ark:/88435/5m60qr98h</a>"]
+        expect(manifest.metadata).to include label: "PDF Type", value: ["Gray"]
+        expect(manifest.metadata).to include label: "Created", value: ["1465-1480"]
+        expect(manifest.metadata).to include label: "Updated", value: ["06/07/1470"]
+      end
+    end
+  end
+end

--- a/spec/services/manifest_builder/see_also_builder_spec.rb
+++ b/spec/services/manifest_builder/see_also_builder_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ManifestBuilder::SeeAlsoBuilder do
+  describe '#apply' do
+    let(:builder) { described_class.new(scanned_resource) }
+    let(:manifest) { IIIF::Presentation::Manifest.new }
+    let(:decorated) { ScannedResourceDecorator.new(scanned_resource) }
+    let(:remote_record_class) { class_double(RemoteRecord).as_stubbed_const }
+    let(:remote_record_response) { instance_double(Faraday::Response) }
+
+    before do
+      allow(remote_record_class).to receive(:source_metadata_url).with('4609321').and_return("https://bibdata.princeton.edu/bibliographic/4609321")
+      allow(remote_record_class).to receive(:source_metadata_url).with('AC044_c0003').and_return("https://findingaids.princeton.edu/collections/AC044/c0003.xml?scope=record")
+      allow(remote_record_class).to receive(:retrieve).and_return(remote_record_response)
+      allow(remote_record_response).to receive(:success?).and_return(true)
+      builder.apply(manifest)
+    end
+
+    context 'when viewing a Scanned Resource with Voyager source ID' do
+      let(:scanned_resource) do
+        FactoryGirl.create_for_repository(:scanned_resource,
+                                          source_metadata_identifier: "4609321")
+      end
+
+      it 'appends the transformed metadata to the Manifest' do
+        expect(manifest.see_also).to be_a Array
+        expect(manifest.see_also.length).to eq(2)
+        expect(manifest.see_also.first).to include "@id" => "http://www.example.com/concern/scanned_resources/#{scanned_resource.id}.jsonld", "format" => "application/ld+json"
+        expect(manifest.see_also.last).to include "@id" => 'https://bibdata.princeton.edu/bibliographic/4609321', "format" => "text/xml"
+      end
+    end
+
+    context 'when viewing a Scanned Resource with PULFA source ID' do
+      let(:scanned_resource) do
+        FactoryGirl.create_for_repository(:scanned_resource,
+                                          source_metadata_identifier: "AC044_c0003")
+      end
+
+      it 'appends the transformed metadata to the Manifest' do
+        expect(manifest.see_also).to be_a Array
+        expect(manifest.see_also.length).to eq(2)
+        expect(manifest.see_also.first).to include "@id" => "http://www.example.com/concern/scanned_resources/#{scanned_resource.id}.jsonld", "format" => "application/ld+json"
+        expect(manifest.see_also.last).to include "@id" => 'https://findingaids.princeton.edu/collections/AC044/c0003.xml?scope=record', "format" => "text/xml"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Addresses #18 by:
- Exposing metadata in implementing the `MetadataBuilder` and locally overriding the `ManifestServiceLocator`
- Exposing the license restrictions for the resource
- Exposing links to other resources (using `see_also`)