### PR TITLE
Implementing the MissingThumbnailJob for linking MVWs to member thumbnails when `thumbnail_id` values are missing or deleted

### DIFF
--- a/app/jobs/missing_thumbnail_job.rb
+++ b/app/jobs/missing_thumbnail_job.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+class MissingThumbnailJob < ApplicationJob
+  # Sets the thumbnail ID for a repository resource missing a thumbnail
+  # @param id [String] the ID for the repository resource
+  def perform(id)
+    resource = metadata_adapter.query_service.find_by(id: Valkyrie::ID.new(id))
+
+    return resource unless resource.thumbnail_id.nil?
+
+    member_thumbnail_ids = member_thumbnail_ids_for(resource)
+    if member_thumbnail_ids.empty?
+      @logger.warn "Failed to locate a thumbnail for #{id}"
+      return resource
+    end
+    new_thumbnail_id = member_thumbnail_ids.first
+
+    resource.thumbnail_id = new_thumbnail_id
+    change_set = DynamicChangeSet.new(resource)
+    updated_resource = change_set_persister.save(change_set: change_set)
+    logger.info "Linked the missing thumbnail for #{updated_resource.id}"
+    updated_resource
+  end
+
+  private
+
+    # Recursively retrieve all thumbnail IDs for a given repository resource from its members
+    # (This shall halt recursing if a thumbnail ID is found for a member resource)
+    # @param resource [Valhalla::Resource] the repository resource
+    # @return [Array<Valkyrie::ID>] the array of thumbnail IDs
+    def member_thumbnail_ids_for(resource)
+      return if resource.member_ids.empty?
+      members = metadata_adapter.query_service.find_members(resource: resource)
+      thumbnail_ids = members.to_a.map(&:thumbnail_id).reject(&:nil?)
+      thumbnail_ids += members.map { |member| member_thumbnail_ids(member) } if thumbnail_ids.empty?
+      thumbnail_ids.flatten
+    end
+
+    # Retrieve the metadata adapter for repository metadata
+    # @return [Valkyrie::MetadataAdapter]
+    def metadata_adapter
+      Valkyrie::MetadataAdapter.find(:indexing_persister)
+    end
+
+    # Retrieve the change set persister for repository resources
+    # @return [PlumChangeSetPersister]
+    def change_set_persister
+      PlumChangeSetPersister.new(metadata_adapter: metadata_adapter, storage_adapter: Valkyrie.config.storage_adapter)
+    end
+end

--- a/app/queries/find_missing_thumbnail_resources.rb
+++ b/app/queries/find_missing_thumbnail_resources.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+class FindMissingThumbnailResources
+  # Access the list of methods exposed for the query
+  # @return [Array<Symbol>] query method signatures
+  def self.queries
+    [:find_missing_thumbnail_resources]
+  end
+
+  attr_reader :query_service
+  delegate :connection, to: :query_service
+  delegate :resource_factory, to: :query_service
+  # Constructor
+  # @param query_service [Valkyrie::Persistence::Solr::QueryService] the query service for Solr
+  def initialize(query_service:)
+    @query_service = query_service
+  end
+
+  # Method for finding all resources missing thumbnail IDs
+  # @param model [Valhalla::Resource] the model for the resources
+  def find_missing_thumbnail_resources(model: ScannedResource)
+    run(model)
+  end
+
+  private
+
+    # The query for Solr
+    # @param model [Valhalla::Resource] the model for the resources
+    def query(model)
+      "#{Valkyrie::Persistence::Solr::Queries::MODEL}:#{model} AND -thumbnail_id_ssim:[* TO *]"
+    end
+
+    # Iterate through the results of the query
+    # @param model [Valhalla::Resource] the model for the resources
+    # @yield [Valhalla::Resource] a resource missing a thumbnail ID
+    def each(model)
+      docs = Valkyrie::Persistence::Solr::Queries::DefaultPaginator.new
+      while docs.has_next?
+        docs = connection.paginate(docs.next_page, docs.per_page, "select", params: { q: query(model) })["response"]["docs"]
+        docs.each do |doc|
+          yield resource_factory.to_resource(object: doc)
+        end
+      end
+    end
+
+    # Execute the query
+    # @param model [Valhalla::Resource] the model for the resources
+    def run(model)
+      enum_for(:each, model)
+    end
+end

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -128,5 +128,10 @@ Rails.application.config.to_prepare do
   [FindByLocalIdentifier, FindByStringProperty, FindEphemeraTermByLabel, FindEphemeraVocabularyByLabel, MemoryEfficientAllQuery, FindProjectFolders, FindIdentifiersToReconcile].each do |query_handler|
     Valkyrie.config.metadata_adapter.query_service.custom_queries.register_query_handler(query_handler)
   end
