### PR TITLE
Adjust FileSet events

### DIFF
--- a/app/change_set_persisters/change_set_persister/publish_message.rb
+++ b/app/change_set_persisters/change_set_persister/publish_message.rb
@@ -51,7 +51,7 @@ class ChangeSetPersister
     def run
       messenger.record_updated(post_save_resource)
       # For cases where the resource is a FileSet, propagate for the parent resource
-      messenger.record_updated(post_save_resource.decorate.parent) if post_save_resource.is_a? FileSet
+      messenger.record_member_updated(post_save_resource.decorate.parent) if post_save_resource.is_a? FileSet
     end
 
     delegate :messenger, to: :change_set_persister

--- a/app/decorators/file_set_decorator.rb
+++ b/app/decorators/file_set_decorator.rb
@@ -29,6 +29,6 @@ class FileSetDecorator < Valkyrie::ResourceDecorator
   end
 
   def collection_slugs
-    @collection_slugs ||= parent.try(:collection_slugs)
+    []
   end
 end

--- a/app/services/event_generator.rb
+++ b/app/services/event_generator.rb
@@ -7,6 +7,7 @@ class EventGenerator
   delegate :record_created, to: :generators
   delegate :record_deleted, to: :generators
   delegate :record_updated, to: :generators
+  delegate :record_member_updated, to: :generators
 
   def generators
     @generators ||= CompositeGenerator.new(

--- a/app/services/event_generator/composite_generator.rb
+++ b/app/services/event_generator/composite_generator.rb
@@ -27,6 +27,10 @@ class EventGenerator
       delegate_to_generator(__method__, record)
     end
 
+    def record_member_updated(record)
+      delegate_to_generator(__method__, record)
+    end
+
     private
 
       # Send method with record argument to first valid generator

--- a/app/services/event_generator/geoblacklight_event_generator.rb
+++ b/app/services/event_generator/geoblacklight_event_generator.rb
@@ -30,6 +30,17 @@ class EventGenerator
       end
     end
 
+    def record_member_updated(record)
+      state = record.state.first
+      if state == "takedown"
+        record_deleted(record)
+      elsif state == "complete"
+        publish_message(
+          message("MEMBER_UPDATED", record)
+        )
+      end
+    end
+
     def valid?(record)
       return false if record.is_a?(FileSet)
       record.try(:geo_resource?) || false

--- a/app/services/event_generator/geoserver_event_generator.rb
+++ b/app/services/event_generator/geoserver_event_generator.rb
@@ -25,6 +25,8 @@ class EventGenerator
 
     def record_updated(record); end
 
+    def record_member_updated(record); end
+
     def valid?(record)
       return false unless record.is_a?(FileSet)
       return false unless geo_file_set?(record)

--- a/app/services/event_generator/manifest_event_generator.rb
+++ b/app/services/event_generator/manifest_event_generator.rb
@@ -32,6 +32,13 @@ class EventGenerator
       )
     end
 
+    def record_member_updated(record)
+      return unless record
+      publish_message(
+        message_with_collections("MEMBER_UPDATED", record)
+      )
+    end
+
     def valid?(record)
       if record.is_a?(FileSet)
         record.decorate.parent.try(:geo_resource?) ? false : true
@@ -44,8 +51,6 @@ class EventGenerator
 
       def manifest_url(record)
         helper.manifest_url(record)
-      rescue
-        ""
       end
 
       def message(type, record)

--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -381,7 +381,7 @@ class ManifestBuilder
       when Collection
         "#{protocol}://#{host}/collections/#{resource.id}/manifest"
       when FileSet
-        "#{protocol}://#{host}/concern/#{resource.decorate.parent.model_name.plural}/#{resource.decorate.parent.id}/manifest"
+        ""
       else
         "#{protocol}://#{host}/concern/#{resource.model_name.plural}/#{resource.id}/manifest"
       end

--- a/app/validators/unique_archival_media_barcode_validator.rb
+++ b/app/validators/unique_archival_media_barcode_validator.rb
@@ -3,32 +3,45 @@ class UniqueArchivalMediaBarcodeValidator < ActiveModel::Validator
   attr_reader :record
 
   def validate(record)
