### PR TITLE
Scanned map thumbnail_id points to a file set

### DIFF
--- a/app/services/geo_resources/discovery/document_builder/document_path.rb
+++ b/app/services/geo_resources/discovery/document_builder/document_path.rb
@@ -80,9 +80,8 @@ module GeoResources
           def map_set_file_set
             member_id = Array.wrap(resource_decorator.thumbnail_id).first
             return unless member_id
-            member = query_service.find_by(id: member_id)
-            member_file_sets = member.decorate.geo_members
-            member_file_sets.first.decorate unless member_file_sets.empty?
+            file_set = query_service.find_by(id: member_id)
+            file_set.decorate if file_set && file_set.is_a?(FileSet)
           rescue Valkyrie::Persistence::ObjectNotFoundError
             nil
           end

--- a/app/services/geo_resources/discovery/document_builder/iiif_builder.rb
+++ b/app/services/geo_resources/discovery/document_builder/iiif_builder.rb
@@ -67,9 +67,8 @@ module GeoResources
             @map_set_file_set ||= begin
               member_id = Array.wrap(resource_decorator.thumbnail_id).first
               return unless member_id
-              member = query_service.find_by(id: member_id)
-              member_file_sets = member.decorate.geo_members
-              member_file_sets.first.decorate unless member_file_sets.empty?
+              file_set = query_service.find_by(id: member_id)
+              file_set.decorate if file_set && file_set.is_a?(FileSet)
             end
           rescue Valkyrie::Persistence::ObjectNotFoundError
             nil

--- a/spec/services/geo_resources/discovery/document_builder_spec.rb
+++ b/spec/services/geo_resources/discovery/document_builder_spec.rb
@@ -176,7 +176,6 @@ describe GeoResources::Discovery::DocumentBuilder do
     let(:geo_work) do
       FactoryBot.create_for_repository(:scanned_map,
                                        member_ids: child.id,
-                                       thumbnail_id: child.id,
                                        coverage: coverage.to_s,
                                        visibility: visibility,
                                        identifier: 'ark:/99999/fk4')
@@ -201,6 +200,13 @@ describe GeoResources::Discovery::DocumentBuilder do
     context 'with a parent resource' do
       let(:child_change_set) { ScannedMapChangeSet.new(child, files: [file]) }
       let(:file) { fixture_file_upload('files/example.tif', 'image/tiff') }
+
+      before do
+        change_set = ScannedMapChangeSet.new(geo_work)
+        change_set.validate(thumbnail_id: child.member_ids[0])
+        change_set.sync
+        change_set_persister.save(change_set: change_set)
+      end
 
       it 'returns an un-suppressed document with a thumbnail ref and no source field' do
         expect(document['suppressed_b']).to be_nil


### PR DESCRIPTION
GeoBlacklight document builders assumed that a map set's thumbnail id pointed to a ScannedMap. The thumbnail id should be the id for a file set instead.

Closes #855 