### PR TITLE
Removes coverage from scanned map edit page

### DIFF
--- a/app/change_sets/scanned_map_change_set.rb
+++ b/app/change_sets/scanned_map_change_set.rb
@@ -15,7 +15,6 @@ class ScannedMapChangeSet < ScannedResourceChangeSet
       :source_metadata_identifier,
       :rights_statement,
       :rights_note,
-      :coverage,
       :local_identifier,
       :holding_location,
       :member_of_collection_ids,

--- a/spec/change_set_persisters/plum_change_set_persister_spec.rb
+++ b/spec/change_set_persisters/plum_change_set_persister_spec.rb
@@ -38,20 +38,21 @@ RSpec.describe PlumChangeSetPersister do
   context "when a source_metadata_identifier is set for the first time on a scanned map" do
     let(:change_set_class) { ScannedMapChangeSet }
     before do
-      stub_bibdata(bib_id: '6592452')
+      stub_bibdata(bib_id: '10001789')
       stub_ezid(shoulder: "99999/fk4", blade: "123456")
     end
     it "applies remote metadata from bibdata to an imported metadata resource" do
       resource = FactoryBot.build(:scanned_map, title: [])
       change_set = change_set_class.new(resource)
-      change_set.validate(source_metadata_identifier: '6592452')
+      change_set.validate(source_metadata_identifier: '10001789')
       change_set.sync
       output = change_set_persister.save(change_set: change_set)
 
-      expect(output.primary_imported_metadata.title).to eq [RDF::Literal.new("Brazil, Uruguay, Paraguay & Guyana", language: :eng)]
-      expect(output.primary_imported_metadata.creator).to eq ["Bartholomew, John, 1805-1861"]
-      expect(output.primary_imported_metadata.subject).to eq ["Brazil—Maps", "Guiana—Maps", "Paraguay—Maps", "Uruguay—Maps"]
-      expect(output.primary_imported_metadata.spatial).to eq ["Brazil", "Uruguay", "Paraguay", "Guyana"]
+      expect(output.primary_imported_metadata.title).to eq [RDF::Literal.new("Cameroons under United Kingdom Trusteeship 1949", language: :eng)]
+      expect(output.primary_imported_metadata.creator).to eq ["Nigeria. Survey Department"]
+      expect(output.primary_imported_metadata.subject).to include "Administrative and political divisions—Maps"
+      expect(output.primary_imported_metadata.spatial).to eq ["Cameroon", "Nigeria"]
+      expect(output.primary_imported_metadata.coverage).to eq ["northlimit=12.500000; eastlimit=014.620000; southlimit=03.890000; westlimit=008.550000; units=degrees; projection=EPSG:4326"]
     end
   end
 

--- a/spec/features/scanned_map_spec.rb
+++ b/spec/features/scanned_map_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.feature "ScannedMaps", js: true do
+  let(:user) { FactoryBot.create(:admin) }
+  let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
+  let(:persister) { adapter.persister }
+  let(:scanned_map) do
+    res = FactoryBot.create_for_repository(:scanned_map)
+    persister.save(resource: res)
+  end
+  let(:change_set) do
+    ScannedMapChangeSet.new(scanned_map)
+  end
+  let(:change_set_persister) do
+    PlumChangeSetPersister.new(metadata_adapter: adapter, storage_adapter: Valkyrie.config.storage_adapter)
+  end
+
+  before do
+    change_set.sync
+    change_set_persister.save(change_set: change_set)
+    sign_in user
+  end
+
+  scenario 'creating a new resource' do
+    visit new_scanned_map_path
+
+    expect(page).to have_field 'Title'
+    expect(page).to have_field 'Source Metadata ID'
+    expect(page).to have_css '.select[for="scanned_map_rights_statement"]', text: 'Rights Statement'
+    expect(page).to have_field 'Rights Note'
+    expect(page).to have_field 'Local identifier'
+    expect(page).to have_css '.select[for="scanned_map_holding_location"]', text: 'Holding Location'
+    expect(page).to have_css '.select[for="scanned_map_member_of_collection_ids"]', text: 'Collections'
+    expect(page).not_to have_css '.control-label[for="scanned_map_coverage"]', text: 'Coverage'
+    expect(page).to have_field 'Description'
+    expect(page).to have_field 'Subject'
+    expect(page).to have_field 'Spatial'
+    expect(page).to have_field 'Temporal'
+    expect(page).to have_field 'Issued'
+    expect(page).to have_field 'Creator'
+    expect(page).to have_field 'Language'
+    expect(page).to have_field 'Cartographic scale'
+  end
+end

