### PR TITLE
Set visibility based on Date Created

### DIFF
--- a/app/change_set_persisters/plum_change_set_persister.rb
+++ b/app/change_set_persisters/plum_change_set_persister.rb
@@ -14,6 +14,7 @@ class PlumChangeSetPersister
     {
       before_save: [
         ApplyRemoteMetadata,
+        ApplyVisibilityByDate,
         CreateFile::Factory.new(file_appender: FileAppender),
         PropagateVisibilityAndState
       ],

--- a/app/change_set_persisters/plum_change_set_persister/apply_visibility_by_date.rb
+++ b/app/change_set_persisters/plum_change_set_persister/apply_visibility_by_date.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+class PlumChangeSetPersister
+  class ApplyVisibilityByDate
+    attr_reader :change_set_persister, :change_set
+    def initialize(change_set_persister:, change_set:, post_save_resource: nil)
+      @change_set = change_set
+      @change_set_persister = change_set_persister
+    end
+
+    def run
+      return unless change_set.try(:set_visibility_by_date?)
+      return unless date_object
+      change_set.validate(visibility: calculated_visibility, rights_statement: calculated_rights_statement)
+      change_set.sync
+      change_set
+    end
+
+    private
+
+      def date
+        Array.wrap(change_set.resource.primary_imported_metadata.created).first
+      end
+
+      def date_object
+        return unless date
+        Time.zone.parse(date)
+      rescue
+        Rails.logger.warn("Unable to parse created date: #{change_set.resource.primary_imported_metadata.created}")
+        nil
+      end
+
+      def limit_date
+        Time.zone.parse("1924-01-01T00:00:00Z")
+      end
+
+      def public_access?
+        date_object < limit_date
+      end
+
+      def calculated_visibility
+        if public_access?
+          Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+        else
+          Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+        end
+      end
+
+      def calculated_rights_statement
+        if public_access?
+          "http://rightsstatements.org/vocab/NKC/1.0/"
+        else
+          "http://rightsstatements.org/vocab/InC/1.0/"
+        end
+      end
+  end
+end

--- a/app/change_sets/concerns/visibility_property.rb
+++ b/app/change_sets/concerns/visibility_property.rb
@@ -6,6 +6,11 @@ module VisibilityProperty
   included do
     # override this property to define a different default
     property :visibility, multiple: false, default: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    property :set_visibility_by_date, virtual: true, multiple: false
+
+    def set_visibility_by_date?
+      set_visibility_by_date == "1"
+    end
 
     def visibility=(visibility)
       super.tap do |_result|

--- a/app/views/records/edit_fields/_source_metadata_identifier.html.erb
+++ b/app/views/records/edit_fields/_source_metadata_identifier.html.erb
@@ -1,3 +1,12 @@
 <% current_id = @change_set.id if @change_set %>
 <%= f.input :source_metadata_identifier, label: 'Source Metadata ID', input_html: { class: 'mutex detect-duplicates', data: { value: current_id, field: 'source_metadata_identifier_ssim', model: f.object.model.class.to_s } } %>
-<%= f.input :refresh_remote_metadata, label: 'Refresh metadata from PULFA/Voyager', as: :boolean %>
+<div class="row">
+  <div class="col-xs-3">
+    <%= f.input :refresh_remote_metadata, label: 'Refresh metadata from PULFA/Voyager', as: :boolean %>
+  </div>
+  <div class="col-xs-3">
+    <%= f.input :set_visibility_by_date, label: 'Set visibility by Date Created', as: :boolean %>
+  </div>
+  <div class="col-xs-6">
+  </div>
+</div>

--- a/spec/factories/scanned_resource.rb
+++ b/spec/factories/scanned_resource.rb
@@ -46,6 +46,10 @@ FactoryBot.define do
       state "complete"
       visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
     end
+    factory :pending_private_scanned_resource do
+      state "pending"
+      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+    end
     factory :takedown_scanned_resource do
       state "takedown"
     end

--- a/spec/fixtures/files/bibdata/123456789.jsonld
+++ b/spec/fixtures/files/bibdata/123456789.jsonld
@@ -1,0 +1,24 @@
+{  
+   "@context":"http://bibdata.princeton.edu/context.json",
+   "@id":"http://bibdata.princeton.edu/bibliographic/123456",
+   "title":{  
+      "@value":"Earth rites : fertility rites in pre-industrial Britain",
+      "@language":"fr"
+   },
+   "language":"eng",
+   "creator":"Bord, Janet, 1945-",
+   "call_number":"BL980.G7 B66 1982",
+   "extent":"xiv, 273 p. : ill. ; 24 cm.",
+   "format":"Book",
+   "description":"Includes index.",
+   "publisher":"London ; New York : Granada, 1982.",
+   "subject":"Fertility cults—Great Britain—History",
+   "title_sort":"Earth rites : fertility rites in pre-industrial Britain / Janet and Colin Bord.",
+   "spatial":"Great Britain",
+   "contributor":[  
+      "Bord, Colin"
+   ],
+   "author":"Bord, Janet, 1945-",
+   "created":"1982",
+   "date":"1982"
+}


### PR DESCRIPTION
Closes #691.

This adds a new checkbox to automatically set visibility/rights statement based on what the date of the object is. The checkbox looks like this:

![screen shot 2017-12-27 at 1 28 44 pm](https://user-images.githubusercontent.com/2806645/34393786-e639d4dc-eb09-11e7-86bc-76e202271bad.png)
