### PR TITLE
Overriding `Blacklight::CatalogHelperBehavior#render_search_to_page_title_filter` in order to handle nil or empty facet parameter values

### DIFF
--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -2,6 +2,9 @@
 module CatalogHelper
   include Blacklight::CatalogHelperBehavior
 
+  # Generates the markup for search result items
+  # @param args [Array<Object>]
+  # @return [String] the markup
   def render_document_heading(*args)
     options = args.extract_options!
     document = args.first
@@ -11,5 +14,16 @@ module CatalogHelper
     # escape manually to allow <br /> to go through unescaped
     val = Array.wrap(presenter(document).heading).map { |v| h(v) }.join("<br />")
     content_tag(tag, val, { itemprop: "name", dir: val.to_s.dir }, false)
+  end
+
+  # Generates the text for faceted search parameters
+  # @see Blacklight::CatalogHelperBehavior#render_search_to_page_title_filter
+  #
+  # @param facet [String] the facet parameter name
+  # @param values [Array<String>] the facet parameter values
+  # @return [String]
+  def render_search_to_page_title_filter(facet, values)
+    return "" unless facet && values
+    super(facet, values)
   end
 end

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -34,4 +34,26 @@ RSpec.describe ::BlacklightHelper do
       end
     end
   end
+
+  describe "render_search_to_page_title_filter" do
+    let(:facet) { "human_readable_type_ssim" }
+    let(:values) { ["Scanned Resource", "Vector Resource"] }
+
+    before do
+      allow(helper).to receive(:blacklight_config).and_return(CatalogController.blacklight_config)
+      allow(helper).to receive(:action_name).and_return("show")
+    end
+
+    it "generates the text for the faceted search" do
+      expect(helper.render_search_to_page_title_filter(facet, values)).to eq "Type of Work: Scanned Resource and Vector Resource"
+    end
+
+    context "with empty values for the facet parameters" do
+      let(:values) { nil }
+
+      it "generates no text" do
+        expect(helper.render_search_to_page_title_filter(facet, values)).to eq ""
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves #1343 