### PR TITLE
Adds support for RabbitMQ messaging 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 
 gem "autoprefixer-rails"
 gem "blacklight"
+gem 'bunny'
 gem "devise-guests", git: "https://github.com/cbeer/devise-guests.git"
 gem "flutie"
 gem "honeybadger"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,7 @@ GEM
       sshkit (>= 1.6.1, != 1.7.0)
     almond-rails (0.1.0)
       rails (>= 4.2, < 6)
+    amq-protocol (2.2.0)
     archive-zip (0.7.0)
       io-like (~> 0.3.0)
     arel (8.0.0)
@@ -205,6 +206,8 @@ GEM
     bundler-audit (0.6.0)
       bundler (~> 1.2)
       thor (~> 0.18)
+    bunny (2.6.6)
+      amq-protocol (>= 2.1.0)
     byebug (9.0.6)
     cancancan (1.17.0)
     capistrano (3.7.2)
@@ -765,6 +768,7 @@ DEPENDENCIES
   browse-everything
   bullet
   bundler-audit (>= 0.5.0)
+  bunny
   capistrano (~> 3.7.1)
   capistrano-passenger
   capistrano-rails

--- a/app/change_set_persisters/plum_change_set_persister/publish_message.rb
+++ b/app/change_set_persisters/plum_change_set_persister/publish_message.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+class PlumChangeSetPersister
+  class PublishMessage
+    class Factory
+      attr_reader :operation
+      def initialize(operation:)
+        @operation = operation
+      end
+
+      def new(*args)
+        klass.new(*args)
+      end
+
+      private
+
+        def klass_name
+          "PlumChangeSetPersister::Publish#{operation.to_s.capitalize}#{'e' unless operation.to_s.last == 'e'}dMessage"
+        end
+
+        def klass
+          klass_name.constantize
+        rescue
+          raise NotImplementedError, "#{klass_name} not supported as a change set persistence handler"
+        end
+    end
+  end
+
+  class PublishCreatedMessage
+    attr_reader :change_set_persister, :change_set
+    def initialize(change_set_persister:, change_set: nil)
+      @change_set = change_set
+      @change_set_persister = change_set_persister
+    end
+
+    def run
+      created_file_sets.each { |created_file_set| messenger.record_created(created_file_set) } unless created_file_sets.blank?
+    end
+
+    delegate :messenger, :created_file_sets, to: :change_set_persister
+  end
+
+  class PublishUpdatedMessage
+    attr_reader :change_set_persister, :change_set, :post_save_resource
+    def initialize(change_set_persister:, change_set:, post_save_resource: nil)
+      @change_set = change_set
+      @change_set_persister = change_set_persister
+      @post_save_resource = post_save_resource
+    end
+
+    def run
+      messenger.record_updated(post_save_resource)
+    end
+
+    delegate :messenger, to: :change_set_persister
+  end
+
+  class PublishDeletedMessage
+    attr_reader :change_set_persister, :change_set
+    def initialize(change_set_persister:, change_set:)
+      @change_set = change_set
+      @change_set_persister = change_set_persister
+    end
+
+    def run
+      messenger.record_deleted(change_set.resource)
+    end
+
+    delegate :messenger, to: :change_set_persister
+  end
+end

--- a/app/decorators/collection_decorator.rb
+++ b/app/decorators/collection_decorator.rb
@@ -7,4 +7,11 @@ class CollectionDecorator < Valkyrie::ResourceDecorator
   def manageable_files?
     false
   end
+
+  # Nested collections are not currently supported
+  def parents
+    []
+  end
+
+  alias collections parents
 end

--- a/app/decorators/file_set_decorator.rb
+++ b/app/decorators/file_set_decorator.rb
@@ -2,6 +2,7 @@
 class FileSetDecorator < Valkyrie::ResourceDecorator
   delegate :query_service, to: :metadata_adapter
   self.display_attributes += [:height, :width, :mime_type, :size, :md5, :sha1, :sha256]
