### PR TITLE
 Add workflow and identifier to archival media collection

### DIFF
--- a/app/change_sets/archival_media_collection_change_set.rb
+++ b/app/change_sets/archival_media_collection_change_set.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
-class ArchivalMediaCollectionChangeSet < Valkyrie::ChangeSet
-  include RemoteMetadataProperty
+class ArchivalMediaCollectionChangeSet < Valhalla::ChangeSet
+  apply_workflow(WorkflowRegistry.workflow_for(ArchivalMediaCollection))
   delegate :human_readable_type, to: :model
 
+  include RemoteMetadataProperty
   property :source_metadata_identifier, multiple: false, required: true
   property :bag_path, multiple: false, required: true, virtual: true
   property :visibility, multiple: false, required: false
 
   validates :source_metadata_identifier, presence: true
-  validates_with SourceMetadataIdentifierValidator
   validates_with BagPathValidator
+  validates_with SourceMetadataIdentifierValidator
 
   def primary_terms
     [:source_metadata_identifier, :bag_path]

--- a/app/decorators/archival_media_collection_decorator.rb
+++ b/app/decorators/archival_media_collection_decorator.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+class ArchivalMediaCollectionDecorator < CollectionDecorator
+  display :identifier
+end

--- a/app/models/archival_media_collection.rb
+++ b/app/models/archival_media_collection.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 class ArchivalMediaCollection < Collection
+  attribute :identifier
   attribute :imported_metadata, Valkyrie::Types::Set.member(ImportedMetadata).optional
   attribute :source_metadata_identifier
+  attribute :state
+  attribute :workflow_note, Valkyrie::Types::Array.member(WorkflowNote).optional
 
   def primary_imported_metadata
     Array.wrap(imported_metadata).first || ImportedMetadata.new

--- a/app/validators/bag_path_validator.rb
+++ b/app/validators/bag_path_validator.rb
@@ -3,7 +3,8 @@ class BagPathValidator < ActiveModel::Validator
   # @param [record] a ChangeSet object
   def validate(record)
     # can't use the activerecord validator on a virtual field
-    return if record.bag_path.present?
-    record.errors.add(:bag_path, "No value found")
+    return unless record.bag_path.present?
+    return if Dir.exist?(record.bag_path)
+    record.errors.add(:bag_path, "Not a valid bag path")
   end
 end

--- a/config/initializers/workflows.rb
+++ b/config/initializers/workflows.rb
@@ -2,6 +2,11 @@
 
 Rails.application.config.to_prepare do
   WorkflowRegistry.register(
+    resource_class: ArchivalMediaCollection,
+    workflow_class: DraftPublishWorkflow
+  )
+
+  WorkflowRegistry.register(
     resource_class: EphemeraFolder,
     workflow_class: FolderWorkflow
   )

--- a/spec/controllers/archival_media_collections_controller_spec.rb
+++ b/spec/controllers/archival_media_collections_controller_spec.rb
@@ -29,6 +29,10 @@ RSpec.describe ArchivalMediaCollectionsController do
     describe "POST /archival_media_collections" do
       let(:file) { File.open(Rails.root.join("spec", "fixtures", "some_finding_aid.xml"), 'r') }
 
+      before do
+        allow(Dir).to receive(:exist?).and_return(true)
+      end
+
       it "creates a collection and imports metadata" do
         stub_request(:get, "https://findingaids.princeton.edu/collections/AC044/c0003.xml?scope=record")
           .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent' => 'Faraday v0.9.2' })

--- a/spec/decorators/archival_media_collection_decorator_spec.rb
+++ b/spec/decorators/archival_media_collection_decorator_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe ArchivalMediaCollectionDecorator do
+  subject(:decorator) { described_class.new(collection) }
+  let(:collection) { FactoryBot.build(:archival_media_collection) }
+
+  it_behaves_like "a CollectionDecorator"
+
+  describe "#identifier" do
+    let(:collection) do
+      FactoryBot.build(:archival_media_collection,
+                       identifier: "ark:/99999/fk4")
+    end
+    it "displays the identifier" do
+      expect(decorator.display_attributes[:identifier]).to eq ["ark:/99999/fk4"]
+    end
+  end
+end

--- a/spec/decorators/collection_decorator_spec.rb
+++ b/spec/decorators/collection_decorator_spec.rb
@@ -3,24 +3,9 @@ require 'rails_helper'
 
 RSpec.describe CollectionDecorator do
   subject(:decorator) { described_class.new(collection) }
-  let(:collection) { FactoryBot.create_for_repository(:collection) }
-  let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
+  let(:collection) { FactoryBot.build(:collection) }
 
-  it 'has no files which can be managed' do
-    expect(decorator.manageable_files?).to be false
-  end
-
-  describe '#collections' do
-    it "cannot have parent collections" do
-      expect(decorator.collections).to be_empty
-    end
-  end
-
-  describe '#parents' do
-    it "cannot have parent resources" do
-      expect(decorator.parents).to be_empty
-    end
-  end
+  it_behaves_like 'a CollectionDecorator'
 
   describe '#title' do
     it 'exposes the title' do

--- a/spec/shared_specs.rb
+++ b/spec/shared_specs.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require_relative 'shared_specs/controllers/base_resource_controller.rb'
+require_relative 'shared_specs/decorators/collection_decorator.rb'
 require_relative 'shared_specs/models/linked_data/linked_resource.rb'
 require_relative 'shared_specs/services/event_generator.rb'
 require_relative 'shared_specs/valhalla/change_sets/change_set.rb'

--- a/spec/shared_specs/decorators/collection_decorator.rb
+++ b/spec/shared_specs/decorators/collection_decorator.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.shared_examples 'a CollectionDecorator' do
+  before do
+    raise 'collection must be set with `let(:collection)`' unless
+      defined? collection
+    raise 'decorator must be set with `let(:decorator)`' unless
+      defined? decorator
+  end
+
+  it 'has no files which can be managed' do
+    expect(decorator.manageable_files?).to be false
+  end
+
+  describe '#collections' do
+    it "cannot have parent collections" do
+      expect(decorator.collections).to be_empty
+    end
+  end
+
+  describe '#parents' do
+    it "cannot have parent resources" do
+      expect(decorator.parents).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
- Adds DraftPublishWorkflow and identifier property to archival media collection.
- Modifies BagPathValidator to allow nil values so workflow state can be updated. Bag path is a required field, so the user must still enter an initial value in the form.
- Modifies BagPathValidator to test if a bag path directory actually exists.

Closes #1003 
Closes #1004 