### PR TITLE
Ensures that Dublin Core attributes are exposed for `SimpleResource` forms

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,6 +47,7 @@ Metrics/BlockLength:
     - 'valhalla/app/change_sets/valhalla/change_set_workflow.rb'
     - 'lib/tasks/bulk.rake'
     - 'lib/tasks/lae.rake'
+    - 'app/change_sets/simple_resource_change_set.rb'
 Metrics/ClassLength:
   Exclude:
     - 'app/change_set_persisters/plum_change_set_persister.rb'
@@ -81,6 +82,7 @@ Metrics/MethodLength:
     - 'app/services/folder_json_importer.rb'
     - 'app/models/ability.rb'
     - 'app/models/controlled_vocabulary.rb'
+    - 'app/change_sets/simple_resource_change_set.rb'
 Metrics/ModuleLength:
   Exclude:
     - 'app/models/schema/marc_relators.rb'

--- a/app/change_sets/simple_resource_change_set.rb
+++ b/app/change_sets/simple_resource_change_set.rb
@@ -22,6 +22,30 @@ class SimpleResourceChangeSet < Valhalla::ChangeSet
   property :file_metadata, multiple: true, required: false, default: []
   property :depositor, multiple: false, require: false
 
+  property :abstract, multiple: true, required: false, default: []
+  property :alternative, multiple: true, required: false, default: []
+  property :alternative_title, multiple: true, required: false, default: []
+  property :bibliographic_citation, multiple: true, required: false, default: []
+  property :contents, multiple: true, required: false, default: []
+  property :extent, multiple: true, required: false, default: []
+  property :genre, multiple: true, required: false, default: []
+  property :geo_subject, multiple: true, required: false, default: []
+  property :identifier, multiple: true, required: false, default: []
+  property :license, multiple: true, required: false, default: []
+  property :part_of, multiple: true, required: false, default: []
+  property :replaces, multiple: true, required: false, default: []
+  property :type, multiple: true, required: false, default: []
+  property :contributor, multiple: true, required: false, default: []
+  property :coverage, multiple: true, required: false, default: []
+  property :creator, multiple: true, required: false, default: []
+  property :date, multiple: true, required: false, default: []
+  property :description, multiple: true, required: false, default: []
+  property :keyword, multiple: true, required: false, default: []
+  property :language, multiple: true, required: false, default: []
+  property :publisher, multiple: true, required: false, default: []
+  property :source, multiple: true, required: false, default: []
+  property :subject, multiple: true, required: false, default: []
+
   # Virtual Attributes
   property :files, virtual: true, multiple: true, required: false
   property :pending_uploads, multiple: true, required: false
@@ -41,7 +65,30 @@ class SimpleResourceChangeSet < Valhalla::ChangeSet
       :portion_note,
       :nav_date,
       :member_of_collection_ids,
-      :append_id
+      :append_id,
+      :abstract,
+      :alternative,
+      :alternative_title,
+      :bibliographic_citation,
+      :contents,
+      :extent,
+      :genre,
+      :geo_subject,
+      :identifier,
+      :license,
+      :part_of,
+      :replaces,
+      :type,
+      :contributor,
+      :coverage,
+      :creator,
+      :date,
+      :description,
+      :keyword,
+      :language,
+      :publisher,
+      :source,
+      :subject
     ]
   end
 end

--- a/app/decorators/simple_resource_decorator.rb
+++ b/app/decorators/simple_resource_decorator.rb
@@ -48,7 +48,7 @@ class SimpleResourceDecorator < Valkyrie::ResourceDecorator
                          :thumbnail_id
 
   def members
-    @members ||= query_service.find_members(resource: model).to_a
+    @members ||= query_service.find_members(resource: model).map(&:decorate).to_a
   end
 
   def file_sets

--- a/app/views/catalog/_members_simple_resource.html.erb
+++ b/app/views/catalog/_members_simple_resource.html.erb
@@ -1,0 +1,40 @@
+<h2>Members</h2>
+<table id="members" class="table table-striped">
+  <thead>
+    <tr>
+     <th>Thumbnail</th>
+     <th>Title</th>
+     <th>Date Uploaded</th>
+     <th>Visibility</th>
+     <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% unless decorated_resource.members.empty? %>
+      <% decorated_resource.members.each do |member| %>
+        <% member_url = parent_solr_document_path("#{resource.id}", "#{member.id}") %>
+        <tr>
+          <td><%= link_to figgy_thumbnail_path(member, { class: 'thumbnail-inner', onerror: default_icon_fallback }), member_url %></td>
+          <td><%= member.first_title %></td>
+          <td><%= member.created_at %></td>
+          <td><%= member.visibility.first.html_safe %></td>
+          <td>
+            <%= link_to 'View', member_url, class: 'btn btn-default' %>
+            <%= link_to 'Edit', main_app.polymorphic_path([:edit, member]), class: 'btn btn-default' %>
+            <%= link_to "Delete", main_app.polymorphic_path([member]), class: 'btn btn-danger',
+                                  data: { confirm: "Delete this #{resource.human_readable_type}?" },
+                                  method: :delete %>
+          </td>
+        </tr>
+      <% end %>
+    <% else %>
+      <tr>
+        <td>This work has no members attached.  Click "Attach Child" to attach members.</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/records/edit_fields/_coverage.html.erb
+++ b/app/views/records/edit_fields/_coverage.html.erb
@@ -1,3 +1,3 @@
-<label class="control-label text optional" for="scanned_map_coverage">Coverage</label>
+<label class="control-label text optional" for="<%= ActiveModel::Naming.param_key(@change_set.resource) %>_coverage">Coverage</label>
 <%= f.input :coverage, as: :hidden %>
 <%= bbox_input(:coverage, @change_set) %>