+
   def manageable_files?
     false
   end
@@ -12,5 +13,9 @@ class FileSetDecorator < Valkyrie::ResourceDecorator
 
   def metadata_adapter
     Valkyrie.config.metadata_adapter
+  end
+
+  def collections
+    []
   end
 end

--- a/app/decorators/scanned_resource_decorator.rb
+++ b/app/decorators/scanned_resource_decorator.rb
@@ -73,4 +73,9 @@ class ScannedResourceDecorator < Valkyrie::ResourceDecorator
 
     current_attributes
   end
+
+  def parents
+    Valkyrie::MetadataAdapter.find(:indexing_persister).query_service.find_references_by(resource: self, property: :member_of_collection_ids).to_a
+  end
+  alias collections parents
 end

--- a/app/services/manifest_event_generator.rb
+++ b/app/services/manifest_event_generator.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+class ManifestEventGenerator
+  attr_reader :rabbit_exchange
+  def initialize(rabbit_exchange)
+    @rabbit_exchange = rabbit_exchange
+  end
+
+  def record_created(record)
+    publish_message(
+      message_with_collections("CREATED", record)
+    )
+  end
+
+  def record_deleted(record)
+    publish_message(
+      message("DELETED", record)
+    )
+  end
+
+  def record_updated(record)
+    publish_message(
+      message_with_collections("UPDATED", record)
+    )
+  end
+
+  private
+
+    def manifest_url(record)
+      helper.polymorphic_url([:manifest, record])
+    rescue
+      ''
+    end
+
+    def message(type, record)
+      {
+        "id" => record ? record.id.to_s : nil,
+        "event" => type,
+        "manifest_url" => manifest_url(record)
+      }
+    end
+
+    def message_with_collections(type, record)
+      output = message(type, record)
+      if record.decorate.respond_to? :collections
+        output["collection_slugs"] = record.decorate.collections.map { |collection| collection.try(:slug) }.compact
+      end
+      output
+    end
+
+    def publish_message(message)
+      rabbit_exchange.publish(message.to_json)
+    end
+
+    def helper
+      @helper ||= ManifestBuilder::ManifestHelper.new
+    end
+end

--- a/app/services/messaging_client.rb
+++ b/app/services/messaging_client.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+class MessagingClient
+  class Config < OpenStruct
+    def log_level
+      value = super
+      value = value.constantize if %w[Logger::DEBUG Logger::INFO Logger::WARN Logger::ERROR Logger::FATAL Logger:UNKNOWN].include? value
+      value
+    end
+
+    def log_file
+      value = super
+      value = value.constantize if %w[STDIN STDOUT STDERR].include? value
+      value
+    end
+  end
+
+  attr_reader :amqp_url, :config
+  def initialize(amqp_url, config: {})
+    @amqp_url = amqp_url
+    @config = Config.new(config)
+  end
+
+  def publish(message)
+    exchange.publish(message, persistent: true)
+  rescue
+    Rails.logger.warn "Unable to publish message to #{amqp_url}"
+  end
+
+  private
+
+    def bunny_args
+      config.to_h.merge(host: amqp_url)
+    end
+
+    def bunny_client
+      @bunny_client ||= Bunny.new(*bunny_args).tap(&:start)
+    end
+
+    def channel
+      @channel ||= bunny_client.create_channel
+    end
+
+    def exchange
+      @exchange ||= channel.fanout(Figgy.config['events']['exchange']['plum'], durable: true)
+    end
+end

--- a/config/config.yml
+++ b/config/config.yml
@@ -8,67 +8,72 @@ defaults: &defaults
   plum_derivative_path: "/mnt/libimages1/data/jp2s/plum_prod"
   jp2_recipes:
     default_color: >
