### PR TITLE
Downgrading the Ruby release for Circle CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   ruby:
-    version: 2.3.4
+    version: 2.3.3
   services:
     - redis
 dependencies:


### PR DESCRIPTION
bundler encounters failures when attempting to install either `nio4r` or `json` Gems