### PR TITLE
Don't render viewing hint for collection children.

### DIFF
--- a/app/services/manifest_builder/child_record_property_builder.rb
+++ b/app/services/manifest_builder/child_record_property_builder.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+class ManifestBuilder
+  class ChildRecordPropertyBuilder
+    attr_reader :record, :path
+    def initialize(record)
+      @record = record
+    end
+
+    def apply(manifest)
+      manifest['@id'] = record.manifest_url.to_s
+      manifest.label = record.to_s
+      manifest.description = record.description
+      manifest
+    end
+  end
+end

--- a/app/services/manifest_builder/manifest_service_locator.rb
+++ b/app/services/manifest_builder/manifest_service_locator.rb
@@ -26,9 +26,28 @@ class ManifestBuilder
       end
 
       def child_manifest_builder
-        ConditionalCollectionManifest.new(manifest_builder: super, collection_builder: child_collection_builder)
+        ConditionalCollectionManifest.new(manifest_builder: real_child_manifest_builder, collection_builder: child_collection_builder)
       end
 
+      ##
+      # Builder for a manifest which is a sub-item in a collection.
+      def real_child_manifest_builder
+        IIIFManifest::ManifestServiceLocator::InjectedFactory.new(
+          IIIFManifest::ManifestBuilder,
+          builders: child_record_property_builder,
+          top_record_factory: iiif_manifest_factory
+        )
+      end
+
+      ##
+      # Builder for record properties to be applied when rendering as a
+      # "manifest" sub-item in a collection.
+      def child_record_property_builder
+        ManifestBuilder::ChildRecordPropertyBuilder
+      end
+
+      ##
+      # Builder for collections which are sub-collections.
       def child_collection_builder
         IIIFManifest::ManifestServiceLocator::InjectedFactory.new(
           CollectionManifestBuilder,

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -141,6 +141,7 @@ RSpec.describe ManifestBuilder do
       expect(output["viewingHint"]).to eq "multi-part"
       expect(output["manifests"].length).to eq 1
       expect(output["manifests"][0]["@id"]).to eq "http://www.example.com/concern/scanned_resources/#{child.id}/manifest"
+      expect(output["manifests"][0]["viewingHint"]).to be_nil
     end
   end
   context "when given a scanned map" do


### PR DESCRIPTION
It's expensive to determine if an object needs a multi-part viewing hint
or not, and the information isn't useful for a collection sub-manifest.