### PR TITLE
Add a content-addressable storage adapter.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,3 +77,5 @@ RSpec/VerifiedDoubles:
     - 'spec/validators/viewing_hint_validator_spec.rb'
     - 'spec/validators/viewing_direction_validator_spec.rb'
     - 'spec/models/user_spec.rb'
+Lint/UnusedMethodArgument:
+  AllowUnusedKeywordArguments: true

--- a/app/services/file_appender.rb
+++ b/app/services/file_appender.rb
@@ -32,6 +32,7 @@ class FileAppender
       node = resource.file_metadata.select { |x| x.id.to_s == file.keys.first }.first
       file_wrapper = UploadDecorator.new(file.values.first, node.original_filename.first)
       file = storage_adapter.upload(file: file_wrapper, resource: node)
+      node.file_identifiers = file.id
       node
     end
   end

--- a/app/storage_adapters/configurable_path_disk_storage_adapter.rb
+++ b/app/storage_adapters/configurable_path_disk_storage_adapter.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+class ConfigurablePathDiskStorageAdapter
+  attr_reader :base_path, :path_generator, :unique_identifier
+  def initialize(base_path:, unique_identifier:, path_generator: BucketedStorage)
+    @base_path = base_path
+    @unique_identifier = unique_identifier
+    @path_generator = path_generator.new(base_path: base_path)
+  end
+
+  def upload(file:, resource: nil)
+    new_path = path_generator.generate(resource: resource, file: file)
+    return find_by(id: Valkyrie::ID.new("configurable_path_#{unique_identifier}://#{new_path.id}")) if new_path.exist?
+    FileUtils.mkdir_p(new_path.parent)
+    FileUtils.mv(file.path, new_path, force: true)
+    find_by(id: Valkyrie::ID.new("configurable_path_#{unique_identifier}://#{new_path.id}"))
+  end
+
+  def find_by(id:)
+    return unless handles?(id: id)
+    ::Valkyrie::StorageAdapter::File.new(id: Valkyrie::ID.new(id.to_s), io: path_generator.file(clean_id(id)))
+  end
+
+  def clean_id(id)
+    id.to_s.gsub("configurable_path_#{unique_identifier}://", "")
+  end
+
+  def handles?(id:)
+    id.to_s.start_with?("configurable_path_#{unique_identifier}://")
+  end
+
+  class BucketedStorage
+    attr_reader :base_path
+    def initialize(base_path:)
+      @base_path = base_path
+    end
+
+    def generate(file:, resource:)
+      Path.new(Pathname.new(base_path).join(*bucketed_path(resource.id)).join(file.original_filename))
+    end
+
+    def bucketed_path(id)
+      cleaned_id = id.to_s.delete("-")
+      cleaned_id[0..5].chars.each_slice(2).map(&:join) + [cleaned_id]
+    end
+
+    def file(id)
+      File.open(id.to_s, 'rb')
+    end
+
+    class Path
+      attr_reader :path
+      def initialize(path)
+        @path = path
+      end
+
+      def id
+        path.to_s
+      end
+
+      delegate :parent, to: :path
+
+      def to_str
+        path.to_s
+      end
+
+      def exist?
+        false
+      end
+    end
+  end
+
+  class ContentAddressablePath
+    attr_reader :base_path
+    def initialize(base_path:)
+      @base_path = base_path
+    end
+
+    def generate(file:, resource: nil)
+      sha = sha(file).to_s
+      Path.new(sha: sha, path: path_from_sha(sha).join("#{sha}#{file.original_filename.gsub(/^.*\./, '.')}"))
+    end
+
+    def sha(file)
+      Digest::SHA256.file(file.path)
+    end
+
+    def bucketed_path(sha)
+      sha[0..11].chars.each_slice(4).map(&:join)
+    end
+
+    def path_from_sha(sha)
+      Pathname.new(base_path).join(*bucketed_path(sha))
+    end
+
+    def file(id)
+      sha, extension = id.split(".")
+      File.open(path_from_sha(sha).join("#{sha}.#{extension}"), 'rb')
+    end
+
+    class Path
+      attr_reader :sha, :path
+      def initialize(sha:, path:)
+        @sha = sha
+        @path = path
+      end
+
+      delegate :exist?, to: :path
+
+      delegate :parent, to: :path
+
+      def to_str
+        path.to_s
+      end
+
+      def id
+        "#{sha}#{path.extname}"
+      end
+    end
+  end
+end

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -2,12 +2,20 @@
 require_relative 'figgy'
 Rails.application.config.to_prepare do
   Valkyrie::StorageAdapter.register(
-    Valkyrie::Storage::Disk.new(base_path: Figgy.config['repository_path']),
+    ConfigurablePathDiskStorageAdapter.new(
+      base_path: Figgy.config['repository_path'],
+      unique_identifier: :test_disk,
+      path_generator: ConfigurablePathDiskStorageAdapter::ContentAddressablePath
+    ),
     :disk
   )
 
   Valkyrie::StorageAdapter.register(
-    Valkyrie::Storage::Disk.new(base_path: Figgy.config['derivative_path']),
+    ConfigurablePathDiskStorageAdapter.new(
+      base_path: Figgy.config['derivative_path'],
+      unique_identifier: :derivatives,
+      path_generator: ConfigurablePathDiskStorageAdapter::ContentAddressablePath
+    ),
     :derivatives
   )
 

