### PR TITLE
Ensures that the thumbnails for member resources within Multi-Volume Works are used as thumbnail URIs for Manifests within ManifestBuilder::ThumbnailBuilder

### DIFF
--- a/app/services/manifest_builder/thumbnail_builder.rb
+++ b/app/services/manifest_builder/thumbnail_builder.rb
@@ -27,19 +27,34 @@ class ManifestBuilder
         @helper ||= ManifestHelper.new
       end
 
-      # Generate the value Hash modeling the thumbnail resource for the Manifest
+      # Retrieve the member resources (for multi-volume works)
+      # @return [Array<Valkyrie::Resource>]
+      def nearest_member_thumbnail_uri
+        members = query_service.find_members(resource: resource, model: resource.class)
+        members.find { |member| !member.thumbnail_id.empty? }
+      end
+
+      # Generate the Hash for structuring thumbnail URIs
       # @see http://iiif.io/api/presentation/2.1/#resource-structure
-      # @return [Hash, nil]
-      def thumbnail
-        return nil unless thumbnail_id && file_set && file_set.derivative_file
+      # @param member [FileSet, Valkyrie::Resource]
+      # @return [Hash]
+      def build_thumbnail_values(member)
         {
-          "@id" => helper.manifest_image_thumbnail_path(file_set.id),
+          "@id" => helper.manifest_image_thumbnail_path(member.id),
           "service" => {
             "@context" => "http://iiiif.io/api/image/2/context.json",
-            "@id" => helper.manifest_image_path(file_set),
+            "@id" => helper.manifest_image_path(member),
             "profile" => "http;//iiiif.io/api/image/2/level2.json"
           }
         }
+      end
+
+      # Generate the value Hash modeling the thumbnail resource for the Manifest
+      # @return [Hash, nil]
+      def thumbnail
+        member = thumbnail_id && file_set && file_set.derivative_file ? file_set : nearest_member_thumbnail_uri
+        return nil unless member
+        build_thumbnail_values(member)
       end
 
       # Retrieve the FileSet Resource for the thumbnail

--- a/app/services/manifest_builder/thumbnail_builder.rb
+++ b/app/services/manifest_builder/thumbnail_builder.rb
@@ -49,10 +49,16 @@ class ManifestBuilder
         }
       end
 
+      # Determine whether or not the Resource has a FileSet (with a derivative file) referenced as a thumbnail
+      # @return [TrueClass, FalseClass]
+      def resource_has_thumbnail_file_set?
+        thumbnail_id && file_set && file_set.derivative_file
+      end
+
       # Generate the value Hash modeling the thumbnail resource for the Manifest
       # @return [Hash, nil]
       def thumbnail
-        member = thumbnail_id && file_set && file_set.derivative_file ? file_set : nearest_member_thumbnail_uri
+        member = resource_has_thumbnail_file_set? ? file_set : nearest_member_thumbnail_uri
         return nil unless member
         build_thumbnail_values(member)
       end

--- a/spec/services/manifest_builder/thumbnail_builder_spec.rb
+++ b/spec/services/manifest_builder/thumbnail_builder_spec.rb
@@ -49,5 +49,29 @@ describe ManifestBuilder::ThumbnailBuilder do
         expect(output["thumbnail"]).to be_blank
       end
     end
+
+    context "when viewing a Multi-Volume Work" do
+      let(:persisted_volume) do
+        change_set_persister.save(change_set: change_set)
+      end
+      let(:parent_change_set) { ScannedResourceChangeSet.new(scanned_resource, member_ids: [persisted_volume.id]) }
+      let(:persisted) do
+        change_set_persister.save(change_set: parent_change_set)
+      end
+
+      before do
+        persisted
+      end
+
+      it "appends the transformed metadata to the Manifest" do
+        expect(output["thumbnail"]).not_to be_blank
+        expect(output["thumbnail"]).to include "@id"
+        expect(output["thumbnail"]["@id"]).to eq "http://www.example.com/image-service/#{persisted_volume.member_ids.first}/full/!200,150/0/default.jpg"
+
+        expect(output["thumbnail"]).to include "service"
+        expect(output["thumbnail"]["service"]).to include "@id"
+        expect(output["thumbnail"]["service"]["@id"]).to eq "http://www.example.com/image-service/#{persisted_volume.member_ids.first}"
+      end
+    end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/pulibrary/pomegranate/issues/366