### PR TITLE
Push state-based visibility logic into workflow classes and decorators

### DIFF
--- a/app/change_sets/ephemera_box_change_set.rb
+++ b/app/change_sets/ephemera_box_change_set.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class EphemeraBoxChangeSet < Valhalla::ChangeSet
-  apply_workflow BoxWorkflow
+  apply_workflow(WorkflowRegistry.workflow_for(EphemeraBox))
   validates :barcode, :box_number, :visibility, :rights_statement, presence: true
 
   include VisibilityProperty

--- a/app/change_sets/ephemera_folder_change_set_base.rb
+++ b/app/change_sets/ephemera_folder_change_set_base.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class EphemeraFolderChangeSetBase < Valhalla::ChangeSet
-  apply_workflow(FolderWorkflow)
+  apply_workflow(WorkflowRegistry.workflow_for(EphemeraFolder))
   validate :date_range_validity
   validate :subject_present
   validates_with StateValidator

--- a/app/change_sets/media_resource_change_set.rb
+++ b/app/change_sets/media_resource_change_set.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class MediaResourceChangeSet < Valhalla::ChangeSet
-  apply_workflow(BookWorkflow)
+  apply_workflow(WorkflowRegistry.workflow_for(MediaResource))
   delegate :human_readable_type, to: :resource
 
   include VisibilityProperty

--- a/app/change_sets/raster_resource_change_set.rb
+++ b/app/change_sets/raster_resource_change_set.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class RasterResourceChangeSet < Valhalla::ChangeSet
-  apply_workflow(BookWorkflow)
+  apply_workflow(WorkflowRegistry.workflow_for(RasterResource))
   delegate :human_readable_type, to: :model
 
   include GeoChangeSetProperties

--- a/app/change_sets/scanned_map_change_set.rb
+++ b/app/change_sets/scanned_map_change_set.rb
@@ -3,7 +3,7 @@
 class ScannedMapChangeSet < ScannedResourceChangeSet
   include GeoChangeSetProperties
 
-  apply_workflow(BookWorkflow)
+  apply_workflow(WorkflowRegistry.workflow_for(ScannedMap))
 
   property :relation, multiple: false, required: false
   property :references, multiple: false, required: false

--- a/app/change_sets/scanned_resource_change_set.rb
+++ b/app/change_sets/scanned_resource_change_set.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class ScannedResourceChangeSet < Valhalla::ChangeSet
-  apply_workflow(BookWorkflow)
+  apply_workflow(WorkflowRegistry.workflow_for(ScannedResource))
   delegate :human_readable_type, to: :model
 
   include VisibilityProperty

--- a/app/change_sets/simple_resource_change_set.rb
+++ b/app/change_sets/simple_resource_change_set.rb
@@ -2,7 +2,7 @@
 class SimpleResourceChangeSet < Valhalla::ChangeSet
   delegate :human_readable_type, to: :model
 
-  apply_workflow(DraftPublishWorkflow)
+  apply_workflow(WorkflowRegistry.workflow_for(SimpleResource))
 
   include VisibilityProperty
   property :title, multiple: true, required: true, default: []

--- a/app/change_sets/vector_resource_change_set.rb
+++ b/app/change_sets/vector_resource_change_set.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class VectorResourceChangeSet < Valhalla::ChangeSet
-  apply_workflow(BookWorkflow)
+  apply_workflow(WorkflowRegistry.workflow_for(VectorResource))
   delegate :human_readable_type, to: :model
 
   include GeoChangeSetProperties

--- a/app/decorators/ephemera_box_decorator.rb
+++ b/app/decorators/ephemera_box_decorator.rb
@@ -36,6 +36,12 @@ class EphemeraBoxDecorator < Valkyrie::ResourceDecorator
     @ephemera_box ||= query_service.find_parents(resource: model).to_a.first.try(:decorate) || NullProject.new
   end
 
+  # Whether this box has a workflow state that grants access to its contents
+  # @return [TrueClass, FalseClass]
+  def grant_access_state?
+    WorkflowRegistry.workflow_for(model.class).grant_access_states.include? Array.wrap(state).first.underscore
+  end
+
   class NullProject
     def title; end
 

--- a/app/decorators/ephemera_folder_decorator.rb
+++ b/app/decorators/ephemera_folder_decorator.rb
@@ -162,6 +162,16 @@ class EphemeraFolderDecorator < Valkyrie::ResourceDecorator
     end.reject(&:nil?)
   end
 
+  def manifestable_state?
+    if ephemera_box.nil? || !ephemera_box.manifestable_state?
+      super
+    else
+      # box is in production; we should publish
+      true
+    end
+  end
+  alias public_readable_state? manifestable_state?
+
   private
 
     def find_resource(resource_id)

--- a/app/decorators/ephemera_folder_decorator.rb
+++ b/app/decorators/ephemera_folder_decorator.rb
@@ -162,6 +162,8 @@ class EphemeraFolderDecorator < Valkyrie::ResourceDecorator
     end.reject(&:nil?)
   end
 
+  # Should this folder have a manifest?
+  # @return [TrueClass, FalseClass]
   def manifestable_state?
     if ephemera_box.nil? || !ephemera_box.manifestable_state?
       super
@@ -171,16 +173,28 @@ class EphemeraFolderDecorator < Valkyrie::ResourceDecorator
     end
   end
 
+  # Is this folder publicly viewable?
+  # @return [TrueClass, FalseClass]
   def public_readable_state?
-    if ephemera_box.nil? || !ephemera_box.public_readable_state?
+    if ephemera_box.nil? || !ephemera_box.grant_access_state?
       super
     else
