### PR TITLE
Move position of coverage on Vector and Raster edit pages

### DIFF
--- a/app/change_sets/raster_resource_change_set.rb
+++ b/app/change_sets/raster_resource_change_set.rb
@@ -35,7 +35,6 @@ class RasterResourceChangeSet < Valhalla::ChangeSet
       :source_metadata_identifier,
       :rights_statement,
       :rights_note,
-      :coverage,
       :local_identifier,
       :holding_location,
       :member_of_collection_ids,
@@ -48,7 +47,8 @@ class RasterResourceChangeSet < Valhalla::ChangeSet
       :creator,
       :language,
       :cartographic_scale,
-      :cartographic_projection
+      :cartographic_projection,
+      :coverage
     ]
   end
   # rubocop:enable Metrics/MethodLength

--- a/app/change_sets/vector_resource_change_set.rb
+++ b/app/change_sets/vector_resource_change_set.rb
@@ -35,7 +35,6 @@ class VectorResourceChangeSet < Valhalla::ChangeSet
       :source_metadata_identifier,
       :rights_statement,
       :rights_note,
-      :coverage,
       :local_identifier,
       :holding_location,
       :member_of_collection_ids,
@@ -48,7 +47,8 @@ class VectorResourceChangeSet < Valhalla::ChangeSet
       :creator,
       :language,
       :cartographic_scale,
-      :cartographic_projection
+      :cartographic_projection,
+      :coverage
     ]
   end
   # rubocop:enable Metrics/MethodLength


### PR DESCRIPTION
- Groups coverage logically with cartographic projection and scale.
- Resolves conflict with rights statement dropdown.

Closes #1092 