### PR TITLE
Stub rabbit on CleanupDerivativesJob and CreateDerivativesJob

### DIFF
--- a/spec/support/stub_rabbit.rb
+++ b/spec/support/stub_rabbit.rb
@@ -5,6 +5,26 @@ RSpec.configure do |config|
         instance_double(MessagingClient, publish: true, amqp_url: "http://example.com")
       end
 
+      allow_any_instance_of(CleanupDerivativesJob).to receive(:messenger) do
+        rabbit = instance_double(EventGenerator)
+        allow(rabbit).to receive(:derivatives_created)
+        allow(rabbit).to receive(:derivatives_deleted)
+        allow(rabbit).to receive(:record_created)
+        allow(rabbit).to receive(:record_updated)
+        allow(rabbit).to receive(:record_deleted)
+        rabbit
+      end
+
+      allow_any_instance_of(CreateDerivativesJob).to receive(:messenger) do
+        rabbit = instance_double(EventGenerator)
+        allow(rabbit).to receive(:derivatives_created)
+        allow(rabbit).to receive(:derivatives_deleted)
+        allow(rabbit).to receive(:record_created)
+        allow(rabbit).to receive(:record_updated)
+        allow(rabbit).to receive(:record_deleted)
+        rabbit
+      end
+
       allow_any_instance_of(PlumChangeSetPersister::Basic).to receive(:messenger) do
         rabbit = instance_double(EventGenerator)
         allow(rabbit).to receive(:derivatives_created)


### PR DESCRIPTION
Quiets bunny warnings when running tests.

Closes #992 