### PR TITLE
Ensures that links for editing and deleting resources are only rendered for users with the appropriate permissions

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -12,4 +12,32 @@ module CatalogHelper
     val = Array.wrap(presenter(document).heading).map { |v| h(v) }.join("<br />")
     content_tag(tag, val, { itemprop: "name", dir: val.to_s.dir }, false)
   end
+
+  def can_edit?
+    can? :update, resource
+  end
+
+  def can_manage_files?
+    can? :file_manager, resource
+  end
+
+  def can_manage_structure?
+    can? :structure, resource
+  end
+
+  def can_delete?
+    can? :destroy, resource
+  end
+
+  def can_create_template_from?
+    can?(:edit, resource) && can?(:create, Template)
+  end
+
+  def can_create_ephemera_folder_for?
+    can?(:edit, resource) && can?(:create, EphemeraFolder)
+  end
+
+  def can_download?
+    can? :download, resource
+  end
 end

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -12,32 +12,4 @@ module CatalogHelper
     val = Array.wrap(presenter(document).heading).map { |v| h(v) }.join("<br />")
     content_tag(tag, val, { itemprop: "name", dir: val.to_s.dir }, false)
   end
-
-  def can_edit?
-    can? :update, resource
-  end
-
-  def can_manage_files?
-    can? :file_manager, resource
-  end
-
-  def can_manage_structure?
-    can? :structure, resource
-  end
-
-  def can_delete?
-    can? :destroy, resource
-  end
-
-  def can_create_template_from?
-    can?(:edit, resource) && can?(:create, Template)
-  end
-
-  def can_create_ephemera_folder_for?
-    can?(:edit, resource) && can?(:create, EphemeraFolder)
-  end
-
-  def can_download?
-    can? :download, resource
-  end
 end

--- a/app/views/catalog/_admin_controls_default.html.erb
+++ b/app/views/catalog/_admin_controls_default.html.erb
@@ -1,25 +1,35 @@
   <div class="form-actions">
-    <%= link_to "Edit This #{resource.human_readable_type}", main_app.polymorphic_path([:edit, resource]), class: 'btn btn-default' %>
-    <% if decorated_resource.manageable_files? %>
-      <%= link_to "File Manager", main_app.polymorphic_path([:file_manager, resource]), class: 'btn btn-default' %>
+    <% if can_edit? %>
+      <%= link_to "Edit This #{resource.human_readable_type}", main_app.polymorphic_path([:edit, resource]), class: 'btn btn-default' %>
     <% end %>
-    <% if decorated_resource.manageable_structure? %>
-      <%= link_to "Edit Structure", main_app.polymorphic_path([:structure, resource]), class: 'btn btn-default' %>
+    <% if can_manage_files? %>
+      <% if decorated_resource.manageable_files? %>
+        <%= link_to "File Manager", main_app.polymorphic_path([:file_manager, resource]), class: 'btn btn-default' %>
+      <% end %>
     <% end %>
-    <% if decorated_resource.attachable_objects.length > 0 %>
-        <div class="btn-group">
-          <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Attach Child <span class="caret"></span>
-          </button>
-          <ul class="dropdown-menu">
-            <% decorated_resource.attachable_objects.each do |concern| %>
-              <li>
-                <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([:parent, :new, resource]) %>
-              </li>
-            <% end %>
-          </ul>
-        </div>
+    <% if can_manage_structure? %>
+      <% if decorated_resource.manageable_structure? %>
+        <%= link_to "Edit Structure", main_app.polymorphic_path([:structure, resource]), class: 'btn btn-default' %>
+      <% end %>
+    <% end %>
+    <% if can_edit? %>
+      <% if decorated_resource.attachable_objects.length > 0 %>
+          <div class="btn-group">
+            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              Attach Child <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu">
+              <% decorated_resource.attachable_objects.each do |concern| %>
+                <li>
+                  <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([:parent, :new, resource]) %>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+      <% end %>
     <% end %>
 
-    <%= link_to "Delete This #{resource.human_readable_type}", main_app.polymorphic_path([resource]), class: 'btn btn-danger pull-right', data: { confirm: "Delete this #{resource.human_readable_type}?" }, method: :delete %>
+    <% if can_delete? %>
+      <%= link_to "Delete This #{resource.human_readable_type}", main_app.polymorphic_path([resource]), class: 'btn btn-danger pull-right', data: { confirm: "Delete this #{resource.human_readable_type}?" }, method: :delete %>
+    <% end %>
   </div>

