### PR TITLE
Add specs for methods without test coverage

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -123,6 +123,7 @@ RSpec/AnyInstance:
     - 'spec/jobs/ingest_mets_job_spec.rb'
     - 'spec/services/manifest_builder_spec.rb'
     - 'spec/services/geoblacklight_messaging_client_spec.rb'
+    - 'spec/services/geoserver_messaging_client_spec.rb'
     - 'spec/services/messaging_client_spec.rb'
     - 'spec/jobs/check_fixity_recursive_job_spec.rb'
     - 'spec/controllers/fixity_dashboard_controller_spec.rb'

--- a/spec/jobs/create_derivatives_job_spec.rb
+++ b/spec/jobs/create_derivatives_job_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe CreateDerivativesJob do
+  let(:derivatives_service) { instance_double(Valkyrie::Derivatives::DerivativeService) }
+  let(:file_set) { FactoryBot.create_for_repository(:file_set) }
+  let(:fixity_job) { instance_double(CheckFixityJob) }
+  let(:generator) { EventGenerator.new }
+
+  before do
+    allow(Valkyrie::Derivatives::DerivativeService).to receive(:for).and_return(derivatives_service)
+    allow(derivatives_service).to receive(:create_derivatives)
+    allow(EventGenerator).to receive(:new).and_return(generator)
+    allow(generator).to receive(:derivatives_created).and_call_original
+    allow(CheckFixityJob).to receive(:set).and_return(CheckFixityJob)
+    allow(CheckFixityJob).to receive(:perform_later)
+  end
+
+  describe "#perform_now" do
+    it "triggers a derivatives_created message and triggers a fixity job", rabbit_stubbed: true do
+      described_class.perform_now(file_set.id)
+      expect(generator).to have_received(:derivatives_created)
+      expect(CheckFixityJob).to have_received(:perform_later)
+    end
+  end
+end

--- a/spec/services/event_generator/geoserver_event_generator_spec.rb
+++ b/spec/services/event_generator/geoserver_event_generator_spec.rb
@@ -30,6 +30,16 @@ RSpec.describe EventGenerator::GeoserverEventGenerator do
   end
 
   describe "#valid?" do
+    context "with a raster file set with a derivative" do
+      let(:file) { fixture_file_upload("files/raster/geotiff.tif", "image/tif") }
+      let(:tika_output) { tika_geotiff_output }
+      let(:resource) { FactoryBot.create_for_repository(:raster_resource, files: [file]) }
+
+      it "publishes a persistent JSON message" do
+        expect(event_generator.valid?(record)).to be true
+      end
+    end
+
     context "with a scanned resource" do
       let(:record) { FactoryBot.create_for_repository(:scanned_resource) }
 
@@ -38,7 +48,7 @@ RSpec.describe EventGenerator::GeoserverEventGenerator do
       end
     end
 
-    context "with a raster file set without a derivative" do
+    context "with a file set without a derivative" do
       before do
         persister = Valkyrie.config.metadata_adapter.persister
         record.file_metadata = record.file_metadata.reject(&:derivative?)

--- a/spec/services/geoserver_messaging_client_spec.rb
+++ b/spec/services/geoserver_messaging_client_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe GeoserverMessagingClient do
+  subject(:client) { described_class.new(url) }
+  let(:url) { "amqp://test.x.z.s:4000" }
+  before do
+    allow_any_instance_of(Logger).to receive(:warn)
+  end
+  describe "#publish" do
+    context "when the URL is bad" do
+      it "doesn't error" do
+        expect { client.publish("testing") }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
Stubbing bunny in CreateDerivativesJob and CleanupDerivativesJob revealed some methods without test coverage. The resulting decrease in coverage was small enough to not trigger a failure. This PR adds specs to bring Figgy back up to 💯.

Closes #1011 