### PR TITLE
Fix collection manifests with MVWs.

### DIFF
--- a/app/services/manifest_builder/thumbnail_builder.rb
+++ b/app/services/manifest_builder/thumbnail_builder.rb
@@ -33,9 +33,19 @@ class ManifestBuilder
       end
 
       def file_set
-        @file_set ||= query_service.find_by(id: thumbnail_id)
+        @file_set ||= find_thumbnail_file_set(thumbnail_id)
       rescue Valkyrie::Persistence::ObjectNotFoundError
         @file_set ||= query_service.find_by(id: resource.file_set_presenters.first.id)
+      end
+
+      def find_thumbnail_file_set(record_id)
+        return unless record_id.present?
+        record = query_service.find_by(id: Valkyrie::ID.new(record_id.to_s))
+        if record.is_a?(FileSet)
+          record
+        else
+          find_thumbnail_file_set(Array.wrap(record.thumbnail_id).first || Array.wrap(record.member_ids.first))
+        end
       end
 
       def query_service

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -354,7 +354,8 @@ RSpec.describe ManifestBuilder do
     subject(:manifest_builder) { described_class.new(query_service.find_by(id: collection.id)) }
     let(:collection) { FactoryBot.create_for_repository(:collection) }
     let(:change_set) { CollectionChangeSet.new(collection) }
-    let(:scanned_resource) { FactoryBot.create_for_repository(:scanned_resource, member_of_collection_ids: [collection.id]) }
+    let(:scanned_resource) { FactoryBot.create_for_repository(:scanned_resource, member_of_collection_ids: [collection.id], member_ids: scanned_resource_2.id, thumbnail_id: scanned_resource_2.id) }
+    let(:scanned_resource_2) { FactoryBot.create_for_repository(:scanned_resource) }
 
     before do
       scanned_resource


### PR DESCRIPTION
When collection manifests have multi-volume works the thumbnail_id of
the MVW points to the scanned resource within it that has the thumbnail
it should use, rather than the FileSet. The thumbnail builder was
assuming it'd get back a FileSet, which caused an error to be thrown
while embedding thumbnails in those manifests. The error can be seen
here: https://app.honeybadger.io/projects/53391/faults/37473184

The change here iterates down thumbnail_ids until it finds a FileSet,
and if it doesn't it just doesn't append a thumbnail to the manifest.