### PR TITLE
Implements CleanupDerivatives change set persister handler and CleanupDerivativesJob

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,7 +44,7 @@ GIT
 
 GIT
   remote: https://github.com/samvera-labs/valkyrie.git
-  revision: 461ca11b2a950bde6a4805bfbda2a29f42f43c5d
+  revision: dfcf1959b8399441a612d826b29cd1b44da10702
   specs:
     valkyrie (0.1.0)
       active-fedora
@@ -148,7 +148,7 @@ GEM
       io-like (~> 0.3.0)
     arel (8.0.0)
     ast (2.3.0)
-    autoprefixer-rails (7.1.2.3)
+    autoprefixer-rails (7.1.5)
       execjs
     awesome_print (1.8.0)
     aws-sdk (2.10.19)
@@ -168,10 +168,11 @@ GEM
     bixby (0.2.1)
       rubocop (~> 0.49)
       rubocop-rspec (~> 1.15)
-    blacklight (6.10.1)
+    blacklight (6.11.2)
       bootstrap-sass (~> 3.2)
       deprecation
       globalid
+      jbuilder
       kaminari (>= 0.15)
       nokogiri (~> 1.6)
       rails (>= 4.2, < 6)
@@ -258,8 +259,9 @@ GEM
       tins (~> 1.6)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
+    crass (1.0.2)
     database_cleaner (1.6.1)
-    declarative (0.0.9)
+    declarative (0.0.10)
     declarative-builder (0.1.0)
       declarative-option (< 0.2.0)
     declarative-option (0.1.0)
@@ -320,7 +322,7 @@ GEM
     ebnf (1.1.1)
       rdf (~> 2.2)
       sxp (~> 1.0)
-    erubi (1.6.1)
+    erubi (1.7.0)
     execjs (2.7.0)
     ezid-client (1.7.1)
       hashie (~> 3.4, >= 3.4.3)
@@ -416,6 +418,9 @@ GEM
     inflecto (0.0.2)
     io-like (0.3.0)
     iso-639 (0.2.8)
+    jbuilder (2.7.0)
+      activesupport (>= 4.2.0)
+      multi_json (>= 1.2)
     jmespath (1.3.1)
     jquery-datatables-rails (3.4.0)
       actionpack (>= 3.1)
@@ -429,9 +434,9 @@ GEM
     jquery-ui-rails (5.0.5)
       railties (>= 3.2.16)
     json (2.1.0)
-    json-ld (2.1.5)
+    json-ld (2.1.7)
       multi_json (~> 1.12)
-      rdf (~> 2.2)
+      rdf (~> 2.2, >= 2.2.8)
     jwt (1.5.6)
     kaminari (1.0.1)
       activesupport (>= 4.1.0)
@@ -465,7 +470,8 @@ GEM
     logging (2.2.2)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
-    loofah (2.0.3)
+    loofah (2.1.1)
+      crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.6.6)
       mime-types (>= 1.16, < 4)
@@ -482,7 +488,7 @@ GEM
     mini_portile2 (2.3.0)
     minitest (5.10.3)
     modernizr-rails (2.7.1)
-    multi_json (1.12.1)
+    multi_json (1.12.2)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     net-scp (1.2.1)
@@ -570,19 +576,19 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.2.2)
       rake
-    rake (12.0.0)
+    rake (12.1.0)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    rdf (2.2.6)
+    rdf (2.2.11)
       hamster (~> 3.0)
       link_header (~> 0.0, >= 0.0.8)
     rdf-isomorphic (2.0.0)
       rdf (~> 2.0)
-    rdf-turtle (2.2.0)
+    rdf-turtle (2.2.1)
       ebnf (~> 1.1)
       rdf (~> 2.2)
-    rdf-vocab (2.2.3)
+    rdf-vocab (2.2.8)
       rdf (~> 2.2)
     recipient_interceptor (0.1.2)
       mail
@@ -638,14 +644,14 @@ GEM
       json
       multipart-post
       oauth2
-    ruby-progressbar (1.8.1)
+    ruby-progressbar (1.9.0)
     ruby-rc4 (0.1.5)
     ruby_dep (1.5.0)
     ruby_tika_app (1.5.0)
       open4
     rubyzip (1.2.1)
     safe_yaml (1.0.4)
-    sass (3.5.1)
+    sass (3.5.2)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -704,7 +710,7 @@ GEM
       babel-source (>= 5.8.11)
       babel-transpiler
       sprockets (>= 3.0.0)
-    sprockets-rails (3.2.0)
+    sprockets-rails (3.2.1)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)

