### PR TITLE
Use imported metadata in geo resources

### DIFF
--- a/app/change_set_persisters/plum_change_set_persister/apply_remote_metadata.rb
+++ b/app/change_set_persisters/plum_change_set_persister/apply_remote_metadata.rb
@@ -25,13 +25,7 @@ class PlumChangeSetPersister
     private
 
       def apply(attributes)
-        if change_set.apply_remote_metadata_directly?
-          attributes.delete(:identifier)
-          change_set.validate(attributes)
-          change_set.sync
-        else
-          change_set.model.imported_metadata = ImportedMetadata.new(attributes)
-        end
+        change_set.model.imported_metadata = ImportedMetadata.new(attributes)
       end
   end
 end

--- a/app/change_sets/concerns/remote_metadata_property.rb
+++ b/app/change_sets/concerns/remote_metadata_property.rb
@@ -9,9 +9,5 @@ module RemoteMetadataProperty
     def apply_remote_metadata?
       source_metadata_identifier.present? && (!persisted? || refresh_remote_metadata == "1")
     end
-
-    def apply_remote_metadata_directly?
-      false
-    end
   end
 end

--- a/app/change_sets/raster_resource_change_set.rb
+++ b/app/change_sets/raster_resource_change_set.rb
@@ -28,10 +28,6 @@ class RasterResourceChangeSet < Valhalla::ChangeSet
   validates_with SourceMetadataIdentifierOrTitleValidator
   validates :visibility, :rights_statement, presence: true
 
-  def apply_remote_metadata_directly?
-    true
-  end
-
   # rubocop:disable Metrics/MethodLength
   def primary_terms
     [

--- a/app/change_sets/scanned_map_change_set.rb
+++ b/app/change_sets/scanned_map_change_set.rb
@@ -30,8 +30,4 @@ class ScannedMapChangeSet < ScannedResourceChangeSet
     ]
   end
   # rubocop:enable Metrics/MethodLength
-
-  def apply_remote_metadata_directly?
-    true
-  end
 end

--- a/app/change_sets/vector_work_change_set.rb
+++ b/app/change_sets/vector_work_change_set.rb
@@ -51,8 +51,4 @@ class VectorWorkChangeSet < Valhalla::ChangeSet
     ]
   end
   # rubocop:enable Metrics/MethodLength
-
-  def apply_remote_metadata_directly?
-    true
-  end
 end

--- a/app/decorators/geoblacklight_metadata_decorator.rb
+++ b/app/decorators/geoblacklight_metadata_decorator.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Decorates geo resources for generation of geoblacklight document.
+# Forwards geo attributes to an object containing merged direct and imported attribute values.
+class GeoblacklightMetadataDecorator < SimpleDelegator
+  extend Forwardable
+
+  def_delegators :merged_attributes_object, *Schema::Geo.attributes
+
+  private
+
+    def merged_attributes_object
+      @merged_attributes_object ||= OpenStruct.new(merged_attributes)
+    end
+
+    # Merge direct attribute values with imported attribute values and deduplicate.
+    def merged_attributes
+      direct_attributes.map do |key, value|
+        imported_value = __getobj__.imported_attributes.fetch(key, nil) || []
+        merged_values = imported_value + value
+        [key, merged_values.uniq]
+      end.to_h
+    end
+
+    def direct_attributes
+      Schema::Geo.attributes.map do |attribute|
+        [attribute, Array.wrap(__getobj__.[](attribute))]
+      end.to_h
+    end
+end

--- a/app/decorators/raster_resource_decorator.rb
+++ b/app/decorators/raster_resource_decorator.rb
@@ -13,6 +13,7 @@ class RasterResourceDecorator < Valkyrie::ResourceDecorator
       :coverage
     ]
   )
+  delegate(*Schema::Geo.attributes, to: :primary_imported_metadata, prefix: :imported)
 
   def attachable_objects
     [RasterResource, VectorWork]