--- a/spec/features/simple_resource_spec.rb
+++ b/spec/features/simple_resource_spec.rb
@@ -24,15 +24,40 @@ RSpec.feature "SimpleResources", js: true do
 
   scenario 'creating a new resource' do
     visit new_simple_resource_path
+    page.save_screenshot('screenshot.png')
 
     expect(page).to have_field 'Title'
-    expect(page).to have_field 'Rights Statement'
+    expect(page).to have_css '.select[for="simple_resource_rights_statement"]', text: 'Rights Statement'
     expect(page).to have_field 'Rights Note'
     expect(page).to have_field 'Local identifier'
-    expect(page).to have_field 'PDF Type'
+    expect(page).to have_css '.select[for="simple_resource_pdf_type"]', text: 'PDF Type'
     expect(page).to have_field 'Portion Note'
     expect(page).to have_field 'Navigation Date'
-    expect(page).to have_field 'Collections'
+    expect(page).to have_css '.select[for="simple_resource_member_of_collection_ids"]', text: 'Collections'
+
+    expect(page).to have_field 'Abstract'
+    expect(page).to have_field 'Alternative'
+    expect(page).to have_field 'Alternative title'
+    expect(page).to have_field 'Bibliographic citation'
+    expect(page).to have_field 'Contents'
+    expect(page).to have_field 'Extent'
+    expect(page).to have_field 'Genre'
+    expect(page).to have_field 'Geo subject'
+    expect(page).to have_field 'Identifier'
+    expect(page).to have_field 'License'
+    expect(page).to have_field 'Part of'
+    expect(page).to have_field 'Replaces'
+    expect(page).to have_field 'Type'
+    expect(page).to have_field 'Contributor'
+    expect(page).to have_css '.control-label[for="simple_resource_coverage"]', text: 'Coverage'
+    expect(page).to have_field 'Creator'
+    expect(page).to have_field 'Date'
+    expect(page).to have_field 'Description'
+    expect(page).to have_field 'Keyword'
+    expect(page).to have_field 'Language'
+    expect(page).to have_field 'Publisher'
+    expect(page).to have_field 'Source'
+    expect(page).to have_field 'Subject'
   end
 
   context 'when a user creates a new simple resource' do
@@ -45,8 +70,31 @@ RSpec.feature "SimpleResources", js: true do
         rights_note: 'test rights note',
         local_identifier: 'test ID',
         portion_note: 'test portion note',
-        nav_date: 'test navigation date',
-        member_of_collection_ids: [collection.id]
+        nav_date: '01/01/1970',
+        member_of_collection_ids: [collection.id],
+        abstract: 'test value',
+        alternative: 'test value',
+        alternative_title: 'test value',
+        bibliographic_citation: 'test value',
+        contents: 'test value',
+        extent: 'test value',
+        genre: 'test value',
+        geo_subject: 'test value',
+        identifier: 'test value',
+        license: 'test value',
+        part_of: 'test value',
+        replaces: 'test value',
+        type: 'test value',
+        contributor: 'test value',
+        coverage: 'test value',
+        creator: 'test value',
+        date: '01/01/1970',
+        description: 'test value',
+        keyword: 'test value',
+        language: 'test value',
+        publisher: 'test value',
+        source: 'test value',
+        subject: 'test value'
       )
     end
 
@@ -60,8 +108,32 @@ RSpec.feature "SimpleResources", js: true do
       expect(page).to have_css '.attribute.visibility', text: 'open'
       expect(page).to have_css '.attribute.local_identifier', text: 'test ID'
       expect(page).to have_css '.attribute.portion_note', text: 'test portion note'
-      expect(page).to have_css '.attribute.nav_date', text: 'test navigation date'
+      expect(page).to have_css '.attribute.nav_date', text: '01/01/1970'
       expect(page).to have_css '.attribute.member_of_collections', text: 'Title'
