### PR TITLE
Don't run after commit change set handler on delete

### DIFF
--- a/app/change_set_persisters/change_set_persister.rb
+++ b/app/change_set_persisters/change_set_persister.rb
@@ -81,7 +81,6 @@ class ChangeSetPersister
       before_delete(change_set: change_set)
       persister.delete(resource: change_set.resource).tap do
         after_delete_commit(change_set: change_set)
-        after_commit
       end
     end
 


### PR DESCRIPTION
The `after_commit` handler runs a Characterize job for file sets and sends a file set created message. Neither of those are needed when deleting.

Closes #773