@@ -32,6 +33,30 @@ class RasterResourceDecorator < Valkyrie::ResourceDecorator
     end
   end
 
+  def imported_attribute(attribute_key)
+    return primary_imported_metadata.send(attribute_key) if primary_imported_metadata.try(attribute_key)
+    Array.wrap(primary_imported_metadata.attributes.fetch(attribute_key, []))
+  end
+
+  # Access the resource attributes imported from an external service
+  # @return [Hash] a Hash of all of the resource attributes
+  def imported_attributes
+    @imported_attributes ||= ImportedAttributes.new(subject: self, keys: self.class.displayed_attributes).to_h
+  end
+
+  def imported_language
+    imported_attribute(:language).map do |language|
+      ControlledVocabulary.for(:language).find(language).label
+    end
+  end
+  alias display_imported_language imported_language
+
+  def language
+    (super || []).map do |language|
+      ControlledVocabulary.for(:language).find(language).label
+    end
+  end
+
   def manageable_structure?
     false
   end
@@ -47,7 +72,8 @@ class RasterResourceDecorator < Valkyrie::ResourceDecorator
   end
 
   def rendered_coverage
-    h.bbox_display(coverage)
+    display_coverage = coverage || imported_metadata.try(:first).try(:coverage)
+    h.bbox_display(display_coverage)
   end
 
   def rendered_rights_statement

--- a/app/decorators/scanned_map_decorator.rb
+++ b/app/decorators/scanned_map_decorator.rb
@@ -29,8 +29,7 @@ class ScannedMapDecorator < Valkyrie::ResourceDecorator
       :thumbnail_id
     ]
   )
-
-  delegate(*Schema::Common.attributes, to: :primary_imported_metadata, prefix: :imported)
+  delegate(*Schema::Geo.attributes, to: :primary_imported_metadata, prefix: :imported)
 
   def attachable_objects
     [ScannedMap, RasterResource]
@@ -104,7 +103,8 @@ class ScannedMapDecorator < Valkyrie::ResourceDecorator
   end
 
   def rendered_coverage
-    h.bbox_display(coverage)
+    display_coverage = coverage || imported_metadata.try(:first).try(:coverage)
+    h.bbox_display(display_coverage)
   end
 
   def rendered_links

--- a/app/decorators/vector_work_decorator.rb
+++ b/app/decorators/vector_work_decorator.rb
@@ -13,15 +13,10 @@ class VectorWorkDecorator < Valkyrie::ResourceDecorator
       :coverage
     ]
   )
+  delegate(*Schema::Geo.attributes, to: :primary_imported_metadata, prefix: :imported)
 
-  def members
-    @members ||= query_service.find_members(resource: model).to_a
-  end
-
-  # Use case for nesting vector works
-  #   - time series: e.g., nyc transit system, released every 6 months
-  def vector_work_members
-    @vector_works ||= members.select { |r| r.is_a?(VectorWork) }.map(&:decorate).to_a
+  def attachable_objects
+    [VectorWork]
   end
 
   def geo_members
@@ -36,6 +31,43 @@ class VectorWorkDecorator < Valkyrie::ResourceDecorator
       next unless member.respond_to?(:mime_type)
       ControlledVocabulary.for(:geo_metadata_format).include?(member.mime_type.first)
     end
+  end
+
+  def imported_attribute(attribute_key)
+    return primary_imported_metadata.send(attribute_key) if primary_imported_metadata.try(attribute_key)
+    Array.wrap(primary_imported_metadata.attributes.fetch(attribute_key, []))
+  end
+
+  # Access the resource attributes imported from an external service
+  # @return [Hash] a Hash of all of the resource attributes
+  def imported_attributes
+    @imported_attributes ||= ImportedAttributes.new(subject: self, keys: self.class.displayed_attributes).to_h
+  end
+
+  def imported_language
+    imported_attribute(:language).map do |language|
+      ControlledVocabulary.for(:language).find(language).label
+    end
+  end
+  alias display_imported_language imported_language
+
+  def language
+    (super || []).map do |language|
+      ControlledVocabulary.for(:language).find(language).label
+    end
+  end
+
+  def manageable_structure?
+    false
+  end
+
+  def members
+    @members ||= query_service.find_members(resource: model).to_a
+  end
+
+  def rendered_coverage
+    display_coverage = coverage || imported_metadata.try(:first).try(:coverage)
+    h.bbox_display(display_coverage)
   end
 
   def rendered_rights_statement
