### PR TITLE
Updating `browse-everything` from upstream for supporting Team Drives

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,7 +35,7 @@ GIT
 
 GIT
   remote: git://github.com/samvera/browse-everything.git
-  revision: 15c81b71cd6b9a12f49bdce907d5013531d9fbb4
+  revision: a1e7939687c6d948e0dd381175194ccbcffe8e30
   specs:
     browse-everything (0.15.1)
       addressable (~> 2.5)
@@ -43,7 +43,7 @@ GIT
       bootstrap-sass (~> 3.2)
       dropbox_api (>= 0.1.10)
       font-awesome-rails
-      google-api-client (~> 0.9)
+      google-api-client (~> 0.21)
       google_drive (~> 2.1)
       httparty (~> 0.15)
       rails (>= 4.2)
@@ -164,7 +164,7 @@ GEM
     autoprefixer-rails (8.2.0)
       execjs
     awesome_print (1.8.0)
-    aws-partitions (1.85.0)
+    aws-partitions (1.87.0)
     aws-sdk-core (3.20.2)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
@@ -357,15 +357,15 @@ GEM
       i18n
     globalid (0.4.1)
       activesupport (>= 4.2.0)
-    google-api-client (0.19.8)
+    google-api-client (0.21.1)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.5, < 0.7.0)
       httpclient (>= 2.8.1, < 3.0)
       mime-types (~> 3.0)
       representable (~> 3.0)
       retriable (>= 2.0, < 4.0)
-    google_drive (2.1.10)
-      google-api-client (>= 0.11.0, < 0.20.0)
+    google_drive (2.1.11)
+      google-api-client (>= 0.11.0, < 0.22.0)
       googleauth (>= 0.5.0, < 1.0.0)
       nokogiri (>= 1.5.3, < 2.0.0)
     googleauth (0.5.1)


### PR DESCRIPTION
Resolves #1133 