### PR TITLE
Ensures that users can delete Ephemera Folders when editing

### DIFF
--- a/app/assets/stylesheets/components/form.scss
+++ b/app/assets/stylesheets/components/form.scss
@@ -6,3 +6,7 @@
 .form-group .radio input.radio_buttons {
   margin-left: 0;
 }
+.panel-delete-controls {
+  border-top-width: 0px;
+  padding-top: 0px;
+}

--- a/spec/features/ephemera_folder_spec.rb
+++ b/spec/features/ephemera_folder_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature "Ephemera Folders", js: true do
+  let(:user) { FactoryGirl.create(:admin) }
+  let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
+
+  before do
+    sign_in user
+  end
+
+  context 'when users have added an ephemera folder' do
+    let(:ephemera_project) do
+      res = FactoryGirl.create_for_repository(:ephemera_project, member_ids: [ephemera_box.id])
+      adapter.persister.save(resource: res)
+    end
+    let(:ephemera_box) do
+      res = FactoryGirl.create_for_repository(:ephemera_box, member_ids: [ephemera_folder.id])
+      adapter.persister.save(resource: res)
+    end
+    let(:ephemera_folder) do
+      res = FactoryGirl.create_for_repository(:ephemera_folder)
+      adapter.persister.save(resource: res)
+    end
+
+    before do
+      ephemera_project
+      ephemera_box
+    end
+
+    scenario 'users can view an existing folder' do
+      visit Valhalla::ContextualPath.new(child: ephemera_folder).show
+      expect(page).to have_content 'test folder'
+    end
+
+    scenario 'users can edit existing folders' do
+      visit polymorphic_path [:edit, ephemera_folder]
+      page.fill_in 'ephemera_folder_title', with: 'updated folder title'
+      page.find('form.edit_ephemera_folder').native.submit
+
+      expect(page).to have_content 'updated folder title'
+    end
+
+    context 'while editing existing folders' do
+      scenario 'users can delete existing folders' do
+        visit polymorphic_path [:edit, ephemera_folder]
+
+        page.accept_confirm do
+          click_link "Delete This Ephemera Folder"
+        end
+
+        expect(page.find(:css, ".alert-info")).to have_content "Deleted EphemeraFolder"
+      end
+    end
+
+    scenario 'users can delete existing folders' do
+      visit Valhalla::ContextualPath.new(child: ephemera_folder).show
+
+      page.accept_confirm do
+        click_link "Delete This Ephemera Folder"
+      end
+
+      expect(page.find(:css, ".alert-info")).to have_content "Deleted EphemeraFolder"
+    end
+  end
+end

--- a/valhalla/app/views/valhalla/base/_form_progress.html.erb
+++ b/valhalla/app/views/valhalla/base/_form_progress.html.erb
@@ -16,16 +16,19 @@
       <%= render 'form_visibility_component', f: f %>
     </div>
   </div>
-  <div class="panel-footer text-center">
-    <br>
-    <%# send user back to object from edit, back to home from new %>
-    <%= link_to t(:'helpers.action.cancel'),
-                f.object.id ? solr_document_path(id: f.object.id) : main_app.root_path,
-                class: 'btn btn-default' %>
-
+  <div class="panel-footer text-center panel-save-controls">
     <%= f.submit class: 'btn btn-primary' %>
     <% if f.object.resource.is_a?(EphemeraFolder) && params[:controller] == "ephemera_folders" %>
       <%= f.submit "Save and Create Another", class: 'btn btn-primary' %>
+
     <% end %>
   </div>
+  <% if params[:action] == "edit" %>
+    <div class="panel-footer text-center panel-delete-controls">
+      <%= link_to t(:'helpers.action.cancel'),
+                  main_app.root_path,
+                  class: 'btn btn-default' %>
+      <%= link_to "Delete This #{f.object.resource.human_readable_type}", main_app.polymorphic_path([f.object.resource]), class: 'btn btn-danger', data: { confirm: "Delete this #{f.object.resource.human_readable_type}?" }, method: :delete %>
+    </div>
+  <% end %>
 </aside>


### PR DESCRIPTION
Resolves #376 by exposing a "Delete" button within the form used for editing:
![issues_376_screenshot_2](https://user-images.githubusercontent.com/1443986/31825446-47c7c296-b580-11e7-8dd3-9d9a2b9ba23d.png)