--- a/app/change_set_persisters/plum_change_set_persister.rb
+++ b/app/change_set_persisters/plum_change_set_persister.rb
@@ -23,6 +23,7 @@ class PlumChangeSetPersister
         PublishMessage::Factory.new(operation: :update)
       ],
       before_delete: [
+        CleanupDerivatives,
         CleanupMembership::Factory.new(property: :member_of_collection_ids),
         CleanupMembership::Factory.new(property: :member_ids),
         DeleteReferenced::Factory.new(property: :member_of_vocabulary_id)

--- a/app/change_set_persisters/plum_change_set_persister/cleanup_derivatives.rb
+++ b/app/change_set_persisters/plum_change_set_persister/cleanup_derivatives.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+class PlumChangeSetPersister
+  class CleanupDerivatives
+    attr_reader :change_set_persister, :change_set
+    delegate :resource, to: :change_set
+    def initialize(change_set_persister:, change_set:)
+      @change_set_persister = change_set_persister
+      @change_set = change_set
+    end
+
+    def run
+      return unless decorated_resource.respond_to?(:file_sets) && file_sets.present?
+      file_sets.each do |file_set|
+        next unless file_set.instance_of?(FileSet)
+        ::CleanupDerivativesJob.perform_later(file_set.id.to_s)
+      end
+    end
+
+    private
+
+      def decorated_resource
+        @decorated_resource ||= resource.decorate
+      end
+
+      def file_sets
+        @file_sets ||= decorated_resource.file_sets
+      end
+  end
+end

--- a/app/change_set_persisters/plum_change_set_persister/cleanup_derivatives.rb
+++ b/app/change_set_persisters/plum_change_set_persister/cleanup_derivatives.rb
@@ -1,13 +1,23 @@
 # frozen_string_literal: true
+#
+# A persistence handler for removing Valkyrie::StorageAdapter::File members objects from Resource
 class PlumChangeSetPersister
   class CleanupDerivatives
+    # Access the ChangeSetPersister and ChangeSet attributes
     attr_reader :change_set_persister, :change_set
+    # Access the resource within the ChangeSet attribute
+    # @return [Valkyrie::Resource]
     delegate :resource, to: :change_set
+    # The initializer
+    # @param change_set_persist [ChangeSetPersister] the change set persister
+    # @param change_set [ChangeSet] the change set for a resource
     def initialize(change_set_persister:, change_set:)
       @change_set_persister = change_set_persister
       @change_set = change_set
     end
 
+    # Run the persistence handler
+    # Iterates through each FileSet for the resource being updated, and deletes its derivative File member
     def run
       return unless decorated_resource.respond_to?(:file_sets) && file_sets.present?
       file_sets.each do |file_set|
@@ -18,12 +28,16 @@ class PlumChangeSetPersister
 
     private
 
+      # Access the decorated resource
+      # @return [Draper::Decorator]
       def decorated_resource
         @decorated_resource ||= resource.decorate
       end
 
+      # Access the FileSets for the resource
+      # @return [Array<FileSet>, nil] return an array of FileSets or nil
       def file_sets
-        @file_sets ||= decorated_resource.file_sets
+        @file_sets ||= decorated_resource.try(:file_sets)
       end
   end
 end

--- a/app/change_set_persisters/plum_change_set_persister/propagate_visibility_and_state.rb
+++ b/app/change_set_persisters/plum_change_set_persister/propagate_visibility_and_state.rb
@@ -22,7 +22,8 @@ class PlumChangeSetPersister
     end
 
     def members
-      query_service.find_members(resource: change_set.resource).select do |x|
+      found = query_service.find_members(resource: change_set.resource) || []
+      found.select do |x|
         !x.is_a?(FileSet)
       end
     end

--- a/app/decorators/ephemera_box_decorator.rb
+++ b/app/decorators/ephemera_box_decorator.rb
@@ -16,11 +16,10 @@ class EphemeraBoxDecorator < Valkyrie::ResourceDecorator
   end
 
   def members
-    @members ||= query_service.find_members(resource: model)
+    @members ||= find_members(resource: model)
   end
 
   def folders
-    return [] if members.nil?
     @folders ||= members.select { |r| r.is_a?(EphemeraFolder) }.map(&:decorate).to_a
   end
 
@@ -55,4 +54,10 @@ class EphemeraBoxDecorator < Valkyrie::ResourceDecorator
   def attachable_objects
     [EphemeraFolder]
   end
+
+  private
+
+    def find_members(resource:)
+      query_service.find_members(resource: resource) || []
+    end
 end

--- a/app/decorators/ephemera_box_decorator.rb
+++ b/app/decorators/ephemera_box_decorator.rb
@@ -54,10 +54,4 @@ class EphemeraBoxDecorator < Valkyrie::ResourceDecorator
   def attachable_objects
     [EphemeraFolder]
   end
-
-  private
-
-    def find_members(resource:)
-      query_service.find_members(resource: resource) || []
-    end
 end

--- a/app/decorators/ephemera_box_decorator.rb
+++ b/app/decorators/ephemera_box_decorator.rb
@@ -20,6 +20,7 @@ class EphemeraBoxDecorator < Valkyrie::ResourceDecorator
   end
 
   def folders
+    return [] if members.nil?
     @folders ||= members.select { |r| r.is_a?(EphemeraFolder) }.map(&:decorate).to_a
   end
 

--- a/app/decorators/ephemera_field_decorator.rb
+++ b/app/decorators/ephemera_field_decorator.rb
@@ -2,10 +2,6 @@
 class EphemeraFieldDecorator < Valkyrie::ResourceDecorator
   self.display_attributes = [:rendered_name, :vocabulary]
 
-  def parents
-    @parents ||= find_parents(resource: model)
-  end
-
   def projects
     @projects ||= parents.select { |r| r.is_a?(EphemeraProject) }.map(&:decorate).to_a
   end
@@ -59,9 +55,5 @@ class EphemeraFieldDecorator < Valkyrie::ResourceDecorator
 
     def name_term
       @name_term ||= ControlledVocabulary.for(:ephemera_field).find(field_name.first)
-    end
-
-    def find_parents(resource:)
-      query_service.find_parents(resource: resource) || []
     end
 end

--- a/app/decorators/ephemera_field_decorator.rb
+++ b/app/decorators/ephemera_field_decorator.rb
@@ -3,11 +3,10 @@ class EphemeraFieldDecorator < Valkyrie::ResourceDecorator
   self.display_attributes = [:rendered_name, :vocabulary]
 
   def parents
-    @parents ||= query_service.find_parents(resource: model)
+    @parents ||= find_parents(resource: model)
   end
 
   def projects
-    return [] if parents.nil?
     @projects ||= parents.select { |r| r.is_a?(EphemeraProject) }.map(&:decorate).to_a
   end
 
@@ -60,5 +59,9 @@ class EphemeraFieldDecorator < Valkyrie::ResourceDecorator
 
     def name_term
       @name_term ||= ControlledVocabulary.for(:ephemera_field).find(field_name.first)
+    end
+
+    def find_parents(resource:)
+      query_service.find_parents(resource: resource) || []
     end
 end

--- a/app/decorators/ephemera_field_decorator.rb
+++ b/app/decorators/ephemera_field_decorator.rb
@@ -7,6 +7,7 @@ class EphemeraFieldDecorator < Valkyrie::ResourceDecorator
   end
 
   def projects
+    return [] if parents.nil?
     @projects ||= parents.select { |r| r.is_a?(EphemeraProject) }.map(&:decorate).to_a
   end
 

--- a/app/decorators/ephemera_folder_decorator.rb
+++ b/app/decorators/ephemera_folder_decorator.rb
@@ -37,6 +37,7 @@ class EphemeraFolderDecorator < Valkyrie::ResourceDecorator
   end
 
   def collections
+    return [] if members.nil?
     @collections ||= query_service.find_references_by(resource: self, property: :member_of_collection_ids).to_a.map(&:decorate)
   end
 

--- a/app/decorators/ephemera_folder_decorator.rb
+++ b/app/decorators/ephemera_folder_decorator.rb
@@ -33,11 +33,10 @@ class EphemeraFolderDecorator < Valkyrie::ResourceDecorator
                                   Schema::IIIF.attributes - [:visibility, :internal_resource, :rights_statement, :rendered_rights_statement, :thumbnail_id]
 
   def members
-    @members ||= query_service.find_members(resource: model)
+    @members ||= find_members(resource: model)
   end
 
   def collections
-    return [] if members.nil?
     @collections ||= query_service.find_references_by(resource: self, property: :member_of_collection_ids).to_a.map(&:decorate)
   end
 
@@ -141,5 +140,9 @@ class EphemeraFolderDecorator < Valkyrie::ResourceDecorator
 
     def controlled_value_for(value)
       value.present? && value.is_a?(Valkyrie::ID) ? find_resource(value) : value
+    end
+
+    def find_members(resource:)
+      query_service.find_members(resource: resource) || []
     end
 end

--- a/app/decorators/ephemera_folder_decorator.rb
+++ b/app/decorators/ephemera_folder_decorator.rb
@@ -32,10 +32,6 @@ class EphemeraFolderDecorator < Valkyrie::ResourceDecorator
                                   imported_attributes(Schema::Common.attributes) - \
                                   Schema::IIIF.attributes - [:visibility, :internal_resource, :rights_statement, :rendered_rights_statement, :thumbnail_id]
 
-  def members
-    @members ||= find_members(resource: model)
-  end
-
   def collections
     @collections ||= query_service.find_references_by(resource: self, property: :member_of_collection_ids).to_a.map(&:decorate)
   end
@@ -140,9 +136,5 @@ class EphemeraFolderDecorator < Valkyrie::ResourceDecorator
 
     def controlled_value_for(value)
       value.present? && value.is_a?(Valkyrie::ID) ? find_resource(value) : value
-    end
-
-    def find_members(resource:)
-      query_service.find_members(resource: resource) || []
     end
 end

--- a/app/decorators/ephemera_project_decorator.rb
+++ b/app/decorators/ephemera_project_decorator.rb
@@ -7,10 +7,12 @@ class EphemeraProjectDecorator < Valkyrie::ResourceDecorator
   end
 
   def boxes
+    return [] if members.nil?
     @boxes ||= members.select { |r| r.is_a?(EphemeraBox) }.map(&:decorate).to_a
   end
 
   def fields
+    return [] if members.nil?
     @fields ||= members.select { |r| r.is_a?(EphemeraField) }.map(&:decorate).to_a
   end
 

--- a/app/decorators/ephemera_project_decorator.rb
+++ b/app/decorators/ephemera_project_decorator.rb
@@ -3,16 +3,14 @@ class EphemeraProjectDecorator < Valkyrie::ResourceDecorator
   self.display_attributes = [:title]
 
   def members
-    @members ||= query_service.find_members(resource: model)
+    @members ||= find_members(resource: model)
   end
 
   def boxes
-    return [] if members.nil?
     @boxes ||= members.select { |r| r.is_a?(EphemeraBox) }.map(&:decorate).to_a
   end
 
   def fields
-    return [] if members.nil?
     @fields ||= members.select { |r| r.is_a?(EphemeraField) }.map(&:decorate).to_a
   end
 
@@ -31,4 +29,10 @@ class EphemeraProjectDecorator < Valkyrie::ResourceDecorator
   def title
     super.first
   end
+
+  private
+
+    def find_members(resource:)
+      query_service.find_members(resource: resource) || []
+    end
 end

--- a/app/decorators/ephemera_project_decorator.rb
+++ b/app/decorators/ephemera_project_decorator.rb
@@ -2,10 +2,6 @@
 class EphemeraProjectDecorator < Valkyrie::ResourceDecorator
   self.display_attributes = [:title]
 
-  def members
-    @members ||= find_members(resource: model)
-  end
-
   def boxes
     @boxes ||= members.select { |r| r.is_a?(EphemeraBox) }.map(&:decorate).to_a
   end
@@ -29,10 +25,4 @@ class EphemeraProjectDecorator < Valkyrie::ResourceDecorator
   def title
     super.first
   end
-
-  private
-
-    def find_members(resource:)
-      query_service.find_members(resource: resource) || []
-    end
 end

--- a/app/decorators/file_set_decorator.rb
+++ b/app/decorators/file_set_decorator.rb
@@ -7,7 +7,7 @@ class FileSetDecorator < Valkyrie::ResourceDecorator
   end
 
   def parent
-    query_service.find_parents(resource: model).try(:first)
+    parents.first
   end
 
   def collections

--- a/app/decorators/scanned_map_decorator.rb
+++ b/app/decorators/scanned_map_decorator.rb
@@ -4,10 +4,6 @@ class ScannedMapDecorator < Valkyrie::ResourceDecorator
   self.iiif_manifest_attributes = display_attributes + [:title] - \
                                   Schema::IIIF.attributes - [:visibility, :internal_resource, :rights_statement, :rendered_rights_statement, :thumbnail_id]
 
-  def members
-    @members ||= find_members(resource: model)
-  end
-
   def scanned_map_members
     @scanned_maps ||= members.select { |r| r.is_a?(ScannedMap) }.map(&:decorate).to_a
   end
@@ -56,10 +52,4 @@ class ScannedMapDecorator < Valkyrie::ResourceDecorator
   def iiif_manifest_attributes
     local_attributes(self.class.iiif_manifest_attributes)
   end
-
-  private
-
-    def find_members(resource:)
-      query_service.find_members(resource: resource) || []
-    end
 end

--- a/app/decorators/scanned_map_decorator.rb
+++ b/app/decorators/scanned_map_decorator.rb
@@ -5,16 +5,14 @@ class ScannedMapDecorator < Valkyrie::ResourceDecorator
                                   Schema::IIIF.attributes - [:visibility, :internal_resource, :rights_statement, :rendered_rights_statement, :thumbnail_id]
 
   def members
-    @members ||= query_service.find_members(resource: model)
+    @members ||= find_members(resource: model)
   end
 
   def scanned_map_members
-    return [] if members.nil?
     @scanned_maps ||= members.select { |r| r.is_a?(ScannedMap) }.map(&:decorate).to_a
   end
 
   def geo_members
-    return [] if members.nil?
     members.select do |member|
       next unless member.respond_to?(:mime_type)
       ControlledVocabulary.for(:geo_image_format).include?(member.mime_type.first)
@@ -22,7 +20,6 @@ class ScannedMapDecorator < Valkyrie::ResourceDecorator
   end
 
   def geo_metadata_members
-    return [] if members.nil?
     members.select do |member|
       next unless member.respond_to?(:mime_type)
       ControlledVocabulary.for(:geo_metadata_format).include?(member.mime_type.first)
@@ -59,4 +56,10 @@ class ScannedMapDecorator < Valkyrie::ResourceDecorator
   def iiif_manifest_attributes
     local_attributes(self.class.iiif_manifest_attributes)
   end
+
+  private
+
+    def find_members(resource:)
+      query_service.find_members(resource: resource) || []
+    end
 end

--- a/app/decorators/scanned_map_decorator.rb
+++ b/app/decorators/scanned_map_decorator.rb
@@ -9,10 +9,12 @@ class ScannedMapDecorator < Valkyrie::ResourceDecorator
   end
 
   def scanned_map_members
+    return [] if members.nil?
     @scanned_maps ||= members.select { |r| r.is_a?(ScannedMap) }.map(&:decorate).to_a
   end
 
   def geo_members
+    return [] if members.nil?
     members.select do |member|
       next unless member.respond_to?(:mime_type)
       ControlledVocabulary.for(:geo_image_format).include?(member.mime_type.first)
@@ -20,6 +22,7 @@ class ScannedMapDecorator < Valkyrie::ResourceDecorator
   end
 
   def geo_metadata_members
+    return [] if members.nil?
     members.select do |member|
       next unless member.respond_to?(:mime_type)
       ControlledVocabulary.for(:geo_metadata_format).include?(member.mime_type.first)

--- a/app/decorators/scanned_resource_decorator.rb
+++ b/app/decorators/scanned_resource_decorator.rb
@@ -11,7 +11,13 @@ class ScannedResourceDecorator < Valkyrie::ResourceDecorator
   end
 
   def volumes
+    return [] if members.nil?
     @volumes ||= members.select { |r| r.is_a?(ScannedResource) }.map(&:decorate).to_a
+  end
+
+  def file_sets
+    return [] if members.nil?
+    @file_sets ||= members.select { |r| r.is_a?(FileSet) }.map(&:decorate).to_a
   end
 
   def rendered_rights_statement

--- a/app/decorators/scanned_resource_decorator.rb
+++ b/app/decorators/scanned_resource_decorator.rb
@@ -6,10 +6,6 @@ class ScannedResourceDecorator < Valkyrie::ResourceDecorator
                                   Schema::IIIF.attributes - [:visibility, :internal_resource, :rights_statement, :rendered_rights_statement, :thumbnail_id]
   delegate(*Schema::Common.attributes, to: :primary_imported_metadata, prefix: :imported)
 
-  def members
-    @members ||= find_members(resource: model)
-  end
-
   def volumes
     @volumes ||= members.select { |r| r.is_a?(ScannedResource) }.map(&:decorate).to_a
   end
@@ -79,10 +75,4 @@ class ScannedResourceDecorator < Valkyrie::ResourceDecorator
     return model.human_readable_type if volumes.empty?
     I18n.translate("valhalla.models.multi_volume_work", default: 'Multi Volume Work')
   end
-
-  private
-
-    def find_members(resource:)
-      query_service.find_members(resource: resource) || []
-    end
 end

--- a/app/decorators/scanned_resource_decorator.rb
+++ b/app/decorators/scanned_resource_decorator.rb
@@ -7,16 +7,14 @@ class ScannedResourceDecorator < Valkyrie::ResourceDecorator
   delegate(*Schema::Common.attributes, to: :primary_imported_metadata, prefix: :imported)
 
   def members
-    @members ||= query_service.find_members(resource: model)
+    @members ||= find_members(resource: model)
   end
 
   def volumes
-    return [] if members.nil?
     @volumes ||= members.select { |r| r.is_a?(ScannedResource) }.map(&:decorate).to_a
   end
 
   def file_sets
-    return [] if members.nil?
     @file_sets ||= members.select { |r| r.is_a?(FileSet) }.map(&:decorate).to_a
   end
 
@@ -81,4 +79,10 @@ class ScannedResourceDecorator < Valkyrie::ResourceDecorator
     return model.human_readable_type if volumes.empty?
     I18n.translate("valhalla.models.multi_volume_work", default: 'Multi Volume Work')
   end
+
+  private
+
+    def find_members(resource:)
+      query_service.find_members(resource: resource) || []
+    end
 end

--- a/app/decorators/valkyrie/resource_decorator.rb
+++ b/app/decorators/valkyrie/resource_decorator.rb
@@ -70,4 +70,35 @@ class Valkyrie::ResourceDecorator < ApplicationDecorator
                      .map(&:title).to_a
       end
   end
+
+  # Accesses all Resources referenced by a given Resource using the :member_ids property
+  # @return [Array<Valkyrie::Resource>] an array of Resources (possibly empty)
+  def members
+    @members ||= find_members(resource: model)
+  end
+
+  # Accesses all Resources referencing a given Resource using the :member_ids property
+  # i. e. it "accesses all Resources for which a given Resource is a member of"
+  # @return [Array<Valkyrie::Resource>] an array of Resources (possibly empty)
+  def parents
+    @parents ||= find_parents(resource: model)
+  end
+
+  private
+
+    # Queries the metadata adapter for all referenced resources for a given resource using :member_ids
+    # Returns an empty Array rather than nil
+    # @see Valkyrie::Persistence::Solr::Queries::FindMembersQuery
+    # @return [Array<Valkyrie::Resource>] an array of Resources (possibly empty)
+    def find_members(resource:)
+      query_service.find_members(resource: resource) || []
+    end
+
+    # Queries the metadata adapter for all resources referencing a given resource using :member_ids
+    # Returns an empty Array rather than nil
+    # @see Valkyrie::Persistence::Solr::Queries::FindInverseReferencesQuery
+    # @return [Array<Valkyrie::Resource>] an array of Resources (possibly empty)
+    def find_parents(resource:)
+      query_service.find_parents(resource: resource) || []
+    end
 end

--- a/app/decorators/vector_work_decorator.rb
+++ b/app/decorators/vector_work_decorator.rb
@@ -2,10 +2,6 @@
 class VectorWorkDecorator < Valkyrie::ResourceDecorator
   self.display_attributes += Schema::Geo.attributes + [:rendered_coverage, :member_of_collections] - [:thumbnail_id, :coverage]
 
-  def members
-    @members ||= find_members(resource: model)
-  end
-
   # Use case for nesting vector works
   #   - time series: e.g., nyc transit system, released every 6 months
   def vector_work_members
@@ -52,10 +48,4 @@ class VectorWorkDecorator < Valkyrie::ResourceDecorator
   def attachable_objects
     [VectorWork]
   end
-
-  private
-
-    def find_members(resource:)
-      query_service.find_members(resource: resource) || []
-    end
 end

--- a/app/decorators/vector_work_decorator.rb
+++ b/app/decorators/vector_work_decorator.rb
@@ -3,7 +3,7 @@ class VectorWorkDecorator < Valkyrie::ResourceDecorator
   self.display_attributes += Schema::Geo.attributes + [:rendered_coverage, :member_of_collections] - [:thumbnail_id, :coverage]
 
   def members
-    @members ||= query_service.find_members(resource: model)
+    @members ||= find_members(resource: model)
   end
 
   # Use case for nesting vector works
@@ -52,4 +52,10 @@ class VectorWorkDecorator < Valkyrie::ResourceDecorator
   def attachable_objects
     [VectorWork]
   end
+
+  private
+
+    def find_members(resource:)
+      query_service.find_members(resource: resource) || []
+    end
 end

--- a/app/derivative-services/image_derivative_service.rb
+++ b/app/derivative-services/image_derivative_service.rb
@@ -25,9 +25,19 @@ class ImageDerivativeService
       attribute :output_name, Valkyrie::Types::String
     end
   end
+  class IoDecorator < SimpleDelegator
+    attr_reader :original_filename, :content_type, :use
+    def initialize(io, original_filename, content_type, use)
+      @original_filename = original_filename
+      @content_type = content_type
+      @use = use
+      super(io)
+    end
+  end
   attr_reader :change_set, :original_file, :image_config, :use, :change_set_persister
   delegate :width, :height, :format, :output_name, to: :image_config
   delegate :mime_type, to: :original_file
+  delegate :resource, to: :change_set
   def initialize(change_set:, original_file:, change_set_persister:, image_config:)
     @change_set = change_set
     @original_file = original_file
@@ -59,16 +69,6 @@ class ImageDerivativeService
     )
   end
 