-      # box is in production; we should publish
+      # box is in production; it's public
       true
     end
   end
 
+  # Should this folder be indexed?
+  # @return [TrueClass, FalseClass]
+  def indexable?
+    index_state? || (!ephemera_box.nil? && ephemera_box.grant_access_state?)
+  end
+
   private
+
+    def index_state?
+      WorkflowRegistry.workflow_for(model.class).index_states.include? Array.wrap(state).first.underscore
+    end
 
     def find_resource(resource_id)
       query_service.find_by(id: resource_id).decorate

--- a/app/decorators/ephemera_folder_decorator.rb
+++ b/app/decorators/ephemera_folder_decorator.rb
@@ -170,7 +170,15 @@ class EphemeraFolderDecorator < Valkyrie::ResourceDecorator
       true
     end
   end
-  alias public_readable_state? manifestable_state?
+
+  def public_readable_state?
+    if ephemera_box.nil? || !ephemera_box.public_readable_state?
+      super
+    else
+      # box is in production; we should publish
+      true
+    end
+  end
 
   private
 

--- a/app/decorators/valkyrie/resource_decorator.rb
+++ b/app/decorators/valkyrie/resource_decorator.rb
@@ -100,6 +100,15 @@ class Valkyrie::ResourceDecorator < ApplicationDecorator
     end
   end
 
+  def manifestable_state?
+    WorkflowRegistry.workflow_for(model.class).manifest_states.include? Array.wrap(state).first.underscore.to_sym
+  rescue WorkflowRegistry::EntryNotFound
+    # if there's no workflow, default to true
+    true
+  end
+  # alias until there's some reason to vary the logic
+  alias public_readable_state? manifestable_state?
+
   # Models metadata values within a manifest
   class MetadataObject
     # Constructor

--- a/app/decorators/valkyrie/resource_decorator.rb
+++ b/app/decorators/valkyrie/resource_decorator.rb
@@ -106,8 +106,13 @@ class Valkyrie::ResourceDecorator < ApplicationDecorator
     # if there's no workflow, default to true
     true
   end
-  # alias until there's some reason to vary the logic
-  alias public_readable_state? manifestable_state?
+
+  def public_readable_state?
+    WorkflowRegistry.workflow_for(model.class).public_read_states.include? Array.wrap(state).first.underscore
+  rescue WorkflowRegistry::EntryNotFound
+    # if there's no workflow, default to true
+    true
+  end
 
   # Models metadata values within a manifest
   class MetadataObject

--- a/app/decorators/valkyrie/resource_decorator.rb
+++ b/app/decorators/valkyrie/resource_decorator.rb
@@ -100,6 +100,8 @@ class Valkyrie::ResourceDecorator < ApplicationDecorator
     end
   end
 
+  # Should this folder have a manifest?
+  # @return [TrueClass, FalseClass]
   def manifestable_state?
     WorkflowRegistry.workflow_for(model.class).manifest_states.include? Array.wrap(state).first.underscore
   rescue WorkflowRegistry::EntryNotFound
@@ -107,6 +109,8 @@ class Valkyrie::ResourceDecorator < ApplicationDecorator
     true
   end
 
+  # Is this folder publicly viewable?
+  # @return [TrueClass, FalseClass]
   def public_readable_state?
     WorkflowRegistry.workflow_for(model.class).public_read_states.include? Array.wrap(state).first.underscore
   rescue WorkflowRegistry::EntryNotFound

--- a/app/decorators/valkyrie/resource_decorator.rb
+++ b/app/decorators/valkyrie/resource_decorator.rb
@@ -101,7 +101,7 @@ class Valkyrie::ResourceDecorator < ApplicationDecorator
   end
 
   def manifestable_state?
-    WorkflowRegistry.workflow_for(model.class).manifest_states.include? Array.wrap(state).first.underscore.to_sym
+    WorkflowRegistry.workflow_for(model.class).manifest_states.include? Array.wrap(state).first.underscore
   rescue WorkflowRegistry::EntryNotFound
     # if there's no workflow, default to true
     true

--- a/app/indexers/ephemera_folder_indexer.rb
+++ b/app/indexers/ephemera_folder_indexer.rb
@@ -16,11 +16,7 @@ class EphemeraFolderIndexer
   private
 
     def read_groups
-      return resource.read_groups if resource.decorate.public_readable_state?
+      return resource.read_groups if resource.decorate.indexable?
       []
-    end
-
-    def decorated
-      @decorated ||= resource.decorate
     end
 end

--- a/app/indexers/ephemera_folder_indexer.rb
+++ b/app/indexers/ephemera_folder_indexer.rb
@@ -16,8 +16,8 @@ class EphemeraFolderIndexer
   private
 
     def read_groups
-      return [] unless decorated.state == 'complete' || (decorated.ephemera_box.present? && decorated.ephemera_box.try(:state) == 'all_in_production')
-      resource.read_groups
+      return resource.read_groups if resource.decorate.public_readable_state?
+      []
     end
 
     def decorated

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -181,7 +181,10 @@ class Ability
     resource.decorate.public_readable_state?
   end
 
-  # also used by search builder
+  # The search builder needs to enumerate actual names of states
+  #   so although this duplicates some logic with #readable_concern?
+  #   we need both
+  # @see app/models/search_builder.rb
   def unreadable_states
     return ["pending"] if current_user.curator?
     return [] if universal_reader?

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -176,9 +176,16 @@ class Ability
   end
 
   def readable_concern?(resource)
