### PR TITLE
Modify permissions to allow for anonymous downloading of geo files

### DIFF
--- a/valhalla/app/controllers/valhalla/downloads_controller.rb
+++ b/valhalla/app/controllers/valhalla/downloads_controller.rb
@@ -18,7 +18,7 @@ class Valhalla::DownloadsController < ApplicationController
 
   def load_file
     return unless binary_file && file_desc
-    @load_file ||= FileWithMetadata.new(id: params[:id], file: binary_file, mime_type: file_desc.mime_type, original_name: file_desc.original_filename.first)
+    @load_file ||= FileWithMetadata.new(id: params[:id], file: binary_file, mime_type: file_desc.mime_type, original_name: file_desc.original_filename.first, file_set_id: resource.id)
   end
 
   def file_desc
@@ -37,6 +37,7 @@ class Valhalla::DownloadsController < ApplicationController
     attribute :file, Valkyrie::Types::Any
     attribute :mime_type, Valkyrie::Types::SingleValuedString
     attribute :original_name, Valkyrie::Types::SingleValuedString
+    attribute :file_set_id, Valkyrie::Types::Any
   end
 
   # Customize the :download ability in your Ability class, or override this method


### PR DESCRIPTION
- Allows geo thumbnails and external metadata to be anonymously downloaded regardless of the visibility of the parent resource.
- Allows geo files (shapefiles, raster datasets, scanned map tiffs) to be anonymously downloaded when the parent resource is open (public). 
- Reorganizes and partially alphabetizes methods in Ability class.

Because of the way CanCanCan works in conjunction with Figgy; allowing anonymous downloading for different files on a file set required adding an attribute to the FileWithMetadata struct to hold the parent file set id

Closes #1025 