-  class IoDecorator < SimpleDelegator
-    attr_reader :original_filename, :content_type, :use
-    def initialize(io, original_filename, content_type, use)
-      @original_filename = original_filename
-      @content_type = content_type
-      @use = use
-      super(io)
-    end
-  end
-
   def build_file
     IoDecorator.new(temporary_output, "#{output_name}.#{format}", image_mime_type, use)
   end
@@ -77,7 +77,15 @@ class ImageDerivativeService
     [Valkyrie::Vocab::PCDMUse.ServiceFile]
   end
 
-  def cleanup_derivatives; end
+  def cleanup_derivatives
+    deleted_files = []
+    image_derivatives = resource.file_metadata.select { |file| file.derivative? && file.mime_type.include?(image_mime_type) }
+    image_derivatives.each do |file|
+      storage_adapter.delete(id: file.id)
+      deleted_files << file.id
+      cleanup_derivative_metadata(derivatives: deleted_files)
+    end
+  end
 
   def filename
     return Pathname.new(file_object.io.path) if file_object.io.respond_to?(:path) && File.exist?(file_object.io.path)
@@ -102,4 +110,18 @@ class ImageDerivativeService
   def valid?
     ALLOWABLE_FORMATS.include?(mime_type.first)
   end
+
+  private
+
+    def storage_adapter
+      @storage_adapter ||= Valkyrie::StorageAdapter.find(:derivatives)
+    end
+
+    def cleanup_derivative_metadata(derivatives:)
+      resource.file_metadata = resource.file_metadata.reject { |file| derivatives.include?(file.id) }
+      updated_change_set = FileSetChangeSet.new(resource)
+      change_set_persister.buffer_into_index do |buffered_persister|
+        buffered_persister.save(change_set: updated_change_set)
+      end
+    end
 end