-    return false if current_user.curator? && Array.wrap(resource.state).include?("pending")
+    return false if unreadable_states.include? Array.wrap(resource.state).first
     return true if universal_reader?
     resource.decorate.public_readable_state?
+  end
+
+  # also used by search builder
+  def unreadable_states
+    return ["pending"] if current_user.curator?
+    return [] if universal_reader?
+    WorkflowRegistry.all_states - WorkflowRegistry.public_read_states
   end
 
   def query_service

--- a/app/models/book_workflow.rb
+++ b/app/models/book_workflow.rb
@@ -58,4 +58,14 @@ class BookWorkflow
   def valid_transitions
     aasm.states(permitted: true).map(&:name).map(&:to_s)
   end
+
+  # States in which the record can be indexed as publicly viewable
+  def self.public_read_states
+    [:complete, :flagged]
+  end
+
+  # States in which a manifest can be published for the record
+  def self.manifest_states
+    [:complete, :flagged]
+  end
 end

--- a/app/models/book_workflow.rb
+++ b/app/models/book_workflow.rb
@@ -55,7 +55,7 @@ class BookWorkflow
     aasm.states(permitted: true).map(&:name).map(&:to_s)
   end
 
-  # States in which the record can be indexed as publicly viewable
+  # States in which the record is publicly readable (as allowed by visilibility)
   def self.public_read_states
     [:complete, :flagged].map(&:to_s)
   end

--- a/app/models/book_workflow.rb
+++ b/app/models/book_workflow.rb
@@ -57,11 +57,11 @@ class BookWorkflow
 
   # States in which the record can be indexed as publicly viewable
   def self.public_read_states
-    [:complete, :flagged]
+    [:complete, :flagged].map(&:to_s)
   end
 
   # States in which a manifest can be published for the record
   def self.manifest_states
-    [:complete, :flagged]
+    [:complete, :flagged].map(&:to_s)
   end
 end

--- a/app/models/book_workflow.rb
+++ b/app/models/book_workflow.rb
@@ -47,10 +47,6 @@ class BookWorkflow
     end
   end
 
-  def suppressed?
-    pending? || metadata_review? || final_review? || takedown?
-  end
-
   def valid_states
     aasm.states.map(&:name).map(&:to_s)
   end

--- a/app/models/box_workflow.rb
+++ b/app/models/box_workflow.rb
@@ -37,13 +37,19 @@ class BoxWorkflow
     aasm.states(permitted: true).map(&:name).map(&:to_s)
   end
 
-  # States in which the record can be indexed as publicly viewable
+  # States in which the record should be publicly viewable
+  # (boxes are never publicly viewable)
   def self.public_read_states
+    []
+  end
+
+  # States in which a manifest can be published
+  def self.manifest_states
     [:all_in_production].map(&:to_s)
   end
 
-  # States in which a manifest can be published for the record
-  def self.manifest_states
+  # states that grant read access to contained items
+  def self.grant_access_states
     [:all_in_production].map(&:to_s)
   end
 end

--- a/app/models/box_workflow.rb
+++ b/app/models/box_workflow.rb
@@ -39,11 +39,11 @@ class BoxWorkflow
 
   # States in which the record can be indexed as publicly viewable
   def self.public_read_states
-    [:all_in_production]
+    [:all_in_production].map(&:to_s)
   end
 
   # States in which a manifest can be published for the record
   def self.manifest_states
-    [:all_in_production]
+    [:all_in_production].map(&:to_s)
   end
 end

--- a/app/models/box_workflow.rb
+++ b/app/models/box_workflow.rb
@@ -29,10 +29,6 @@ class BoxWorkflow
     end
   end
 
-  def suppressed?
-    false
-  end
-
   def valid_states
     aasm.states.map(&:name).map(&:to_s)
   end

--- a/app/models/box_workflow.rb
+++ b/app/models/box_workflow.rb
@@ -40,4 +40,14 @@ class BoxWorkflow
   def valid_transitions
     aasm.states(permitted: true).map(&:name).map(&:to_s)
   end
+
+  # States in which the record can be indexed as publicly viewable
+  def self.public_read_states
+    [:all_in_production]
+  end
+
+  # States in which a manifest can be published for the record
+  def self.manifest_states
+    [:all_in_production]
+  end
 end

--- a/app/models/draft_publish_workflow.rb
+++ b/app/models/draft_publish_workflow.rb
@@ -35,4 +35,14 @@ class DraftPublishWorkflow
   def valid_transitions
     aasm.states(permitted: true).map(&:name).map(&:to_s)
   end
+
+  # States in which the record can be indexed as publicly viewable
+  def self.public_read_states
+    [:published]
+  end
+
+  # States in which a manifest can be published for the record
+  def self.manifest_states
+    [:published]
+  end
 end

--- a/app/models/draft_publish_workflow.rb
+++ b/app/models/draft_publish_workflow.rb
@@ -33,11 +33,11 @@ class DraftPublishWorkflow
 
   # States in which the record can be indexed as publicly viewable
   def self.public_read_states
-    [:published]
+    [:published].map(&:to_s)
   end
 
   # States in which a manifest can be published for the record
   def self.manifest_states
-    [:published]
+    [:published].map(&:to_s)
   end
 end

--- a/app/models/draft_publish_workflow.rb
+++ b/app/models/draft_publish_workflow.rb
@@ -31,7 +31,7 @@ class DraftPublishWorkflow
     aasm.states(permitted: true).map(&:name).map(&:to_s)
   end
 
