### PR TITLE
Extends the `FileAppender` Service to improve file updates for FileSets

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,6 +69,7 @@ Metrics/MethodLength:
     - 'app/models/concerns/linked_data/linked_ephemera_folder.rb'
     - 'app/utils/data_seeder.rb'
     - 'app/services/bulk_ingest_service.rb'
+    - 'app/controllers/file_sets_controller.rb'
 Metrics/ModuleLength:
   Exclude:
     - 'app/models/schema/dublin_core.rb'
@@ -80,6 +81,7 @@ Metrics/ParameterLists:
 Metrics/CyclomaticComplexity:
   Exclude:
     - 'app/models/concerns/linked_data/linked_resource_factory.rb'
+    - 'app/services/file_appender.rb'
 RSpec/MultipleExpectations:
   Enabled: false
 RSpec/ExampleLength:

--- a/app/assets/javascripts/figgy_boot.es6
+++ b/app/assets/javascripts/figgy_boot.es6
@@ -6,6 +6,8 @@ import ModalViewer from "modal_viewer"
 import DerivativeForm from "derivative_form"
 import MetadataForm from "metadata_form"
 import UniversalViewer from "universal_viewer"
+import FileSetForm from "file_set_form"
+
 export default class Initializer {
   constructor() {
     this.server_uploader = new ServerUploader
@@ -42,8 +44,12 @@ export default class Initializer {
       new SaveWorkControl($("#form-progress"))
     }
 
-    $(".detect-duplicates").each(function(_i, element) {
+    $(".detect-duplicates").each((_i, element) =>
       DuplicateResourceDetectorFactory.build($(element))
-    })
+    )
+
+    $("form.edit_file_set.admin_controls").each((_i, element) =>
+      new FileSetForm($(element))
+    )
   }
 }

--- a/app/assets/javascripts/file_set_form.es6
+++ b/app/assets/javascripts/file_set_form.es6
@@ -1,0 +1,25 @@
+export default class FileSetForm {
+  constructor($element) {
+    this.$formElement = $element
+    this.$fileInputElements = $element.find('input[type="file"]')
+    this.$submitElement = $element.find('input[type="submit"]')
+
+    this.$fileInputElements.data('_object', this)
+    this.$fileInputElements.change(this.onchange)
+    // Update the DOM upon instantiation
+    this.update()
+  }
+
+  update() {
+    let fileInputValues = this.$fileInputElements.map((_i, element) => element.value).toArray()
+    if(fileInputValues.reduce((u, v) => u || v))
+      this.$submitElement.prop('disabled', false)
+    else
+      this.$submitElement.prop('disabled', true)
+  }
+
+  onchange(event) {
+    let that = $(this).data('_object')
+    that.update()
+  }
+}

--- a/app/services/file_appender/file_resource_adapter.rb
+++ b/app/services/file_appender/file_resource_adapter.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+class FileAppender
+  class FileResourceAdapter
+    def initialize(file_resource:)
+      @file_resource = file_resource
+    end
+
+    def file_metadata
+      return @file_resource if ResourceDetector.file_metadata?(@file_resource)
+      return @file_resource.file_metadata if ResourceDetector.file_set?(@file_resource)
+      raise NotImplementedError, "Attempted to retrieve the metadata for an unsupported file resource: #{@file_resource.class}"
+    end
+
+    def id
+      @file_resource.id
+    rescue
+      raise NotImplementedError, "Attempted to retrieve the ID for an unsupported file resource: #{@file_resource.class}"
+    end
+  end
+end

--- a/app/services/file_appender/file_resources.rb
+++ b/app/services/file_appender/file_resources.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+class FileAppender
+  class FileResources < Array
+    def initialize(*args)
+      super(*args)
+      @file_resources = {}
+    end
+
+    # Retrieve the file metadata for all elements in the set
+    def file_metadata
+      map { |file_node| file_resource(file_node).file_metadata }
+    end
+
+    # Retrieve the ID's for the set
+    def ids
+      map { |file_node| file_resource(file_node).id }
+    end
+
+    private
+
+      def file_resource(file_node)
+        @file_resources[file_node] ||= FileResourceAdapter.new(file_resource: file_node)
+      end
+  end
+end

