### PR TITLE
Add processing note for scanned map images

### DIFF
--- a/app/characterization_services/geo_characterization_service.rb
+++ b/app/characterization_services/geo_characterization_service.rb
@@ -19,6 +19,7 @@ class GeoCharacterizationService
   #   Valkyrie::Derivatives::FileCharacterizationService.for(file_node, persister).characterize(save: false)
   def characterize(save: true)
     TikaFileCharacterizationService.new(file_node: file_node, persister: persister).characterize
+    scanned_map_characterization_service.characterize if scanned_map_characterization_service.valid?
     vector_characterization_service.characterize if vector_characterization_service.valid?
     raster_characterization_service.characterize if raster_characterization_service.valid?
     external_metadata_service.characterize if external_metadata_service.valid?
@@ -34,6 +35,10 @@ class GeoCharacterizationService
 
   def external_metadata_service
     @external_metadata_service ||= ExternalMetadataCharacterizationService.new(file_node: file_node, persister: persister)
+  end
+
+  def scanned_map_characterization_service
+    @scanned_map_characterization_service ||= ScannedMapCharacterizationService.new(file_node: file_node, persister: persister)
   end
 
   def raster_characterization_service

--- a/app/characterization_services/scanned_map_characterization_service.rb
+++ b/app/characterization_services/scanned_map_characterization_service.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Class for characterizatizing scanned maps. Adds processing note.
+class ScannedMapCharacterizationService
+  attr_reader :file_node, :persister
+  def initialize(file_node:, persister:)
+    @file_node = file_node
+    @persister = persister
+  end
+
+  # characterizes the file_node passed into this service
+  # Default options are:
+  #   save: true
+  # @param save [Boolean] should the persister save the file_node after Characterization
+  # @return [FileNode]
+  # @example characterize a file and persist the changes by default
+  #   Valkyrie::Derivatives::FileCharacterizationService.for(file_node, persister).characterize
+  # @example characterize a file and do not persist the changes
+  #   Valkyrie::Derivatives::FileCharacterizationService.for(file_node, persister).characterize(save: false)
+  def characterize(save: true)
+    @file_characterization_attributes = {
+      processing_note: processing_note
+    }
+    new_file = original_file.new(@file_characterization_attributes.to_h)
+    @file_node.file_metadata = @file_node.file_metadata.select { |x| x.id != new_file.id } + [new_file]
+    @persister.save(resource: @file_node) if save
+    @file_node
+  end
+
+  def original_file
+    @file_node.original_file
+  end
+
+  def parent
+    file_node.decorate.parent
+  end
+
+  def processing_note
+    Figgy.config["scanned_map_processing_note"]
+  end
+
+  def valid?
+    parent.is_a?(ScannedMap)
+  end
+end

--- a/app/decorators/file_set_decorator.rb
+++ b/app/decorators/file_set_decorator.rb
@@ -4,6 +4,9 @@ class FileSetDecorator < Valkyrie::ResourceDecorator
     [
       :height,
       :width,
+      :x_resolution,
+      :y_resolution,
+      :bits_per_sample,
       :mime_type,
       :size,
       :md5,
@@ -11,7 +14,8 @@ class FileSetDecorator < Valkyrie::ResourceDecorator
       :sha256,
       :camera_model,
       :software,
-      :geometry
+      :geometry,
+      :processing_note
     ]
   )
 

--- a/app/models/file_metadata.rb
+++ b/app/models/file_metadata.rb
@@ -17,6 +17,7 @@ class FileMetadata < Valkyrie::Resource
   attribute :use, Valkyrie::Types::Set
   attribute :size, Valkyrie::Types::Set
   attribute :geometry, Valkyrie::Types::Set
+  attribute :processing_note, Valkyrie::Types::Set
 
   # fixity attributes
   attribute :fixity_actual_checksum, Valkyrie::Types::Set

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -8,7 +8,7 @@ class FileSet < Valhalla::Resource
   attribute :depositor
   attribute :local_identifier
 
-  delegate :width, :height, :mime_type, :size, :camera_model, :software, :geometry, :run_fixity, to: :original_file, allow_nil: true
+  delegate :width, :height, :x_resolution, :y_resolution, :bits_per_sample, :mime_type, :size, :camera_model, :software, :geometry, :run_fixity, :processing_note, to: :original_file, allow_nil: true
   delegate :md5, :sha1, :sha256, to: :original_file_checksum, allow_nil: true
 
   def thumbnail_id

--- a/config/config.yml
+++ b/config/config.yml
@@ -9,6 +9,7 @@ defaults: &defaults
   plum_derivative_path: "/mnt/libimages1/data/jp2s/plum_prod"
   bag_path: <%= Rails.root.join("tmp", "bags") %>
   pudl_root: <%= Rails.root.join("tmp", "pudl_root") %>
+  scanned_map_processing_note: <%= ENV.fetch('SCANNED_MAP_PROCESSING_NOTE', 'Scanned with an HD Ultra i4290s scanner using Nextimage 4.5.2 software') %>
   jp2_recipes:
     default_color: >
       -rate 2.4,1.48331273,.91673033,.56657224,.35016049,.21641118,.13374944,.08266171

--- a/spec/characterization_services/scanned_map_characterization_service_spec.rb
+++ b/spec/characterization_services/scanned_map_characterization_service_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'valkyrie/specs/shared_specs'
+include ActionDispatch::TestProcess
+
+RSpec.describe ScannedMapCharacterizationService do
+  let(:file_characterization_service) { described_class }
+  let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
+  let(:storage_adapter) { Valkyrie.config.storage_adapter }
+  let(:persister) { adapter.persister }
+  let(:query_service) { adapter.query_service }
+  let(:file) { fixture_file_upload('files/example.tif', 'image/tiff') }
+  let(:change_set_persister) { PlumChangeSetPersister.new(metadata_adapter: adapter, storage_adapter: storage_adapter) }
+  let(:map) do
+    change_set_persister.save(change_set: ScannedMapChangeSet.new(ScannedMap.new, files: [file]))
+  end
+  let(:map_members) { query_service.find_members(resource: map) }
+  let(:valid_file_set) { map_members.first }
+
+  describe "#characterize" do
+    it 'sets the processing note attribute for a file_node on characterize' do
+      t_file_node = valid_file_set
+      t_file_node.original_file.width = nil
+      new_file_node = described_class.new(file_node: t_file_node, persister: persister).characterize(save: false)
+      expect(new_file_node.original_file.processing_note).not_to be_empty
+    end
+  end
+
+  describe "#valid?" do
+    let(:subject) { described_class.new(file_node: valid_file_set, persister: persister).valid? }
+
+    it { is_expected.to be true }
+  end
+end


### PR DESCRIPTION
- Add processing note property to file metadata.
- Creates characterization service to add boilerplate text into the field for scanned map original files.
- Makes the existing x_resolution, y_resolution, and bits_per_sample properties visible in the file set view.

Closes #930 