-    @record = record
-    return if duplicates.empty?
-    record.errors.add(:bag_path, "The following barcodes have already been imported to this object. Delete their file sets to reingest: #{previously_imported}")
+    # Validators aren't instantiated at the instance level to check if
+    # something's valid, so delegate to a class which is and can use instance
+    # variables.
+    Checker.new(record: record).validate!
   end
 
-  private
-
-    def duplicates
-      files_to_import & previously_imported
+  class Checker
+    attr_reader :record
+    def initialize(record:)
+      @record = record
     end
 
-    def files_to_import
-      return [] if record.bag_path.nil?
-      bag.file_groups.keys
+    def validate!
+      return if duplicates.empty?
+      record.errors.add(:bag_path, "The following barcodes have already been imported to this object. Delete their file sets to reingest: #{previously_imported}")
     end
 
-    def previously_imported
-      return [] if record.model.id.nil? # it's a new resource
-      decorator.media_resources.map { |resource| resource.decorate.file_sets }.flatten.map { |file_set| "#{file_set.barcode.first}_#{file_set.part.first}" }
-    end
+    private
 
-    def decorator
-      @decorator ||= record.model.decorate
-    end
+      def duplicates
+        files_to_import & previously_imported
+      end
 
-    def bag
-      @bag ||= ArchivalMediaBagParser.new(path: Pathname.new(record.bag_path), component_id: record.source_metadata_identifier)
-    end
+      def files_to_import
+        return [] if record.bag_path.nil?
+        bag.file_groups.keys
+      end
+
+      def previously_imported
+        return [] if record.model.id.nil? # it's a new resource
+        decorator.media_resources.map { |resource| resource.decorate.file_sets }.flatten.map { |file_set| "#{file_set.barcode.first}_#{file_set.part.first}" }
+      end
+
+      def decorator
+        @decorator ||= record.model.decorate
+      end
+
+      def bag
+        @bag ||= ArchivalMediaBagParser.new(path: Pathname.new(record.bag_path), component_id: record.source_metadata_identifier)
+      end
+  end
 end

--- a/spec/change_set_persisters/change_set_persister_spec.rb
+++ b/spec/change_set_persisters/change_set_persister_spec.rb
@@ -852,7 +852,7 @@ RSpec.describe ChangeSetPersister do
     before do
       stub_pulfa(pulfa_id: "C0652")
       change_set.prepopulate!
-      change_set.validate(source_metadata_identifier: "C0652")
+      change_set.source_metadata_identifier = "C0652"
     end
 
     it "persists the file using the bag adapter" do

--- a/spec/change_set_persisters/change_set_persister_spec.rb
+++ b/spec/change_set_persisters/change_set_persister_spec.rb
@@ -394,12 +394,21 @@ RSpec.describe ChangeSetPersister do
 
         expected_result = {
           "id" => output.id.to_s,
-          "event" => "UPDATED",
+          "event" => "MEMBER_UPDATED",
           "manifest_url" => "http://www.example.com/concern/scanned_resources/#{output.id}/manifest",
           "collection_slugs" => ["test"]
         }
 
         expect(rabbit_connection).to have_received(:publish).at_least(:once).with(expected_result.to_json)
+
+        expected_result_fs = {
+          "id" => file_set.id.to_s,
+          "event" => "UPDATED",
+          "manifest_url" => "",
+          "collection_slugs" => []
+        }
+
+        expect(rabbit_connection).to have_received(:publish).at_least(:once).with(expected_result_fs.to_json)
       end
 
       it "publishes messages for updates and creating file sets", run_real_derivatives: false, rabbit_stubbed: true do
@@ -421,7 +430,7 @@ RSpec.describe ChangeSetPersister do
         fs_expected_result = {
           "id" => fs_output.id.to_s,
           "event" => "CREATED",
-          "manifest_url" => "http://www.example.com/concern/scanned_resources/#{output.id}/manifest",
+          "manifest_url" => "",
           "collection_slugs" => []
         }
 