+
+      expect(page).to have_css '.attribute.abstract', text: 'test value'
+      expect(page).to have_css '.attribute.alternative', text: 'test value'
+      expect(page).to have_css '.attribute.alternative_title', text: 'test value'
+      expect(page).to have_css '.attribute.bibliographic_citation', text: 'test value'
+      expect(page).to have_css '.attribute.contents', text: 'test value'
+      expect(page).to have_css '.attribute.extent', text: 'test value'
+      expect(page).to have_css '.attribute.genre', text: 'test value'
+      expect(page).to have_css '.attribute.geo_subject', text: 'test value'
+      expect(page).to have_css '.attribute.identifier', text: 'test value'
+      expect(page).to have_css '.attribute.license', text: 'test value'
+      expect(page).to have_css '.attribute.part_of', text: 'test value'
+      expect(page).to have_css '.attribute.replaces', text: 'test value'
+      expect(page).to have_css '.attribute.type', text: 'test value'
+      expect(page).to have_css '.attribute.contributor', text: 'test value'
+      expect(page).to have_css '.attribute.coverage', text: 'test value'
+      expect(page).to have_css '.attribute.creator', text: 'test value'
+      expect(page).to have_css '.attribute.date', text: '01/01/1970'
+      expect(page).to have_css '.attribute.description', text: 'test value'
+      expect(page).to have_css '.attribute.keyword', text: 'test value'
+      expect(page).to have_css '.attribute.language', text: 'test value'
+      expect(page).to have_css '.attribute.publisher', text: 'test value'
+      expect(page).to have_css '.attribute.source', text: 'test value'
+      expect(page).to have_css '.attribute.subject', text: 'test value'
     end
   end
 

--- a/spec/features/simple_resource_spec.rb
+++ b/spec/features/simple_resource_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature "SimpleResources", js: true do
+  let(:user) { FactoryBot.create(:admin) }
+  let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
+  let(:persister) { adapter.persister }
+  let(:simple_resource) do
+    res = FactoryBot.create_for_repository(:simple_resource)
+    persister.save(resource: res)
+  end
+  let(:change_set) do
+    SimpleResourceChangeSet.new(simple_resource)
+  end
+  let(:change_set_persister) do
+    PlumChangeSetPersister.new(metadata_adapter: adapter, storage_adapter: Valkyrie.config.storage_adapter)
+  end
+
+  before do
+    change_set.sync
+    change_set_persister.save(change_set: change_set)
+    sign_in user
+  end
+
+  scenario 'creating a new resource' do
+    visit new_simple_resource_path
+
+    expect(page).to have_field 'Title'
+    expect(page).to have_field 'Rights Statement'
+    expect(page).to have_field 'Rights Note'
+    expect(page).to have_field 'Local identifier'
+    expect(page).to have_field 'PDF Type'
+    expect(page).to have_field 'Portion Note'
+    expect(page).to have_field 'Navigation Date'
+    expect(page).to have_field 'Collections'
+  end
+
+  context 'when a user creates a new simple resource' do
+    let(:collection) { FactoryBot.create_for_repository(:collection) }
+    let(:simple_resource) do
+      FactoryBot.create_for_repository(
+        :simple_resource,
+        title: 'new simple resource',
+        rights_statement: 'http://rightsstatements.org/vocab/CNE/1.0/',
+        rights_note: 'test rights note',
+        local_identifier: 'test ID',
+        portion_note: 'test portion note',
+        nav_date: 'test navigation date',
+        member_of_collection_ids: [collection.id]
+      )
+    end
+
+    scenario 'viewing a resource' do
+      visit solr_document_path simple_resource
+
+      expect(page).to have_css '.attribute.title', text: 'new simple resource'
+      expect(page).to have_css '.attribute.rights_statement', text: 'http://rightsstatements.org/vocab/CNE/1.0/'
+      expect(page).to have_css '.attribute.rights_note', text: 'test rights note'
+      expect(page).to have_css '.attribute.viewing_hint', text: 'individuals'
+      expect(page).to have_css '.attribute.visibility', text: 'open'
+      expect(page).to have_css '.attribute.local_identifier', text: 'test ID'
+      expect(page).to have_css '.attribute.portion_note', text: 'test portion note'
+      expect(page).to have_css '.attribute.nav_date', text: 'test navigation date'
+      expect(page).to have_css '.attribute.member_of_collections', text: 'Title'
+    end
+  end
+
+  context 'nested within an existing SimpleResource' do
+    let(:member) do
+      persister.save(resource: FactoryBot.create_for_repository(:simple_resource, title: 'member resource'))
+    end
+    let(:parent) do
+      persister.save(resource: FactoryBot.create_for_repository(:simple_resource, member_ids: [member.id]))
+    end
+    before do
+      parent
+    end
+
+    scenario 'saved SimpleResources are displayed as members' do
+      visit solr_document_path(parent)
+
+      expect(page).to have_selector 'h2', text: 'Members'
+      expect(page).to have_selector 'td', text: 'member resource'
+    end
+  end
+end


### PR DESCRIPTION
Resolves #1027 