### PR TITLE
Separate CAS host and URL for the Omniauth config.

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -75,6 +75,11 @@ defaults: &defaults
       plum: "plum_events"
       geoblacklight: "gbl_events"
   vocabulary_namespace: <%= ENV.fetch('FIGGY_VOCAB_NS', 'https://plum.princeton.edu/ns/') %>
+  devise:
+    omniauth:
+      cas:
+        host: <%= ENV.fetch('CAS_HOST', 'fed.princeton.edu') %>
+        url: <%= ENV.fetch('CAS_URL', 'https://fed.princeton.edu/cas') %>
 
 development:
   <<: *defaults
@@ -88,6 +93,11 @@ test:
   derivative_path: <%= Rails.root.join("tmp", "test_derivatives") %>
   events:
     log_file: '/dev/null'
+  devise:
+    omniauth:
+      cas:
+        host: <%= ENV.fetch('CAS_HOST', 'localhost.localdomain') %>
+        url: <%= ENV.fetch('CAS_URL', 'https://localhost.localdomain/cas') %>
 
 production:
   <<: *defaults

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require_relative 'figgy'
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|
@@ -253,8 +254,8 @@ Devise.setup do |config|
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
   config.omniauth(:cas,
-                  host: (Rails.env.test? ? 'localhost.localdomain' : 'fed.princeton.edu'),
-                  url: (Rails.env.test? ? 'https://localhost.localdomain/cas' : 'https://fed.princeton.edu/cas'))
+                  host: Figgy.config['devise']['omniauth']['cas']['host'],
+                  url: Figgy.config['devise']['omniauth']['cas']['url'])
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -252,7 +252,9 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
-  config.omniauth :cas, host: 'fed.princeton.edu', url: 'https://fed.princeton.edu/cas'
+  config.omniauth(:cas,
+                  host: (Rails.env.test? ? 'localhost.localdomain' : 'fed.princeton.edu'),
+                  url: (Rails.env.test? ? 'https://localhost.localdomain/cas' : 'https://fed.princeton.edu/cas'))
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/spec/support/capybara_selenium.rb
+++ b/spec/support/capybara_selenium.rb
@@ -7,9 +7,12 @@ Capybara.register_driver(:headless_chrome) do |app|
     chromeOptions: { args: %w(headless disable-gpu disable-setuid-sandbox window-size=7680,4320) }
   )
 
+  http_client = Selenium::WebDriver::Remote::Http::Default.new
+  http_client.timeout = 120
   Capybara::Selenium::Driver.new(app,
                                  browser: :chrome,
-                                 desired_capabilities: capabilities)
+                                 desired_capabilities: capabilities,
+                                 http_client: http_client)
 end
 
 Capybara.javascript_driver = :headless_chrome

--- a/spec/support/features/session_helpers.rb
+++ b/spec/support/features/session_helpers.rb
@@ -8,6 +8,7 @@ module Features
              else
                FactoryGirl.create(:user).uid
              end
+      OmniAuth.config.test_mode = true
       OmniAuth.config.add_mock(:cas, uid: user)
       visit user_cas_omniauth_authorize_path
     end

--- a/spec/support/reset_auth.rb
+++ b/spec/support/reset_auth.rb
@@ -3,7 +3,6 @@ RSpec.configure do |config|
   config.before(:each) do
     OmniAuth.config.mock_auth[:cas] = nil
     Rails.application.env_config["devise.mapping"] = Devise.mappings[:user] # If using Devise
-    Rails.application.env_config["omniauth.auth"] = OmniAuth.config.mock_auth[:twitter]
-    stub_request(:get, Devise.omniauth_configs[:cas].strategy.url).to_return(status: 200, body: "", headers: {})
+    Rails.application.env_config["omniauth.auth"] = OmniAuth.config.mock_auth[:cas]
   end
 end


### PR DESCRIPTION
This attempts to resolve #265 