@@ -53,15 +85,9 @@ class VectorWorkDecorator < Valkyrie::ResourceDecorator
     end
   end
 
-  def rendered_coverage
-    h.bbox_display(coverage)
-  end
-
-  def manageable_structure?
-    false
-  end
-
-  def attachable_objects
-    [VectorWork]
+  # Use case for nesting vector works
+  #   - time series: e.g., nyc transit system, released every 6 months
+  def vector_work_members
+    @vector_works ||= members.select { |r| r.is_a?(VectorWork) }.map(&:decorate).to_a
   end
 end

--- a/app/models/imported_metadata.rb
+++ b/app/models/imported_metadata.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class ImportedMetadata < Valkyrie::Resource
-  include Schema::Common
+  include Schema::Geo
 end

--- a/app/models/raster_resource.rb
+++ b/app/models/raster_resource.rb
@@ -6,6 +6,7 @@ class RasterResource < Valhalla::Resource
   attribute :id, Valkyrie::Types::ID.optional
   attribute :member_ids, Valkyrie::Types::Array
   attribute :member_of_collection_ids
+  attribute :imported_metadata, Valkyrie::Types::Set.member(ImportedMetadata).optional
   attribute :state
   attribute :workflow_note, Valkyrie::Types::Array.member(WorkflowNote).optional
   attribute :file_metadata, Valkyrie::Types::Set.member(FileMetadata.optional)
@@ -17,5 +18,14 @@ class RasterResource < Valhalla::Resource
 
   def geo_resource?
     true
+  end
+
+  def primary_imported_metadata
+    Array.wrap(imported_metadata).first || ImportedMetadata.new
+  end
+
+  def title
+    imported_title = primary_imported_metadata.title.present? ? primary_imported_metadata.title : []
+    @title.present? ? @title : imported_title
   end
 end

--- a/app/models/scanned_map.rb
+++ b/app/models/scanned_map.rb
@@ -30,4 +30,9 @@ class ScannedMap < Valhalla::Resource
   def geo_resource?
     true
   end
+
+  def title
+    imported_title = primary_imported_metadata.title.present? ? primary_imported_metadata.title : []
+    @title.present? ? @title : imported_title
+  end
 end

--- a/app/models/vector_work.rb
+++ b/app/models/vector_work.rb
@@ -6,6 +6,7 @@ class VectorWork < Valhalla::Resource
   attribute :id, Valkyrie::Types::ID.optional
   attribute :member_ids, Valkyrie::Types::Array
   attribute :member_of_collection_ids
+  attribute :imported_metadata, Valkyrie::Types::Set.member(ImportedMetadata).optional
   attribute :state
   attribute :workflow_note, Valkyrie::Types::Array.member(WorkflowNote).optional
   attribute :file_metadata, Valkyrie::Types::Set.member(FileMetadata.optional)
@@ -17,5 +18,14 @@ class VectorWork < Valhalla::Resource
 
   def geo_resource?
     true
+  end
+
+  def primary_imported_metadata
+    Array.wrap(imported_metadata).first || ImportedMetadata.new
+  end
+
+  def title
+    imported_title = primary_imported_metadata.title.present? ? primary_imported_metadata.title : []
+    @title.present? ? @title : imported_title
   end
 end

