### PR TITLE
Ensures that the `ManifestBuilder::ThumbnailBuilder#file_set` handles cases where `ManifestBuilder::RootNode#file_set_presenters` returns empty Arrays

### DIFF
--- a/app/services/manifest_builder/thumbnail_builder.rb
+++ b/app/services/manifest_builder/thumbnail_builder.rb
@@ -1,14 +1,19 @@
 # frozen_string_literal: true
 class ManifestBuilder
+  # Builder Class for thumbnail resources within IIIF Presentation Manifests
+  # @see http://iiif.io/api/presentation/2.1/#thumbnail
   class ThumbnailBuilder
     attr_reader :resource
 
-    ##
-    # @param [Resource] resource the Resource being viewed
+    # Constructor
+    # @param resource [Valkyrie::Resource] the Resource being viewed
     def initialize(resource)
       @resource = resource
     end
 
+    # Adds the thumbnail URI to the Manifest object
+    # @param manifest [IIIFManifest::ManifestBuilder::IIIFManifest] the manifest
+    # @return [IIIFManifest::ManifestBuilder::IIIFManifest] the updated manifest
     def apply(manifest)
       manifest["thumbnail"] = thumbnail if thumbnail.present?
       manifest
@@ -16,10 +21,15 @@ class ManifestBuilder
 
     private
 
+      # Construct or retrieve the memoized ManifestHelper Object
+      # @return [ManifestHelper]
       def helper
         @helper ||= ManifestHelper.new
       end
 
+      # Generate the value Hash modeling the thumbnail resource for the Manifest
+      # @see http://iiif.io/api/presentation/2.1/#resource-structure
+      # @return [Hash, nil]
       def thumbnail
         return nil unless thumbnail_id && file_set && file_set.derivative_file
         {
@@ -32,12 +42,18 @@ class ManifestBuilder
         }
       end
 
+      # Retrieve the FileSet Resource for the thumbnail
+      # @return [FileSet, nil]
       def file_set
         @file_set ||= find_thumbnail_file_set(thumbnail_id)
       rescue Valkyrie::Persistence::ObjectNotFoundError
+        return if resource.file_set_presenters.empty?
         @file_set ||= query_service.find_by(id: resource.file_set_presenters.first.id)
       end
 
+      # Retrieve the FileSet resource for a given Valkyrie ID
+      # @param record_id [Valkyrie::ID, String] the ID for the FileSet
+      # @return [FileSet]
       def find_thumbnail_file_set(record_id)
         return unless record_id.present?
         record = query_service.find_by(id: Valkyrie::ID.new(record_id.to_s))
@@ -48,10 +64,14 @@ class ManifestBuilder
         end
       end
 
+      # Retrieve the query service from the metadata adapter
+      # @return [Valkyrie::Persistence::Postgres::QueryService]
       def query_service
         Valkyrie.config.metadata_adapter.query_service
       end
 
+      # Retrieve the ID for the resource used as a thumbnail
+      # @return [Valkyrie::ID]
       def thumbnail_id
         Array.wrap(resource.thumbnail_id).first
       end

--- a/spec/services/manifest_builder/thumbnail_builder_spec.rb
+++ b/spec/services/manifest_builder/thumbnail_builder_spec.rb
@@ -42,9 +42,10 @@ describe ManifestBuilder::ThumbnailBuilder do
         cs = ScannedResourceChangeSet.new(scanned_resource, thumbnail_id: ["invalid-id"])
         change_set_persister.save(change_set: cs)
       end
+      let(:output) { builder.apply(manifest) }
 
-      it "logs a warning" do
-        output = builder.apply(manifest)
+      it "does not raise an exception" do
+        expect { output }.not_to raise_error
         expect(output["thumbnail"]).to be_blank
       end
     end

--- a/spec/services/manifest_builder/thumbnail_builder_spec.rb
+++ b/spec/services/manifest_builder/thumbnail_builder_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+require "rails_helper"
+include ActionDispatch::TestProcess
+
+describe ManifestBuilder::ThumbnailBuilder do
+  with_queue_adapter :inline
+  subject(:output) { builder.apply(manifest) }
+  let(:change_set) { ScannedResourceChangeSet.new(scanned_resource, files: [file]) }
+  let(:metadata_adapter) { Valkyrie.config.metadata_adapter }
+  let(:change_set_persister) { ChangeSetPersister.new(metadata_adapter: metadata_adapter, storage_adapter: Valkyrie.config.storage_adapter) }
+  let(:file) { fixture_file_upload("files/abstract.tiff", "image/tiff") }
+  let(:manifest) { ManifestBuilder::ManifestServiceLocator.iiif_manifest_factory.new }
+  let(:scanned_resource) do
+    FactoryBot.create_for_repository(:scanned_resource)
+  end
+  let(:root_node) { ManifestBuilder::RootNode.new(scanned_resource) }
+  let(:builder) { described_class.new(root_node) }
+
+  describe "#apply" do
+    context "when viewing a Scanned Resource" do
+      let(:persisted) do
+        change_set_persister.save(change_set: change_set)
+      end
+
+      before do
+        persisted
+      end
+
+      it "appends the transformed metadata to the Manifest" do
+        expect(output["thumbnail"]).not_to be_blank
+        expect(output["thumbnail"]).to include "@id"
+        expect(output["thumbnail"]["@id"]).to eq "http://www.example.com/image-service/#{persisted.member_ids.first}/full/!200,150/0/default.jpg"
+
+        expect(output["thumbnail"]).to include "service"
+        expect(output["thumbnail"]["service"]).to include "@id"
+        expect(output["thumbnail"]["service"]["@id"]).to eq "http://www.example.com/image-service/#{persisted.member_ids.first}"
+      end
+    end
+
+    context "when the FileSet cannot be loaded" do
+      let(:persisted) do
+        cs = ScannedResourceChangeSet.new(scanned_resource, thumbnail_id: ["invalid-id"])
+        change_set_persister.save(change_set: cs)
+      end
+
+      it "logs a warning" do
+        output = builder.apply(manifest)
+        expect(output["thumbnail"]).to be_blank
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #1322 