### PR TITLE
Start all optgroups as closed.

### DIFF
--- a/app/assets/javascripts/figgy_boot.es6
+++ b/app/assets/javascripts/figgy_boot.es6
@@ -13,6 +13,7 @@ export default class Initializer {
     this.modal_viewer = new ModalViewer
     this.derivative_form = new DerivativeForm
     this.universal_viewer = new UniversalViewer
+    $("optgroup").addClass("closed")
     $("select").selectpicker({'liveSearch': true})
     $(".datatable").DataTable()
   }


### PR DESCRIPTION
Fixes the subject selector not having categories collapsed by default.