### PR TITLE
Adding ephemera hard drive management

### DIFF
--- a/app/change_sets/ephemera_box_change_set.rb
+++ b/app/change_sets/ephemera_box_change_set.rb
@@ -9,6 +9,7 @@ class EphemeraBoxChangeSet < Valhalla::ChangeSet
   property :shipped_date, multiple: false, required: false
   property :received_date, multiple: false, required: false
   property :tracking_number, multiple: false, required: false
+  property :drive_barcode, multiple: false, required: false
   property :member_ids, multiple: true, required: false, type: Types::Strict::Array.member(Valkyrie::Types::ID)
   property :member_of_collection_ids, multiple: true, required: false, type: Types::Strict::Array.member(Valkyrie::Types::ID)
   # override the default value defined in VisibilityProperty
@@ -18,10 +19,16 @@ class EphemeraBoxChangeSet < Valhalla::ChangeSet
   property :rights_note, multiple: false, required: false
   delegate :human_readable_type, to: :model
   validate :barcode_valid?
+  validate :drive_barcode_valid?
 
   def barcode_valid?
     return if Barcode.new(Array.wrap(barcode).first).valid?
     errors.add(:barcode, 'has an invalid checkdigit')
+  end
+
+  def drive_barcode_valid?
+    return if drive_barcode.nil? || drive_barcode.empty? || Barcode.new(Array.wrap(drive_barcode).first).valid?
+    errors.add(:drive_barcode, 'has an invalid checkdigit')
   end
 
   def primary_terms
@@ -31,6 +38,7 @@ class EphemeraBoxChangeSet < Valhalla::ChangeSet
       :shipped_date,
       :received_date,
       :tracking_number,
+      :drive_barcode,
       :member_of_collection_ids,
       :append_id
     ]

--- a/app/controllers/ephemera_boxes_controller.rb
+++ b/app/controllers/ephemera_boxes_controller.rb
@@ -10,6 +10,10 @@ class EphemeraBoxesController < BaseResourceController
   before_action :load_collections, only: [:new, :edit]
   before_action :cache_project, only: :destroy
 
+  def attach_drive
+    edit
+  end
+
   def cache_project
     @ephemera_project = find_resource(params[:id]).decorate.ephemera_project
   end

--- a/app/decorators/ephemera_box_decorator.rb
+++ b/app/decorators/ephemera_box_decorator.rb
@@ -6,6 +6,7 @@ class EphemeraBoxDecorator < Valkyrie::ResourceDecorator
       :box_number,
       :shipped_date,
       :tracking_number,
+      :drive_barcode,
       :visibility,
       :member_of_collections
     ]
@@ -68,6 +69,10 @@ class EphemeraBoxDecorator < Valkyrie::ResourceDecorator
   end
 
   def state
+    super.first
+  end
+
+  def drive_barcode
     super.first
   end
 

--- a/app/models/ephemera_box.rb
+++ b/app/models/ephemera_box.rb
@@ -6,6 +6,7 @@ class EphemeraBox < Valhalla::Resource
   attribute :member_of_collection_ids
   attribute :title, Valkyrie::Types::Set
   attribute :barcode, Valkyrie::Types::Set
+  attribute :drive_barcode, Valkyrie::Types::Set
   attribute :box_number, Valkyrie::Types::Set
   attribute :shipped_date, Valkyrie::Types::Set
   attribute :received_date, Valkyrie::Types::Set

--- a/app/views/catalog/_admin_controls_ephemera_box.html.erb
+++ b/app/views/catalog/_admin_controls_ephemera_box.html.erb
@@ -18,5 +18,8 @@
           </div>
       </div>
 
-    <%= link_to "Delete This #{resource.human_readable_type}", main_app.polymorphic_path([resource]), class: 'btn btn-danger pull-right', data: { confirm: "Delete this #{resource.human_readable_type}?" }, method: :delete %>
+    <div class="pull-right">
+      <%= link_to "Attach Hard Drive", attach_drive_ephemera_box_path(resource), class: 'btn btn-primary' %>
+      <%= link_to "Delete This #{resource.human_readable_type}", main_app.polymorphic_path([resource]), class: 'btn btn-danger', data: { confirm: "Delete this #{resource.human_readable_type}?" }, method: :delete %>
+    </div>
   </div>

--- a/app/views/catalog/_members_ephemera_project.html.erb
+++ b/app/views/catalog/_members_ephemera_project.html.erb
@@ -5,6 +5,7 @@
       <th>Workflow State</th>
       <th>Box Number</th>
       <th>Barcode</th>
+      <th>Hard Drive</th>
       <th>Actions</th>
     </tr>
     </thead>
@@ -15,6 +16,7 @@
         <td><%= box.rendered_state %></td>
         <td><%= box.box_number.first %></td>
         <td class="barcode"><%= box.barcode %></td>
+        <td class="drive_barcode"><%= box.drive_barcode %></td>
         <td>
           <%= link_to 'View', box_url, class: 'btn btn-default' %>
           <%= link_to 'Edit', main_app.polymorphic_path([:edit, box]), class: 'btn btn-default' %>

--- a/app/views/catalog/_resource_attributes_ephemera_box.html.erb
+++ b/app/views/catalog/_resource_attributes_ephemera_box.html.erb
@@ -20,7 +20,16 @@
             <td>
               <ul class="tabular">
                 <% values.each do |value| %>