--- a/app/views/catalog/_admin_controls_default.html.erb
+++ b/app/views/catalog/_admin_controls_default.html.erb
@@ -1,18 +1,18 @@
   <div class="form-actions">
-    <% if can_edit? %>
+    <% if can?(:update, resource) %>
       <%= link_to "Edit This #{resource.human_readable_type}", main_app.polymorphic_path([:edit, resource]), class: 'btn btn-default' %>
     <% end %>
-    <% if can_manage_files? %>
+    <% if can?(:file_manager, resource) %>
       <% if decorated_resource.manageable_files? %>
         <%= link_to "File Manager", main_app.polymorphic_path([:file_manager, resource]), class: 'btn btn-default' %>
       <% end %>
     <% end %>
-    <% if can_manage_structure? %>
+    <% if can?(:structure, resource) %>
       <% if decorated_resource.manageable_structure? %>
         <%= link_to "Edit Structure", main_app.polymorphic_path([:structure, resource]), class: 'btn btn-default' %>
       <% end %>
     <% end %>
-    <% if can_edit? %>
+    <% if can?(:update, resource) %>
       <% if decorated_resource.attachable_objects.length > 0 %>
           <div class="btn-group">
             <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -29,7 +29,7 @@
       <% end %>
     <% end %>
 
-    <% if can_delete? %>
+    <% if can?(:destroy, resource) %>
       <%= link_to "Delete This #{resource.human_readable_type}", main_app.polymorphic_path([resource]), class: 'btn btn-danger pull-right', data: { confirm: "Delete this #{resource.human_readable_type}?" }, method: :delete %>
     <% end %>
   </div>

--- a/app/views/catalog/_admin_controls_ephemera_box.html.erb
+++ b/app/views/catalog/_admin_controls_ephemera_box.html.erb
@@ -1,8 +1,8 @@
   <div class="form-actions">
-    <% if can_edit? %>
+    <% if can?(:update, resource) %>
       <%= link_to "Edit This #{resource.human_readable_type}", main_app.polymorphic_path([:edit, resource]), class: 'btn btn-default' %>
     <% end %>
-    <% if can_create_template_from? %>
+    <% if can?(:edit, resource) && can?(:create, Template) %>
       <div class="btn-group">
         <%= link_to "Create New Folder Template", new_ephemera_project_template_path([decorated_resource.ephemera_project], model_class: "EphemeraFolder"), class: 'btn btn-default' %>
           <div class="btn-group">
@@ -23,10 +23,10 @@
     <% end %>
 
     <div class="pull-right">
-      <% if can_edit? %>
+      <% if can?(:update, resource) %>
         <%= link_to "Attach Hard Drive", attach_drive_ephemera_box_path(resource), class: 'btn btn-primary' %>
       <% end %>
-      <% if can_delete? %>
+      <% if can?(:destroy, resource) %>
         <%= link_to "Delete This #{resource.human_readable_type}", main_app.polymorphic_path([resource]), class: 'btn btn-danger', data: { confirm: "Delete this #{resource.human_readable_type}?" }, method: :delete %>
       <% end %>
     </div>

--- a/app/views/catalog/_admin_controls_ephemera_box.html.erb
+++ b/app/views/catalog/_admin_controls_ephemera_box.html.erb
@@ -1,5 +1,8 @@
   <div class="form-actions">
-    <%= link_to "Edit This #{resource.human_readable_type}", main_app.polymorphic_path([:edit, resource]), class: 'btn btn-default' %>
+    <% if can_edit? %>
+      <%= link_to "Edit This #{resource.human_readable_type}", main_app.polymorphic_path([:edit, resource]), class: 'btn btn-default' %>
+    <% end %>
+    <% if can_create_template_from? %>
       <div class="btn-group">
         <%= link_to "Create New Folder Template", new_ephemera_project_template_path([decorated_resource.ephemera_project], model_class: "EphemeraFolder"), class: 'btn btn-default' %>
           <div class="btn-group">
@@ -17,9 +20,14 @@
             </ul>
           </div>
       </div>
+    <% end %>
 
     <div class="pull-right">