--- a/app/derivative-services/image_derivative_service.rb
+++ b/app/derivative-services/image_derivative_service.rb
@@ -83,8 +83,8 @@ class ImageDerivativeService
     image_derivatives.each do |file|
       storage_adapter.delete(id: file.id)
       deleted_files << file.id
-      cleanup_derivative_metadata(derivatives: deleted_files)
     end
+    cleanup_derivative_metadata(derivatives: deleted_files)
   end
 
   def filename

--- a/app/derivative-services/jp2_derivative_service.rb
+++ b/app/derivative-services/jp2_derivative_service.rb
@@ -72,6 +72,9 @@ class Jp2DerivativeService
     )
   end
 
+  # Removes Valkyrie::StorageAdapter::File member Objects for any given Resource (usually a FileSet)
+  # Please note that this simply deletes the files themselves from storage
+  # File membership for the parent of the Valkyrie::StorageAdapter::File is removed using #cleanup_derivative_metadata
   def cleanup_derivatives
     deleted_files = []
     jp2_derivatives = resource.file_metadata.select { |file| file.derivative? && file.mime_type.include?('image/jp2') }
@@ -108,9 +111,12 @@ class Jp2DerivativeService
       @storage_adapter ||= Valkyrie::StorageAdapter.find(:derivatives)
     end
 