-  # States in which the record can be indexed as publicly viewable
+  # States in which the record is publicly readable (as allowed by visilibility)
   def self.public_read_states
     [:published].map(&:to_s)
   end

--- a/app/models/draft_publish_workflow.rb
+++ b/app/models/draft_publish_workflow.rb
@@ -23,11 +23,6 @@ class DraftPublishWorkflow
     end
   end
 
-  # this workflow doesn't have a suppressed state but other code checks for it; make it false
-  def suppressed?
-    false
-  end
-
   def valid_states
     aasm.states.map(&:name).map(&:to_s)
   end

--- a/app/models/folder_workflow.rb
+++ b/app/models/folder_workflow.rb
@@ -22,11 +22,6 @@ class FolderWorkflow
     end
   end
 
-  # note suppression can be overridden by the box a folder belongs to
-  def suppressed?
-    false
-  end
-
   def valid_states
     aasm.states.map(&:name).map(&:to_s)
   end

--- a/app/models/folder_workflow.rb
+++ b/app/models/folder_workflow.rb
@@ -30,11 +30,16 @@ class FolderWorkflow
     aasm.states(permitted: true).map(&:name).map(&:to_s)
   end
 
-  # States in which the record can be indexed as publicly viewable
-  # Note that a folder should be readable in any state if it is contained
-  # by a box with state 'all_in_production'
+  # States in which the record can be publicly viewable
+  # All states must be included here because any state is viewable if its container allows it
   # @return array of strings
   def self.public_read_states
+    [:needs_qa, :complete].map(&:to_s)
+  end
+
+  # States in which the record is indexable
+  # Folders are consulted and will override this if appropriate
+  def self.index_states
     [:complete].map(&:to_s)
   end
 

--- a/app/models/folder_workflow.rb
+++ b/app/models/folder_workflow.rb
@@ -22,6 +22,7 @@ class FolderWorkflow
     end
   end
 
+  # note suppression can be overridden by the box a folder belongs to
   def suppressed?
     false
   end
@@ -32,5 +33,19 @@ class FolderWorkflow
 
   def valid_transitions
     aasm.states(permitted: true).map(&:name).map(&:to_s)
+  end
+
+  # States in which the record can be indexed as publicly viewable
+  # Note that a folder should be readable in any state if it is contained
+  # by a box with state 'all_in_production'
+  def self.public_read_states
+    [:complete]
+  end
+
+  # States in which a manifest can be published for the record
+  # Note that a folder manifest should be published in any state if it is contained
+  # by a box with state 'all_in_production'
+  def self.manifest_states
+    [:complete]
   end
 end

--- a/app/models/folder_workflow.rb
+++ b/app/models/folder_workflow.rb
@@ -33,14 +33,16 @@ class FolderWorkflow
   # States in which the record can be indexed as publicly viewable
   # Note that a folder should be readable in any state if it is contained
   # by a box with state 'all_in_production'
+  # @return array of strings
   def self.public_read_states
-    [:complete]
+    [:complete].map(&:to_s)
   end
 
   # States in which a manifest can be published for the record
   # Note that a folder manifest should be published in any state if it is contained
   # by a box with state 'all_in_production'
+  # @return array of strings
   def self.manifest_states
-    [:complete]
+    [:complete].map(&:to_s)
   end
 end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -30,11 +30,7 @@ class SearchBuilder < Blacklight::SearchBuilder
   end
 
   def readable_states
-    all_states - unreadable_states
-  end
-
-  def all_states
-    BookWorkflow.new(nil).valid_states + FolderWorkflow.new(nil).valid_states + DraftPublishWorkflow.new(nil).valid_states
+    WorkflowRegistry.all_states - unreadable_states
   end
 
   def models_to_solr_clause

--- a/app/models/workflow_registry.rb
+++ b/app/models/workflow_registry.rb
@@ -16,4 +16,18 @@ class WorkflowRegistry
   rescue KeyError
     raise EntryNotFound, resource_class
   end
+
+  def self.unregister(resource_class)
+    hash.delete(resource_class)
+  end
+
+  # @return array of strings
+  def self.all_states
+    hash.values.uniq.map { |klass| klass.new(nil).valid_states }.flatten.uniq
+  end
+
+  # @return array of strings
+  def self.public_read_states
+    hash.values.uniq.map(&:public_read_states).flatten.uniq
+  end
 end

--- a/app/models/workflow_registry.rb
+++ b/app/models/workflow_registry.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# Provides access to a workflow given a resource class and
+#   provides data about workflows in agregate
 class WorkflowRegistry
   class EntryNotFound < StandardError; end
 

--- a/config/initializers/workflows.rb
+++ b/config/initializers/workflows.rb
@@ -2,7 +2,42 @@
 
 Rails.application.config.to_prepare do
   WorkflowRegistry.register(
+    resource_class: EphemeraFolder,
+    workflow_class: FolderWorkflow
+  )
+
+  WorkflowRegistry.register(
+    resource_class: EphemeraBox,
+    workflow_class: BoxWorkflow
+  )
+
+  WorkflowRegistry.register(
+    resource_class: MediaResource,
+    workflow_class: BookWorkflow
+  )
+
+  WorkflowRegistry.register(
+    resource_class: RasterResource,
+    workflow_class: BookWorkflow
+  )
+
+  WorkflowRegistry.register(
+    resource_class: ScannedMap,
+    workflow_class: BookWorkflow
+  )
+
+  WorkflowRegistry.register(
+    resource_class: ScannedResource,
+    workflow_class: BookWorkflow
+  )
+
+  WorkflowRegistry.register(
     resource_class: SimpleResource,
     workflow_class: DraftPublishWorkflow
+  )
+
+  WorkflowRegistry.register(
+    resource_class: VectorResource,
+    workflow_class: BookWorkflow
   )
 end