@@ -468,7 +477,7 @@ RSpec.describe ChangeSetPersister do
 
         expected_result = {
           "id" => output.id.to_s,
-          "event" => "UPDATED",
+          "event" => "MEMBER_UPDATED",
           "manifest_url" => "http://www.example.com/concern/ephemera_folders/#{output.id}/manifest",
           "collection_slugs" => [ephemera_project.decorate.slug]
         }
@@ -488,7 +497,7 @@ RSpec.describe ChangeSetPersister do
 
         expected_result = {
           "id" => output.id.to_s,
-          "event" => "UPDATED",
+          "event" => "MEMBER_UPDATED",
           "manifest_url" => "http://www.example.com/concern/ephemera_folders/#{output.id}/manifest",
           "collection_slugs" => [ephemera_project.decorate.slug]
         }
@@ -498,7 +507,7 @@ RSpec.describe ChangeSetPersister do
         fs_expected_result = {
           "id" => fs_output.id.to_s,
           "event" => "CREATED",
-          "manifest_url" => "http://www.example.com/concern/ephemera_folders/#{output.id}/manifest",
+          "manifest_url" => "",
           "collection_slugs" => []
         }
 

--- a/spec/services/event_generator/geoblacklight_event_generator_spec.rb
+++ b/spec/services/event_generator/geoblacklight_event_generator_spec.rb
@@ -66,6 +66,49 @@ RSpec.describe EventGenerator::GeoblacklightEventGenerator do
     end
   end
 
+  describe "#record_member_updated" do
+    context "with a record in a completed state" do
+      it "publishes a persistent JSON updated message with geoblacklight document" do
+        gbl_doc = GeoDiscovery::DocumentBuilder.new(record, GeoDiscovery::GeoblacklightDocument.new)
+        expected_result = {
+          "id" => record.id.to_s,
+          "event" => "MEMBER_UPDATED",
+          "doc" => gbl_doc
+        }
+
+        event_generator.record_member_updated(record)
+
+        expect(rabbit_connection).to have_received(:publish).with(expected_result.to_json)
+      end
+    end
+
+    context "with a record in a takedown state" do
+      let(:record) { FactoryBot.create_for_repository(:scanned_map, state: "takedown") }
+
+      it "publishes a persistent JSON delete message with the geoblacklight slug as the id" do
+        slug = GeoDiscovery::DocumentBuilder::SlugBuilder.new(record).slug
+        expected_result = {
+          "id" => slug,
+          "event" => "DELETED"
+        }
+
+        event_generator.record_member_updated(record)
+
+        expect(rabbit_connection).to have_received(:publish).with(expected_result.to_json)
+      end
+    end
+
+    context "with a record in a pending state" do
+      let(:record) { FactoryBot.create_for_repository(:scanned_map, state: "pending") }
+
+      it "does not publish a JSON message" do
+        event_generator.record_member_updated(record)
+
+        expect(rabbit_connection).not_to have_received(:publish)
+      end
+    end
+  end
+
   describe "#valid?" do
     context "with a fileset" do
       let(:record) { FactoryBot.create_for_repository(:file_set) }

--- a/spec/support/stub_rabbit.rb
+++ b/spec/support/stub_rabbit.rb
@@ -12,6 +12,7 @@ RSpec.configure do |config|
         allow(rabbit).to receive(:record_created)
         allow(rabbit).to receive(:record_updated)
         allow(rabbit).to receive(:record_deleted)
+        allow(rabbit).to receive(:record_member_updated)
         rabbit
       end
 
@@ -22,6 +23,7 @@ RSpec.configure do |config|
         allow(rabbit).to receive(:record_created)
         allow(rabbit).to receive(:record_updated)
         allow(rabbit).to receive(:record_deleted)
+        allow(rabbit).to receive(:record_member_updated)
         rabbit
       end
     end


### PR DESCRIPTION
Send parent events as a new event type on update and don't send manifest
URL so DPUL won't try to reindex every time a FileSet changes.