### PR TITLE
Add a simple draft-publish workflow for use with plates (SimpleResource), refs #1031

### DIFF
--- a/app/models/controlled_vocabulary.rb
+++ b/app/models/controlled_vocabulary.rb
@@ -72,6 +72,7 @@ class ControlledVocabulary
     ControlledVocabulary.register(:state_book_workflow, self)
     ControlledVocabulary.register(:state_folder_workflow, self)
     ControlledVocabulary.register(:state_box_workflow, self)
+    ControlledVocabulary.register(:state_draft_publish_workflow, self)
 
     # Access all of the terms within this vocabulary
     # @param scope an object restricting the terms retrieved

--- a/app/models/draft_publish_workflow.rb
+++ b/app/models/draft_publish_workflow.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Simple draft / published state-based workflow: Start as draft (will be
+# visible, but not able to view the manifest.) When published, the
+# manifest is visible.
+class DraftPublishWorkflow
+  include AASM
+
+  def initialize(state)
+    aasm.current_state = state.to_sym unless state.nil?
+  end
+
+  aasm do
+    state :draft, initial: true
+    state :published
+
+    # ingest workflow
+    event :publish do
+      transitions from: :draft, to: :published
+    end
+    event :unpublish do
+      transitions from: :published, to: :draft
+    end
+  end
+
+  # this workflow doesn't have a suppressed state but other code checks for it; make it false
+  def suppressed?
+    false
+  end
+
+  def valid_states
+    aasm.states.map(&:name).map(&:to_s)
+  end
+
+  def valid_transitions
+    aasm.states(permitted: true).map(&:name).map(&:to_s)
+  end
+end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -34,7 +34,7 @@ class SearchBuilder < Blacklight::SearchBuilder
   end
 
   def all_states
-    BookWorkflow.new(nil).valid_states + FolderWorkflow.new(nil).valid_states
+    BookWorkflow.new(nil).valid_states + FolderWorkflow.new(nil).valid_states + DraftPublishWorkflow.new(nil).valid_states
   end
 
   def models_to_solr_clause

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -116,3 +116,9 @@ en:
     all_in_production:
       label: 'All in Production'
       desc: 'Mark all contained folders as having received QA, and put them into the public display.'
+    draft:
+      label: 'Draft'
+      desc: 'Still in-progress, should not be published to public sites or manifests'
+    published:
+      label: 'Published'
+      desc: 'Published and accessible according to access control rules'

--- a/spec/models/draft_publish_workflow_spec.rb
+++ b/spec/models/draft_publish_workflow_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe DraftPublishWorkflow do
+  subject(:workflow) { described_class.new 'draft' }
+
+  describe 'ingest workflow' do
+    it 'proceeds through ingest workflow' do
+      # initial state: draft
+      expect(workflow.draft?).to be true
+      expect(workflow.may_publish?).to be true
+      expect(workflow.published?).to be false
+      expect(workflow.suppressed?).to eq false
+      expect(workflow.valid_transitions).to contain_exactly "published"
+
+      expect(workflow.publish).to be true
+      expect(workflow.published?).to be true
+      expect(workflow.may_unpublish?).to eq true
+      expect(workflow.draft?).to eq false
+      expect(workflow.suppressed?).to eq false
+      expect(workflow.valid_transitions).to contain_exactly "draft"
+
+      expect(workflow.unpublish).to eq true
+      expect(workflow.draft?).to eq true
+      expect(workflow.published?).to eq false
+      expect(workflow.may_publish?).to eq true
+      expect(workflow.suppressed?).to eq false
+      expect(workflow.valid_transitions).to contain_exactly "published"
+    end
+  end
+
+  it 'reports valid states' do
+    expect(workflow.valid_states).to eq %w[draft published]
+  end
+end


### PR DESCRIPTION
It's nearly identical to the folder workflow; the only difference is the names of the states / transitions.