--- a/app/services/resource_detector.rb
+++ b/app/services/resource_detector.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class ResourceDetector
+  def self.viewable_resource?(resource)
+    resource.respond_to?(:member_ids) && resource.respond_to?(:thumbnail_id)
+  end
+
+  def self.file_metadata?(resource)
+    !resource.respond_to?(:file_metadata) && resource.respond_to?(:original_filename)
+  end
+
+  def self.file_set?(resource)
+    resource.respond_to?(:file_metadata) && !resource.respond_to?(:member_ids)
+  end
+end

--- a/app/views/catalog/_admin_controls_file_set.html.erb
+++ b/app/views/catalog/_admin_controls_file_set.html.erb
@@ -1,29 +1,35 @@
 <h2>Files</h2>
-<%= simple_form_for FileSetChangeSet.new(resource) do |f| %>
+<%= simple_form_for FileSetChangeSet.new(resource), html: { class: ['edit_file_set', 'admin_controls'] } do |f| %>
   <table class="table table-striped files">
-    <tr>
-      <th>Label</th>
-      <th>Download</th>
-      <th>Update</th>
-    </tr>
+    <thead>
+      <tr>
+        <th>Label</th>
+        <th>Download</th>
+        <th>Update</th>
+      </tr>
+    </thead>
+    <tbody>
     <% resource.original_files.each do |file| %>
       <tr>
-        <td><%= file.label.first %></td>
+        <td><span class="label label-success">Original File</span>&nbsp;<%= file.label.first %></td>
         <td><%= link_to "Download", valhalla.download_path(resource.id, file.id) %></td>
         <td><%= f.input "files[][#{file.id}]", as: :file, label: false, required: false %></td>
       </tr>
     <% end %>
     <% resource.derivative_files.each do |file| %>
       <tr>
-        <td><%= file.label.first %></td>
+        <td><span class="label label-info">Derivative File</span>&nbsp;<%= file.label.first %></td>
         <td><%= link_to "Download", valhalla.download_path(resource.id, file.id) %></td>
         <td><%= f.input "derivative_files[][#{file.id}]", as: :file, label: false, required: false %></td>
       </tr>
     <% end %>
-    <tr>
-      <td colspan="2"></td>
-      <td><%= f.submit 'Update Files', class: 'btn btn-primary' %></td>
-    </tr>
+    </tbody>
+    <tfoot>
+      <tr>
+        <td colspan="2"></td>
+        <td><%= f.submit 'Update Files', class: 'btn btn-primary', disabled: true %></td>
+      </tr>
+    </tfoot>
   </table>
 <% end %>
 <%= render "admin_controls_default" %>

--- a/spec/controllers/file_sets_controller_spec.rb
+++ b/spec/controllers/file_sets_controller_spec.rb
@@ -24,6 +24,12 @@ RSpec.describe FileSetsController do
       expect(file_set.title).to eq ["Second"]
     end
 
+    context "with an invalid FileSet ID" do
+      it 'displays an error' do
+        expect { patch :update, params: { id: 'no-exist', file_set: { title: ["Second"] } } }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+      end
+    end
+
     context 'with replacement master and derivative files' do
       let(:master_file) { fixture_file_upload('files/example.tif', 'image/tiff') }
       let(:derivative_file) { fixture_file_upload('files/example.jp2', 'image/jp2') }

