### PR TITLE
Ensures that `IngestFolderLocator#folder_pathname` handles cases where the directory cannot be found

### DIFF
--- a/app/services/ingest_folder_locator.rb
+++ b/app/services/ingest_folder_locator.rb
@@ -15,21 +15,27 @@ class IngestFolderLocator
     file_system_config[:home]
   end
 
-  # Generate the path to parent directory
+  # Generate the path to the studio directory used for ingestion
   # @return [Pathname]
   def root_path
     Pathname.new(upload_path_value).join("studio_new")
   end
 
+  # Determines whether or not the directory exists
+  # @return [TrueClass, FalseClass]
   def exists?
     folder_location.present?
   end
 
+  # Retrieves the relative path from the studio ingestion directory
+  # @return [Pathname]
   def location
     return unless exists?
     folder_pathname.relative_path_from(root_path)
   end
 
+  # Counts the number of files in the directory
+  # @return [Integer]
   def file_count
     return unless exists?
     Dir.glob(folder_pathname.join("**")).select do |file|
@@ -37,6 +43,8 @@ class IngestFolderLocator
     end.count
   end
 
+  # Counts the number of child directories in the directory
+  # @return [Integer]
   def volume_count
     return unless exists?
     Dir.glob(folder_pathname.join("**")).select do |file|
@@ -44,12 +52,17 @@ class IngestFolderLocator
     end.count
   end
 
+  # Construct or retrieve the memoized path name for the directory
+  # @return [Pathname]
   def folder_pathname
+    return unless exists?
     @folder_pathname ||= Pathname.new(folder_location)
   end
 
   private
 
+    # Construct or retrieve the memoized file system path for the directory whose name matches the ID
+    # @return [String]
     def folder_location
       @folder_location ||= Dir.glob(root_path.join("**/#{id}")).first
     end

--- a/spec/services/ingest_folder_locator_spec.rb
+++ b/spec/services/ingest_folder_locator_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe IngestFolderLocator do
+  subject(:locator) { described_class.new(id: id) }
+  let(:id) { "123456" }
+  let(:upload_path_value) { Rails.root.join("spec", "fixtures", "staged_files") }
+
+  before do
+    allow(BrowseEverything).to receive(:config).and_return(file_system: {
+                                                             home: upload_path_value
+                                                           })
+  end
+
+  describe "#upload_path_value" do
+    it "parses the upload path from the BrowseEverything config." do
+      expect(locator.upload_path_value).to eq upload_path_value
+    end
+  end
+
+  describe "#root_path" do
+    let(:root_path) { Pathname.new(upload_path_value).join("studio_new") }
+    it "generates the root path from the upload directory" do
+      expect(locator.root_path).to eq root_path
+    end
+  end
+
+  describe "#exists?" do
+    it "determines if the folder location exists on disk" do
+      expect(locator.exists?).to be true
+    end
+  end
+
+  describe "#location" do
+    it "retrieves relative root" do
+      expect(locator.location).to be_a Pathname
+      expect(locator.location.to_s).to eq "DPUL/Santa/ready/123456"
+    end
+  end
+
+  describe "#file_count" do
+    it "counts the files" do
+      expect(locator.file_count).to eq 2
+    end
+  end
+
+  describe "#volume_count" do
+    let(:id) { "4609321" }
+    it "counts the directories" do
+      expect(locator.volume_count).to eq 2
+    end
+  end
+
+  describe "#folder_pathname" do
+    let(:folder_pathname) { Pathname.new(File.join(upload_path_value, "studio_new", "DPUL", "Santa", "ready", "123456")) }
+
+    it "constructs a Pathname for the folder" do
+      expect(locator.folder_pathname).to eq folder_pathname
+    end
+
+    context "without a valid folder path" do
+      subject(:locator) { described_class.new(id: "foo") }
+
+      it "returns nil" do
+        expect(locator.folder_pathname).to be nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #1345 