--- a/app/services/geo_resources/discovery/document_builder.rb
+++ b/app/services/geo_resources/discovery/document_builder.rb
@@ -28,7 +28,7 @@ module GeoResources
       self.root_path_class = DocumentPath
 
       def initialize(record, document)
-        @resource_decorator = record.decorate
+        @resource_decorator = GeoblacklightMetadataDecorator.new(record.decorate)
         @document = document
         builders.build(document)
       end

--- a/app/services/geo_resources/discovery/document_builder/iiif_builder.rb
+++ b/app/services/geo_resources/discovery/document_builder/iiif_builder.rb
@@ -58,7 +58,7 @@ module GeoResources
           end
 
           def manifestable?
-            resource_decorator.class.try(:can_have_manifests?)
+            resource_decorator.model.class.can_have_manifests?
           end
 
           # Returns a map set's representative file set decorator.

--- a/app/services/geo_resources/discovery/document_builder/relationship_builder.rb
+++ b/app/services/geo_resources/discovery/document_builder/relationship_builder.rb
@@ -27,7 +27,7 @@ module GeoResources
           end
 
           def scanned_map?
-            resource_decorator.is_a?(ScannedMap)
+            resource_decorator.model.is_a?(ScannedMap)
           end
 
           # Returns an array of parent document ids (slugs).

--- a/spec/change_set_persisters/plum_change_set_persister_spec.rb
+++ b/spec/change_set_persisters/plum_change_set_persister_spec.rb
@@ -35,25 +35,62 @@ RSpec.describe PlumChangeSetPersister do
       expect(output.primary_imported_metadata.source_jsonld).not_to be_blank
     end
   end
-  context "when a source_metadata_identifier is set for the first time on a map image" do
+  context "when a source_metadata_identifier is set for the first time on a scanned map" do
     let(:change_set_class) { ScannedMapChangeSet }
     before do
       stub_bibdata(bib_id: '6592452')
       stub_ezid(shoulder: "99999/fk4", blade: "123456")
     end
-    it "applies remote metadata from bibdata directly to the resource" do
+    it "applies remote metadata from bibdata to an imported metadata resource" do
       resource = FactoryBot.build(:scanned_map, title: [])
       change_set = change_set_class.new(resource)
       change_set.validate(source_metadata_identifier: '6592452')
       change_set.sync
       output = change_set_persister.save(change_set: change_set)
 
-      expect(output.title).to eq ["Brazil, Uruguay, Paraguay & Guyana"]
-      expect(output.creator).to eq ["Bartholomew, John, 1805-1861"]
-      expect(output.subject).to eq ["Brazil—Maps", "Guiana—Maps", "Paraguay—Maps", "Uruguay—Maps"]
-      expect(output.spatial).to eq ["Brazil", "Uruguay", "Paraguay", "Guyana"]
+      expect(output.primary_imported_metadata.title).to eq [RDF::Literal.new("Brazil, Uruguay, Paraguay & Guyana", language: :eng)]
+      expect(output.primary_imported_metadata.creator).to eq ["Bartholomew, John, 1805-1861"]
+      expect(output.primary_imported_metadata.subject).to eq ["Brazil—Maps", "Guiana—Maps", "Paraguay—Maps", "Uruguay—Maps"]
+      expect(output.primary_imported_metadata.spatial).to eq ["Brazil", "Uruguay", "Paraguay", "Guyana"]
     end
   end
