### PR TITLE
Use X-Accel-Redirect for NGINX download

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -10,6 +10,11 @@ class DownloadsController < ApplicationController
     end
   end
 
+  def send_content
+    prepare_file_headers
+    send_file(load_file.file.disk_path, filename: load_file.original_name, type: load_file.mime_type, disposition: :inline)
+  end
+
   def resource
     @resource ||= query_service.find_by(id: Valkyrie::ID.new(params[:resource_id]))
   rescue Valkyrie::Persistence::ObjectNotFoundError
@@ -49,7 +54,6 @@ class DownloadsController < ApplicationController
   # Copied from hydra-head and adjusted to handle the fact that we don't have a
   # modified_date in Valkyrie yet.
   def prepare_file_headers
-    send_file_headers! content_options
     response.headers["Content-Type"] = file_desc.mime_type.first.to_s
     response.headers["Content-Length"] ||= binary_file.size.to_s
     # Prevent Rack::ETag from calculating a digest over body

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -12,6 +12,11 @@ class DownloadsController < ApplicationController
 
   def send_content
     prepare_file_headers
+    # Necessary until a Rack version is released which allows for multiple
+    # HTTP_X_ACCEL_MAPPING. When this commit is in a released version:
+    # https://github.com/rack/rack/commit/f2361997623e5141e6baa907d79f1212b36fbb8b
+    # remove this line and move it to the nginx configuration.
+    request.env["HTTP_X_ACCEL_MAPPING"] = "/opt/repository/=/restricted_repository/"
     send_file(load_file.file.disk_path, filename: load_file.original_name, type: load_file.mime_type, disposition: :inline)
   end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -12,7 +12,6 @@ Rails.application.configure do
   config.i18n.fallbacks = true
   config.active_support.deprecation = :notify
   config.active_record.dump_schema_after_migration = false
-  config.middleware.use Rack::Deflater
   config.public_file_server.headers = {
     "Cache-Control" => "public, max-age=31557600"
   }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,4 +19,5 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: ENV.fetch("APPLICATION_HOST", "localhost"), protocol: ENV.fetch("APPLICATION_HOST_PROTOCOL", "http") }
   config.action_controller.action_on_unpermitted_parameters = false
   config.force_ssl = true
+  config.action_dispatch.x_sendfile_header = "X-Accel-Redirect"
 end


### PR DESCRIPTION
Greatly improves the efficiency of downloading of full-res images by delegating down to nginx. The request comes in, authorizes in Figgy, and then passes to an internal path in nginx for handling the request.

This enables file resumption on server restart, HTTP Range requests, and download estimates when downloading in a browser.