### PR TITLE
Prevents "Apply Changes" from being hidden in OrderManager

### DIFF
--- a/app/javascript/components/FilesetsForm.vue
+++ b/app/javascript/components/FilesetsForm.vue
@@ -133,4 +133,7 @@ legend {
   padding-left: 30px;
 }
 
+.form-group {
+  margin-bottom: 15px;
+}
 </style>


### PR DESCRIPTION
fixes #1294 Tightens up form so that "Apply Changes" is not hidden on smaller screens when using foliation options.