### PR TITLE
Refactor PlumChangeSetPersister

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -83,3 +83,5 @@ RSpec/VerifiedDoubles:
 Metrics/ClassLength:
   Exclude:
     - 'app/change_set_persisters/plum_change_set_persister.rb'
+Lint/UnusedMethodArgument:
+  AllowUnusedKeywordArguments: true

--- a/app/change_set_persisters/plum_change_set_persister/append_to_parent.rb
+++ b/app/change_set_persisters/plum_change_set_persister/append_to_parent.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+class PlumChangeSetPersister
+  class AppendToParent
+    PlumChangeSetPersister.register_handler(:after_save, self)
+    attr_reader :change_set_persister, :change_set, :post_save_resource
+    delegate :query_service, :persister, :transaction?, to: :change_set_persister
+    def initialize(change_set_persister:, change_set:, post_save_resource: nil)
+      @change_set = change_set
+      @change_set_persister = change_set_persister
+      @post_save_resource = post_save_resource
+    end
+
+    def run
+      return unless append_id.present?
+      parent.thumbnail_id = post_save_resource.id if parent.member_ids.blank?
+      parent.member_ids = parent.member_ids + [post_save_resource.id]
+      persister.save(resource: parent)
+      # Re-save to solr unless it's going to be done by save_all
+      persister.save(resource: post_save_resource) unless transaction?
+    end
+
+    def parent
+      @parent ||= query_service.find_by(id: append_id)
+    end
+
+    delegate :append_id, to: :change_set
+  end
+end

--- a/app/change_set_persisters/plum_change_set_persister/characterize.rb
+++ b/app/change_set_persisters/plum_change_set_persister/characterize.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+class PlumChangeSetPersister
+  class Characterize
+    PlumChangeSetPersister.register_handler(:after_commit, self)
+    attr_reader :change_set_persister, :change_set, :post_save_resource
+    delegate :created_file_sets, :characterize?, to: :change_set_persister
+    def initialize(change_set_persister:, change_set:, post_save_resource: nil)
+      @change_set = change_set
+      @change_set_persister = change_set_persister
+      @post_save_resource = post_save_resource
+    end
+
+    def run
+      return unless created_file_sets.present?
+      created_file_sets.each do |file_set|
+        next unless file_set.instance_of?(FileSet) && characterize?
+        ::CharacterizationJob.perform_later(file_set.id.to_s)
+      end
+    end
+  end
+end

--- a/app/change_set_persisters/plum_change_set_persister/cleanup_membership.rb
+++ b/app/change_set_persisters/plum_change_set_persister/cleanup_membership.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+class PlumChangeSetPersister
+  class CleanupMembership
+    class Factory
+      attr_reader :property
+      def initialize(property:)
+        @property = property
+      end
+
+      def new(change_set_persister:, change_set:, post_save_resource: nil)
+        CleanupMembership.new(change_set_persister: change_set_persister,
+                              change_set: change_set,
+                              post_save_resource: post_save_resource,
+                              property: property)
+      end
+    end
+    PlumChangeSetPersister.register_handler(:before_delete, Factory.new(property: :member_of_collection_ids))
+    PlumChangeSetPersister.register_handler(:before_delete, Factory.new(property: :member_ids))
+    attr_reader :change_set_persister, :change_set, :post_save_resource, :property
+    delegate :query_service, :persister, :transaction?, to: :change_set_persister
+    def initialize(change_set_persister:, change_set:, property:, post_save_resource: nil)
+      @change_set = change_set
+      @change_set_persister = change_set_persister
+      @post_save_resource = post_save_resource
+      @property = property
+    end
+
+    def run
+      resources.each do |resource|
+        resource.__send__("#{property}=", resource.__send__(property) - [change_set.id])
+        persister.save(resource: resource)
+      end
+    end
+
+    def resources
+      query_service.find_inverse_references_by(resource: change_set.resource, property: property)
+    end
+  end
+end

--- a/app/change_set_persisters/plum_change_set_persister/create_file.rb
+++ b/app/change_set_persisters/plum_change_set_persister/create_file.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+class PlumChangeSetPersister
+  class CreateFiles
+    PlumChangeSetPersister.register_handler(:before_save, self)
+    attr_reader :change_set_persister, :change_set
+    delegate :file_appender, :persister, :storage_adapter, to: :change_set_persister
+    def initialize(change_set_persister:, change_set:, post_save_resource: nil)
+      @change_set = change_set
+      @change_set_persister = change_set_persister
+    end
+
+    def run
+      appender = file_appender.new(storage_adapter: storage_adapter, persister: persister, files: files)
+      change_set_persister.instance_variable_set(:@created_file_sets, appender.append_to(change_set.resource))
+    end
+
+    def files
+      change_set.try(:files) || []
+    end
+  end
+end

