### PR TITLE
Fixes breaking feature tests for Selenium due to ephemera_project_add_box invocation

### DIFF
--- a/app/views/catalog/_ephemera_box_home.html.erb
+++ b/app/views/catalog/_ephemera_box_home.html.erb
@@ -12,7 +12,7 @@
                 <%= content_tag(:div, nil, class: ['work-icon', "icon-#{project.title.downcase.gsub(' ','-')}"]) %>
                 <%= link_to 'View Boxes', solr_document_path(id: "id-#{project.id}"),
                   class: "add-button btn btn-primary #{dom_class(project, 'view')}" %>
-                <%= link_to 'Add Box', ephemera_project_add_box_path(project),
+                <%= link_to 'Add Box', ephemera_project_add_box_path(project, parent_id: project.id),
                   class: "add-button btn btn-primary #{dom_class(project, 'add_new')}" %>
               </li>
             <% end %>
@@ -22,4 +22,3 @@
     </div>
   </div>
 <% end %>
-


### PR DESCRIPTION
Resolves #188 as an improper invocation of `ephemera_project_add_box` triggered certain breaking functional tests in which Selenium (and headless Chrome) are used