### PR TITLE
Hide imported extent field on scanned maps

### DIFF
--- a/app/decorators/scanned_map_decorator.rb
+++ b/app/decorators/scanned_map_decorator.rb
@@ -11,6 +11,7 @@ class ScannedMapDecorator < Valkyrie::ResourceDecorator
   suppress :thumbnail_id,
            :coverage,
            :cartographic_projection,
+           :extent,
            :identifier,
            :source_jsonld,
            :sort_title

--- a/spec/features/scanned_map_spec.rb
+++ b/spec/features/scanned_map_spec.rb
@@ -56,7 +56,10 @@ RSpec.feature "ScannedMaps", js: true do
         cartographic_scale: "test value",
         spatial: "test value",
         temporal: "test value",
-        issued: "test value"
+        issued: "test value",
+        imported_metadata: [{
+          extent: "test extent"
+        }]
       )
     end
 
@@ -84,6 +87,7 @@ RSpec.feature "ScannedMaps", js: true do
       expect(page).to have_css ".attribute.spatial", text: "test value"
       expect(page).to have_css ".attribute.temporal", text: "test value"
       expect(page).to have_css ".attribute.issued", text: "test value"
+      expect(page).not_to have_css ".attribute.extent", text: "test extent"
     end
   end
 end

--- a/spec/views/catalog/_resource_attributes_default.html.erb_spec.rb
+++ b/spec/views/catalog/_resource_attributes_default.html.erb_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe "catalog/_resource_attributes_default.html.erb" do
       render
     end
     after { Timecop.return }
-    it "renders all available attributes" do
+    it "renders all available attributes, except if supressed" do
       expect(rendered).to have_selector "#attributes h2", text: "Attributes"
 
       # Language
@@ -237,9 +237,8 @@ RSpec.describe "catalog/_resource_attributes_default.html.erb" do
       expect(rendered).to have_selector "th", text: "Call Number"
       expect(rendered).to have_content "G8731.F7 1927 .C6"
 
-      # Extent
-      expect(rendered).to have_selector "th", text: "Extent"
-      expect(rendered).to have_content "Scale 1:3,000,000 (E 8°33ʹ00ʹʹ--E 14°37ʹ00ʹʹ/N 12°30ʹ00ʹʹ--N 3°53ʹ24ʹʹ)."
+      # Extent (supressed)
+      expect(rendered).not_to have_selector "th", text: "Extent"
 
       # Type
       expect(rendered).to have_selector "th", text: "Type"


### PR DESCRIPTION
Closes #1307