--- a/spec/decorators/ephemera_box_decorator_spec.rb
+++ b/spec/decorators/ephemera_box_decorator_spec.rb
@@ -42,4 +42,19 @@ RSpec.describe EphemeraBoxDecorator do
       expect(resource.decorate.folders.to_a.first).to be_a EphemeraFolder
     end
   end
+
+  describe "#grant_access_state?" do
+    context 'in state: new' do
+      let(:resource) { FactoryBot.build(:ephemera_box, state: 'new') }
+      it "doesn't grant access" do
+        expect(resource.decorate.grant_access_state?).to be false
+      end
+    end
+    context 'in state: all_in_production' do
+      let(:resource) { FactoryBot.build(:ephemera_box, state: 'all_in_production') }
+      it "does grant access" do
+        expect(resource.decorate.grant_access_state?).to be true
+      end
+    end
+  end
 end

--- a/spec/decorators/ephemera_folder_decorator_spec.rb
+++ b/spec/decorators/ephemera_folder_decorator_spec.rb
@@ -83,14 +83,59 @@ RSpec.describe EphemeraFolderDecorator do
     end
   end
 
+  # rubocop:disable RSpec/NestedGroups
   context "within a box" do
     let(:resource) { FactoryBot.create_for_repository(:ephemera_folder) }
-    it "can return the box it's a member of" do
-      box = FactoryBot.create_for_repository(:ephemera_box, member_ids: resource.id)
+    let(:box) { FactoryBot.create_for_repository(:ephemera_box, member_ids: resource.id, state: "new") }
+    before { box }
 
+    it "can return the box it's a member of" do
       expect(resource.decorate.ephemera_box.id).to eq box.id
     end
+
+    describe 'manifestable_state?' do
+      describe 'the box is not all in production' do
+        it 'returns true when in a manifestable state' do
+          resource.state = ["complete"]
+          expect(resource.decorate.manifestable_state?).to eq true
+        end
+        it 'returns false when in a non-manifestable state' do
+          resource.state = ['needs_qa']
+          expect(resource.decorate.manifestable_state?).to eq false
+        end
+      end
+
+      describe 'the box is all in production' do
+        let(:box) { FactoryBot.create_for_repository(:ephemera_box, member_ids: resource.id, state: "all_in_production") }
+        it 'returns true when in a non-manifestable state' do
+          resource.state = ['needs_qa']
+          expect(resource.decorate.manifestable_state?).to eq true
+        end
+      end
+    end
+
+    describe 'public_readable_state?' do
+      describe 'the box is not all in production' do
+        it 'returns true when in an indexable state' do
+          resource.state = ["complete"]
+          expect(resource.decorate.public_readable_state?).to eq true
+        end
+        it 'returns false when in a non-indexable state' do
+          resource.state = ['needs_qa']
+          expect(resource.decorate.public_readable_state?).to eq false
+        end
+      end
+
+      describe 'the box is all in production' do
+        let(:box) { FactoryBot.create_for_repository(:ephemera_box, member_ids: resource.id, state: "all_in_production") }
+        it 'returns true when in a non-indexable state' do
+          resource.state = ['needs_qa']
+          expect(resource.decorate.public_readable_state?).to eq true
+        end
+      end
+    end
   end
+  # rubocop:enable RSpec/NestedGroups
 
   context "within a project" do
     let(:resource) { FactoryBot.create_for_repository(:ephemera_folder) }
@@ -99,6 +144,28 @@ RSpec.describe EphemeraFolderDecorator do
 
       expect(resource.decorate.ephemera_project.id).to eq project.id
       expect(resource.decorate.ephemera_box).to be nil
+    end
+
+    describe 'manifestable_state?' do
+      it 'returns true when in a manifestable state' do
+        resource.state = ["complete"]
+        expect(resource.decorate.manifestable_state?).to eq true
+      end
+      it 'returns false when in a non-manifestable state' do
+        resource.state = ['needs_qa']
+        expect(resource.decorate.manifestable_state?).to eq false
+      end
+    end
+
+    describe 'public_readable_state?' do
+      it 'returns true when in an indexable state' do
+        resource.state = ["complete"]
+        expect(resource.decorate.public_readable_state?).to eq true
+      end
+      it 'returns false when in a non-indexable state' do
+        resource.state = ['needs_qa']
+        expect(resource.decorate.public_readable_state?).to eq false
+      end
     end
   end
 

--- a/spec/decorators/ephemera_folder_decorator_spec.rb
+++ b/spec/decorators/ephemera_folder_decorator_spec.rb
@@ -116,13 +116,30 @@ RSpec.describe EphemeraFolderDecorator do
 
     describe 'public_readable_state?' do
       describe 'the box is not all in production' do
-        it 'returns true when in an indexable state' do
+        it 'returns true when in a readable state' do
           resource.state = ["complete"]
           expect(resource.decorate.public_readable_state?).to eq true
         end
+      end
+
+      describe 'the box is all in production' do
+        let(:box) { FactoryBot.create_for_repository(:ephemera_box, member_ids: resource.id, state: "all_in_production") }
+        it 'returns true when in a non-readable state' do
+          resource.state = ['needs_qa']
+          expect(resource.decorate.public_readable_state?).to eq true
+        end
+      end
+    end
+
+    describe 'indexable?' do
+      describe 'the box is not all in production' do
+        it 'returns true when in an indexable state' do
+          resource.state = ["complete"]
+          expect(resource.decorate.indexable?).to eq true
+        end
         it 'returns false when in a non-indexable state' do
           resource.state = ['needs_qa']