+    # This removes all Valkyrie::StorageAdapter::File member Objects from a given Resource (usually a FileSet)
+    # Resources consistently store the membership using #file_metadata
+    # A ChangeSet for the purged members is created and persisted
     def cleanup_derivative_metadata(derivatives:)
       resource.file_metadata = resource.file_metadata.reject { |file| derivatives.include?(file.id) }
-      updated_change_set = FileSetChangeSet.new(resource)
+      updated_change_set = DynamicChangeSet.new(resource)
       change_set_persister.buffer_into_index do |buffered_persister|
         buffered_persister.save(change_set: updated_change_set)
       end

--- a/app/derivative-services/plum_derivative_service.rb
+++ b/app/derivative-services/plum_derivative_service.rb
@@ -38,6 +38,8 @@ class PlumDerivativeService
     jp2_derivative_service.create_derivatives if jp2_derivative_service.valid?
   end
 
+  # Removes Valkyrie::StorageAdapter::File member Objects for any given Resource (usually a FileSet)
+  # (see Jp2DerivativeService#cleanup_derivatives)
   def cleanup_derivatives
     jp2_derivative_service.cleanup_derivatives if jp2_derivative_service.valid?
   end

--- a/app/derivative-services/plum_derivative_service.rb
+++ b/app/derivative-services/plum_derivative_service.rb
@@ -38,7 +38,9 @@ class PlumDerivativeService
     jp2_derivative_service.create_derivatives if jp2_derivative_service.valid?
   end
 
