### PR TITLE
Add members relation to FileSetWayfinder

### DIFF
--- a/app/wayfinders/file_set_wayfinder.rb
+++ b/app/wayfinders/file_set_wayfinder.rb
@@ -5,4 +5,9 @@ class FileSetWayfinder < BaseWayfinder
   def collections
     []
   end
+
+  def members
+    []
+  end
+  alias decorated_members members
 end

--- a/spec/wayfinders/wayfinder_spec.rb
+++ b/spec/wayfinders/wayfinder_spec.rb
@@ -736,4 +736,16 @@ RSpec.describe Wayfinder do
       end
     end
   end
+  context "when given a file set" do
+    describe "#members" do
+      it "returns an empty array" do
+        file_set = FactoryBot.create_for_repository(:file_set)
+
+        wayfinder = described_class.for(file_set)
+
+        expect(wayfinder.members).to eq []
+        expect(wayfinder.decorated_members).to eq []
+      end
+    end
+  end
 end


### PR DESCRIPTION
ScannedMaps are unable to generate a manifest without this in
production.