-      <%= link_to "Attach Hard Drive", attach_drive_ephemera_box_path(resource), class: 'btn btn-primary' %>
-      <%= link_to "Delete This #{resource.human_readable_type}", main_app.polymorphic_path([resource]), class: 'btn btn-danger', data: { confirm: "Delete this #{resource.human_readable_type}?" }, method: :delete %>
+      <% if can_edit? %>
+        <%= link_to "Attach Hard Drive", attach_drive_ephemera_box_path(resource), class: 'btn btn-primary' %>
+      <% end %>
+      <% if can_delete? %>
+        <%= link_to "Delete This #{resource.human_readable_type}", main_app.polymorphic_path([resource]), class: 'btn btn-danger', data: { confirm: "Delete this #{resource.human_readable_type}?" }, method: :delete %>
+      <% end %>
     </div>
   </div>

--- a/app/views/catalog/_admin_controls_ephemera_folder.html.erb
+++ b/app/views/catalog/_admin_controls_ephemera_folder.html.erb
@@ -1,33 +1,44 @@
   <div class="form-actions">
-    <%= link_to "Edit This #{resource.human_readable_type}", main_app.polymorphic_path([:edit, resource]), class: 'btn btn-default' %>
-    <% if decorated_resource.manageable_files? %>
-      <%= link_to "File Manager", main_app.polymorphic_path([:file_manager, resource]), class: 'btn btn-default' %>
+    <% if can_edit? %>
+      <%= link_to "Edit This #{resource.human_readable_type}", main_app.polymorphic_path([:edit, resource]), class: 'btn btn-default' %>
     <% end %>
-    <% if decorated_resource.manageable_structure? %>
-      <%= link_to "Edit Structure", main_app.polymorphic_path([:structure, resource]), class: 'btn btn-default' %>
+    <% if can_manage_files? %>
+      <% if decorated_resource.manageable_files? %>
+        <%= link_to "File Manager", main_app.polymorphic_path([:file_manager, resource]), class: 'btn btn-default' %>
+      <% end %>
     <% end %>
-    <% if decorated_resource.attachable_objects.length > 0 %>
-        <div class="btn-group">
-          <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Attach Child <span class="caret"></span>
-          </button>
-          <ul class="dropdown-menu">
-            <% decorated_resource.attachable_objects.each do |concern| %>
-              <li>
-                <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([:parent, :new, resource]) %>
-              </li>
-            <% end %>
-          </ul>
-        </div>
+    <% if can_manage_structure? %>
+      <% if decorated_resource.manageable_structure? %>
+        <%= link_to "Edit Structure", main_app.polymorphic_path([:structure, resource]), class: 'btn btn-default' %>
+      <% end %>
+    <% end %>
+    <% if can_edit? %>
+      <% if decorated_resource.attachable_objects.length > 0 %>
+          <div class="btn-group">
+            <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              Attach Child <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu">
+              <% decorated_resource.attachable_objects.each do |concern| %>
+                <li>
+                  <%= link_to "Attach #{concern.human_readable_type}", polymorphic_path([:parent, :new, resource]) %>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+      <% end %>
     <% end %>
 
     <div class="pull-right">
-      <% if decorated_resource.ephemera_box %>
-        <%= link_to 'Attach Another Folder', new_ephemera_folder_path(parent_id: decorated_resource.ephemera_box.id), class: 'btn btn-primary' %>
-      <% elsif decorated_resource.ephemera_project %>
-        <%= link_to 'Attach Another Folder', boxless_new_ephemera_folder_path(parent_id: decorated_resource.ephemera_project.id), class: 'btn btn-primary' %>
+      <% if can_create_ephemera_folder_for? %>
+        <% if decorated_resource.ephemera_box %>
+          <%= link_to 'Attach Another Folder', new_ephemera_folder_path(parent_id: decorated_resource.ephemera_box.id), class: 'btn btn-primary' %>
+        <% elsif decorated_resource.ephemera_project %>
+          <%= link_to 'Attach Another Folder', boxless_new_ephemera_folder_path(parent_id: decorated_resource.ephemera_project.id), class: 'btn btn-primary' %>
+        <% end %>
       <% end %>
-
-      <%= link_to "Delete This #{resource.human_readable_type}", main_app.polymorphic_path([resource]), class: 'btn btn-danger', data: { confirm: "Delete this #{resource.human_readable_type}?" }, method: :delete %>
+      <% if can_delete? %>
+        <%= link_to "Delete This #{resource.human_readable_type}", main_app.polymorphic_path([resource]), class: 'btn btn-danger', data: { confirm: "Delete this #{resource.human_readable_type}?" }, method: :delete %>
+      <% end %>
     </div>
   </div>