-  def cleanup_derivatives; end
+  def cleanup_derivatives
+    jp2_derivative_service.cleanup_derivatives if jp2_derivative_service.valid?
+  end
 
   def jp2_derivative_service
     Jp2DerivativeService::Factory.new(change_set_persister: change_set_persister).new(change_set)

--- a/app/derivative-services/scanned_map_derivative_service.rb
+++ b/app/derivative-services/scanned_map_derivative_service.rb
@@ -39,7 +39,10 @@ class ScannedMapDerivativeService
     thumbnail_derivative_service.create_derivatives if thumbnail_derivative_service.valid?
   end
 
-  def cleanup_derivatives; end
+  def cleanup_derivatives
+    jp2_derivative_service.cleanup_derivatives if jp2_derivative_service.valid?
+    thumbnail_derivative_service.cleanup_derivatives if thumbnail_derivative_service.valid?
+  end
 
   def jp2_derivative_service
     Jp2DerivativeService::Factory.new(change_set_persister: change_set_persister).new(change_set)

--- a/app/derivative-services/scanned_map_derivative_service.rb
+++ b/app/derivative-services/scanned_map_derivative_service.rb
@@ -39,6 +39,9 @@ class ScannedMapDerivativeService
     thumbnail_derivative_service.create_derivatives if thumbnail_derivative_service.valid?
   end
 
