### PR TITLE
Extends the File Management interface for regenerating derivatives

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,9 +47,10 @@ group :development, :staging do
 end
 
 group :test do
+  gem 'chromedriver-helper'
   gem "database_cleaner"
   gem "formulaic"
-  gem "poltergeist"
+  gem 'selenium-webdriver'
   gem "simplecov", require: false
   gem "timecop"
   gem "webmock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,8 @@ GEM
       sshkit (>= 1.6.1, != 1.7.0)
     almond-rails (0.1.0)
       rails (>= 4.2, < 6)
+    archive-zip (0.7.0)
+      io-like (~> 0.3.0)
     arel (8.0.0)
     ast (2.3.0)
     autoprefixer-rails (7.1.2.3)
@@ -229,7 +231,11 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    cliver (0.3.2)
+    childprocess (0.7.1)
+      ffi (~> 1.0, >= 1.0.11)
+    chromedriver-helper (1.1.0)
+      archive-zip (~> 0.7.0)
+      nokogiri (~> 1.6)
     coderay (1.1.1)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -402,6 +408,7 @@ GEM
       faraday (>= 0.9)
       json
     inflecto (0.0.2)
+    io-like (0.3.0)
     jmespath (1.3.1)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
@@ -495,10 +502,6 @@ GEM
       ast (~> 2.2)
     pdf-core (0.7.0)
     pg (0.21.0)
-    poltergeist (1.15.0)
-      capybara (~> 2.1)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     prawn (2.2.2)
       pdf-core (~> 0.7.0)
@@ -641,6 +644,9 @@ GEM
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
     scrub_rb (1.0.1)
+    selenium-webdriver (3.4.4)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.0)
     sidekiq (5.0.4)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
@@ -756,6 +762,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-rails-console
+  chromedriver-helper
   coffee-rails
   coveralls
   database_cleaner
@@ -779,7 +786,6 @@ DEPENDENCIES
   openseadragon
   pdf-reader!
   pg
-  poltergeist
   prawn
   pry-byebug
   pry-rails
@@ -796,6 +802,7 @@ DEPENDENCIES
   rsolr (>= 1.0)
   rspec-rails (~> 3.5)
   sass-rails (~> 5.0)
+  selenium-webdriver
   sidekiq
   simple_form
   simplecov

--- a/app/assets/javascripts/derivative_form.es6
+++ b/app/assets/javascripts/derivative_form.es6
@@ -1,0 +1,30 @@
+export default class DerivativeForm {
+  constructor() {
+    this.form = $(".rederive")
+    this.element = this.form.find('button')
+    this.element.click(this.onclick)
+  }
+
+  onclick(event) {
+    $.ajax({
+      type: "PUT",
+      url: $(this).parents('.rederive').attr('action'),
+      data: $(this).parents('.rederive').serializeArray(),
+      dataType: 'json'
+    }).done(function(data, textStatus, response) {
+      $('.flash-message span.text')
+        .text("Derivatives are being regenerated")
+        .parent()
+        .removeClass('alert-danger')
+        .addClass('alert-success')
+        .removeClass('hidden')
+    }).fail(function(response, textStatus, errorThrown) {
+      $('.flash-message span.text')
+        .text("Derivatives cannot be regenerated")
+        .parent()
+        .removeClass('alert-success')
+        .addClass('alert-danger')
+        .removeClass('hidden')
+    })
+  }
+}

--- a/app/assets/javascripts/figgy_boot.es6
+++ b/app/assets/javascripts/figgy_boot.es6
@@ -2,6 +2,7 @@ import SaveWorkControl from 'form/save_work_control'
 import ServerUploader from "./server_uploader"
 import StructureManager from "structure_manager"
 import ModalViewer from "modal_viewer"
+import DerivativeForm from "derivative_form"
 export default class Initializer {
   constructor() {
     this.server_uploader = new ServerUploader
@@ -9,6 +10,7 @@ export default class Initializer {
     this.initialize_timepicker()
     this.structure_manager = new StructureManager
     this.modal_viewer = new ModalViewer
+    this.derivative_form = new DerivativeForm
     $("select").selectpicker({'liveSearch': true})
   }
 

--- a/app/controllers/file_sets_controller.rb
+++ b/app/controllers/file_sets_controller.rb
@@ -7,4 +7,19 @@ class FileSetsController < ApplicationController
     metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister),
     storage_adapter: Valkyrie.config.storage_adapter
   )
+
+  def derivatives
+    file_set = find_resource(params[:id])
+    @change_set = change_set_class.new(file_set).prepopulate!
+    authorize! :derive, @change_set.resource
+    output = CreateDerivativesJob.perform_later(params[:id])
+    respond_to do |format|
+      format.json do
+        render json: output
+      end
+      format.html do
+        redirect_to polymorphic_path file_set
+      end
+    end
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -18,7 +18,7 @@ class Ability
   # Abilities that should be granted to technicians
   def image_editor_permissions
     can [:read, :create, :modify, :update, :publish], curation_concerns