--- a/spec/fixtures/files/bibdata/10001789.jsonld
+++ b/spec/fixtures/files/bibdata/10001789.jsonld
@@ -1,0 +1,53 @@
+{
+  "@context": "http://bibdata.princeton.edu/context.json",
+  "@id": "http://bibdata.princeton.edu/bibliographic/10001789",
+  "title": {
+    "@value": "Cameroons under United Kingdom Trusteeship 1949",
+    "@language": "eng"
+  },
+  "language": "eng",
+  "creator": "Nigeria. Survey Department",
+  "call_number": "G8731.F7 1949 .C6 (b)",
+  "extent": [
+    "Scale 1:2,000,000 or 1 inch to 31.56 miles. (E 8°33ʹ00ʹʹ--E 14°37ʹ00ʹʹ/N 12°30ʹ00ʹʹ--N 3°53ʹ24ʹʹ).",
+    "1 map : color ; 38 x 58 cm"
+  ],
+  "edition": "Issued in 1950.",
+  "format": "Map",
+  "type": "Maps",
+  "description": [
+    "The territory of the Cameroons under the United KIngdom trusteeship consisted of two mountainous strips on the eastern frontier of Nigeria, extending from Lake Chad to the Atlantic Ocean. It is divided by a strech of approximately 45 miles into north and south by the Benue River.",
+    "Map shows international, provincial, Nigeria-Cameroons, divisional, and district boundaries, customs stations, three classes of roads, railways, lighthouses, telegraph lines, wireless stations, and native courts. The Trustee Territories administered as part of Bornu, Adamawa, Benue, and Eastern Provinces are shown by color code.",
+    "\"1750/766/4-50\"",
+    "Original maps is filed in the Map/Geospatial Center, a map reproduction is attached to companion volumes."
+  ],
+  "publisher": [
+    "Lagos, Nigeria : Survey Department, 1950.",
+    "London : His Majesty's Stationery Office, 1950."
+  ],
+  "subject": [
+    "Administrative and political divisions—Maps",
+    "Cameroon—Administrative and political divisions",
+    "Nigeria—Administrative and political divisions",
+    "Great Britain—Colonies",
+    "Cameroon—Maps",
+    "Nigeria—Maps"
+  ],
+  "coverage": "northlimit=12.500000; eastlimit=014.620000; southlimit=03.890000; westlimit=008.550000; units=degrees; projection=EPSG:4326",
+  "title_sort": "Cameroons under United Kingdom Trusteeship 1949 / drawn & reproduced by Survey Department, Lagos, Nigeria.",
+  "cartographic_scale": "Scale 1:2,000,000 or 1 inch to 31.56 miles.",
+  "spatial": [
+    "Cameroon",
+    "Nigeria"
+  ],
+  "relation": "Colonial Office. Report by His Majesty's Government in the United Kingdom of Great Britain and Northern Ireland to the General Assembly of the United Nations on the administration of the Cameroons under United Kingdom Trusteeship for the year 1949. Colonial 262, map facing page 384. London : His Majesty's Stationery Office, 1950. (384 pages : 2 maps ; 25 cm).",
+  "references": "{\"http://arks.princeton.edu/ark:/88435/jq085p05h\":[\"arks.princeton.edu\",\"See the map.\"]}",
+  "issuing_body": [
+    "Great Britain. Colonial Office",
+    "Great Britain. His Majesty's Stationery Office"
+  ],
+  "cartographer": "Nigeria. Survey Department",
+  "created": "1949-01-01T00:00:00Z/1950-12-31T23:59:59Z",
+  "date": "1949-1950",
+  "identifier": "http://arks.princeton.edu/ark:/88435/jq085p05h"
+}


### PR DESCRIPTION
Coverage should come from Voyager metadata.
 
Closes #1090 