-      -rate 2.4,1.48331273,.91673033,.56657224,.35016049,.21641118,.13374944,.08266171 
-      -jp2_space sRGB 
-      -double_buffering 10 
-      -num_threads 1 
-      -no_weights 
-      Clevels=6 
-      Clayers=8 
-      Cblk=\{64,64\} 
-      Cuse_sop=yes 
-      Cuse_eph=yes  
-      Corder=RPCL 
-      ORGgen_plt=yes 
-      ORGtparts=R 
+      -rate 2.4,1.48331273,.91673033,.56657224,.35016049,.21641118,.13374944,.08266171
+      -jp2_space sRGB
+      -double_buffering 10
+      -num_threads 1
+      -no_weights
+      Clevels=6
+      Clayers=8
+      Cblk=\{64,64\}
+      Cuse_sop=yes
+      Cuse_eph=yes
+      Corder=RPCL
+      ORGgen_plt=yes
+      ORGtparts=R
       Stiles=\{1024,1024\}
     default_gray: >
-      -rate 2.4,1.48331273,.91673033,.56657224,.35016049,.21641118,.13374944,.08266171 
-      -jp2_space sLUM 
-      -double_buffering 10 
+      -rate 2.4,1.48331273,.91673033,.56657224,.35016049,.21641118,.13374944,.08266171
+      -jp2_space sLUM
+      -double_buffering 10
       -num_threads 1
-      -no_weights 
-      Clevels=6 
-      Clayers=8 
-      Cblk=\{64,64\} 
-      Cuse_sop=yes 
-      Cuse_eph=yes  
-      Corder=RPCL 
-      ORGgen_plt=yes 
-      ORGtparts=R 
+      -no_weights
+      Clevels=6
+      Clayers=8
+      Cblk=\{64,64\}
+      Cuse_sop=yes
+      Cuse_eph=yes
+      Corder=RPCL
+      ORGgen_plt=yes
+      ORGtparts=R
       Stiles=\{1024,1024\}
     geo_color: >
       -no_palette
-      -rate 2.4,1.48331273,.91673033,.56657224,.35016049,.21641118,.13374944,.08266171 
-      -jp2_space sRGB 
-      -double_buffering 10 
-      -num_threads 1 
-      -no_weights 
-      Clevels=6 
-      Clayers=8 
-      Cblk=\{64,64\} 
-      Cuse_sop=yes 
-      Cuse_eph=yes  
-      Corder=RPCL 
-      ORGgen_plt=yes 
-      ORGtparts=R 
+      -rate 2.4,1.48331273,.91673033,.56657224,.35016049,.21641118,.13374944,.08266171
+      -jp2_space sRGB
+      -double_buffering 10
+      -num_threads 1
+      -no_weights
+      Clevels=6
+      Clayers=8
+      Cblk=\{64,64\}
+      Cuse_sop=yes
+      Cuse_eph=yes
+      Corder=RPCL
+      ORGgen_plt=yes
+      ORGtparts=R
       Stiles=\{1024,1024\}
     geo_gray: >
       -no_palette
-      -rate 2.4,1.48331273,.91673033,.56657224,.35016049,.21641118,.13374944,.08266171 
-      -jp2_space sLUM 
-      -double_buffering 10 
+      -rate 2.4,1.48331273,.91673033,.56657224,.35016049,.21641118,.13374944,.08266171
+      -jp2_space sLUM
+      -double_buffering 10
       -num_threads 1
-      -no_weights 
-      Clevels=6 
-      Clayers=8 
-      Cblk=\{64,64\} 
-      Cuse_sop=yes 
-      Cuse_eph=yes  
-      Corder=RPCL 
-      ORGgen_plt=yes 
-      ORGtparts=R 
+      -no_weights
+      Clevels=6
+      Clayers=8
+      Cblk=\{64,64\}
+      Cuse_sop=yes
+      Cuse_eph=yes
+      Corder=RPCL
+      ORGgen_plt=yes
+      ORGtparts=R
       Stiles=\{1024,1024\}
