### PR TITLE
Raises errors for cases where FileSet derivatives cannot be loaded

### DIFF
--- a/app/helpers/osd_modal_helper.rb
+++ b/app/helpers/osd_modal_helper.rb
@@ -7,6 +7,8 @@ module OsdModalHelper
     else
       content_tag :span, class: 'ignore-select', data: { modal_manifest: "#{ManifestBuilder::ManifestHelper.new.manifest_image_path(id)}/info.json" }, &block
     end
+  rescue
+    content_tag :span
   end
 
   def default_icon_fallback

--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -336,6 +336,7 @@ class ManifestBuilder
     def base_url(id)
       file_set = query_service.find_by(id: Valkyrie::ID.new(id))
       file_metadata = file_set.derivative_file
+      raise Valkyrie::Persistence::ObjectNotFoundError, id if file_metadata.nil?
       Pathname.new(Figgy.config['cantaloupe_url']).join(
         CGI.escape("#{file_metadata.id}/intermediate_file.jp2")
       ).to_s

--- a/app/services/riiif_resolver.rb
+++ b/app/services/riiif_resolver.rb
@@ -7,6 +7,7 @@ class RiiifResolver < Riiif::AbstractFileSystemResolver
     raise ArgumentError, "Invalid characters in id `#{id}`" unless id =~ /^[\w\-:]+$/
     file_set = query_service.find_by(id: Valkyrie::ID.new(id))
     file_metadata = file_set.derivative_file
+    raise Valkyrie::Persistence::ObjectNotFoundError, id if file_metadata.nil?
     derivative_file = Valkyrie::StorageAdapter.find_by(id: file_metadata.file_identifiers.first)
     derivative_file.io.path
   end

--- a/spec/features/file_manager_spec.rb
+++ b/spec/features/file_manager_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature "File Manager" do
+  let(:user) { FactoryGirl.create(:admin) }
+  let(:file_set) { FactoryGirl.create_for_repository(:file_set) }
+  let(:resource) do
+    res = FactoryGirl.create_for_repository(:scanned_resource)
+    res.member_ids = [file_set.id]
+    adapter = Valkyrie::MetadataAdapter.find(:indexing_persister)
+    adapter.persister.save(resource: res)
+  end
+
+  before do
+    sign_in user
+  end
+
+  context 'without a derivative file' do
+    let(:manifest_helper_class) { class_double(ManifestBuilder::ManifestHelper).as_stubbed_const(transfer_nested_constants: true) }
+    let(:manifest_helper) { instance_double(ManifestBuilder::ManifestHelper) }
+    before do
+      allow(manifest_helper_class).to receive(:new).and_return(manifest_helper)
+      allow(manifest_helper).to receive(:manifest_image_path).and_raise(Valkyrie::Persistence::ObjectNotFoundError)
+    end
+    scenario 'visiting the file management interface' do
+      visit polymorphic_path [:file_manager, resource]
+
+      expect(page).to have_selector('.thumbnail span')
+      expect(page).not_to have_selector('.thumbnail span.ignore-select')
+    end
+  end
+
+  context 'with a derivative file' do
+    let(:derivative_file) { instance_double(FileMetadata) }
+    before do
+      allow(file_set).to receive(:derivative_file).and_return(derivative_file)
+    end
+    scenario 'visiting the file management interface' do
+      visit polymorphic_path [:file_manager, resource]
+
+      expect(page).to have_selector('.thumbnail span')
+      expect(page).to have_selector('.thumbnail span.ignore-select')
+    end
+  end
+end

--- a/spec/helpers/osd_modal_helper_spec.rb
+++ b/spec/helpers/osd_modal_helper_spec.rb
@@ -11,6 +11,18 @@ RSpec.describe OsdModalHelper do
         expect(output).to eq "bla"
       end
     end
+    context "when encountering an error retrieving the derivative" do
+      let(:file_set) { FactoryGirl.create_for_repository(:file_set) }
+      let(:manifest_helper_class) { class_double(ManifestBuilder::ManifestHelper).as_stubbed_const(transfer_nested_constants: true) }
+      let(:manifest_helper) { instance_double(ManifestBuilder::ManifestHelper) }
+      before do
+        allow(manifest_helper_class).to receive(:new).and_return(manifest_helper)
+        allow(manifest_helper).to receive(:manifest_image_path).and_raise(Valkyrie::Persistence::ObjectNotFoundError)
+      end
+      it 'generates an empty <span>' do
+        expect(helper.osd_modal_for(file_set.id)).to eq "<span></span>"
+      end
+    end
   end
 
   describe "#figgy_thumbnail_path" do

--- a/spec/services/manifest_builder/cantaloupe_helper_spec.rb
+++ b/spec/services/manifest_builder/cantaloupe_helper_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ManifestBuilder::CantaloupeHelper do
+  let(:cantaloupe_helper) { described_class.new }
+  let(:file_set) { FactoryGirl.create_for_repository(:file_set) }
+  let(:derivative_file) { instance_double(FileMetadata) }
+  let(:query_service) { class_double(Valkyrie::Persistence::Postgres::QueryService) }
+
+  describe '#base_url' do
+    context 'with generated derivatives' do
+      before do
+        allow(derivative_file).to receive(:id).and_return('test')
+        allow(file_set).to receive(:derivative_file).and_return(derivative_file)
+        allow(query_service).to receive(:find_by).and_return(file_set)
+        allow(cantaloupe_helper).to receive(:query_service).and_return(query_service)
+      end
+      it 'generates a base URL for a JPEG2000 derivative' do
+        expect(cantaloupe_helper.base_url(file_set.id)).to eq 'http://localhost:8182/iiif/2/test%2Fintermediate_file.jp2'
+      end
+    end
+    context 'without generated derivatives' do
+      it 'raises an Valkyrie::Persistence::ObjectNotFoundError' do
+        expect { cantaloupe_helper.base_url(file_set.id) }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #132 by raising Valkyrie::Persistence::ObjectNotFoundError when derivatives cannot be loaded for a FileSet (and handles this by generating an empty <span> for the OpenSeadragon modal)