--- a/app/views/catalog/_admin_controls_ephemera_folder.html.erb
+++ b/app/views/catalog/_admin_controls_ephemera_folder.html.erb
@@ -1,18 +1,18 @@
   <div class="form-actions">
-    <% if can_edit? %>
+    <% if can?(:update, resource) %>
       <%= link_to "Edit This #{resource.human_readable_type}", main_app.polymorphic_path([:edit, resource]), class: 'btn btn-default' %>
     <% end %>
-    <% if can_manage_files? %>
+    <% if can?(:file_manager, resource) %>
       <% if decorated_resource.manageable_files? %>
         <%= link_to "File Manager", main_app.polymorphic_path([:file_manager, resource]), class: 'btn btn-default' %>
       <% end %>
     <% end %>
-    <% if can_manage_structure? %>
+    <% if can?(:structure, resource) %>
       <% if decorated_resource.manageable_structure? %>
         <%= link_to "Edit Structure", main_app.polymorphic_path([:structure, resource]), class: 'btn btn-default' %>
       <% end %>
     <% end %>
-    <% if can_edit? %>
+    <% if can?(:update, resource) %>
       <% if decorated_resource.attachable_objects.length > 0 %>
           <div class="btn-group">
             <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -30,14 +30,14 @@
     <% end %>
 
     <div class="pull-right">
-      <% if can_create_ephemera_folder_for? %>
+      <% if can?(:edit, resource) && can?(:create, EphemeraFolder) %>
         <% if decorated_resource.ephemera_box %>
           <%= link_to 'Attach Another Folder', new_ephemera_folder_path(parent_id: decorated_resource.ephemera_box.id), class: 'btn btn-primary' %>
         <% elsif decorated_resource.ephemera_project %>
           <%= link_to 'Attach Another Folder', boxless_new_ephemera_folder_path(parent_id: decorated_resource.ephemera_project.id), class: 'btn btn-primary' %>
         <% end %>
       <% end %>
-      <% if can_delete? %>
+      <% if can?(:destroy, resource) %>
         <%= link_to "Delete This #{resource.human_readable_type}", main_app.polymorphic_path([resource]), class: 'btn btn-danger', data: { confirm: "Delete this #{resource.human_readable_type}?" }, method: :delete %>
       <% end %>
     </div>

--- a/app/views/catalog/_admin_controls_ephemera_term.html.erb
+++ b/app/views/catalog/_admin_controls_ephemera_term.html.erb
@@ -1,5 +1,9 @@
   <div class="form-actions">
     <%= link_to "All Terms", ephemera_terms_path, class: 'btn btn-default' %>
-    <%= link_to "Edit This #{resource.human_readable_type}", main_app.polymorphic_path([:edit, resource]), class: 'btn btn-default' %>
-    <%= link_to "Delete This #{resource.human_readable_type}", main_app.polymorphic_path([resource]), class: 'btn btn-danger pull-right', data: { confirm: "Delete this #{resource.human_readable_type}?" }, method: :delete %>
+    <% if can_edit? %>
+      <%= link_to "Edit This #{resource.human_readable_type}", main_app.polymorphic_path([:edit, resource]), class: 'btn btn-default' %>
+    <% end %>
+    <% if can_delete? %>
+      <%= link_to "Delete This #{resource.human_readable_type}", main_app.polymorphic_path([resource]), class: 'btn btn-danger pull-right', data: { confirm: "Delete this #{resource.human_readable_type}?" }, method: :delete %>
+    <% end %>
   </div>

--- a/app/views/catalog/_admin_controls_ephemera_term.html.erb
+++ b/app/views/catalog/_admin_controls_ephemera_term.html.erb
@@ -1,9 +1,9 @@
   <div class="form-actions">
     <%= link_to "All Terms", ephemera_terms_path, class: 'btn btn-default' %>
-    <% if can_edit? %>
+    <% if can?(:update, resource) %>
       <%= link_to "Edit This #{resource.human_readable_type}", main_app.polymorphic_path([:edit, resource]), class: 'btn btn-default' %>
     <% end %>