+  events:
+    server: 'amqp://localhost:5672'
+    exchange:
+      plum: "plum_events"
+      geoblacklight: "gbl_events"
 
 development:
   <<: *defaults
@@ -78,6 +83,8 @@ test:
   <<: *defaults
   plum_binary_path: <%= Rails.root.join("spec", "fixtures", "plum_binaries") %>
   plum_derivative_path: <%= Rails.root.join("spec", "fixtures", "plum_derivatives") %>
+  events:
+    log_file: '/dev/null'
 
 production:
   <<: *defaults

--- a/config/initializers/figgy.rb
+++ b/config/initializers/figgy.rb
@@ -4,6 +4,10 @@ module Figgy
     @config ||= config_yaml.with_indifferent_access
   end
 
+  def messaging_client
+    @messaging_client ||= MessagingClient.new(Figgy.config['events']['server'], config: Figgy.config['events'])
+  end
+
   def default_url_options
     @default_url_options ||= ActionMailer::Base.default_url_options
   end
@@ -14,5 +18,5 @@ module Figgy
       YAML.safe_load(ERB.new(File.read(Rails.root.join("config", "config.yml"))).result, [], [], true)[Rails.env]
     end
 
-    module_function :config, :config_yaml, :default_url_options
+    module_function :config, :config_yaml, :messaging_client, :default_url_options
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 Rails.application.routes.draw do
   resources :auth_tokens
+  default_url_options Rails.application.config.action_mailer.default_url_options
   concern :exportable, Blacklight::Routes::Exportable.new
 
   resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do

--- a/spec/change_set_persisters/plum_change_set_persister/publish_message/factory_spec.rb
+++ b/spec/change_set_persisters/plum_change_set_persister/publish_message/factory_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe PlumChangeSetPersister::PublishMessage::Factory do
+  let(:query_service) { instance_double(Valkyrie::Persistence::Memory::QueryService) }
+  let(:change_set_persister) { instance_double(PlumChangeSetPersister::Basic, query_service: query_service) }
+  let(:change_set) { ScannedResourceChangeSet.new(scanned_resource) }
+  let(:scanned_resource) { ScannedResource.new }
+
+  describe '.new' do
+    it 'initializes a new PublishMessage Object' do
+      expect(described_class.new(operation: :create)
+              .new(change_set_persister: change_set_persister, change_set: change_set))
+        .to be_a PlumChangeSetPersister::PublishCreatedMessage
+      expect(described_class.new(operation: :update)
+              .new(change_set_persister: change_set_persister, change_set: change_set, post_save_resource: scanned_resource))
+        .to be_a PlumChangeSetPersister::PublishUpdatedMessage
+      expect(described_class.new(operation: :delete)
+              .new(change_set_persister: change_set_persister, change_set: change_set))
+        .to be_a PlumChangeSetPersister::PublishDeletedMessage
+    end
+
+    it 'raises an issue when attempting to initialize a publisher object for unsupported operations' do
+      expect do
+        described_class.new(operation: :unsupport)
+                       .new(change_set_persister: change_set_persister, change_set: change_set)
+      end.to raise_error(NotImplementedError, "PlumChangeSetPersister::PublishUnsupportedMessage not supported as a change set persistence handler")
+    end
+  end
+end

--- a/spec/change_set_persisters/plum_change_set_persister_spec.rb
+++ b/spec/change_set_persisters/plum_change_set_persister_spec.rb
@@ -7,11 +7,13 @@ RSpec.describe PlumChangeSetPersister do
   subject(:change_set_persister) do
     described_class.new(metadata_adapter: adapter, storage_adapter: storage_adapter)
   end
+
   let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
   let(:persister) { adapter.persister }
   let(:query_service) { adapter.query_service }
   let(:storage_adapter) { Valkyrie.config.storage_adapter }
   let(:change_set_class) { ScannedResourceChangeSet }