-    can [:create, :read, :edit, :update, :publish, :download], FileSet
+    can [:create, :read, :edit, :update, :publish, :download, :derive], FileSet
     can [:create, :read, :edit, :update, :publish], Collection
 
     # do not allow completing resources

--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,11 @@ machine:
   services:
     - redis
 dependencies:
+  pre:
+    # Install the latest release of Google Chrome for functional JavaScript testing
+    - curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+    - sudo dpkg -i google-chrome.deb
+    - rm google-chrome.deb
   cache_directories:
     - kakadu
   post:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,7 +58,11 @@ Rails.application.routes.draw do
 
   # Consider moving these to Valhalla
   scope '/concern' do
-    resources :file_sets
+    resources :file_sets do
+      member do
+        put :derivatives
+      end
+    end
     resources :scanned_resources do
       member do
         get :file_manager

--- a/spec/controllers/file_sets_controller_spec.rb
+++ b/spec/controllers/file_sets_controller_spec.rb
@@ -26,4 +26,24 @@ RSpec.describe FileSetsController do
       expect { get :edit, params: { id: file_set.id.to_s } }.not_to raise_error
     end
   end
+
+  describe "PUT /file_sets/id" do
+    context 'with a derivative service for images in the TIFF' do
+      let(:create_derivatives_class) { class_double(CreateDerivativesJob).as_stubbed_const(transfer_nested_constants: true) }
+      let(:original_file) { instance_double(FileMetadata) }
+      let(:file_set) { FactoryGirl.create_for_repository(:file_set) }
+      before do
+        allow(original_file).to receive(:mime_type).and_return('image/tiff')
+        allow(file_set).to receive(:original_file).and_return(original_file)
+        allow(create_derivatives_class).to receive(:perform_later).and_return(success: true)
+      end
+
+      it "can regenerate derivatives" do
+        put :derivatives, params: { id: file_set.id.to_s }
+
+        expect(response).to redirect_to(file_set)
+        expect(create_derivatives_class).to have_received(:perform_later)
+      end
+    end
+  end
 end

--- a/spec/features/file_manager_spec.rb
+++ b/spec/features/file_manager_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.feature "File Manager" do
+RSpec.feature "File Manager", js: true do
   let(:user) { FactoryGirl.create(:admin) }
+  let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
   let(:file_set) { FactoryGirl.create_for_repository(:file_set) }
   let(:resource) do
     res = FactoryGirl.create_for_repository(:scanned_resource)
     res.member_ids = [file_set.id]
-    adapter = Valkyrie::MetadataAdapter.find(:indexing_persister)
     adapter.persister.save(resource: res)
   end
 
@@ -16,30 +16,59 @@ RSpec.feature "File Manager" do
   end
 
   context 'without a derivative file' do
-    let(:manifest_helper_class) { class_double(ManifestBuilder::ManifestHelper).as_stubbed_const(transfer_nested_constants: true) }
-    let(:manifest_helper) { instance_double(ManifestBuilder::ManifestHelper) }
+    let(:riiif_helper) { instance_double(ManifestBuilder::RiiifHelper) }
+    let(:riiif_helper_class) { class_double(ManifestBuilder::RiiifHelper).as_stubbed_const(transfer_nested_constants: true) }
     before do
-      allow(manifest_helper_class).to receive(:new).and_return(manifest_helper)
-      allow(manifest_helper).to receive(:manifest_image_path).and_raise(Valkyrie::Persistence::ObjectNotFoundError)
+      allow(riiif_helper).to receive(:base_url).and_raise(Valkyrie::Persistence::ObjectNotFoundError)
+      allow(riiif_helper_class).to receive(:new).and_return(riiif_helper)
     end
-    scenario 'visiting the file management interface' do
+    scenario 'users visit the file management interface' do
       visit polymorphic_path [:file_manager, resource]
 
-      expect(page).to have_selector('.thumbnail span')
       expect(page).not_to have_selector('.thumbnail span.ignore-select')
     end
   end
 
   context 'with a derivative file' do
-    let(:derivative_file) { instance_double(FileMetadata) }
+    let(:riiif_helper) { instance_double(ManifestBuilder::RiiifHelper) }
+    let(:riiif_helper_class) { class_double(ManifestBuilder::RiiifHelper).as_stubbed_const(transfer_nested_constants: true) }
     before do
-      allow(file_set).to receive(:derivative_file).and_return(derivative_file)
+      allow(riiif_helper).to receive(:base_url).and_return('http://localhost/test-resource')
+      allow(riiif_helper_class).to receive(:new).and_return(riiif_helper)
     end
-    scenario 'visiting the file management interface' do
+    scenario 'users can visiting the file management interface' do
       visit polymorphic_path [:file_manager, resource]
 
       expect(page).to have_selector('.thumbnail span')
       expect(page).to have_selector('.thumbnail span.ignore-select')
