### PR TITLE
No datadog in staging.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ group :development, :staging do
   gem "rack-mini-profiler", require: false
 end
 
-group :production, :staging do
+group :production do
   gem 'ddtrace'
 end
 

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-if Rails.env.production? || Rails.env.staging?
+if Rails.env.production?
   require 'ddtrace'
   Datadog.configure do |c|
     # Rails


### PR DESCRIPTION
Staging wasn't in our datadog quote, and this throws errors if the agent
isn't installed.