+  # Removes Valkyrie::StorageAdapter::File member Objects for any given Resource (usually a FileSet)
+  # (see Jp2DerivativeService#cleanup_derivatives)
+  # (see ImageDerivativeService#cleanup_derivatives)
   def cleanup_derivatives
     jp2_derivative_service.cleanup_derivatives if jp2_derivative_service.valid?
     thumbnail_derivative_service.cleanup_derivatives if thumbnail_derivative_service.valid?

--- a/app/jobs/cleanup_derivatives_job.rb
+++ b/app/jobs/cleanup_derivatives_job.rb
@@ -1,13 +1,26 @@
 # frozen_string_literal: true
+#
+# An asynchronous job for cleaning derivative Valkyrie::StorageAdapter::File objects
 class CleanupDerivativesJob < ApplicationJob
+  # Uses the query service from the metadata adapter
+  # @return [Valkyrie::Persistence::Memory::QueryService,
+  #   Valkyrie::Persistence::Solr::QueryService, Valkyrie::Persistence::Postgres::QueryService,
+  #   Valkyrie::Persistence::ActiveFedora::QueryService]
   delegate :query_service, to: :metadata_adapter
 
+  # Perform the cleanup as a job
+  # @param file_set_id [Valkyrie::ID, String] the ID for the Valkyrie Resource
   def perform(file_set_id)
     file_set = query_service.find_by(id: Valkyrie::ID.new(file_set_id))
     Valkyrie::DerivativeService.for(FileSetChangeSet.new(file_set)).cleanup_derivatives
   end
 
