### PR TITLE
Force guest user to use the first available

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,4 +27,10 @@ class ApplicationController < ActionController::Base
       end
     end
   end
+
+  # Figgy has no use cases for having unique shared searches, and this prevents
+  # the user list from growing out of control.
+  def guest_user
+    @guest_user ||= User.where(guest: true).first || super
+  end
 end


### PR DESCRIPTION
Should stop tons of guests being created. For Figgy we don't care about
saving non-logged in searches and things.

Closes #858