+
+  [FindMissingThumbnailResources].each do |solr_query_handler|
+    Valkyrie::MetadataAdapter.find(:index_solr).query_service.custom_queries.register_query_handler(solr_query_handler)
+  end
+
   Valkyrie.logger = Rails.logger
 end

--- a/spec/jobs/missing_thumbnail_job_spec.rb
+++ b/spec/jobs/missing_thumbnail_job_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include ActionDispatch::TestProcess
+
+RSpec.describe MissingThumbnailJob do
+  describe ".perform" do
+    let(:file) { fixture_file_upload('files/color-landscape.tif', 'image/tiff') }
+    let(:resource) do
+      sr = FactoryBot.create_for_repository(:scanned_resource, files: [file])
+      change_set = ScannedResourceChangeSet.new(sr)
+      change_set.thumbnail_id = nil
+      change_set.prepopulate!
+      change_set_persister.save(change_set: change_set)
+    end
+    let(:metadata_adapter) { Valkyrie.config.metadata_adapter }
+    let(:change_set_persister) { PlumChangeSetPersister.new(metadata_adapter: metadata_adapter, storage_adapter: Valkyrie.config.storage_adapter) }
+    let(:query_service) { metadata_adapter.query_service }
+    let(:updated_resource) { query_service.find_by(id: Valkyrie::ID.new(resource.id)) }
+    let(:file_sets) { query_service.find_members(resource: resource) }
+
+    before do
+      described_class.perform_now(resource.id.to_s)
+    end
+
+    it 'sets the thumbnail for the resource' do
+      expect(updated_resource.thumbnail_id).not_to be_empty
+      expect(updated_resource.thumbnail_id.first.to_s).to eq file_sets.first.thumbnail_id.to_s
+    end
+
+    context 'when the resource is a multi-volume work' do
+      let(:file) { fixture_file_upload('files/color-landscape.tif', 'image/tiff') }
+      let(:member) { FactoryBot.create_for_repository(:scanned_resource, files: [file]) }
+      let(:resource) { FactoryBot.create_for_repository(:scanned_resource, member_ids: [member.id]) }
+      it 'sets the thumbnail using the first member of the multi-volume work' do
+        expect(updated_resource.thumbnail_id).not_to be_empty
+        expect(updated_resource.thumbnail_id.first.to_s).to eq member.thumbnail_id.first.to_s
+      end
+    end
+  end
+end

--- a/spec/queries/find_missing_thumbnail_resources_spec.rb
+++ b/spec/queries/find_missing_thumbnail_resources_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include ActionDispatch::TestProcess
+
+RSpec.describe FindMissingThumbnailResources do
+  subject(:query) { described_class.new(query_service: query_service) }
+  let(:metadata_adapter) { Valkyrie::MetadataAdapter.find(:index_solr) }
+  let(:query_service) { metadata_adapter.query_service }
+  let(:resource) do
+    sr = FactoryBot.create_for_repository(:scanned_resource)
+    change_set = ScannedResourceChangeSet.new(sr)
+    change_set.thumbnail_id = nil
+    change_set.prepopulate!
+    change_set_persister.save(change_set: change_set)
+  end
+  let(:file) { fixture_file_upload('files/color-landscape.tif', 'image/tiff') }
+  let(:resource2) { FactoryBot.create_for_repository(:scanned_resource, files: [file]) }
+  let(:change_set_persister) { PlumChangeSetPersister.new(metadata_adapter: metadata_adapter, storage_adapter: Valkyrie.config.storage_adapter) }
+
+  before do
+    stub_bibdata(bib_id: '123456')
+    stub_ezid(shoulder: "99999/fk4", blade: "8675309")
+  end
+
+  describe "#find_missing_thumbnail_resources" do
+    let(:connection) { Blacklight.default_index.connection }
+    before do
+      resource
+    end
+    it 'only finds resources missing thumbnails' do
+      output = query.find_missing_thumbnail_resources(model: ScannedResource)
+      ids = output.map(&:id)
+      expect(ids).to include resource.id
+      expect(ids).not_to include resource2.id
+    end
+  end
+end


### PR DESCRIPTION
Provides a Rake task which resolves #781 