-          expect(resource.decorate.public_readable_state?).to eq false
+          expect(resource.decorate.indexable?).to eq false
         end
       end
 
@@ -130,7 +147,7 @@ RSpec.describe EphemeraFolderDecorator do
         let(:box) { FactoryBot.create_for_repository(:ephemera_box, member_ids: resource.id, state: "all_in_production") }
         it 'returns true when in a non-indexable state' do
           resource.state = ['needs_qa']
-          expect(resource.decorate.public_readable_state?).to eq true
+          expect(resource.decorate.indexable?).to eq true
         end
       end
     end
@@ -158,13 +175,21 @@ RSpec.describe EphemeraFolderDecorator do
     end
 
     describe 'public_readable_state?' do
-      it 'returns true when in an indexable state' do
+      it 'returns true when in a readable state' do
         resource.state = ["complete"]
         expect(resource.decorate.public_readable_state?).to eq true
       end
+    end
+
+    describe 'indexable?' do
+      it 'returns true when in an indexable state' do
+        resource.state = ["complete"]
+        expect(resource.decorate.indexable?).to eq true
+      end
+
       it 'returns false when in a non-indexable state' do
         resource.state = ['needs_qa']
-        expect(resource.decorate.public_readable_state?).to eq false
+        expect(resource.decorate.indexable?).to eq false
       end
     end
   end

--- a/spec/decorators/valkyrie/resource_decorator_spec.rb
+++ b/spec/decorators/valkyrie/resource_decorator_spec.rb
@@ -96,4 +96,48 @@ RSpec.describe Valkyrie::ResourceDecorator do
       expect(resource.decorate.iiif_metadata).to include('label' => 'Member Of Collections', 'value' => ['My Nietzsche Collection'])
     end
   end
+
+  describe 'manifestable_state?' do
+    describe 'for resources without workflows' do
+      let(:resource) { FactoryBot.build(:ephemera_term) }
+      it 'defaults to true' do
+        expect(resource.decorate.manifestable_state?).to eq true
+      end
+    end
+
+    describe 'a resource with manifestable workflow state' do
+      it 'returns true' do
+        expect(resource.decorate.manifestable_state?).to eq true
+      end
+    end
+
+    describe 'a resource with non-manifestable workflow state' do
+      it 'returns false' do
+        resource.state = ['metadata_review']
+        expect(resource.decorate.manifestable_state?).to eq false
+      end
+    end
+  end
+
+  describe 'public_readable_state?' do
+    describe 'for resources without workflows' do
+      let(:resource) { FactoryBot.build(:ephemera_term) }
+      it 'defaults to true' do
+        expect(resource.decorate.public_readable_state?).to eq true
+      end
+    end
+
+    describe 'a resource with indexable workflow state' do
+      it 'returns true' do
+        expect(resource.decorate.public_readable_state?).to eq true
+      end
+    end
+
+    describe 'a resource with non-indexable workflow state' do
+      it 'returns false' do
+        resource.state = ['pending']
+        expect(resource.decorate.public_readable_state?).to eq false
+      end
+    end
+  end
 end

--- a/spec/factories/simple_resource.rb
+++ b/spec/factories/simple_resource.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     rights_statement RDF::URI('http://rightsstatements.org/vocab/NKC/1.0/')
     read_groups 'public'
     pdf_type ["gray"]
-    state 'complete'
+    state 'published'
     to_create do |instance|
       Valkyrie.config.metadata_adapter.persister.save(resource: instance)
     end

--- a/spec/models/book_workflow_spec.rb
+++ b/spec/models/book_workflow_spec.rb
@@ -81,11 +81,11 @@ describe BookWorkflow do
 
   describe 'access states' do
     it 'provides a list of read-accessible states' do
-      expect(described_class.public_read_states).to contain_exactly :complete, :flagged
+      expect(described_class.public_read_states).to contain_exactly "complete", "flagged"
     end
 
     it 'provides a list of manifest-publishable states' do
-      expect(described_class.manifest_states).to contain_exactly :complete, :flagged
+      expect(described_class.manifest_states).to contain_exactly "complete", "flagged"
     end
   end
 end

--- a/spec/models/book_workflow_spec.rb
+++ b/spec/models/book_workflow_spec.rb
@@ -88,4 +88,14 @@ describe BookWorkflow do
       expect(workflow.suppressed?).to be false
     end
   end
+
+  describe 'access states' do
+    it 'provides a list of read-accessible states' do
+      expect(described_class.public_read_states).to contain_exactly :complete, :flagged
+    end
+
+    it 'provides a list of manifest-publishable states' do
+      expect(described_class.manifest_states).to contain_exactly :complete, :flagged
+    end
+  end
 end

--- a/spec/models/book_workflow_spec.rb
+++ b/spec/models/book_workflow_spec.rb
@@ -13,7 +13,6 @@ describe BookWorkflow do
       expect(workflow.may_complete?).to be false
       expect(workflow.may_takedown?).to be false
       expect(workflow.may_flag?).to be false
-      expect(workflow.suppressed?).to be true
 
       # digitization signoff moves to metadata review
       expect(workflow.finalize_digitization).to be true
@@ -23,7 +22,6 @@ describe BookWorkflow do
       expect(workflow.may_complete?).to be false
       expect(workflow.may_takedown?).to be false
       expect(workflow.may_flag?).to be false
