### PR TITLE
Fix extract metadata functionality

### DIFF
--- a/app/assets/javascripts/figgy_boot.es6
+++ b/app/assets/javascripts/figgy_boot.es6
@@ -4,6 +4,7 @@ import ServerUploader from "./server_uploader"
 import StructureManager from "structure_manager"
 import ModalViewer from "modal_viewer"
 import DerivativeForm from "derivative_form"
+import MetadataForm from "metadata_form"
 import UniversalViewer from "universal_viewer"
 export default class Initializer {
   constructor() {
@@ -13,6 +14,7 @@ export default class Initializer {
     this.structure_manager = new StructureManager
     this.modal_viewer = new ModalViewer
     this.derivative_form = new DerivativeForm
+    this.metadata_form = new MetadataForm
     this.universal_viewer = new UniversalViewer
     $("optgroup").addClass("closed")
     $("select").selectpicker({'liveSearch': true})

--- a/app/assets/javascripts/metadata_form.es6
+++ b/app/assets/javascripts/metadata_form.es6
@@ -1,0 +1,30 @@
+export default class MetadataForm {
+  constructor() {
+    this.form = $(".extract_metadata")
+    this.element = this.form.find('button')
+    this.element.click(this.onclick)
+  }
+
+  onclick(event) {
+    $.ajax({
+      type: "PUT",
+      url: $(this).parents('.extract_metadata').attr('action'),
+      data: $(this).parents('.extract_metadata').serializeArray(),
+      dataType: 'json'
+    }).done(function(data, textStatus, response) {
+      $('.flash-message span.text')
+        .text("Metadata is being extracted")
+        .parent()
+        .removeClass('alert-danger')
+        .addClass('alert-success')
+        .removeClass('hidden')
+    }).fail(function(response, textStatus, errorThrown) {
+      $('.flash-message span.text')
+        .text("Metadata cannot be extracted")
+        .parent()
+        .removeClass('alert-success')
+        .addClass('alert-danger')
+        .removeClass('hidden')
+    })
+  }
+}

--- a/app/views/scanned_maps/file_manager.html.erb
+++ b/app/views/scanned_maps/file_manager.html.erb
@@ -3,7 +3,7 @@
   <li><%= link_to decorated_change_set_resource.header, solr_document_path(id: "#{@change_set.id}") %></li>
   <li class="active">File Manager</li>
 </ul>
-<% if !@children.empty? %>
+<% if !@children.empty? || !@metadata_children.empty? %>
   <div data-action="file-manager">
     <div class="col-md-3" id="file-manager-tools">
       <h2>Toolbar</h2>
@@ -11,9 +11,11 @@
     </div>
     <div class="col-md-3" id="label-tools-spacer" class="fixed"></div>
     <div class="col-md-9" id="order-grid">
+      <% if !@children.empty? %>
       <%= render "file_manager_members" %>
+      <% end %>
       <% if !@metadata_children.empty? %>
-        <%= render 'geo_metadata_members' %>
+        <%= render "geo_metadata_members" %>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
Adds javascript to re-enable broken geo metadata Extract button in scanned map file manager.

Closes #571 