### PR TITLE
Dont create empty updated at

### DIFF
--- a/app/models/structure_node.rb
+++ b/app/models/structure_node.rb
@@ -7,6 +7,6 @@ class StructureNode < Valkyrie::Resource
   # Prevents empty updated_at/created_at properties from filling up the postgres
   # column.
   def to_hash
-    super.compact
+    super.compact.select { |_k, v| v.present? }
   end
 end

--- a/app/models/structure_node.rb
+++ b/app/models/structure_node.rb
@@ -4,6 +4,8 @@ class StructureNode < Valkyrie::Resource
   attribute :proxy, Valkyrie::Types::Set.member(Valkyrie::Types::ID.optional)
   attribute :nodes, Valkyrie::Types::Array.member(StructureNode)
 
+  # Prevents empty updated_at/created_at properties from filling up the postgres
+  # column.
   def to_hash
     super.compact
   end

--- a/app/models/structure_node.rb
+++ b/app/models/structure_node.rb
@@ -3,4 +3,8 @@ class StructureNode < Valkyrie::Resource
   attribute :label, Valkyrie::Types::Set
   attribute :proxy, Valkyrie::Types::Set.member(Valkyrie::Types::ID.optional)
   attribute :nodes, Valkyrie::Types::Array.member(StructureNode)
+
+  def to_hash
+    super.compact
+  end
 end

--- a/spec/models/structure_spec.rb
+++ b/spec/models/structure_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe Structure do
   let(:node) { described_class.new(nodes: [StructureNode.new]) }
   describe "#as_json" do
     it "does not build updated_at/created_at for structure nodes" do
-      expect(node.as_json["nodes"].first).not_to have_key "created_at"
+      expect(node.as_json["nodes"].first).to eq(
+        "internal_resource" => "StructureNode"
+      )
     end
   end
 end

--- a/spec/models/structure_spec.rb
+++ b/spec/models/structure_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Structure do
+  let(:node) { described_class.new(nodes: [StructureNode.new]) }
+  describe "#as_json" do
+    it "does not build updated_at/created_at for structure nodes" do
+      expect(node.as_json["nodes"].first).not_to have_key "created_at"
+    end
+  end
+end


### PR DESCRIPTION
Having a bunch of empty updated_at/created_at values when saving to postgres was making it take even longer to parse in Valkyrie.