### PR TITLE
Add job for regenerating derivatives

### DIFF
--- a/app/controllers/file_sets_controller.rb
+++ b/app/controllers/file_sets_controller.rb
@@ -13,7 +13,7 @@ class FileSetsController < ApplicationController
     file_set = find_resource(params[:id])
     @change_set = change_set_class.new(file_set).prepopulate!
     authorize! :derive, @change_set.resource
-    output = CreateDerivativesJob.perform_later(params[:id])
+    output = RegenerateDerivativesJob.perform_later(params[:id])
     respond_to do |format|
       format.json do
         render json: output

--- a/app/jobs/regenerate_derivatives_job.rb
+++ b/app/jobs/regenerate_derivatives_job.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+class RegenerateDerivativesJob < ApplicationJob
+  delegate :query_service, to: :metadata_adapter
+
+  def perform(file_set_id)
+    file_set = query_service.find_by(id: Valkyrie::ID.new(file_set_id))
+    messenger.derivatives_deleted(file_set)
+    Valkyrie::Derivatives::DerivativeService.for(FileSetChangeSet.new(file_set)).cleanup_derivatives
+    Valkyrie::Derivatives::DerivativeService.for(FileSetChangeSet.new(file_set)).create_derivatives
+    messenger.derivatives_created(file_set)
+  rescue Valkyrie::Persistence::ObjectNotFoundError
+    Rails.logger.error "Unable to find FileSet #{file_set_id}"
+  end
+
+  def metadata_adapter
+    Valkyrie.config.metadata_adapter
+  end
+
+  def messenger
+    @messenger ||= EventGenerator.new
+  end
+end

--- a/spec/controllers/file_sets_controller_spec.rb
+++ b/spec/controllers/file_sets_controller_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe FileSetsController do
 
   describe "PUT /file_sets/id" do
     context 'with a derivative service for images in the TIFF' do
-      let(:create_derivatives_class) { class_double(CreateDerivativesJob).as_stubbed_const(transfer_nested_constants: true) }
+      let(:create_derivatives_class) { class_double(RegenerateDerivativesJob).as_stubbed_const(transfer_nested_constants: true) }
       let(:original_file) { instance_double(FileMetadata) }
       let(:file_set) { FactoryBot.create_for_repository(:file_set) }
       before do

--- a/spec/jobs/regenerate_derivatives_job_spec.rb
+++ b/spec/jobs/regenerate_derivatives_job_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe RegenerateDerivativesJob do
+  describe "#perform" do
+    context "with a valid file set id" do
+      let(:derivatives_service) { instance_double(Valkyrie::Derivatives::DerivativeService) }
+      let(:file_set) { FactoryBot.create_for_repository(:file_set) }
+      let(:generator) { instance_double(EventGenerator, derivatives_deleted: nil, derivatives_created: nil) }
+
+      before do
+        allow(Valkyrie::Derivatives::DerivativeService).to receive(:for).and_return(derivatives_service)
+        allow(derivatives_service).to receive(:create_derivatives)
+        allow(derivatives_service).to receive(:cleanup_derivatives)
+        allow(EventGenerator).to receive(:new).and_return(generator)
+      end
+
+      it "cleans up exisitng derivatives and generates new ones" do
+        described_class.perform_now(file_set.id)
+        expect(derivatives_service).to have_received(:cleanup_derivatives)
+        expect(derivatives_service).to have_received(:create_derivatives)
+      end
+    end
+
+    context "with an invalid file set id" do
+      let(:logger) { instance_double(ActiveSupport::Logger) }
+
+      before do
+        allow(Rails).to receive(:logger).and_return(logger)
+        allow(logger).to receive(:error)
+      end
+
+      it "logs the exception" do
+        described_class.perform_now('bogus')
+        expect(logger).to have_received(:error)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Adds RegenerateDerivativesJob to clean up existing derivatives before creating new ones.
- The FileSetsController `derivatives` method triggers this job instead of create derivatives job.

Closes #1168