### PR TITLE
 Send updated message after extracting external geo metadata

### DIFF
--- a/app/controllers/concerns/geo_resource_controller.rb
+++ b/app/controllers/concerns/geo_resource_controller.rb
@@ -6,7 +6,7 @@ module GeoResourceController
       change_set = change_set_class.new(find_resource(params[:id])).prepopulate!
       authorize! :update, change_set.resource
       file_node = query_service.find_by(id: Valkyrie::ID.new(params[:file_set_id]))
-      GeoMetadataExtractor.new(change_set: change_set, file_node: file_node, persister: persister).extract
+      GeoMetadataExtractor.new(change_set: change_set, file_node: file_node, persister: change_set_persister).extract
     end
   end
 end

--- a/app/derivative-services/external_metadata_derivative_service.rb
+++ b/app/derivative-services/external_metadata_derivative_service.rb
@@ -17,8 +17,6 @@ class ExternalMetadataDerivativeService
 
   attr_reader :change_set, :change_set_persister, :original_file
   delegate :mime_type, to: :original_file
-  delegate :metadata_adapter, to: :change_set_persister
-  delegate :persister, to: :metadata_adapter
   def initialize(change_set:, change_set_persister:, original_file:)
     @change_set = change_set
     @change_set_persister = change_set_persister
@@ -29,7 +27,7 @@ class ExternalMetadataDerivativeService
 
   # Extract external geo metadata into parent vector or raster resource.
   def create_derivatives
-    GeoMetadataExtractor.new(change_set: parent_change_set, file_node: change_set.resource, persister: persister).extract
+    GeoMetadataExtractor.new(change_set: parent_change_set, file_node: change_set.resource, persister: change_set_persister).extract
   end
 
   def parent

--- a/app/services/event_generator/geoblacklight_event_generator.rb
+++ b/app/services/event_generator/geoblacklight_event_generator.rb
@@ -31,14 +31,7 @@ class EventGenerator
     end
 
     def record_member_updated(record)
-      state = record.state.first
-      if state == "takedown"
-        record_deleted(record)
-      elsif state == "complete"
-        publish_message(
-          message("MEMBER_UPDATED", record)
-        )
-      end
+      record_updated(record)
     end
 
     def valid?(record)

--- a/app/services/geo_metadata_extractor.rb
+++ b/app/services/geo_metadata_extractor.rb
@@ -11,14 +11,14 @@ class GeoMetadataExtractor
     raise ArgumentError, "MIME type unspecified or not configured" if schema.blank?
     attributes = extractor_class.new(metadata_xml).extract
     apply_metadata(attributes)
-    persister.save(resource: change_set.resource)
+    persister.save(change_set: change_set)
   end
 
   private
 
     def apply_metadata(attributes)
       attributes.each do |key, value|
-        change_set.model.send("#{key}=".to_sym, value) if change_set.respond_to?(key)
+        change_set.send("#{key}=".to_sym, value) if change_set.respond_to?(key)
       end
     end
 

--- a/spec/services/event_generator/geoblacklight_event_generator_spec.rb
+++ b/spec/services/event_generator/geoblacklight_event_generator_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe EventGenerator::GeoblacklightEventGenerator do
         gbl_doc = GeoDiscovery::DocumentBuilder.new(record, GeoDiscovery::GeoblacklightDocument.new)
         expected_result = {
           "id" => record.id.to_s,
-          "event" => "MEMBER_UPDATED",
+          "event" => "UPDATED",
           "doc" => gbl_doc
         }
 

--- a/spec/services/geo_metadata_extractor_spec.rb
+++ b/spec/services/geo_metadata_extractor_spec.rb
@@ -4,10 +4,9 @@ include ActionDispatch::TestProcess
 
 RSpec.describe GeoMetadataExtractor do
   with_queue_adapter :inline
-  subject(:extractor) { described_class.new(change_set: change_set, file_node: file_set, persister: persister) }
+  subject(:extractor) { described_class.new(change_set: change_set, file_node: file_set, persister: change_set_persister) }
   let(:adapter) { Valkyrie.config.metadata_adapter }
   let(:storage_adapter) { Valkyrie.config.storage_adapter }
-  let(:persister) { adapter.persister }
   let(:query_service) { adapter.query_service }
   let(:change_set_persister) { ChangeSetPersister.new(metadata_adapter: adapter, storage_adapter: storage_adapter) }
   let(:map) do


### PR DESCRIPTION
- Sends a `record_updated` message after extracting external geo metadata.
- Sends UPDATED geoblacklight event message when a member is updated instead of MEMBER_UPDATED

Closes #1335 