+
   it_behaves_like "a Valkyrie::ChangeSetPersister"
 
   context "when a source_metadata_identifier is set for the first time on a scanned resource" do
@@ -139,9 +141,13 @@ RSpec.describe PlumChangeSetPersister do
 
   describe "uploading files" do
     let(:file) { fixture_file_upload('files/example.tif', 'image/tiff') }
+    let(:change_set_persister) do
+      described_class.new(metadata_adapter: adapter, storage_adapter: storage_adapter, characterize: true)
+    end
+
     it "can append files as FileSets", run_real_derivatives: true do
       resource = FactoryGirl.build(:scanned_resource)
-      change_set = change_set_class.new(resource)
+      change_set = change_set_class.new(resource, characterize: false)
       change_set.files = [file]
 
       output = change_set_persister.save(change_set: change_set)
@@ -178,13 +184,18 @@ RSpec.describe PlumChangeSetPersister do
       expect(query_service.find_all.to_a.map(&:class)).to contain_exactly ScannedResource, FileSet
     end
   end
+
   describe "updating files" do
     let(:file1) { fixture_file_upload('files/example.tif', 'image/tiff') }
     let(:file2) { fixture_file_upload('files/holding_locations.json', 'application/json') }
+    let(:change_set_persister) do
+      described_class.new(metadata_adapter: adapter, storage_adapter: storage_adapter, characterize: false)
+    end
+
     it "can append files as FileSets", run_real_derivatives: true do
       # upload a file
       resource = FactoryGirl.build(:scanned_resource)
-      change_set = change_set_class.new(resource)
+      change_set = change_set_class.new(resource, characterize: false)
       change_set.files = [file1]
       output = change_set_persister.save(change_set: change_set)
       file_set = query_service.find_members(resource: output).first
@@ -200,6 +211,38 @@ RSpec.describe PlumChangeSetPersister do
       updated_file_node = updated_file_set.file_metadata.find { |x| x.id == file_node.id }
       updated_file = storage_adapter.find_by(id: updated_file_node.file_identifiers.first)
       expect(updated_file.size).to eq 5600
+    end
+
+    context 'with a messaging service' do
+      let(:rabbit_connection) { instance_double(MessagingClient, publish: true) }
+      let(:change_set_persister) do
+        described_class.new(metadata_adapter: adapter, storage_adapter: storage_adapter, characterize: false)
+      end
+
+      before do
+        allow(Figgy).to receive(:messaging_client).and_return(rabbit_connection)
+      end
+
+      it 'publishes messages for updated file sets', run_real_derivatives: false, rabbit_stubbed: true do
+        resource = FactoryGirl.build(:scanned_resource)
+        change_set = change_set_class.new(resource, characterize: false)
+        change_set.files = [file1]
+
+        output = change_set_persister.save(change_set: change_set)
+        file_set = query_service.find_members(resource: output).first
+
+        change_set = FileSetChangeSet.new(file_set)
+        change_set_persister.save(change_set: change_set)
+
+        expected_result = {
+          "id" => output.id.to_s,
+          "event" => "UPDATED",
+          "manifest_url" => "http://www.example.com/concern/scanned_resources/#{output.id}/manifest",
+          "collection_slugs" => []
+        }
+
+        expect(rabbit_connection).to have_received(:publish).at_least(:once).with(expected_result.to_json)
+      end
     end
   end
 

--- a/spec/decorators/collection_decorator_spec.rb
+++ b/spec/decorators/collection_decorator_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe CollectionDecorator do
+  subject(:decorator) { described_class.new(collection) }
+  let(:collection) { FactoryGirl.create_for_repository(:collection) }
+  let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
+
+  it 'has no files which can be managed' do
+    expect(decorator.manageable_files?).to be false
+  end
+
+  describe '#collections' do
+    it "cannot have parent collections" do
+      expect(decorator.collections).to be_empty
+    end
+  end
+
+  describe '#parents' do
+    it "cannot have parent resources" do
+      expect(decorator.parents).to be_empty
+    end
+  end
+
+  describe '#title' do
+    it 'exposes the title' do
+      expect(decorator.title).to eq 'Title'
+    end
+  end
+end

