### PR TITLE
Ensures that users need not be authenticated in order to download derivatives in the PDF

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,6 +78,7 @@ Metrics/MethodLength:
     - 'app/controllers/file_sets_controller.rb'
     - 'valhalla/app/controllers/concerns/valhalla/resource_controller.rb'
     - 'app/services/folder_json_importer.rb'
+    - 'app/models/ability.rb'
 Metrics/ModuleLength:
   Exclude:
     - 'app/models/schema/marc_relators.rb'

--- a/spec/requests/scanned_resource_spec.rb
+++ b/spec/requests/scanned_resource_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+require 'rails_helper'
+include ActionDispatch::TestProcess
+
+RSpec.describe "ScannedResource requests", type: :request do
+  with_queue_adapter :inline
+  let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
+  let(:sample_file) { fixture_file_upload('files/example.tif', 'image/tiff') }
+  let(:scanned_resource) { FactoryBot.create_for_repository(:scanned_resource, files: [sample_file]) }
+  let(:file_set) { scanned_resource.member_ids.first }
+  let(:user) { FactoryBot.create(:admin) }
+
+  before do
+    stub_request(:any, "http://www.example.com/image-service/#{file_set.id}/full/200,287/0/gray.jpg")
+      .to_return(body: File.open(Rails.root.join("spec", "fixtures", "files", "derivatives", "grey-pdf.jpg")), status: 200)
+  end
+
+  it 'serves derivatives in the PDF' do
+    get "/concern/scanned_resources/#{scanned_resource.id}/pdf"
+
+    reloaded = adapter.query_service.find_by(id: scanned_resource.id)
+    expect(response).to redirect_to Valhalla::Engine.routes.url_helpers.download_path(resource_id: scanned_resource.id.to_s, id: reloaded.pdf_file.id.to_s)
+
+    follow_redirect!
+
+    expect(response.status).to eq 200
+    expect(response.body).not_to be_empty
+    expect(response.content_length).to be > 0
+    expect(response.content_type).to eq 'application/pdf'
+    expect(response.headers['Content-Disposition']).to eq 'inline; filename="derivative_pdf.pdf"'
+  end
+
+  context 'when other derivatives are requested' do
+    let(:download_path) { Valhalla::Engine.routes.url_helpers.download_path(resource_id: scanned_resource.id.to_s, id: file_set.id.to_s) }
+
+    it 'redirects the client to be authenticated' do
+      get download_path
+      expect(response).to redirect_to user_cas_omniauth_authorize_path
+    end
+  end
+
+  context 'when the resource is privately accessible' do
+    let(:scanned_resource) { FactoryBot.create_for_repository(:complete_private_scanned_resource, files: [sample_file]) }
+
+    it 'redirects the client to be authenticated' do
+      get "/concern/scanned_resources/#{scanned_resource.id}/pdf"
+
+      reloaded = adapter.query_service.find_by(id: scanned_resource.id)
+      expect(response).to redirect_to Valhalla::Engine.routes.url_helpers.download_path(resource_id: scanned_resource.id.to_s, id: reloaded.pdf_file.id.to_s)
+
+      follow_redirect!
+      expect(response).to redirect_to user_cas_omniauth_authorize_path
+    end
+  end
+end

--- a/valhalla/app/controllers/valhalla/downloads_controller.rb
+++ b/valhalla/app/controllers/valhalla/downloads_controller.rb
@@ -42,6 +42,7 @@ class Valhalla::DownloadsController < ApplicationController
   # Customize the :download ability in your Ability class, or override this method
   def authorize_download!
     authorize! :download, resource
+    authorize! :download, load_file
   end
 
   # Copied from hydra-head and adjusted to handle the fact that we don't have a


### PR DESCRIPTION
Resolves #935