+
+  context "when a source_metadata_identifier is set for the first time on a vector work" do
+    let(:change_set_class) { VectorWorkChangeSet }
+    before do
+      stub_bibdata(bib_id: '9649080')
+      stub_ezid(shoulder: "99999/fk4", blade: "123456")
+    end
+    it "applies remote metadata from bibdata to an imported metadata resource" do
+      resource = FactoryBot.build(:vector_work, title: [])
+      change_set = change_set_class.new(resource)
+      change_set.validate(source_metadata_identifier: '9649080')
+      change_set.sync
+      output = change_set_persister.save(change_set: change_set)
+
+      expect(output.primary_imported_metadata.title).to eq ["Syria 100K Vector Dataset"]
+      expect(output.primary_imported_metadata.creator).to eq ["East View Geospatial, Inc"]
+    end
+  end
+
+  context "when a source_metadata_identifier is set for the first time on a raster resource" do
+    let(:change_set_class) { RasterResourceChangeSet }
+    before do
+      stub_bibdata(bib_id: '9637153')
+      stub_ezid(shoulder: "99999/fk4", blade: "123456")
+    end
+    it "applies remote metadata from bibdata to an imported metadata resource" do
+      resource = FactoryBot.build(:raster_resource, title: [])
+      change_set = change_set_class.new(resource)
+      change_set.validate(source_metadata_identifier: '9637153')
+      change_set.sync
+      output = change_set_persister.save(change_set: change_set)
+
+      expect(output.primary_imported_metadata.title).to eq ["Laos : 1:50,000 scale : Digital Raster graphics (DRGs) of topographic maps : complete coverage of the country (Full GeoTiff); 403 maps"]
+      expect(output.primary_imported_metadata.creator).to eq ["Land Info Worldwide Mapping, LLC"]
+    end
+  end
+
   context "when a resource is completed" do
     let(:shoulder) { '99999/fk4' }
     let(:blade) { '123456' }
@@ -146,15 +183,15 @@ RSpec.describe PlumChangeSetPersister do
       stub_bibdata(bib_id: '6866386')
       stub_ezid(shoulder: "99999/fk4", blade: "6866386")
     end
-    it "applies remote metadata from bibdata, without identifier, directly to resource" do
+    it "applies remote metadata from bibdata" do
       resource = FactoryBot.build(:scanned_map, title: [])
       change_set = change_set_class.new(resource)
       change_set.validate(source_metadata_identifier: '6866386')
       change_set.sync
       output = change_set_persister.save(change_set: change_set)
 
-      expect(output.title).to eq [RDF::Literal.new("Eastern Turkey in Asia. Malatia, sheet 16. Series I.D.W.O. no. 1522", language: :und)]
-      expect(output.identifier).to be nil
+      expect(output.primary_imported_metadata.title).to eq [RDF::Literal.new("Eastern Turkey in Asia. Malatia, sheet 16. Series I.D.W.O. no. 1522", language: :und)]
+      expect(output.source_metadata_identifier).to eq ['6866386']
     end
   end
 

--- a/spec/change_sets/raster_resource_change_set_spec.rb
+++ b/spec/change_sets/raster_resource_change_set_spec.rb
@@ -100,10 +100,4 @@ RSpec.describe RasterResourceChangeSet do
       expect(change_set.workflow.pending?).to be true
     end
   end
-
-  describe "#apply_remote_metadata_directly?" do
-    it "applies remote metadata directly to the model" do
-      expect(change_set.apply_remote_metadata_directly?).to be true
-    end
-  end
 end

--- a/spec/change_sets/vector_work_change_set_spec.rb
+++ b/spec/change_sets/vector_work_change_set_spec.rb
@@ -100,10 +100,4 @@ RSpec.describe VectorWorkChangeSet do
       expect(change_set.workflow.pending?).to be true
     end
   end
-
-  describe "#apply_remote_metadata_directly?" do
-    it "applies remote metadata directly to the model" do
-      expect(change_set.apply_remote_metadata_directly?).to be true
-    end
-  end
 end

--- a/spec/decorators/raster_resource_decorator_spec.rb
+++ b/spec/decorators/raster_resource_decorator_spec.rb
@@ -24,6 +24,33 @@ RSpec.describe RasterResourceDecorator do
   it "cannot manage structure" do
     expect(decorator.manageable_structure?).to be false
   end