--- a/spec/services/file_appender/file_resource_adapter_spec.rb
+++ b/spec/services/file_appender/file_resource_adapter_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe FileAppender::FileResourceAdapter do
+  subject(:file_resource_adapter) { described_class.new(file_resource: file_node) }
+  let(:file_set) { instance_double(FileSet) }
+  let(:file_metadata) { instance_double(FileMetadata) }
+  let(:file_metadata_id) { instance_double(Valkyrie::ID) }
+  let(:file_node) { file_metadata }
+
+  describe '#file_metadata' do
+    before do
+      allow(file_metadata).to receive(:original_filename)
+    end
+    it 'retrieves the file metadata for the resource' do
+      expect(file_resource_adapter.file_metadata).to eq file_metadata
+    end
+
+    context 'with a FileSet' do
+      let(:file_node) { file_set }
+
+      before do
+        allow(file_set).to receive(:file_metadata).and_return(file_metadata)
+      end
+      it 'retrieves the file metadata for the resource' do
+        expect(file_resource_adapter.file_metadata).to eq file_metadata
+        expect(file_set).to have_received(:file_metadata)
+      end
+    end
+
+    context "with an object which isn't a file resource" do
+      let(:file_node) { 'this is not a file' }
+      it 'raises an error' do
+        expect { file_resource_adapter.file_metadata }.to raise_error(NotImplementedError, "Attempted to retrieve the metadata for an unsupported file resource: String")
+      end
+    end
+  end
+
+  describe '#id' do
+    before do
+      allow(file_metadata).to receive(:id).and_return(file_metadata_id)
+    end
+
+    it 'retrieves the ID for the resource' do
+      expect(file_resource_adapter.id).to eq file_metadata_id
+    end
+
+    context "with an object which isn't a file resource" do
+      let(:file_node) { 'this is not a file' }
+      it 'raises an error' do
+        expect { file_resource_adapter.id }.to raise_error(NotImplementedError, "Attempted to retrieve the ID for an unsupported file resource: String")
+      end
+    end
+  end
+end

--- a/spec/services/file_appender/file_resources_spec.rb
+++ b/spec/services/file_appender/file_resources_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe FileAppender::FileResources do
+  subject(:file_resources) { described_class.new(file_nodes) }
+  let(:file_set) { instance_double(FileSet) }
+  let(:file_set_metadata) { instance_double(FileMetadata) }
+  let(:file_set_id) { instance_double(Valkyrie::ID) }
+  let(:file_metadata) { instance_double(FileMetadata) }
+  let(:file_metadata_id) { instance_double(Valkyrie::ID) }
+  let(:file_nodes) { [file_set, file_metadata] }
+
+  describe '#file_metadata' do
+    before do
+      allow(file_set).to receive(:file_metadata).and_return(file_set_metadata)
+      allow(file_metadata).to receive(:original_filename)
+    end
+    it 'retrieves the file metadata for each file resource element' do
+      expect(file_resources.file_metadata).to be_an Array
+      expect(file_resources.file_metadata.length).to eq 2
+      expect(file_resources.file_metadata.first).to eq file_set_metadata
+      expect(file_resources.file_metadata.last).to eq file_metadata
+    end
+    context "with elements which aren't file resources" do
+      let(:file_nodes) { [file_set, file_metadata, 'foo'] }
+
+      it 'raises an error' do
+        expect { file_resources.file_metadata }.to raise_error(NotImplementedError, "Attempted to retrieve the metadata for an unsupported file resource: String")
+      end
+    end
+  end
+
+  describe '#ids' do
+    before do
+      allow(file_set).to receive(:id).and_return(file_set_id)
+      allow(file_metadata).to receive(:id).and_return(file_metadata_id)
+    end
+    it 'retrieves the ID for each file resource element' do
+      expect(file_resources.ids).to be_an Array
+      expect(file_resources.ids.length).to eq 2
+      expect(file_resources.ids.first).to eq file_set_id
+      expect(file_resources.ids.last).to eq file_metadata_id
+    end
+    context "with elements which aren't file resources" do
+      let(:file_nodes) { [file_set, file_metadata, 'foo'] }
+
+      it 'raises an error' do
+        expect { file_resources.ids }.to raise_error(NotImplementedError, "Attempted to retrieve the ID for an unsupported file resource: String")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #605 by addressing the following:
- Restructuring FileSetsController#update in parity with Valhalla::ResourceController#update
- Uses the services FileResources and FileResourceAdapter to ensure that file metadata is properly copied when files are added or updated for FileSets
- Ensures that the "Update Files" button on the FileSet catalog View is disabled by default
- Ensures that file labels and names are updated when files in FileSets are updated