### PR TITLE
Move data table sorting icon.

### DIFF
--- a/app/assets/stylesheets/components/show.scss
+++ b/app/assets/stylesheets/components/show.scss
@@ -13,3 +13,13 @@ ul.tabular {
 .attribute.visibility {
   padding-left: 0;
 }
+
+table.dataTable thead .sorting:after, table.dataTable thead .sorting_asc:after,
+table.dataTable thead .sorting_desc:after {
+    left: 0px;
+    right: 0px;
+}
+
+table.dataTable thead > tr > th {
+  padding-left: 20px;
+}


### PR DESCRIPTION
Closes #659.

Looks like this:

![screen shot 2017-12-27 at 9 52 54 am](https://user-images.githubusercontent.com/2806645/34388974-bad28122-eaeb-11e7-878f-6be5f1c3ceb2.png)
