### PR TITLE
Implements an indexer for the EphemeraFolders for cases where the folders should be hidden

### DIFF
--- a/app/indexers/ephemera_folder_indexer.rb
+++ b/app/indexers/ephemera_folder_indexer.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+class EphemeraFolderIndexer
+  delegate :query_service, to: :metadata_adapter
+  attr_reader :resource
+  def initialize(resource:)
+    @resource = resource
+  end
+
+  def to_solr
+    return {} unless resource.is_a?(::EphemeraFolder)
+    {
+      Hydra.config[:permissions][:read].group => read_groups
+    }
+  end
+
+  private
+
+    def read_groups
+      return [] unless decorated.state == 'complete' && (decorated.ephemera_box.blank? || decorated.ephemera_box.try(:state) == 'all_in_production')
+      resource.read_groups
+    end
+
+    def decorated
+      @decorated ||= resource.decorate
+    end
+end

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -68,6 +68,7 @@ Rails.application.config.to_prepare do
         Valkyrie::Indexers::AccessControlsIndexer,
         CollectionIndexer,
         EphemeraBoxIndexer,
+        EphemeraFolderIndexer,
         MemberOfIndexer,
         FacetIndexer,
         ProjectIndexer,


### PR DESCRIPTION
Resolves #494 by implementing an indexer for the EphemeraFolders supporting the following:

- [x] Incomplete Folders (all EphemeraFolders in a state other than `complete`) within incomplete EphemeraBoxes (this assumes that a Box exists for the Folder, and that it is in a state other than `all_in_production`) are privately visible
- [x] Incomplete Folders without Boxes are `private`, but restored to their current visibility once in a state of `complete`
- [x] Incomplete Folders are not indexed for discovery within [pulibrary/lae-blacklight](https://github.com/pulibrary/lae-blacklight)