--- a/spec/storage_adapters/configurable_path_disk_storage_adapter_spec.rb
+++ b/spec/storage_adapters/configurable_path_disk_storage_adapter_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require 'valkyrie/specs/shared_specs'
+include ActionDispatch::TestProcess
+
+RSpec.describe ConfigurablePathDiskStorageAdapter do
+  it_behaves_like "a Valkyrie::StorageAdapter"
+  let(:storage_adapter) { described_class.new(base_path: Rails.root.join("tmp", "repo_test"), unique_identifier: :testing) }
+  let(:file) { fixture_file_upload('files/example.tif', 'image/tiff') }
+  before do
+    class Resource < Valkyrie::Resource
+      attribute :id, Valkyrie::Types::ID.optional
+    end
+  end
+  after do
+    Object.send(:remove_const, :Resource)
+  end
+  it "creates a bucketed file" do
+    stored_file = storage_adapter.upload(file: file, resource: Resource.new(id: "testi-ngthis"))
+
+    expect(stored_file.io.path).to eq Rails.root.join("tmp", "repo_test", "te", "st", "in", "testingthis", "example.tif").to_s
+  end
+  context "when passed an ID generator" do
+    let(:storage_adapter) do
+      described_class.new(
+        base_path: Rails.root.join("tmp", "repo_test"),
+        path_generator: ConfigurablePathDiskStorageAdapter::ContentAddressablePath,
+        unique_identifier: :testing
+      )
+    end
+    it "uses it" do
+      stored_file = storage_adapter.upload(file: file, resource: Resource.new(id: "test"))
+
+      expect(stored_file.io.path).to eq Rails.root.join("tmp", "repo_test", "547c", "81b0", "80eb", "547c81b080eb2d7c09e363a670c46960ac15a6821033263867dd59a31376509c.tif").to_s
+    end
+    it "only does it once" do
+      FileUtils.rm_f(Rails.root.join("tmp", "repo_test", "547c", "81b0", "80eb", "547c81b080eb2d7c09e363a670c46960ac15a6821033263867dd59a31376509c.tif"))
+      allow(FileUtils).to receive(:mv).and_call_original
+
+      storage_adapter.upload(file: file, resource: Resource.new(id: "test"))
+      duplicate_file = fixture_file_upload('files/example.tif', 'image/tiff')
+      storage_adapter.upload(file: duplicate_file, resource: Resource.new(id: "test"))
+
+      expect(FileUtils).to have_received(:mv).exactly(1).times
+    end
+  end
+end


### PR DESCRIPTION
Closes #111

This doesn't actually take advantage of the content-addressable storage - theoretically we could use this to make Characterization and
  Derivative Generation of duplicate files MUCH faster, but we'd have to
assume that we're using content addressable storage.