### PR TITLE
Ensuring that linked vocabulary terms only have their labels exposed in IIIF Manifests

### DIFF
--- a/app/change_sets/ephemera_folder_change_set.rb
+++ b/app/change_sets/ephemera_folder_change_set.rb
@@ -18,7 +18,7 @@ class EphemeraFolderChangeSet < Valhalla::ChangeSet
   property :sort_title, required: false
   property :alternative_title, multiple: true, required: false
   property :language, multiple: true, required: true
-  property :genre, multiple: false, required: true, type: Valkyrie::Types::ID
+  property :genre, multiple: false, required: true
   property :width, multiple: false, required: true
   property :height, multiple: false, required: true
   property :page_count, multiple: false, required: true

--- a/app/decorators/ephemera_folder_decorator.rb
+++ b/app/decorators/ephemera_folder_decorator.rb
@@ -38,7 +38,12 @@ class EphemeraFolderDecorator < Valkyrie::ResourceDecorator
       :internal_resource,
       :rights_statement,
       :rendered_rights_statement,
-      :thumbnail_id
+      :thumbnail_id,
+      :rendered_date_range,
+      :rendered_subject,
+      :created_at,
+      :updated_at,
+      :sort_title
     ]
   )
 

--- a/app/decorators/valkyrie/resource_decorator.rb
+++ b/app/decorators/valkyrie/resource_decorator.rb
@@ -184,13 +184,14 @@ class Valkyrie::ResourceDecorator < ApplicationDecorator
         return element unless element.is_a?(EphemeraTerm)
 
         factory = LinkedData::LinkedResourceFactory.new(resource: element)
-        factory.new.without_context
+        resource = factory.new.without_context
+        resource.fetch('pref_label')
       end
     end
 
     # Aliases all methods which may contain linked data terms
     alias geo_subject_value linkable_value
-    alias genre_value_value linkable_value
+    alias genre_value linkable_value
     alias geographic_origin_value linkable_value
     alias language_value linkable_value
     alias subject_value linkable_value

--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -98,6 +98,8 @@ class ManifestBuilder
       helper.manifest_url(resource)
     end
 
+    # Generate the IIIF Manifest metadata using the resource decorator
+    # @return [Hash] the manifest metadata
     def manifest_metadata
       resource.decorate.iiif_metadata
     end

--- a/spec/decorators/ephemera_folder_decorator_spec.rb
+++ b/spec/decorators/ephemera_folder_decorator_spec.rb
@@ -119,7 +119,6 @@ RSpec.describe EphemeraFolderDecorator do
     expect(decorator.iiif_manifest_attributes).to include page_count: ['30']
     expect(decorator.iiif_manifest_attributes).to include publisher: ['test publisher']
     expect(decorator.iiif_manifest_attributes).to include series: ['test series']
-    expect(decorator.iiif_manifest_attributes).to include sort_title: []
     expect(decorator.iiif_manifest_attributes).to include source_url: ['http://example.com']
     expect(decorator.iiif_manifest_attributes).to include subject: ["test subject"]
     expect(decorator.iiif_manifest_attributes).to include title: ['test folder']

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -170,30 +170,33 @@ RSpec.describe ManifestBuilder do
 
       let(:category) { FactoryBot.create_for_repository(:ephemera_vocabulary, label: 'Art and Culture') }
       let(:subject_term) { FactoryBot.create_for_repository(:ephemera_term, label: 'Architecture', member_of_vocabulary_id: category.id) }
+
+      let(:genres_category) { FactoryBot.create_for_repository(:ephemera_vocabulary, label: 'Library of Congress Genre/Form Terms') }
+      let(:genre_term) { FactoryBot.create_for_repository(:ephemera_term, label: 'Experimental films', member_of_vocabulary_id: genres_category.id) }
       let(:ephemera_folder) do
-        FactoryBot.create_for_repository(:ephemera_folder, subject: [subject_term.id])
+        FactoryBot.create_for_repository(:ephemera_folder, subject: [subject_term.id], genre: genre_term.id)
       end
-      it "transforms the term into JSON-LD" do
+      it "transforms the subject terms into JSON-LD" do
         output = manifest_builder.build
         expect(output).to be_kind_of Hash
         expect(output).to include 'metadata'
         metadata = output["metadata"]
         expect(metadata).to be_kind_of Array
-        expect(metadata.length).to eq(23)
+        expect(metadata.length).to eq(20)
 
         metadata_object = metadata.find { |h| h['label'] == 'Subject' }
         metadata_values = metadata_object['value']
         expect(metadata_values).to be_kind_of Array
         metadata_value = metadata_values.shift
 
-        expect(metadata_value['@id']).to eq "http://www.example.com/catalog/#{subject_term.id}"
-        expect(metadata_value['@type']).to eq 'skos:Concept'
-        expect(metadata_value['pref_label']).to eq 'Architecture'
+        expect(metadata_value).to eq subject_term.label
 
-        metadata_value_vocab = metadata_value['in_scheme']
-        expect(metadata_value_vocab['@id']).to eq "https://plum.princeton.edu/ns/artAndCulture"
-        expect(metadata_value_vocab['@type']).to eq 'skos:ConceptScheme'
-        expect(metadata_value_vocab['pref_label']).to eq 'Art and Culture'
+        metadata_object = metadata.find { |h| h['label'] == 'Genre' }
+        metadata_values = metadata_object['value']
+        expect(metadata_values).to be_kind_of Array
+        metadata_value = metadata_values.shift
+
+        expect(metadata_value).to eq genre_term.label
       end
     end
 


### PR DESCRIPTION
Progresses towards a resolution for #756 and addresses some existing bugs:
- An `alias` typographic error
- The casting of all `genre` attribute values for `EphemeraFolders` into `Valkyrie::IDs`