### PR TITLE
Use URL for catalog record in GeoBalcklight references field

### DIFF
--- a/app/services/geo_discovery/document_builder/document_helper.rb
+++ b/app/services/geo_discovery/document_builder/document_helper.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-module GeoDiscovery
-  class DocumentBuilder
-    class DocumentHelper
-      include Rails.application.routes.url_helpers
-      include ActionDispatch::Routing::PolymorphicRoutes
-    end
-  end
-end

--- a/app/services/geo_discovery/document_builder/document_path.rb
+++ b/app/services/geo_discovery/document_builder/document_path.rb
@@ -7,6 +7,12 @@ module GeoDiscovery
         @resource_decorator = resource_decorator
       end
 
+      def catalog_record
+        bib_id = resource_decorator.source_metadata_identifier.first
+        return nil unless bib_id
+        "https://catalog.princeton.edu/catalog/#{bib_id}"
+      end
+
       # Returns url for downloading the original file.
       # @return [String] original file download url
       def file_download
@@ -40,25 +46,12 @@ module GeoDiscovery
         "#{protocol}://#{host}#{path}"
       end
 
-      # Returns url for geo concern show page.
-      # @return [String] geo concern show page url
-      def to_s
-        document_helper.polymorphic_url(resource_decorator, host: host, protocol: protocol)
-      end
-
       private
 
         # Retrieve the default options for URL's
         # @return [Hash]
         def default_url_options
           Figgy.default_url_options
-        end
-
-        # Instantiates a DocumentHelper object.
-        # Used for access to rails url_helpers and poymorphic routes.
-        # @return [DocumentHelper] document helper
-        def document_helper
-          @helper ||= DocumentHelper.new
         end
 
         # Returns the first geo file set decorator attached to work.

--- a/app/services/geo_discovery/document_builder/references_builder.rb
+++ b/app/services/geo_discovery/document_builder/references_builder.rb
@@ -69,9 +69,9 @@ module GeoDiscovery
         end
 
         # Returns a url to access further descriptive information.
-        # @return [String] work show page url
+        # @return [String] link to related record in catalog
         def url
-          path.to_s
+          path.catalog_record
         end
 
         def wxs

--- a/spec/services/geo_discovery/document_builder_spec.rb
+++ b/spec/services/geo_discovery/document_builder_spec.rb
@@ -83,13 +83,13 @@ describe GeoDiscovery::DocumentBuilder do
 
       # references
       refs = JSON.parse(document["dct_references_s"])
-      expect(refs["http://schema.org/url"]).to match(/concern\/vector_resources/)
       expect(refs["http://www.isotc211.org/schemas/2005/gmd/"]).to match(/downloads/)
       expect(refs["http://schema.org/downloadUrl"]).to match(/downloads/)
       expect(refs["http://www.opengis.net/def/serviceType/ogc/wms"]).to match(/geoserver\/public-figgy\/wms/)
       expect(refs["http://www.opengis.net/def/serviceType/ogc/wfs"]).to match(/geoserver\/public-figgy\/wfs/)
       expect(refs["http://iiif.io/api/image"]).to be nil
       expect(refs["http://iiif.io/api/presentation#manifest"]).to be nil
+      expect(refs["http://schema.org/url"]).to be nil
     end
   end
 
@@ -120,6 +120,11 @@ describe GeoDiscovery::DocumentBuilder do
         expect(document["dc_subject_sm"]).to eq ["Mount Holly (N.J.)—Maps", "Sanborn"]
         expect(document["dc_identifier_s"]).to eq "ark:/99999/fk4"
         expect(document["layer_slug_s"]).to eq "princeton-fk4"
+      end
+
+      it "has url reference to the catalog record" do
+        refs = JSON.parse(document["dct_references_s"])
+        expect(refs["http://schema.org/url"]).to match(/catalog\/5144620/)
       end
     end
 
@@ -156,7 +161,6 @@ describe GeoDiscovery::DocumentBuilder do
 
       it "returns a document with reduced references and restricted access" do
         refs = JSON.parse(document["dct_references_s"])
-        expect(refs).to have_key "http://schema.org/url"
         expect(refs).to have_key "http://schema.org/thumbnailUrl"
         expect(refs).not_to have_key "http://schema.org/downloadUrl"
         expect(refs).not_to have_key "http://iiif.io/api/image"
@@ -171,7 +175,6 @@ describe GeoDiscovery::DocumentBuilder do
 
       it "returns a document with reduced references and restricted access" do
         refs = JSON.parse(document["dct_references_s"])
-        expect(refs).to have_key "http://schema.org/url"
         expect(refs).to have_key "http://schema.org/thumbnailUrl"
         expect(refs).not_to have_key "http://schema.org/downloadUrl"
         expect(refs).not_to have_key "http://iiif.io/api/image"


### PR DESCRIPTION
Use a link to a resource's catalog record instead of a link to Figgy in a geo resource's GeoBlacklight references.

Closes #1420 