-  def metadata_adapter
-    Valkyrie.config.metadata_adapter
-  end
+  private
+
+    # Retrieve the current metadata adapter configured for Figgy
+    # @return [Valkyrie::Persistence::Memory::MetadataAdapter, Valkyrie::Persistence::Solr::MetadataAdapter,
+    #   Valkyrie::Persistence::Postgres::MetadataAdapter, Valkyrie::Persistence::ActiveFedora::MetadataAdapter]
+    def metadata_adapter
+      Valkyrie.config.metadata_adapter
+    end
 end

--- a/app/jobs/cleanup_derivatives_job.rb
+++ b/app/jobs/cleanup_derivatives_job.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+class CleanupDerivativesJob < ApplicationJob
+  delegate :query_service, to: :metadata_adapter
+
+  def perform(file_set_id)
+    file_set = query_service.find_by(id: Valkyrie::ID.new(file_set_id))
+    Valkyrie::DerivativeService.for(FileSetChangeSet.new(file_set)).cleanup_derivatives
+  end
+
+  def metadata_adapter
+    Valkyrie.config.metadata_adapter
+  end
+end

--- a/spec/decorators/solr_node_spec.rb
+++ b/spec/decorators/solr_node_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe SolrNode do
+  subject(:decorator) { described_class.new(resource) }
+  let(:resource) { FactoryGirl.build(:scanned_resource) }
+
+  describe '#id' do
+    it 'prepends a string for the ID' do
+      expect(decorator.id).to match(/^id\-/)
+    end
+  end
+end

--- a/spec/derivative_services/image_derivative_service_spec.rb
+++ b/spec/derivative_services/image_derivative_service_spec.rb
@@ -42,4 +42,17 @@ RSpec.describe ImageDerivativeService do
     expect(image.width).to eq 200
     expect(image.height).to eq 287
   end
+
+  describe '#cleanup_derivatives' do
+    before do
+      derivative_service.new(valid_change_set).create_derivatives
+    end
+
+    it "deletes the attached fileset when the resource is deleted" do
+      derivative_service.new(valid_change_set).cleanup_derivatives
+
+      reloaded = query_service.find_by(id: valid_resource.id)
+      expect(reloaded.file_metadata.select { |file| file.derivative? && file.mime_type.include?('image/jpeg') }).to be_empty
+    end
+  end
 end

--- a/spec/derivative_services/jp2_derivative_service_spec.rb
+++ b/spec/derivative_services/jp2_derivative_service_spec.rb
@@ -50,4 +50,16 @@ RSpec.describe Jp2DerivativeService do
     derivative_file = Valkyrie::StorageAdapter.find_by(id: derivative.file_identifiers.first)
     expect(derivative_file.read).not_to be_blank
   end
+
+  describe '#cleanup_derivatives' do
+    before do
+      derivative_service.new(valid_change_set).create_derivatives
+    end
+
+    it "deletes the attached fileset when the resource is deleted" do
+      derivative_service.new(valid_change_set).cleanup_derivatives
+      reloaded = query_service.find_by(id: valid_resource.id)
+      expect(reloaded.file_metadata.select(&:derivative?)).to be_empty
+    end
+  end
 end

--- a/spec/derivative_services/plum_derivative_service_spec.rb
+++ b/spec/derivative_services/plum_derivative_service_spec.rb
@@ -41,4 +41,16 @@ RSpec.describe PlumDerivativeService do
     derivative_file = Valkyrie::StorageAdapter.find_by(id: derivative.file_identifiers.first)
     expect(derivative_file.read).not_to be_blank
   end
+
+  describe '#cleanup_derivatives' do
+    before do
+      derivative_service.new(valid_change_set).create_derivatives
+    end
+
+    it "deletes the attached fileset when the resource is deleted" do
+      derivative_service.new(valid_change_set).cleanup_derivatives
+      reloaded = query_service.find_by(id: valid_resource.id)
+      expect(reloaded.file_metadata.select(&:derivative?)).to be_empty
+    end
+  end
 end

--- a/spec/derivative_services/scanned_map_derivative_service_spec.rb
+++ b/spec/derivative_services/scanned_map_derivative_service_spec.rb
@@ -46,4 +46,12 @@ RSpec.describe ScannedMapDerivativeService do
     expect(jp2s.count).to eq 1
     expect(thumbnails.count).to eq 1
   end
+
+  describe '#cleanup_derivatives' do
+    it "deletes the attached fileset when the resource is deleted" do
+      derivative_service.new(valid_change_set).cleanup_derivatives
+      reloaded = query_service.find_by(id: valid_resource.id)
+      expect(reloaded.file_metadata.select(&:derivative?)).to be_empty
+    end
+  end
 end


### PR DESCRIPTION
- Updating Valkyrie to https://github.com/samvera-labs/valkyrie/commit/dfcf1959b8399441a612d826b29cd1b44da10702
- Resolves #147 by extending the derivative services and implementing the CleanupDerivatives handler for the PlumChangeSetPersister