-    <% if can_delete? %>
+    <% if can?(:destroy, resource) %>
       <%= link_to "Delete This #{resource.human_readable_type}", main_app.polymorphic_path([resource]), class: 'btn btn-danger pull-right', data: { confirm: "Delete this #{resource.human_readable_type}?" }, method: :delete %>
     <% end %>
   </div>

--- a/app/views/catalog/_admin_controls_file_set.html.erb
+++ b/app/views/catalog/_admin_controls_file_set.html.erb
@@ -12,12 +12,12 @@
     <% resource.original_files.each do |file| %>
       <tr>
         <td><span class="label label-success">Original File</span>&nbsp;<%= file.label.first %></td>
-        <% if can_download? %>
+        <% if can?(:download, resource) %>
           <td><%= link_to "Download", valhalla.download_path(resource.id, file.id) %></td>
         <% else %>
           <td></td>
         <% end %>
-        <% if can_edit? %>
+        <% if can?(:update, resource) %>
           <td><%= f.input "files[][#{file.id}]", as: :file, label: false, required: false %></td>
         <% else %>
           <td></td>
@@ -27,12 +27,12 @@
     <% resource.derivative_files.each do |file| %>
       <tr>
         <td><span class="label label-info">Derivative File</span>&nbsp;<%= file.label.first %></td>
-        <% if can_download? %>
+        <% if can?(:download, resource) %>
           <td><%= link_to "Download", valhalla.download_path(resource.id, file.id) %></td>
         <% else %>
           <td></td>
         <% end %>
-        <% if can_edit? %>
+        <% if can?(:update, resource) %>
           <td><%= f.input "derivative_files[][#{file.id}]", as: :file, label: false, required: false %></td>
         <% else %>
           <td></td>
@@ -42,12 +42,12 @@
     <% resource.thumbnail_files.each do |file| %>
       <tr>
         <td><span class="label label-info">Thumbnail File</span>&nbsp;<%= file.label.first %></td>
-        <% if can_download? %>
+        <% if can?(:download, resource) %>
           <td><%= link_to "Download", valhalla.download_path(resource.id, file.id) %></td>
         <% else %>
           <td></td>
         <% end %>
-        <% if can_edit? %>
+        <% if can?(:update, resource) %>
           <td><%= f.input "thumbnail_files[][#{file.id}]", as: :file, label: false, required: false %></td>
         <% else %>
           <td></td>
@@ -58,7 +58,7 @@
     <tfoot>
       <tr>
         <td colspan="2"></td>
-        <% if can_edit? %>
+        <% if can?(:update, resource) %>
           <td><%= f.submit 'Update Files', class: 'btn btn-primary', disabled: true %></td>
         <% else %>
           <td></td>

--- a/app/views/catalog/_admin_controls_file_set.html.erb
+++ b/app/views/catalog/_admin_controls_file_set.html.erb
@@ -12,29 +12,57 @@
     <% resource.original_files.each do |file| %>
       <tr>
         <td><span class="label label-success">Original File</span>&nbsp;<%= file.label.first %></td>
-        <td><%= link_to "Download", valhalla.download_path(resource.id, file.id) %></td>
-        <td><%= f.input "files[][#{file.id}]", as: :file, label: false, required: false %></td>
+        <% if can_download? %>
+          <td><%= link_to "Download", valhalla.download_path(resource.id, file.id) %></td>
+        <% else %>
+          <td></td>
+        <% end %>
+        <% if can_edit? %>
+          <td><%= f.input "files[][#{file.id}]", as: :file, label: false, required: false %></td>
+        <% else %>
+          <td></td>
+        <% end %>
       </tr>
     <% end %>
     <% resource.derivative_files.each do |file| %>
       <tr>
         <td><span class="label label-info">Derivative File</span>&nbsp;<%= file.label.first %></td>
-        <td><%= link_to "Download", valhalla.download_path(resource.id, file.id) %></td>
-        <td><%= f.input "derivative_files[][#{file.id}]", as: :file, label: false, required: false %></td>
+        <% if can_download? %>
+          <td><%= link_to "Download", valhalla.download_path(resource.id, file.id) %></td>
+        <% else %>
+          <td></td>
+        <% end %>
+        <% if can_edit? %>
+          <td><%= f.input "derivative_files[][#{file.id}]", as: :file, label: false, required: false %></td>
+        <% else %>
+          <td></td>
+        <% end %>
       </tr>
     <% end %>
     <% resource.thumbnail_files.each do |file| %>
       <tr>
         <td><span class="label label-info">Thumbnail File</span>&nbsp;<%= file.label.first %></td>