-      expect(workflow.suppressed?).to be true
 
       # metadata signoff moves to final review
       expect(workflow.finalize_metadata).to be true
@@ -33,7 +31,6 @@ describe BookWorkflow do
       expect(workflow.may_complete?).to be true
       expect(workflow.may_takedown?).to be false
       expect(workflow.may_flag?).to be false
-      expect(workflow.suppressed?).to be true
 
       # final signoff moves to complete
       expect(workflow.complete).to be true
@@ -43,7 +40,6 @@ describe BookWorkflow do
       expect(workflow.may_complete?).to be false
       expect(workflow.may_takedown?).to be true
       expect(workflow.may_flag?).to be true
-      expect(workflow.suppressed?).to be false
     end
   end
 
@@ -53,19 +49,16 @@ describe BookWorkflow do
       expect(workflow.complete?).to be true
       expect(workflow.may_restore?).to be false
       expect(workflow.may_takedown?).to be true
-      expect(workflow.suppressed?).to be false
 
       expect(workflow.takedown).to be true
       expect(workflow.takedown?).to be true
       expect(workflow.may_restore?).to be true
       expect(workflow.may_takedown?).to be false
-      expect(workflow.suppressed?).to be true
 
       expect(workflow.restore).to be true
       expect(workflow.complete?).to be true
       expect(workflow.may_restore?).to be false
       expect(workflow.may_takedown?).to be true
-      expect(workflow.suppressed?).to be false
     end
   end
 
@@ -75,17 +68,14 @@ describe BookWorkflow do
       expect(workflow.complete?).to be true
       expect(workflow.may_flag?).to be true
       expect(workflow.may_unflag?).to be false
-      expect(workflow.suppressed?).to be false
 
       expect(workflow.flag).to be true
       expect(workflow.may_flag?).to be false
       expect(workflow.may_unflag?).to be true
-      expect(workflow.suppressed?).to be false
 
       expect(workflow.unflag).to be true
       expect(workflow.may_flag?).to be true
       expect(workflow.may_unflag?).to be false
-      expect(workflow.suppressed?).to be false
     end
   end
 

--- a/spec/models/box_workflow_spec.rb
+++ b/spec/models/box_workflow_spec.rb
@@ -66,7 +66,7 @@ describe BoxWorkflow do
 
   describe 'access states' do
     it 'provides a list of read-accessible states' do
-      expect(described_class.public_read_states).to contain_exactly "all_in_production"
+      expect(described_class.public_read_states).to be_empty
     end
 
     it 'provides a list of manifest-publishable states' do

--- a/spec/models/box_workflow_spec.rb
+++ b/spec/models/box_workflow_spec.rb
@@ -64,4 +64,14 @@ describe BoxWorkflow do
       expect(workflow.valid_states).to eq [:new, :ready_to_ship, :shipped, :received, :all_in_production].map(&:to_s)
     end
   end
+
+  describe 'access states' do
+    it 'provides a list of read-accessible states' do
+      expect(described_class.public_read_states).to contain_exactly :all_in_production
+    end
+
+    it 'provides a list of manifest-publishable states' do
+      expect(described_class.manifest_states).to contain_exactly :all_in_production
+    end
+  end
 end

--- a/spec/models/box_workflow_spec.rb
+++ b/spec/models/box_workflow_spec.rb
@@ -60,7 +60,6 @@ describe BoxWorkflow do
       expect(workflow.received?).to eq false
       expect(workflow.all_in_production?).to eq true
 
-      expect(workflow.suppressed?).to eq false
       expect(workflow.valid_states).to eq [:new, :ready_to_ship, :shipped, :received, :all_in_production].map(&:to_s)
     end
   end

--- a/spec/models/box_workflow_spec.rb
+++ b/spec/models/box_workflow_spec.rb
@@ -66,11 +66,11 @@ describe BoxWorkflow do
 
   describe 'access states' do
     it 'provides a list of read-accessible states' do
-      expect(described_class.public_read_states).to contain_exactly :all_in_production
+      expect(described_class.public_read_states).to contain_exactly "all_in_production"
     end
 
     it 'provides a list of manifest-publishable states' do
-      expect(described_class.manifest_states).to contain_exactly :all_in_production
+      expect(described_class.manifest_states).to contain_exactly "all_in_production"
     end
   end
 end

--- a/spec/models/draft_publish_workflow_spec.rb
+++ b/spec/models/draft_publish_workflow_spec.rb
@@ -32,4 +32,14 @@ describe DraftPublishWorkflow do
   it 'reports valid states' do
     expect(workflow.valid_states).to eq %w[draft published]
   end
+
+  describe 'access states' do
+    it 'provides a list of read-accessible states' do
+      expect(described_class.public_read_states).to contain_exactly :published
+    end
+
+    it 'provides a list of manifest-publishable states' do
+      expect(described_class.manifest_states).to contain_exactly :published
+    end
+  end
 end

--- a/spec/models/draft_publish_workflow_spec.rb
+++ b/spec/models/draft_publish_workflow_spec.rb
@@ -10,21 +10,18 @@ describe DraftPublishWorkflow do
       expect(workflow.draft?).to be true
       expect(workflow.may_publish?).to be true
       expect(workflow.published?).to be false
-      expect(workflow.suppressed?).to eq false
       expect(workflow.valid_transitions).to contain_exactly "published"
 
       expect(workflow.publish).to be true
       expect(workflow.published?).to be true
       expect(workflow.may_unpublish?).to eq true
       expect(workflow.draft?).to eq false
