### PR TITLE
Move bag validation from bag parser initializer to public method

### DIFF
--- a/spec/change_set_persisters/change_set_persister_spec.rb
+++ b/spec/change_set_persisters/change_set_persister_spec.rb
@@ -1022,7 +1022,7 @@ RSpec.describe ChangeSetPersister do
       end
 
       it "raises an error and does not persist the file" do
-        expect { change_set_persister.save(change_set: change_set) }.to raise_error(ArchivalMediaBagParser::InvalidBagError, "Bag at #{bag_path} is an invalid bag")
+        expect { change_set_persister.save(change_set: change_set) }.to raise_error(IngestArchivalMediaBagJob::InvalidBagError, "Bag at #{bag_path} is an invalid bag")
       end
     end
   end

--- a/spec/change_sets/archival_media_collection_change_set_spec.rb
+++ b/spec/change_sets/archival_media_collection_change_set_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe ArchivalMediaCollectionChangeSet do
       it "is invalid" do
         # create the collection so we know its id
         collection = FactoryBot.create_for_repository(:archival_media_collection, source_metadata_identifier: collection_cid)
-        # ingest the bag so it has the barcoes
+        # ingest the bag so it has the barcodes
         IngestArchivalMediaBagJob.perform_now(collection_component: collection_cid, bag_path: av_fixture_bag, user: nil)
         # retrieve the collection via the query service and put it in a change set with the bag
         collection = query_service.find_by(id: collection.id)

--- a/spec/jobs/ingest_archival_media_bag_job_spec.rb
+++ b/spec/jobs/ingest_archival_media_bag_job_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe IngestArchivalMediaBagJob do
 
       it "raises an error" do
         expect { described_class.perform_now(collection_component: collection_cid, bag_path: bag_path, user: user) }.to raise_error(
-          ArchivalMediaBagParser::InvalidBagError, "Bag at #{bag_path} is an invalid bag"
+          IngestArchivalMediaBagJob::InvalidBagError, "Bag at #{bag_path} is an invalid bag"
         )
       end
     end

--- a/spec/models/archival_media_bag_parser_spec.rb
+++ b/spec/models/archival_media_bag_parser_spec.rb
@@ -46,6 +46,21 @@ RSpec.describe ArchivalMediaBagParser do
     end
   end
 
+  describe "#valid?" do
+    context "with a valid bag" do
+      it "returns true" do
+        expect(amb_parser.valid?).to eq true
+      end
+    end
+
+    context "with a path to an invalid bag" do
+      let(:bag_path) { Rails.root.join("spec", "fixtures", "bags", "invalid_bag") }
+      it "returns false" do
+        expect(amb_parser.valid?).to eq false
+      end
+    end
+  end
+
   context "when the finding aid has other 'altformavailable' materials" do
     before do
       stub_request(:get, "https://findingaids.princeton.edu/collections/C0652.xml")


### PR DESCRIPTION
And use it in the ingest job, but not the barcode uniqueness validator;
fixes #1393