-                  <li class="attribute <%= attribute %>" dir="<%= value.to_s.dir %>"><%= value %></li>
+                  <li class="attribute <%= attribute %>" dir="<%= value.to_s.dir %>">
+                    <%= value %>
+
+                    <% if (attribute == :drive_barcode) %>
+                      <%= simple_form_for(@change_set, html: { class: 'inline pull-right' }) do |f| %>
+                        <%= f.hidden_field :drive_barcode, value: "" %>
+                        <%= f.submit "Detach Hard Drive", class: "btn btn-danger" %>
+                      <% end %>
+                    <% end %>
+                  </li>
                 <% end %>
               </ul>
             </td>

--- a/app/views/catalog/_resource_attributes_ephemera_term.html.erb
+++ b/app/views/catalog/_resource_attributes_ephemera_term.html.erb
@@ -11,6 +11,7 @@
                   <li class="attribute <%= attribute %>" dir="<%= value.to_s.dir %>"><%= value %></li>
                 <% end %>
               </ul>
+            </td>
           </tr>
         <% end %>
       <% end %>

--- a/app/views/ephemera_boxes/attach_drive.html.erb
+++ b/app/views/ephemera_boxes/attach_drive.html.erb
@@ -1,0 +1,12 @@
+<%= simple_form_for(@change_set) do |f| %>
+  <%= f.error_notification %>
+
+  <div class="form-inputs">
+    <%= f.input :drive_barcode %>
+  </div>
+
+  <div class="form-actions">
+    <%= f.button :submit %>
+    <%= link_to "Cancel", solr_document_path(f.object.id), class: 'btn btn-default' %>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,6 +89,9 @@ Rails.application.routes.draw do
     get '/ephemera_projects/:parent_id/field', to: 'ephemera_fields#new', as: :ephemera_project_add_field
 
     resources :ephemera_boxes do
+      member do
+        get :attach_drive
+      end
     end
 
     resources :ephemera_folders do

--- a/spec/change_sets/ephemera_box_change_set_spec.rb
+++ b/spec/change_sets/ephemera_box_change_set_spec.rb
@@ -13,6 +13,21 @@ RSpec.describe EphemeraBoxChangeSet do
     end
   end
 
+  describe "drive_barcode" do
+    it "is invalid if the drive barcode is invalid" do
+      expect(change_set).to be_valid
+
+      change_set.drive_barcode = ["11111111111111"]
+      expect(change_set).not_to be_valid
+    end
+
+    it "is valid if the drive barcode is valid" do
+      expect(change_set).to be_valid
+      change_set.drive_barcode = ["11111111111110"]
+      expect(change_set).to be_valid
+    end
+  end
+
   describe "#state" do
     it "pre-populates" do
       change_set.prepopulate!

--- a/spec/controllers/ephemera_boxes_controller_spec.rb
+++ b/spec/controllers/ephemera_boxes_controller_spec.rb
@@ -137,6 +137,21 @@ RSpec.describe EphemeraBoxesController do
     end
   end
 
+  describe "attach_drive" do
+    let(:user) { FactoryGirl.create(:admin) }
+
+    context "when it exists" do
+      render_views
+      it "renders a form" do
+        ephemera_box = FactoryGirl.create_for_repository(:ephemera_box)
+        get :attach_drive, params: { id: ephemera_box.id.to_s }
+
+        expect(response.body).to have_field "Drive barcode"
+        expect(response.body).to have_button "Save"
+      end
+    end
+  end
+
   describe "update" do
     let(:user) { FactoryGirl.create(:admin) }
     context "access control" do

--- a/spec/views/catalog/_admin_controls_ephemera_box.html.erb_spec.rb
+++ b/spec/views/catalog/_admin_controls_ephemera_box.html.erb_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "catalog/_admin_controls_ephemera_box" do
+  let(:box) { FactoryGirl.create_for_repository(:ephemera_box) }
+  let(:solr) { Valkyrie::MetadataAdapter.find(:index_solr) }
+  let(:document) { solr.resource_factory.from_resource(resource: box) }
+  let(:solr_document) { SolrDocument.new(document) }
+
+  before do
+    assign :document, solr_document
+    render
+  end
+
+  it 'displays a button to attach a hard drive' do
+    expect(rendered).to have_link 'Attach Hard Drive', href: attach_drive_ephemera_box_path(box.id)
+  end
+end

--- a/spec/views/catalog/_members_ephemera_project.html.erb_spec.rb
+++ b/spec/views/catalog/_members_ephemera_project.html.erb_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe "catalog/_members_ephemera_project" do
   context "when it's a project with boxes and folders" do
     let(:parent) { FactoryGirl.create_for_repository(:ephemera_project, member_ids: [child.id, child_folder.id]) }
-    let(:child) { FactoryGirl.create_for_repository(:ephemera_box) }
+    let(:child) { FactoryGirl.create_for_repository(:ephemera_box, drive_barcode: '11111111111110') }
     let(:child_folder) { FactoryGirl.create_for_repository(:ephemera_folder) }
     let(:document) { Valkyrie::MetadataAdapter.find(:index_solr).resource_factory.from_resource(resource: parent) }
     let(:solr_document) { SolrDocument.new(document) }
@@ -18,6 +18,7 @@ RSpec.describe "catalog/_members_ephemera_project" do
       expect(rendered).to have_selector 'span.label-default', text: 'New'
       expect(rendered).to have_selector 'td', text: '1'
       expect(rendered).to have_selector 'td', text: '00000000000000'
+      expect(rendered).to have_selector 'td', text: '11111111111110'
       expect(rendered).to have_link 'View', href: parent_solr_document_path(parent.id, child.id)
       expect(rendered).to have_link 'Edit', href: edit_ephemera_box_path(child.id)
 


### PR DESCRIPTION
* Adds a drive barcode field to ephemera boxes
* Displays drive barcode in box list
* Adds buttons for attaching and removing drives

Fixes #495 