-      expect(workflow.suppressed?).to eq false
       expect(workflow.valid_transitions).to contain_exactly "draft"
 
       expect(workflow.unpublish).to eq true
       expect(workflow.draft?).to eq true
       expect(workflow.published?).to eq false
       expect(workflow.may_publish?).to eq true
-      expect(workflow.suppressed?).to eq false
       expect(workflow.valid_transitions).to contain_exactly "published"
     end
   end

--- a/spec/models/draft_publish_workflow_spec.rb
+++ b/spec/models/draft_publish_workflow_spec.rb
@@ -32,11 +32,11 @@ describe DraftPublishWorkflow do
 
   describe 'access states' do
     it 'provides a list of read-accessible states' do
-      expect(described_class.public_read_states).to contain_exactly :published
+      expect(described_class.public_read_states).to contain_exactly "published"
     end
 
     it 'provides a list of manifest-publishable states' do
-      expect(described_class.manifest_states).to contain_exactly :published
+      expect(described_class.manifest_states).to contain_exactly "published"
     end
   end
 end

--- a/spec/models/folder_workflow_spec.rb
+++ b/spec/models/folder_workflow_spec.rb
@@ -25,4 +25,14 @@ describe FolderWorkflow do
       expect(workflow.suppressed?).to eq false
     end
   end
+
+  describe 'access states' do
+    it 'provides a list of read-accessible states' do
+      expect(described_class.public_read_states).to contain_exactly :complete
+    end
+
+    it 'provides a list of manifest-publishable states' do
+      expect(described_class.manifest_states).to contain_exactly :complete
+    end
+  end
 end

--- a/spec/models/folder_workflow_spec.rb
+++ b/spec/models/folder_workflow_spec.rb
@@ -25,7 +25,7 @@ describe FolderWorkflow do
 
   describe 'access states' do
     it 'provides a list of read-accessible states' do
-      expect(described_class.public_read_states).to contain_exactly "complete"
+      expect(described_class.public_read_states).to contain_exactly "complete", "needs_qa"
     end
 
     it 'provides a list of manifest-publishable states' do

--- a/spec/models/folder_workflow_spec.rb
+++ b/spec/models/folder_workflow_spec.rb
@@ -10,19 +10,16 @@ describe FolderWorkflow do
       expect(workflow.needs_qa?).to be true
       expect(workflow.may_complete?).to be true
       expect(workflow.complete?).to be false
-      expect(workflow.suppressed?).to eq false
 
       expect(workflow.complete).to be true
       expect(workflow.complete?).to be true
       expect(workflow.may_submit_for_qa?).to eq true
       expect(workflow.needs_qa?).to eq false
-      expect(workflow.suppressed?).to eq false
 
       expect(workflow.submit_for_qa).to eq true
       expect(workflow.needs_qa?).to eq true
       expect(workflow.complete?).to eq false
       expect(workflow.may_complete?).to eq true
-      expect(workflow.suppressed?).to eq false
     end
   end
 

--- a/spec/models/folder_workflow_spec.rb
+++ b/spec/models/folder_workflow_spec.rb
@@ -25,11 +25,11 @@ describe FolderWorkflow do
 
   describe 'access states' do
     it 'provides a list of read-accessible states' do
-      expect(described_class.public_read_states).to contain_exactly :complete
+      expect(described_class.public_read_states).to contain_exactly "complete"
     end
 
     it 'provides a list of manifest-publishable states' do
-      expect(described_class.manifest_states).to contain_exactly :complete
+      expect(described_class.manifest_states).to contain_exactly "complete"
     end
   end
 end

--- a/spec/models/workflow_registry_spec.rb
+++ b/spec/models/workflow_registry_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe WorkflowRegistry do
     end
 
     after do
+      described_class.unregister(MyResource)
       Object.send(:remove_const, :MyResource)
       Object.send(:remove_const, :MyWorkflow)
     end
@@ -18,6 +19,7 @@ RSpec.describe WorkflowRegistry do
       expect(described_class.workflow_for(MyResource)).to eq MyWorkflow
     end
   end
+
   describe ".workflow_for" do
     context "when given a resource that is registered" do
       it "returns the workflow class" do
@@ -32,6 +34,19 @@ RSpec.describe WorkflowRegistry do
       it "throws exception" do
         expect { described_class.workflow_for(TotallyNotAResource) }.to raise_error(WorkflowRegistry::EntryNotFound, "TotallyNotAResource")
       end
+    end
+  end
+
+  describe ".all_states" do
+    it "returns a list of all states" do
+      expect(described_class.all_states).to contain_exactly "all_in_production", "complete", "draft", "final_review",
+                                                            "flagged", "metadata_review", "needs_qa", "new", "pending", "published", "ready_to_ship", "received", "shipped", "takedown"
+    end
+  end
+
+  describe ".public_read_states" do
+    it "returns a list of public read states" do
+      expect(described_class.public_read_states).to contain_exactly "all_in_production", "complete", "flagged", "published"
     end
   end
 end

--- a/spec/models/workflow_registry_spec.rb
+++ b/spec/models/workflow_registry_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe WorkflowRegistry do
 
   describe ".public_read_states" do
     it "returns a list of public read states" do
-      expect(described_class.public_read_states).to contain_exactly "all_in_production", "complete", "flagged", "published"
+      expect(described_class.public_read_states).to contain_exactly "complete", "flagged", "needs_qa", "published"
     end
   end
 end


### PR DESCRIPTION
Refactor `Ability` and `EphemeraFolderIndexer` to call the new logic instead of duplicating with one another.

refs @1040