### PR TITLE
Set member_of_collection_ids to empty array instead of nil

### DIFF
--- a/app/controllers/bulk_ingest_controller.rb
+++ b/app/controllers/bulk_ingest_controller.rb
@@ -21,7 +21,7 @@ class BulkIngestController < ApplicationController
 
     def attributes
       {
-        member_of_collection_ids: params[:collections],
+        member_of_collection_ids: collections_param,
         state: params[:workflow][:state],
         visibility: params[:visibility]
       }
@@ -30,6 +30,10 @@ class BulkIngestController < ApplicationController
     def collections
       collection_decorators = query_service.find_all_of_model(model: Collection).map(&:decorate)
       collection_decorators.to_a.collect { |c| [c.title, c.id.to_s] }
+    end
+
+    def collections_param
+      params[:collections] || []
     end
 
     def file_paths

--- a/spec/controllers/bulk_ingest_controller_spec.rb
+++ b/spec/controllers/bulk_ingest_controller_spec.rb
@@ -64,7 +64,6 @@ RSpec.describe BulkIngestController do
       let(:attributes) do
         {
           workflow: { state: "pending" },
-          collections: ["1234567"],
           visibility: "open",
           mvw: false,
           selected_files: selected_files
@@ -79,7 +78,7 @@ RSpec.describe BulkIngestController do
 
       it "ingests the parent as two resources" do
         post :browse_everything_files, params: { resource_type: "scanned_resource", **attributes }
-        expect(IngestFoldersJob).to have_received(:perform_later).with(hash_including(directory: "/base", state: "pending", visibility: "open", member_of_collection_ids: ["1234567"]))
+        expect(IngestFoldersJob).to have_received(:perform_later).with(hash_including(directory: "/base", state: "pending", visibility: "open", member_of_collection_ids: []))
       end
     end
 
@@ -110,7 +109,6 @@ RSpec.describe BulkIngestController do
       let(:attributes) do
         {
           workflow: { state: "pending" },
-          collections: ["1234567"],
           visibility: "open",
           mvw: true,
           selected_files: selected_files
@@ -127,7 +125,7 @@ RSpec.describe BulkIngestController do
 
       it "ingests the parent as two resources" do
         post :browse_everything_files, params: { resource_type: "scanned_resource", **attributes }
-        expect(IngestFoldersJob).to have_received(:perform_later).with(hash_including(directory: "/base", state: "pending", visibility: "open", member_of_collection_ids: ["1234567"]))
+        expect(IngestFoldersJob).to have_received(:perform_later).with(hash_including(directory: "/base", state: "pending", visibility: "open", member_of_collection_ids: []))
       end
     end
   end


### PR DESCRIPTION
When no collections are selected in bulk ingest, the controller should set member_of_collection_ids  to an empty array instead of a nil value. Setting it to nil raises an exception.

Closes #1375 