### PR TITLE
Improve thumbnail display

### DIFF
--- a/app/assets/stylesheets/components/catalog.scss
+++ b/app/assets/stylesheets/components/catalog.scss
@@ -12,9 +12,10 @@ dl.document-metadata {
     width: 60%;
   }
   > .document-thumbnail {
+    margin-top: 20px;
     padding-left: 0;
     > a img {
-      width: 200px;
+      max-width: 200px;
     }
   }
 }

--- a/valhalla/app/assets/stylesheets/valhalla/file_manager.scss
+++ b/valhalla/app/assets/stylesheets/valhalla/file_manager.scss
@@ -25,10 +25,8 @@
     width: 16rem;
     margin: 0 1rem 1rem 0;
     .thumbnail {
-      height: 150px;
-      img {
-        max-height: 140px;
-      }
+      height: 160px;
+      overflow:hidden;
     }
     .order-title {
       display: inline-block;

--- a/valhalla/app/views/valhalla/base/_file_manager_thumbnail.html.erb
+++ b/valhalla/app/views/valhalla/base/_file_manager_thumbnail.html.erb
@@ -1,3 +1,3 @@
 <%= osd_modal_for(node.resource) do %>
-  <%= render_thumbnail_tag node, { class: 'thumbnail-inner', onerror: default_icon_fallback } %>
+  <%= render_thumbnail_tag node, { onerror: default_icon_fallback } %>
 <% end %>


### PR DESCRIPTION
- Improves thumbnails in File Manager. 
- Improves thumbnails in the catalog search results. Thumbnail images aren't stretched artificially so they fit comfortably in their without blurriness.

![screenshot 2018-05-02 15 25 45](https://user-images.githubusercontent.com/784196/39548908-99c11b58-4e21-11e8-847f-ac9f518f000d.png)

VS

![screenshot 2018-05-02 14 59 52](https://user-images.githubusercontent.com/784196/39548897-9447e526-4e21-11e8-893a-75145610f995.png)

And...

![screenshot 2018-05-02 15 53 06](https://user-images.githubusercontent.com/784196/39548994-e0999ad2-4e21-11e8-98f9-63a40450ed26.png)

VS

![screenshot 2018-05-02 16 01 16](https://user-images.githubusercontent.com/784196/39549075-2a2f4c1e-4e22-11e8-8152-6dfc93897be1.png)