--- a/app/change_set_persisters/plum_change_set_persister/propagate_visibility_and_state.rb
+++ b/app/change_set_persisters/plum_change_set_persister/propagate_visibility_and_state.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+class PlumChangeSetPersister
+  class PropagateVisibilityAndState
+    PlumChangeSetPersister.register_handler(:before_save, self)
+    attr_reader :change_set_persister, :change_set
+    delegate :query_service, :persister, to: :change_set_persister
+    def initialize(change_set_persister:, change_set:, post_save_resource: nil)
+      @change_set = change_set
+      @change_set_persister = change_set_persister
+    end
+
+    def run
+      return if !change_set.changed?(:visibility) && !change_set.changed?(:state)
+      members.each do |member|
+        member.read_groups = change_set.read_groups if change_set.read_groups
+        member.state = change_set.state if change_set.state && member.respond_to?(:state)
+        persister.save(resource: member)
+      end
+    end
+
+    def members
+      query_service.find_members(resource: change_set.resource)
+    end
+  end
+end

--- a/spec/change_set_persisters/plum_change_set_persister/propagate_visibility_and_state_spec.rb
+++ b/spec/change_set_persisters/plum_change_set_persister/propagate_visibility_and_state_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe PlumChangeSetPersister::PropagateVisibilityAndState do
+  subject(:hook) { described_class.new(change_set_persister: change_set_persister, change_set: change_set) }
+  let(:change_set_persister) { instance_double(PlumChangeSetPersister, query_service: query_service) }
+  let(:change_set) { ScannedResourceChangeSet.new(scanned_resource) }
+  let(:scanned_resource) { ScannedResource.new }
+  let(:query_service) { instance_double(Valkyrie::Persistence::Memory::QueryService) }
+
+  describe "#run" do
+    context "when visibility and state haven't been updated" do
+      it "doesn't query for it" do
+        change_set.prepopulate!
+        allow(query_service).to receive(:find_members)
+
+        hook.run
+
+        expect(query_service).not_to have_received(:find_members)
+      end
+    end
+    context "when visibility or state have been updated" do
+      it "queries for children" do
+        change_set.prepopulate!
+        change_set.validate(state: "complete")
+        allow(query_service).to receive(:find_members).and_return([])
+
+        hook.run
+
+        expect(query_service).to have_received(:find_members)
+      end
+    end
+  end
+end

--- a/spec/change_set_persisters/plum_change_set_persister_spec.rb
+++ b/spec/change_set_persisters/plum_change_set_persister_spec.rb
@@ -303,33 +303,4 @@ RSpec.describe PlumChangeSetPersister do
       expect(solr_record["member_of_ssim"]).to eq ["id-#{parent.id}"]
     end
   end
-
-  describe 'propagating visibility and state' do
-    let(:persister) { instance_double(described_class) }
-    let(:resource1) { FactoryGirl.create_for_repository(:file_set) }
-    let(:resource2) { FactoryGirl.create_for_repository(:complete_private_scanned_resource) }
-    before do
-      allow(persister).to receive(:save)
-      allow(persister).to receive(:members)
-    end
-    context "when visibility and state haven't been updated" do
-      it "does not retrieve the member works or file sets" do
-        resource = FactoryGirl.build(:scanned_resource, read_groups: [])
-        resource.member_ids = [resource1.id, resource2.id]
-        adapter = Valkyrie::MetadataAdapter.find(:indexing_persister)
-        resource = adapter.persister.save(resource: resource)
-
-        change_set = change_set_class.new(resource)
-        change_set.sync
-
-        persister.save(change_set: change_set)
-        expect(persister).not_to have_received(:members)
-
-        members = query_service.find_members(resource: resource)
-        expect(members.first.read_groups).to eq []
-        expect(members.to_a.last.visibility).to eq [Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE]
-        expect(members.to_a.last.state).to eq ['complete']
-      end
-    end
-  end
 end


### PR DESCRIPTION
I'm not sure if this is better. This would reduce the churn in
PlumChangeSetPersister by a lot, but it makes knowing what exactly is
going on at each step a lot harder by moving that information out to the
registration.