--- a/spec/decorators/file_set_decorator_spec.rb
+++ b/spec/decorators/file_set_decorator_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe FileSetDecorator do
+  subject(:decorator) { described_class.new(file_set) }
+  let(:file_set) { FactoryGirl.create_for_repository(:file_set) }
+  let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
+
+  it 'has no files which can be managed' do
+    expect(decorator.manageable_files?).to be false
+  end
+
+  describe '#collections' do
+    it "exposes parent collections" do
+      expect(decorator.collections).to eq []
+    end
+  end
+
+  describe '#parent' do
+    it "exposes parent resources" do
+      res = FactoryGirl.create_for_repository(:scanned_resource)
+      res.member_ids = [file_set.id]
+      parent = adapter.persister.save(resource: res)
+
+      expect(decorator.parent).to be_a parent.class
+      expect(decorator.parent.id).to eq parent.id
+    end
+  end
+end

--- a/spec/services/manifest_event_generator_spec.rb
+++ b/spec/services/manifest_event_generator_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ManifestEventGenerator do
+  subject(:manifest_event_generator) { described_class.new(rabbit_connection) }
+  let(:rabbit_connection) { instance_double(MessagingClient, publish: true) }
+  let(:record) { FactoryGirl.create_for_repository(:scanned_resource) }
+  let(:collection) { FactoryGirl.create_for_repository(:collection) }
+  let(:record_in_collection) { FactoryGirl.create_for_repository(:scanned_resource, member_of_collection_ids: [collection.id]) }
+
+  describe "#record_created" do
+    it "publishes a persistent JSON message" do
+      expected_result = {
+        "id" => record.id.to_s,
+        "event" => "CREATED",
+        "manifest_url" => "http://www.example.com/concern/scanned_resources/#{record.id}/manifest",
+        "collection_slugs" => []
+      }
+
+      manifest_event_generator.record_created(record)
+
+      expect(rabbit_connection).to have_received(:publish).with(expected_result.to_json)
+    end
+    context 'with a record in a collection' do
+      it "embeds collection memberships" do
+        expected_result = {
+          "id" => record_in_collection.id.to_s,
+          "event" => "CREATED",
+          "manifest_url" => "http://www.example.com/concern/scanned_resources/#{record_in_collection.id}/manifest",
+          "collection_slugs" => [collection.slug]
+        }
+
+        manifest_event_generator.record_created(record_in_collection)
+
+        expect(rabbit_connection).to have_received(:publish).with(expected_result.to_json)
+      end
+    end
+  end
+
+  describe "#record_deleted" do
+    it "publishes a persistent JSON message" do
+      expected_result = {
+        "id" => record.id.to_s,
+        "event" => "DELETED",
+        "manifest_url" => "http://www.example.com/concern/scanned_resources/#{record.id}/manifest"
+      }
+
+      manifest_event_generator.record_deleted(record)
+
+      expect(rabbit_connection).to have_received(:publish).with(expected_result.to_json)
+    end
+  end
+
+  describe "#record_updated" do
+    context 'with a record in a collection' do
+      it "publishes a persistent JSON message with collection memberships" do
+        expected_result = {
+          "id" => record_in_collection.id.to_s,
+          "event" => "UPDATED",
+          "manifest_url" => "http://www.example.com/concern/scanned_resources/#{record_in_collection.id}/manifest",
+          "collection_slugs" => [collection.slug]
+        }
+
+        manifest_event_generator.record_updated(record_in_collection)
+
+        expect(rabbit_connection).to have_received(:publish).with(expected_result.to_json)
+      end
+    end
+  end
+end