-        <td><%= link_to "Download", valhalla.download_path(resource.id, file.id) %></td>
-        <td><%= f.input "thumbnail_files[][#{file.id}]", as: :file, label: false, required: false %></td>
+        <% if can_download? %>
+          <td><%= link_to "Download", valhalla.download_path(resource.id, file.id) %></td>
+        <% else %>
+          <td></td>
+        <% end %>
+        <% if can_edit? %>
+          <td><%= f.input "thumbnail_files[][#{file.id}]", as: :file, label: false, required: false %></td>
+        <% else %>
+          <td></td>
+        <% end %>
       </tr>
     <% end %>
     </tbody>
     <tfoot>
       <tr>
         <td colspan="2"></td>
-        <td><%= f.submit 'Update Files', class: 'btn btn-primary', disabled: true %></td>
+        <% if can_edit? %>
+          <td><%= f.submit 'Update Files', class: 'btn btn-primary', disabled: true %></td>
+        <% else %>
+          <td></td>
+        <% end %>
       </tr>
     </tfoot>
   </table>

--- a/spec/views/catalog/_admin_controls_default.html.erb_spec.rb
+++ b/spec/views/catalog/_admin_controls_default.html.erb_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "catalog/_admin_controls_default" do
+  let(:scanned_resource) { FactoryBot.create_for_repository(:scanned_resource) }
+  let(:solr) { Valkyrie::MetadataAdapter.find(:index_solr) }
+  let(:document) { solr.resource_factory.from_resource(resource: scanned_resource) }
+  let(:solr_document) { SolrDocument.new(document) }
+  let(:user) { FactoryBot.create(:user) }
+
+  before do
+    assign :resource, scanned_resource
+    assign :document, solr_document
+    sign_in user
+    render
+  end
+
+  it 'hides the edit link for resources' do
+    expect(rendered).not_to have_link 'Edit This Scanned Resource', href: edit_scanned_resource_path(id: scanned_resource.id)
+  end
+
+  it 'hides the file manager link for resources' do
+    expect(rendered).not_to have_link 'File Manager', href: file_manager_scanned_resource_path(id: scanned_resource.id)
+  end
+
+  it 'hides the structure editor link for resources' do
+    expect(rendered).not_to have_link 'Edit Structure', href: structure_scanned_resource_path(id: scanned_resource.id)
+  end
+
+  it 'hides links for attaching child resources' do
+    expect(rendered).not_to have_button 'Attach Child'
+  end
+
+  it 'hides the delete link for resources' do
+    expect(rendered).not_to have_link 'Delete This Scanned Resource', href: scanned_resource_path(id: scanned_resource.id)
+  end
+
+  context 'as an admin. user' do
+    let(:user) { FactoryBot.create(:admin) }
+
+    it 'renders the edit link for resources' do
+      expect(rendered).to have_link 'Edit This Scanned Resource', href: edit_scanned_resource_path(id: scanned_resource.id)
+    end
+
+    it 'renders the file manager link for resources' do
+      expect(rendered).to have_link 'File Manager', href: file_manager_scanned_resource_path(id: scanned_resource.id)
+    end
+
+    it 'renders the structure editor link for resources' do
+      expect(rendered).to have_link 'Edit Structure', href: structure_scanned_resource_path(id: scanned_resource.id)
+    end
+
+    it 'renders links for attaching child resources' do
+      expect(rendered).to have_button 'Attach Child'
+    end
+
+    it 'renders the delete link for resources' do
+      expect(rendered).to have_link 'Delete This Scanned Resource', href: scanned_resource_path(id: scanned_resource.id)
+    end
+  end
+end

--- a/spec/views/catalog/_admin_controls_ephemera_box.html.erb_spec.rb
+++ b/spec/views/catalog/_admin_controls_ephemera_box.html.erb_spec.rb
@@ -6,13 +6,23 @@ RSpec.describe "catalog/_admin_controls_ephemera_box" do
   let(:solr) { Valkyrie::MetadataAdapter.find(:index_solr) }
   let(:document) { solr.resource_factory.from_resource(resource: box) }
   let(:solr_document) { SolrDocument.new(document) }
+  let(:user) { FactoryBot.create(:user) }
 
   before do
     assign :document, solr_document
