### PR TITLE
Ensures that ChangeSet validation errors are rendered on resource edit forms

### DIFF
--- a/app/change_sets/ephemera_folder_change_set.rb
+++ b/app/change_sets/ephemera_folder_change_set.rb
@@ -36,7 +36,7 @@ class EphemeraFolderChangeSet < Valhalla::ChangeSet
   property :rights_statement, multiple: false, required: true, default: "http://rightsstatements.org/vocab/NKC/1.0/", type: ::Types::URI
   property :rights_note, multiple: false, required: false
   property :thumbnail_id, multiple: false, required: false, type: Valkyrie::Types::ID
-  property :member_of_collection_ids, multiple: true, required: false, type: Types::Strict::Array.member(Valkyrie::Types::ID)
+  property :member_of_collection_ids, multiple: true, required: false, default: [], type: Types::Strict::Array.member(Valkyrie::Types::ID)
   property :read_groups, multiple: true, required: false
   property :files, virtual: true, multiple: true, required: false
   property :pending_uploads, multiple: true, required: false
@@ -66,7 +66,7 @@ class EphemeraFolderChangeSet < Valhalla::ChangeSet
   end
 
   def date_range_form
-    @date_range_form ||= DynamicChangeSet.new(Array.wrap(date_range).first || DateRange.new).tap(&:prepopulate!)
+    @date_range_form ||= DynamicChangeSet.new(date_range_value || DateRange.new).tap(&:prepopulate!)
   end
 
   def primary_terms
@@ -144,5 +144,9 @@ class EphemeraFolderChangeSet < Valhalla::ChangeSet
       else
         value
       end
+    end
+
+    def date_range_value
+      Array.wrap(date_range).first
     end
 end

--- a/spec/factories/ephemera_folder.rb
+++ b/spec/factories/ephemera_folder.rb
@@ -23,6 +23,7 @@ FactoryGirl.define do
     rights_statement RDF::URI('http://rightsstatements.org/vocab/NKC/1.0/')
     read_groups 'public'
     state 'needs_qa'
+    member_of_collection_ids []
     to_create do |instance|
       Valkyrie.config.metadata_adapter.persister.save(resource: instance)
     end

--- a/spec/features/ephemera_box_spec.rb
+++ b/spec/features/ephemera_box_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature "Ephemera Boxes", js: true do
+  let(:user) { FactoryGirl.create(:admin) }
+  let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
+  let(:ephemera_box) do
+    res = FactoryGirl.create_for_repository(:ephemera_box)
+    adapter.persister.save(resource: res)
+  end
+  let(:ephemera_project) do
+    res = FactoryGirl.create_for_repository(:ephemera_project, member_ids: [ephemera_box.id])
+    adapter.persister.save(resource: res)
+  end
+
+  before do
+    sign_in user
+    ephemera_project
+  end
+
+  context 'when an ephemera folder has been persisted with invalid data' do
+    let(:change_set) do
+      EphemeraBoxChangeSet.new(ephemera_box)
+    end
+    let(:change_set_persister) do
+      PlumChangeSetPersister.new(metadata_adapter: adapter, storage_adapter: Valkyrie.config.storage_adapter)
+    end
+
+    before do
+      change_set.barcode = '1234'
+      change_set.sync
+      change_set_persister.save(change_set: change_set)
+    end
+
+    scenario 'users see validation errors' do
+      visit polymorphic_path [:edit, ephemera_box]
+      expect(page.find(:css, ".has-error")).to have_content "has an invalid checkdigit"
+    end
+  end
+end

--- a/spec/features/ephemera_folder_spec.rb
+++ b/spec/features/ephemera_folder_spec.rb
@@ -4,30 +4,26 @@ require 'rails_helper'
 RSpec.feature "Ephemera Folders", js: true do
   let(:user) { FactoryGirl.create(:admin) }
   let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
+  let(:ephemera_project) do
+    res = FactoryGirl.create_for_repository(:ephemera_project, member_ids: [ephemera_box.id])
+    adapter.persister.save(resource: res)
+  end
+  let(:ephemera_box) do
+    res = FactoryGirl.create_for_repository(:ephemera_box, member_ids: [ephemera_folder.id])
+    adapter.persister.save(resource: res)
+  end
+  let(:ephemera_folder) do
+    res = FactoryGirl.create_for_repository(:ephemera_folder)
+    adapter.persister.save(resource: res)
+  end
 
   before do
     sign_in user
+    ephemera_project
+    ephemera_box
   end
 
   context 'when users have added an ephemera folder' do
-    let(:ephemera_project) do
-      res = FactoryGirl.create_for_repository(:ephemera_project, member_ids: [ephemera_box.id])
-      adapter.persister.save(resource: res)
-    end
-    let(:ephemera_box) do
-      res = FactoryGirl.create_for_repository(:ephemera_box, member_ids: [ephemera_folder.id])
-      adapter.persister.save(resource: res)
-    end
-    let(:ephemera_folder) do
-      res = FactoryGirl.create_for_repository(:ephemera_folder)
-      adapter.persister.save(resource: res)
-    end
-
-    before do
-      ephemera_project
-      ephemera_box
-    end
-
     scenario 'users can view an existing folder' do
       visit Valhalla::ContextualPath.new(child: ephemera_folder).show
       expect(page).to have_content 'test folder'

--- a/valhalla/app/controllers/concerns/valhalla/resource_controller.rb
+++ b/valhalla/app/controllers/concerns/valhalla/resource_controller.rb
@@ -54,8 +54,8 @@ module Valhalla
     def edit
       @change_set = change_set_class.new(find_resource(params[:id]))
       authorize! :update, @change_set.resource
-      @change_set.validate({})
       @change_set.prepopulate!
+      @change_set.validate({})
     end
 
     def update

--- a/valhalla/app/controllers/concerns/valhalla/resource_controller.rb
+++ b/valhalla/app/controllers/concerns/valhalla/resource_controller.rb
@@ -52,8 +52,10 @@ module Valhalla
     end
 
     def edit
-      @change_set = change_set_class.new(find_resource(params[:id])).prepopulate!
+      @change_set = change_set_class.new(find_resource(params[:id]))
       authorize! :update, @change_set.resource
+      @change_set.validate({})
+      @change_set.prepopulate!
     end
 
     def update


### PR DESCRIPTION
Resolves #440 by ensuring that ChangeSet validations are propagated from the Controller for cases where resources have already been persisted with invalid data