+  describe "#display_imported_language" do
+    context "with imported metadata" do
+      let(:resource) do
+        FactoryBot.build(:raster_resource,
+                         title: "test title",
+                         imported_metadata: [{
+                           language: "eng"
+                         }])
+      end
+
+      it "maps keys to english strings" do
+        expect(decorator.display_imported_language).to eq ["English"]
+      end
+    end
+  end
+  describe "#language" do
+    context "with direct metadata" do
+      let(:resource) do
+        FactoryBot.build(:raster_resource,
+                         title: "test title",
+                         language: ["eng"])
+      end
+      it "exposes the language" do
+        expect(decorator.language).to eq ["English"]
+      end
+    end
+  end
   context "with file sets" do
     let(:file_set) do
       adapter = Valkyrie::MetadataAdapter.find(:indexing_persister)

--- a/spec/decorators/scanned_map_decorator_spec.rb
+++ b/spec/decorators/scanned_map_decorator_spec.rb
@@ -43,17 +43,31 @@ RSpec.describe ScannedMapDecorator do
   it "can manage structure" do
     expect(decorator.manageable_structure?).to be true
   end
-  describe '#language' do
-    let(:resource) do
-      FactoryBot.build(:scanned_map,
-                       title: "test title",
-                       author: "test author",
-                       creator: "test creator",
-                       subject: "test subject",
-                       language: ["eng"])
+  describe "#display_imported_language" do
+    context "with imported metadata" do
+      let(:resource) do
+        FactoryBot.build(:scanned_map,
+                         title: "test title",
+                         imported_metadata: [{
+                           language: "eng"
+                         }])
+      end
+
+      it "maps keys to english strings" do
+        expect(decorator.display_imported_language).to eq ["English"]
+      end
     end
-    it "exposes the language" do
-      expect(decorator.language).to eq ['English']
+  end
+  describe "#language" do
+    context "with direct metadata" do
+      let(:resource) do
+        FactoryBot.build(:scanned_map,
+                         title: "test title",
+                         language: ["eng"])
+      end
+      it "exposes the language" do
+        expect(decorator.language).to eq ["English"]
+      end
     end
   end
   context "with file sets" do

--- a/spec/decorators/vector_work_decorator_spec.rb
+++ b/spec/decorators/vector_work_decorator_spec.rb
@@ -24,6 +24,33 @@ RSpec.describe VectorWorkDecorator do
   it "cannot manage structure" do
     expect(decorator.manageable_structure?).to be false
   end
+  describe "#display_imported_language" do
+    context "with imported metadata" do
+      let(:resource) do
+        FactoryBot.build(:vector_work,
+                         title: "test title",
+                         imported_metadata: [{
+                           language: "eng"
+                         }])
+      end
+
+      it "maps keys to english strings" do
+        expect(decorator.display_imported_language).to eq ["English"]
+      end
+    end
+  end
+  describe "#language" do
+    context "with direct metadata" do
+      let(:resource) do
+        FactoryBot.build(:vector_work,
+                         title: "test title",
+                         language: ["eng"])
+      end
+      it "exposes the language" do
+        expect(decorator.language).to eq ["English"]
+      end
+    end
+  end
   context "with file sets" do
     let(:file_set) do
       adapter = Valkyrie::MetadataAdapter.find(:indexing_persister)

--- a/spec/fixtures/files/bibdata/9637153.jsonld
+++ b/spec/fixtures/files/bibdata/9637153.jsonld
@@ -1,0 +1,16 @@
+{
+  "@context": "http://bibdata.princeton.edu/context.json",
+  "@id": "http://bibdata.princeton.edu/bibliographic/9637153",
+  "title": "Laos : 1:50,000 scale : Digital Raster graphics (DRGs) of topographic maps : complete coverage of the country (Full GeoTiff); 403 maps",
+  "language":"eng",
+  "creator": "Land Info Worldwide Mapping, LLC",
+  "extent": "External Hard Drive",
+  "format": "Map",
+  "description": "1:50,000 Scale",
+  "publisher": "Highlands Ranch, Co.: Land Info Worldwide Mapping, [2016]",
+  "title_sort": "Laos : 1:50,000 scale : Digital Raster graphics (DRGs) of topographic maps : complete coverage of the country (Full GeoTiff); 403 maps.",
+  "alternative": "Digital Raster graphics (DRGs) of topographic maps : complete coverage of the country (Full GeoTiff); 403 maps : Laos",
+  "author": "Land Info Worldwide Mapping, LLC",
+  "created": "2016-01-01T00:00:00Z",
+  "date": "2016"
+}