+    sign_in user
     render
   end
 
-  it 'displays a button to attach a hard drive' do
-    expect(rendered).to have_link 'Attach Hard Drive', href: attach_drive_ephemera_box_path(box.id)
+  it 'hides the button to attach a hard drive from users' do
+    expect(rendered).not_to have_link 'Attach Hard Drive', href: attach_drive_ephemera_box_path(box.id)
+  end
+
+  context 'as an admin. user' do
+    let(:user) { FactoryBot.create(:admin) }
+
+    it 'displays a button to attach a hard drive' do
+      expect(rendered).to have_link 'Attach Hard Drive', href: attach_drive_ephemera_box_path(box.id)
+    end
   end
 end

--- a/spec/views/catalog/_admin_controls_ephemera_folder.html.erb_spec.rb
+++ b/spec/views/catalog/_admin_controls_ephemera_folder.html.erb_spec.rb
@@ -6,26 +6,48 @@ RSpec.describe "catalog/_admin_controls_ephemera_folder" do
   let(:solr) { Valkyrie::MetadataAdapter.find(:index_solr) }
   let(:document) { solr.resource_factory.from_resource(resource: folder) }
   let(:solr_document) { SolrDocument.new(document) }
+  let(:user) { FactoryBot.create(:user) }
 
   before do
     solr.persister.save(resource: parent)
     assign :document, solr_document
+    sign_in user
     render
   end
 
   context "when the parent is a box" do
     let(:parent) { FactoryBot.create_for_repository(:ephemera_box, member_ids: [folder.id]) }
 
-    it 'has a button to attach a new folder to the box ' do
-      expect(rendered).to have_link 'Attach Another Folder', href: new_ephemera_folder_path(parent_id: parent.id)
+    it 'hides the button to attach a new folder to the box ' do
+      expect(rendered).not_to have_link 'Attach Another Folder'
     end
   end
 
   context "when the parent is a project" do
     let(:parent) { FactoryBot.create_for_repository(:ephemera_project, member_ids: [folder.id]) }
 
-    it 'has a button to attach a new folder to the project ' do
-      expect(rendered).to have_link 'Attach Another Folder', href: boxless_new_ephemera_folder_path(parent_id: parent.id)
+    it 'hides the button to attach a new folder to the project ' do
+      expect(rendered).not_to have_link 'Attach Another Folder'
+    end
+  end
+
+  context 'as an admin. user' do
+    let(:user) { FactoryBot.create(:admin) }
+
+    context "when the parent is a box" do
+      let(:parent) { FactoryBot.create_for_repository(:ephemera_box, member_ids: [folder.id]) }
+
+      it 'has a button to attach a new folder to the box ' do
+        expect(rendered).to have_link 'Attach Another Folder', href: new_ephemera_folder_path(parent_id: parent.id)
+      end
+    end
+
+    context "when the parent is a project" do
+      let(:parent) { FactoryBot.create_for_repository(:ephemera_project, member_ids: [folder.id]) }
+
+      it 'has a button to attach a new folder to the project ' do
+        expect(rendered).to have_link 'Attach Another Folder', href: boxless_new_ephemera_folder_path(parent_id: parent.id)
+      end
     end
   end
 end

--- a/spec/views/catalog/_admin_controls_ephemera_term.html.erb_spec.rb
+++ b/spec/views/catalog/_admin_controls_ephemera_term.html.erb_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "catalog/_admin_controls_ephemera_term" do
+  let(:term) { FactoryBot.create_for_repository(:ephemera_term) }
+  let(:solr) { Valkyrie::MetadataAdapter.find(:index_solr) }
+  let(:document) { solr.resource_factory.from_resource(resource: term) }
+  let(:solr_document) { SolrDocument.new(document) }
+  let(:user) { FactoryBot.create(:user) }
+
+  before do
+    assign :document, solr_document
+    sign_in user
+    render
+  end
+
+  it 'hides the edit link from users' do
+    expect(rendered).not_to have_link 'Edit This Ephemera Term'
+  end
+
+  it 'hides the delete link from users' do
+    expect(rendered).not_to have_link 'Delete This Ephemera Term'
+  end
+
+  context 'as an admin. user' do
+    let(:user) { FactoryBot.create(:admin) }
+    it 'renders the edit link' do
+      expect(rendered).to have_link 'Edit This Ephemera Term', href: edit_ephemera_term_path(term.id)
+    end
+  end
+
+  context 'as an admin. user' do
+    let(:user) { FactoryBot.create(:admin) }
+    it 'renders the delete link' do
+      expect(rendered).to have_link 'Delete This Ephemera Term', href: ephemera_term_path(term.id)
+    end
+  end
+end