--- a/spec/services/messaging_client/config_spec.rb
+++ b/spec/services/messaging_client/config_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe MessagingClient::Config do
+  describe '#log_level' do
+    subject(:config) { described_class.new(log_level: 'Logger::WARN').log_level }
+    it 'constantizes log levels' do
+      expect(config).to eq Logger::WARN
+    end
+  end
+
+  describe '#log_file' do
+    subject(:config) { described_class.new(log_file: 'STDOUT').log_file }
+    it 'constantizes log file paths' do
+      expect(config).to eq STDOUT
+    end
+  end
+end

--- a/spec/services/messaging_client_spec.rb
+++ b/spec/services/messaging_client_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe MessagingClient do
+  subject(:messaging_client) { described_class.new('https://localhost:5672', config: { log_level: 'Logger::WARN' }) }
+
+  describe '.new' do
+    it 'initializes a new object with an AMQP URL and configuration object' do
+      expect(messaging_client.amqp_url).to eq 'https://localhost:5672'
+      expect(messaging_client.config).to be_a MessagingClient::Config
+      expect(messaging_client.config.log_level).to eq Logger::WARN
+    end
+  end
+
+  describe '#publish' do
+    let(:bunny_class) { class_double("Bunny").as_stubbed_const(transfer_nested_constants: true) }
+    let(:bunny) { instance_double(Bunny::Session) }
+    let(:channel) { instance_double(Bunny::Channel) }
+    let(:exchange) { instance_double(Bunny::Exchange) }
+
+    before do
+      allow(Figgy).to receive(:config).and_return('events' => { 'exchange' => { 'plum' => true } })
+      allow(channel).to receive(:fanout).and_return(exchange)
+      allow(bunny).to receive(:create_channel).and_return(channel)
+      allow(bunny).to receive(:start)
+      allow(bunny_class).to receive(:new).and_return(bunny)
+      allow(exchange).to receive(:publish)
+    end
+
+    it 'publishes a message to RabbitMQ' do
+      messaging_client.publish(test: :data)
+      expect(exchange).to have_received(:publish).with({ test: :data }, persistent: true)
+    end
+
+    context 'when an error is encountered interfacing with the messaging client' do
+      before do
+        allow(Rails.logger).to receive(:warn)
+        allow(bunny).to receive(:create_channel).and_raise("some rabbitmq error")
+      end
+
+      it 'logs a warning to Rails' do
+        messaging_client.publish(test: :data)
+        expect(Rails.logger).to have_received(:warn).with("Unable to publish message to https://localhost:5672")
+      end
+    end
+  end
+end

--- a/spec/support/maximize_screen.rb
+++ b/spec/support/maximize_screen.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+RSpec.configure do |config|
+  config.before(:each, js: true) do
+    page.driver.browser.manage.window.resize_to(7680, 4320)
+  end
+ end
+ 

--- a/spec/support/stub_rabbit.rb
+++ b/spec/support/stub_rabbit.rb
@@ -1,0 +1,17 @@
+RSpec.configure do |config|
+  config.before(:each) do |ex|
+    unless ex.metadata[:rabbit_stubbed]
+      allow(Figgy).to receive(:messaging_client) do
+        instance_double(MessagingClient, publish: true)
+      end
+
+      allow_any_instance_of(PlumChangeSetPersister::Basic).to receive(:messenger) do
+        rabbit = instance_double(ManifestEventGenerator)
+        allow(rabbit).to receive(:record_created)
+        allow(rabbit).to receive(:record_updated)
+        allow(rabbit).to receive(:record_deleted)
+        rabbit
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #104 by adding support for RabbitMQ messaging for the creation, updates, and deletion of Figgy resources

In addition to the improvements identified by @tpendragon , the following must be addressed:
- [x] Rebase using the latest commits on `master`
- [x] Refactor the messaging methods in `PlumChangeSetPersister` as registered handlers
- [x] Increase the coverage and quality of the test suites
- [x] Implement handlers for `after_save_commit` and `after_delete_commit`