### PR TITLE
Avoid tmp files for IngestMETSJob

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -89,5 +89,8 @@ RSpec/VerifiedDoubles:
     - 'spec/validators/viewing_hint_validator_spec.rb'
     - 'spec/validators/viewing_direction_validator_spec.rb'
     - 'spec/models/user_spec.rb'
+RSpec/AnyInstance:
+  Exclude:
+    - 'spec/jobs/ingest_mets_job_spec.rb'
 Lint/UnusedMethodArgument:
   AllowUnusedKeywordArguments: true

--- a/app/jobs/ingest_mets_job.rb
+++ b/app/jobs/ingest_mets_job.rb
@@ -24,7 +24,7 @@ class IngestMETSJob < ApplicationJob
   end
 
   def storage_adapter
-    Valkyrie.config.storage_adapter
+    Valkyrie::StorageAdapter.find(:disk_via_copy)
   end
 
   class Ingester

--- a/app/models/mets_document.rb
+++ b/app/models/mets_document.rb
@@ -98,7 +98,8 @@ class METSDocument
       mime_type: f[:mime_type],
       original_filename: File.basename(f[:path]),
       container_attributes: container_attributes(f),
-      id: f[:id]
+      id: f[:id],
+      copyable: true
     )
   end
 

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -31,6 +31,14 @@ Rails.application.config.to_prepare do
   )
 
   Valkyrie::StorageAdapter.register(
+    Valkyrie::Storage::Disk.new(
+      base_path: Figgy.config['repository_path'],
+      file_mover: FileUtils.method(:cp)
+    ),
+    :disk_via_copy
+  )
+
+  Valkyrie::StorageAdapter.register(
     Valkyrie::Storage::Disk.new(base_path: Figgy.config['derivative_path']),
     :derivatives
   )


### PR DESCRIPTION
Copying directly should result in far fewer disk operations and a faster
ingest.