--- a/spec/fixtures/files/bibdata/9649080.jsonld
+++ b/spec/fixtures/files/bibdata/9649080.jsonld
@@ -1,0 +1,16 @@
+{
+  "@context": "http://bibdata.princeton.edu/context.json",
+  "@id": "http://bibdata.princeton.edu/bibliographic/9649080",
+  "title": "Syria 100K Vector Dataset",
+  "language":"eng",
+  "creator": "East View Geospatial, Inc",
+  "extent": "External Hard Drive",
+  "edition": "Bilingual edition",
+  "format": "Map",
+  "description": "Scale",
+  "publisher": "Minnetonka, MN : East View Geospatial, Inc., 2016.",
+  "title_sort": "Syria 100K Vector Dataset",
+  "author": "East View Geospatial, Inc",
+  "created": "2016-01-01T00:00:00Z",
+  "date": "2016"
+}

--- a/spec/services/geo_resources/discovery/document_builder_spec.rb
+++ b/spec/services/geo_resources/discovery/document_builder_spec.rb
@@ -98,7 +98,26 @@ describe GeoResources::Discovery::DocumentBuilder do
     let(:change_set) { ScannedMapChangeSet.new(geo_work, files: []) }
 
     before do
+      stub_bibdata(bib_id: '5144620')
       change_set_persister.save(change_set: change_set)
+    end
+
+    context 'with remote metadata' do
+      let(:geo_work) do
+        FactoryBot.create_for_repository(:scanned_map,
+                                         source_metadata_identifier: '5144620',
+                                         coverage: coverage.to_s,
+                                         subject: ['Sanborn', 'Mount Holly (N.J.)—Maps'],
+                                         visibility: visibility,
+                                         identifier: 'ark:/99999/fk4',
+                                         imported_metadata: [{
+                                           subject: ['Mount Holly (N.J.)—Maps']
+                                         }])
+      end
+
+      it 'merges and deduplicates direct and imported attributes' do
+        expect(document['dc_subject_sm']).to eq ['Mount Holly (N.J.)—Maps', 'Sanborn']
+      end
     end
 
     context 'with no description' do

--- a/spec/services/plum_scanned_map_importer_spec.rb
+++ b/spec/services/plum_scanned_map_importer_spec.rb
@@ -88,10 +88,10 @@ RSpec.describe PlumScannedMapImporter do
 
       members = query_service.find_members(resource: output).to_a
       expect(members[0]).to be_a ScannedMap
-      expect(members[0].title).to eq ["Mount Holly, N.J. (Sheet 1)."]
+      expect(members[0].title.first.to_s).to eq "Mount Holly, N.J. (Sheet 1)."
       expect(members[0].visibility).to eq [Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED]
       expect(members[0].member_ids.length).to eq 1
-      expect(members[1].title).to eq ["Mount Holly, N.J. (Sheet 2)."]
+      expect(members[1].title.first.to_s).to eq "Mount Holly, N.J. (Sheet 2)."
       expect(members[1].member_ids.length).to eq 1
       expect(output.thumbnail_id).to eq [members[0].member_ids.first]
 


### PR DESCRIPTION
- Geo resources now use imported metadata to store metadata from Voyager. Allows for adding additional metadata on the resource such as additional non-LC subject terms and place names.
- Implements a decorator for generating geoblacklight documents. Decorator merges, and deduplicates, imported with non-imported data. 

Closes #925 