--- a/spec/views/catalog/_admin_controls_file_set.html.erb_spec.rb
+++ b/spec/views/catalog/_admin_controls_file_set.html.erb_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe "catalog/_admin_controls_file_set" do
+  let(:original_file) { FileMetadata.new(id: 'test-original-file', use: [Valkyrie::Vocab::PCDMUse.OriginalFile]) }
+  let(:derivative_file) { FileMetadata.new(id: 'test-derivative-file', use: [Valkyrie::Vocab::PCDMUse.ServiceFile]) }
+  let(:thumbnail_file) { FileMetadata.new(id: 'test-thumbnail-file', use: [Valkyrie::Vocab::PCDMUse.ThumbnailImage]) }
+  let(:file_set) do
+    FactoryBot.create_for_repository(:file_set, file_metadata: [original_file, derivative_file, thumbnail_file])
+  end
+  let(:solr) { Valkyrie::MetadataAdapter.find(:index_solr) }
+  let(:document) { solr.resource_factory.from_resource(resource: file_set) }
+  let(:solr_document) { SolrDocument.new(document) }
+  let(:user) { FactoryBot.create(:user) }
+
+  before do
+    assign :resource, file_set
+    assign :document, solr_document
+    sign_in user
+    render
+  end
+
+  it 'hides the upload form field for original files' do
+    expect(rendered).not_to have_css "input.file[name='file_set[files[][#{original_file.id}]]']"
+  end
+  it 'hides the upload form field for derivative files' do
+    expect(rendered).not_to have_css "input.file[name='file_set[derivative_files[][#{derivative_file.id}]]']"
+  end
+  it 'hides the upload form field for thumbnail files' do
+    expect(rendered).not_to have_css "input.file[name='file_set[thumbnail_files[][#{thumbnail_file.id}]]']"
+  end
+  it 'hides the submit button for updating files' do
+    expect(rendered).not_to have_css "input[type='submit'][value='Update Files']"
+  end
+
+  it 'hides the download link for original files' do
+    expect(rendered).not_to have_link 'Download', href: valhalla.download_path(resource_id: file_set.id, id: original_file.id)
+  end
+  it 'hides the download link for derivative files' do
+    expect(rendered).not_to have_link 'Download', href: valhalla.download_path(resource_id: file_set.id, id: derivative_file.id)
+  end
+  it 'hides the download link for thumbnail files' do
+    expect(rendered).not_to have_link 'Download', href: valhalla.download_path(resource_id: file_set.id, id: thumbnail_file.id)
+  end
+
+  context 'as an admin. user' do
+    let(:user) { FactoryBot.create(:admin) }
+    it 'renders an upload form field for original files' do
+      expect(rendered).to have_css "input.file[name='file_set[files[][#{original_file.id}]]']"
+    end
+    it 'renders an upload form field for derivative files' do
+      expect(rendered).to have_css "input.file[name='file_set[derivative_files[][#{derivative_file.id}]]']"
+    end
+    it 'renders an upload form field for thumbnail files' do
+      expect(rendered).to have_css "input.file[name='file_set[thumbnail_files[][#{thumbnail_file.id}]]']"
+    end
+    it 'renders the submit button for updating files' do
+      expect(rendered).to have_css "input[type='submit'][value='Update Files']"
+    end
+
+    it 'renders the download link for original files' do
+      expect(rendered).to have_link 'Download', href: valhalla.download_path(resource_id: file_set.id, id: original_file.id)
+    end
+    it 'renders the download link for derivative files' do
+      expect(rendered).to have_link 'Download', href: valhalla.download_path(resource_id: file_set.id, id: derivative_file.id)
+    end
+    it 'renders the download link for thumbnail files' do
+      expect(rendered).to have_link 'Download', href: valhalla.download_path(resource_id: file_set.id, id: thumbnail_file.id)
+    end
+  end
+end


### PR DESCRIPTION
Also encompasses permissions for:
* file management
* editing the logical structure
* downloading derivative files in FileSets

Resolves #795 