### PR TITLE
Update ARK destination URLs 

### DIFF
--- a/app/services/identifier_service.rb
+++ b/app/services/identifier_service.rb
@@ -27,8 +27,8 @@ class IdentifierService
   end
 
   private_class_method def self.url_for(resource)
-    return Rails.application.routes.url_helpers.scanned_resource_url(resource, host: Figgy.default_url_options[:host]) if resource.try(:source_metadata_identifier).blank?
-    return "https://pulsearch.princeton.edu/catalog/#{resource.source_metadata_identifier.first}#view" if PulMetadataServices::Client.bibdata?(resource.source_metadata_identifier.first)
+    return Rails.application.routes.url_helpers.solr_document_url(resource, host: Figgy.default_url_options[:host]) if resource.try(:source_metadata_identifier).blank?
+    return "https://catalog.princeton.edu/catalog/#{resource.source_metadata_identifier.first}#view" if PulMetadataServices::Client.bibdata?(resource.source_metadata_identifier.first)
     "http://findingaids.princeton.edu/collections/#{resource.source_metadata_identifier.first.tr('_', '/')}"
   end
 

--- a/spec/services/identifier_service_spec.rb
+++ b/spec/services/identifier_service_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe IdentifierService do
   let(:persister) { Valkyrie.config.metadata_adapter.persister }
 
   context "when there is an existing identifier" do
-    let(:metadata) { base_metadata.merge(target: "https://pulsearch.princeton.edu/catalog/123456#{obj.id}#view") }
+    let(:metadata) { base_metadata.merge(target: "https://catalog.princeton.edu/catalog/123456#{obj.id}#view") }
     let(:obj) { FactoryBot.build :scanned_resource, source_metadata_identifier: '123456', identifier: ark }
 
     before do
@@ -35,7 +35,7 @@ RSpec.describe IdentifierService do
 
     context "with a bibdata source_metadata_identifier" do
       let(:bib) { '123456' }
-      let(:metadata) { base_metadata.merge(target: "https://pulsearch.princeton.edu/catalog/#{bib}#view") }
+      let(:metadata) { base_metadata.merge(target: "https://catalog.princeton.edu/catalog/#{bib}#view") }
       let(:obj) { FactoryBot.build :scanned_resource, source_metadata_identifier: bib }
 
       before do
@@ -64,7 +64,7 @@ RSpec.describe IdentifierService do
     end
 
     context "without a source_metadata_identifier" do
-      let(:metadata) { base_metadata.merge(target: "http://www.example.com/concern/scanned_resources/#{obj.id}") }
+      let(:metadata) { base_metadata.merge(target: "http://www.example.com/catalog/#{obj.id}") }
       let(:obj) { FactoryBot.create :scanned_resource, id: '1234567', source_metadata_identifier: nil }
       it "links to OrangeLight" do
         described_class.mint_or_update(resource: obj)
@@ -74,7 +74,7 @@ RSpec.describe IdentifierService do
   end
 
   context "integration test" do
-    let(:metadata) { base_metadata.merge(target: "http://example.com/concern/scanned_resources/#{obj.id}") }
+    let(:metadata) { base_metadata.merge(target: "http://example.com/catalog/#{obj.id}") }
     let(:obj) { FactoryBot.create :scanned_resource, id: '1234567', source_metadata_identifier: nil }
     let(:shoulder) { '99999/fk4' }
     let(:blade) { '123456' }


### PR DESCRIPTION
* Use catalog.princeton.edu instead of pulsearch.princeton.edu
* Use Figgy Blacklight show page instead of (non-existent) Valkyrie show page