+    end
+    context 'with a derivative service for images in the TIFF' do
+      let(:create_derivatives_class) { class_double(CreateDerivativesJob).as_stubbed_const(transfer_nested_constants: true) }
+      let(:original_file) { instance_double(FileMetadata) }
+      before do
+        allow(original_file).to receive(:mime_type).and_return('image/tiff')
+        allow(file_set).to receive(:original_file).and_return(original_file)
+        allow(create_derivatives_class).to receive(:perform_later).and_return(success: true)
+      end
+      scenario 'users regenerate derivatives for a file set' do
+        visit polymorphic_path [:file_manager, resource]
+
+        expect(page).to have_selector('form.rederive button')
+        click_button 'Regenerate Derivatives'
+        expect(page).to have_selector '.alert-success .text', text: 'Derivatives are being regenerated'
+      end
+      context 'when the derivative service fails' do
+        before do
+          allow(create_derivatives_class).to receive(:perform_later).and_raise(Hydra::Derivatives::TimeoutError)
+        end
+        scenario 'users cannot regenerate derivatives for a file set' do
+          visit polymorphic_path [:file_manager, resource]
+
+          expect(page).to have_selector('form.rederive button')
+          click_button 'Regenerate Derivatives'
+          expect(page).to have_selector '.alert-danger .text', text: 'Derivatives cannot be regenerated'
+        end
+      end
     end
   end
 end

--- a/spec/features/root_spec.rb
+++ b/spec/features/root_spec.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe "Home Page" do
+RSpec.feature "Home Page", js: true do
   let(:user) { FactoryGirl.create(:admin) }
   before do
     sign_in user
   end
 
-  it "displays creation links for administrators" do
+  scenario "displays creation links for administrators" do
+    click_link 'Add'
     expect(page).to have_link "New Scanned Resource"
     expect(page).to have_link "Add a Collection", href: "/collections/new"
     expect(page).to have_link "Manage Roles"

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -4,3 +4,4 @@ require 'capybara/rspec'
 RSpec.configure do |config|
   config.include Capybara::RSpecMatchers, type: :request
 end
+Capybara.raise_server_errors = false

--- a/spec/support/capybara_poltergeist.rb
+++ b/spec/support/capybara_poltergeist.rb
@@ -1,2 +1,0 @@
-# frozen_string_literal: true
-Capybara.javascript_driver = :poltergeist

--- a/spec/support/capybara_selenium.rb
+++ b/spec/support/capybara_selenium.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require 'capybara/rspec'
+require 'selenium-webdriver'
+
+Capybara.register_driver(:headless_chrome) do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: %w(headless disable-gpu disable-setuid-sandbox) }
+  )
+
+  Capybara::Selenium::Driver.new(app,
+                                 browser: :chrome,
+                                 desired_capabilities: capabilities)
+end
+
+Capybara.javascript_driver = :headless_chrome
+Capybara.default_max_wait_time = 15
+Capybara.default_driver = :selenium

--- a/spec/views/scanned_resources/file_manager.html.erb_spec.rb
+++ b/spec/views/scanned_resources/file_manager.html.erb_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "valhalla/base/file_manager.html.erb", type: :view do
     expect(rendered).to have_selector "input[name='file_set[title][]'][type='text'][value='#{member.title.first}']"
     expect(rendered).to have_selector("a[href=\"#{Valhalla::ContextualPath.new(child: member, parent_id: parent.id).show}\"]")
     expect(rendered).to have_link "Test Title", href: "/catalog/id-#{parent.id}"
-    expect(rendered).to have_selector("#sortable form", count: members.length)
+    expect(rendered).to have_selector("#sortable form", count: 2)
     expect(rendered).to have_selector("form#resource-form")
     expect(rendered).to have_selector("input[name='file_set[viewing_hint]']")
     expect(rendered).to have_selector("img[src='#{ManifestBuilder::ManifestHelper.new.manifest_image_path(member.thumbnail_id)}/full/!200,150/0/default.jpg']")

--- a/valhalla/app/views/valhalla/base/_file_manager_derivatives.html.erb
+++ b/valhalla/app/views/valhalla/base/_file_manager_derivatives.html.erb
@@ -1,0 +1,6 @@
+<div class="form-group member_resource_options">
+  <% if node.model_name.singular == "file_set" %>
+    <%= form_tag derivatives_file_set_path(node), class: "rederive", method: "put" %>
+    <button name="button" type="button" class="btn btn-primary" data-href="<%= derivatives_file_set_path(node) %>">Regenerate Derivatives</button>
+  <% end %>
+</div>

--- a/valhalla/app/views/valhalla/base/_file_manager_member.html.erb
+++ b/valhalla/app/views/valhalla/base/_file_manager_member.html.erb
@@ -23,5 +23,6 @@
         </div>
       <% end %>
       <%= render "file_manager_member_resource_options", node: node %>
+      <%= render "file_manager_derivatives", node: node %>
     </div>
 </li>


### PR DESCRIPTION
Resolves #64 by adding a route for updating FileSet derivatives and providing a jQuery extension for the File Management interface