### PR TITLE
Speed up Figgy

### DIFF
--- a/app/change_sets/scanned_resource_change_set.rb
+++ b/app/change_sets/scanned_resource_change_set.rb
@@ -114,4 +114,10 @@ class ScannedResourceChangeSet < Valkyrie::ChangeSet
   def old_state
     Array.wrap(model.state).first
   end
+
+  def prepopulate!
+    super.tap do
+      @_changes = Disposable::Twin::Changed::Changes.new
+    end
+  end
 end

--- a/app/decorators/scanned_resource_decorator.rb
+++ b/app/decorators/scanned_resource_decorator.rb
@@ -10,24 +10,18 @@ class ScannedResourceDecorator < Valkyrie::ResourceDecorator
   def member_of_collections
     @member_of_collections ||=
       begin
-        member_of_collection_ids.map do |id|
-          query_service.find_by(id: id).decorate
-        end.map(&:title)
+        query_service.find_references_by(resource: model, property: :member_of_collection_ids)
+                     .map(&:decorate)
+                     .map(&:title).to_a
       end
   end
 
-  def member_of_collection_ids
-    super || []
-  end
-
   def members
-    @members ||= member_ids.map do |id|
-      query_service.find_by(id: id)
-    end
+    @members ||= query_service.find_members(resource: model)
   end
 
   def volumes
-    @volumes ||= members.select { |r| r.is_a?(ScannedResource) }.map(&:decorate)
+    @volumes ||= members.select { |r| r.is_a?(ScannedResource) }.map(&:decorate).to_a
   end
 
   def metadata_adapter

--- a/spec/change_sets/scanned_resource_change_set_spec.rb
+++ b/spec/change_sets/scanned_resource_change_set_spec.rb
@@ -8,6 +8,13 @@ RSpec.describe ScannedResourceChangeSet do
   before do
     stub_bibdata(bib_id: '123456')
   end
+  describe "#prepopulate!" do
+    it "doesn't make it look changed" do
+      expect(change_set).not_to be_changed
+      change_set.prepopulate!
+      expect(change_set).not_to be_changed
+    end
+  end
   describe "validations" do
     it "is valid by default" do
       expect(change_set).to be_valid

--- a/spec/services/manifest_builder/cantaloupe_helper_spec.rb
+++ b/spec/services/manifest_builder/cantaloupe_helper_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe ManifestBuilder::CantaloupeHelper do
   let(:cantaloupe_helper) { described_class.new }
   let(:file_set) { FactoryGirl.create_for_repository(:file_set) }
-  let(:derivative_file) { instance_double(FileMetadata) }
+  let(:derivative_file) { instance_double(FileMetadata, nil?: false) }
   let(:query_service) { class_double(Valkyrie::Persistence::Postgres::QueryService) }
 
   describe '#base_url' do
@@ -13,7 +13,7 @@ RSpec.describe ManifestBuilder::CantaloupeHelper do
         allow(derivative_file).to receive(:id).and_return('test')
         allow(file_set).to receive(:derivative_file).and_return(derivative_file)
         allow(query_service).to receive(:find_by).and_return(file_set)
-        allow(cantaloupe_helper).to receive(:query_service).and_return(query_service)
+        allow(Valkyrie.config.metadata_adapter).to receive(:query_service).and_return(query_service)
       end
       it 'generates a base URL for a JPEG2000 derivative' do
         expect(cantaloupe_helper.base_url(file_set.id)).to eq 'http://localhost:8182/iiif/2/test%2Fintermediate_file.jp2'


### PR DESCRIPTION
1. Runs more efficient queries in decorator.
2. Ensures prepopulate! doesn't mess up dirty tracking.