### PR TITLE
Extends ManifestBuilder::CollectionNode in order to hide MVW members

### DIFF
--- a/app/controllers/base_resource_controller.rb
+++ b/app/controllers/base_resource_controller.rb
@@ -88,12 +88,15 @@ class BaseResourceController < ApplicationController
     after_update_error e
   end
 
-  # Determine whether or not a resource
+  # Determine whether or not a resource has parents
   # @param resource [Valkyrie::Resource]
   # @return [TrueClass, FalseClass]
   def resource_has_parents?(resource)
-    return false unless resource.persisted?
-    resource.decorate.respond_to?(:decorated_parent_resource) && !resource.decorate.decorated_parent_resource.nil?
+    if !resource.persisted?
+      params[:parent_id]
+    else
+      resource.decorate.respond_to?(:decorated_parent_resource) && !resource.decorate.decorated_parent_resource.nil?
+    end
   end
 
   private

--- a/app/controllers/base_resource_controller.rb
+++ b/app/controllers/base_resource_controller.rb
@@ -5,6 +5,7 @@ class BaseResourceController < ApplicationController
   include ResourceController
   include TokenAuth
   before_action :load_collections, only: [:new, :edit]
+  helper_method :resource_has_parents?
 
   def load_collections
     @collections = query_service.find_all_of_model(model: Collection).map(&:decorate)
@@ -85,6 +86,14 @@ class BaseResourceController < ApplicationController
     after_update_failure
   rescue Valkyrie::Persistence::ObjectNotFoundError => e
     after_update_error e
+  end
+
+  # Determine whether or not a resource
+  # @param resource [Valkyrie::Resource]
+  # @return [TrueClass, FalseClass]
+  def resource_has_parents?(resource)
+    return false unless resource.persisted?
+    resource.decorate.respond_to?(:decorated_parent_resource) && !resource.decorate.decorated_parent_resource.nil?
   end
 
   private

--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -176,15 +176,22 @@ class ManifestBuilder
       end
   end
 
+  # Wraps a Collection Resource for building Manifests
   class CollectionNode < RootNode
+    # Collections should not have FileSets as members
+    # @return [Array]
     def file_set_presenters
       []
     end
 
+    # Attempt to delegate the description to the CollectionDecorator
+    # @return [String]
     def description
       decorate.try(:description)
     end
 
+    # Collections should not have viewing hints
+    # @return [nil]
     def viewing_hint; end
   end
 

--- a/app/views/records/edit_fields/_member_of_collection_ids.html.erb
+++ b/app/views/records/edit_fields/_member_of_collection_ids.html.erb
@@ -1,7 +1,9 @@
-<%= f.input :member_of_collection_ids,
-            collection: @collections.sort_by(&:title),
-            label_method: :title,
-            value_method: :id,
-            input_html: { multiple: f.object.multiple?(key) },
-            include_blank: false,
-            required: f.object.required?(key) %>
+<% unless resource_has_parents?(f.object.resource) %>
+  <%= f.input :member_of_collection_ids,
+              collection: @collections.sort_by(&:title),
+              label_method: :title,
+              value_method: :id,
+              input_html: { multiple: f.object.multiple?(key) },
+              include_blank: false,
+              required: f.object.required?(key) %>
+<% end %>

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -11,14 +11,38 @@ namespace :migrate do
     end
   end
 
-  desc "Migrated Ephemera Folders in Ephemera Boxes published in production to a completed workflow state"
+  desc "Migrates Ephemera Folders in Ephemera Boxes published in production to a completed workflow state"
   task ephemera_folders: :environment do
     # Ensures that all member EphemeraFolders have their state properly updated
-    resources.each do |resource|
+    resources(model: EphemeraFolder).each do |resource|
       cs = DynamicChangeSet.new(resource)
       cs.prepopulate!
       logger.info "Migrating folders within the box #{resource.id}..."
       change_set_persister.save(change_set: cs)
+    end
+  end
+
+  desc "Migrates Collection members with children who have values in the member_of_collection_ids attribute"
+  task collection_members_with_children: :environment do
+    # Ensures that all member EphemeraFolders have their state properly updated
+    resources(model: Collection).each do |collection|
+      logger.info "Migrating Collection members for #{collection.id}..."
+
+      change_set_persister.buffer_into_index do |buffered_change_set_persister|
+        collection.decorate.decorated_members.each do |collection_member|
+          collection_member.members.each do |child|
+            next if child.member_of_collection_ids.empty?
+
+            logger.info "Migrating the collections for member resource #{child.id}..."
+
+            child_change_set = DynamicChangeSet.new(child)
+            child_change_set.prepopulate!
+            child_change_set.member_of_collection_ids = []
+
+            buffered_change_set_persister.save(change_set: child_change_set)
+          end
+        end
+      end
     end
   end
 
@@ -45,15 +69,9 @@ namespace :migrate do
       Valkyrie.config.metadata_adapter.query_service
     end
 
-    # Retrieves the model for the resource being updated during the migration
-    # @return [Class]
-    def model
-      EphemeraBox
-    end
-
     # Retrieves all of the resources being updated during the migration
     # @return [Enumerable<Valkyrie::Resource>]
-    def resources
+    def resources(model:)
       query_service.find_all_of_model(model: model)
     end
 end

--- a/spec/controllers/raster_resources_controller_spec.rb
+++ b/spec/controllers/raster_resources_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe RasterResourcesController do
         expect(response.body).to have_field "Rights Note"
         expect(response.body).to have_field "Local identifier"
         expect(response.body).to have_selector "#raster_resource_append_id[value='#{parent.id}']", visible: false
-        expect(response.body).to have_select "Collections", name: "raster_resource[member_of_collection_ids][]", options: [collection.title.first]
+        expect(response.body).not_to have_select "Collections", name: "raster_resource[member_of_collection_ids][]", options: [collection.title.first]
         expect(response.body).to have_field "Place Name"
         expect(response.body).to have_field "Temporal"
         expect(response.body).to have_select "Rights Statement", name: "raster_resource[rights_statement]", options: [""] + ControlledVocabulary.for(:rights_statement).all.map(&:label)

--- a/spec/controllers/scanned_maps_controller_spec.rb
+++ b/spec/controllers/scanned_maps_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe ScannedMapsController do
         expect(response.body).to have_field "Rights Note"
         expect(response.body).to have_field "Local identifier"
         expect(response.body).to have_selector "#scanned_map_append_id[value='#{parent.id}']", visible: false
-        expect(response.body).to have_select "Collections", name: "scanned_map[member_of_collection_ids][]", options: [collection.title.first]
+        expect(response.body).not_to have_select "Collections", name: "scanned_map[member_of_collection_ids][]", options: [collection.title.first]
         expect(response.body).to have_field "Place Name"
         expect(response.body).to have_field "Temporal"
         expect(response.body).to have_select "Rights Statement", name: "scanned_map[rights_statement]", options: [""] + ControlledVocabulary.for(:rights_statement).all.map(&:label)

--- a/spec/controllers/scanned_resources_controller_spec.rb
+++ b/spec/controllers/scanned_resources_controller_spec.rb
@@ -103,6 +103,34 @@ RSpec.describe ScannedResourcesController do
     end
   end
 
+  describe "edit" do
+    let(:user) { FactoryBot.create(:admin) }
+    let(:scanned_resource) { FactoryBot.create_for_repository(:scanned_resource) }
+
+    render_views
+
+    it "does not render a collections form field" do
+      get :edit, params: { id: scanned_resource.id.to_s }
+
+      expect(response.body).to have_select "Collections", name: "scanned_resource[member_of_collection_ids][]"
+    end
+
+    context "when it has a member resource" do
+      let(:member_resource) { FactoryBot.create_for_repository(:scanned_resource) }
+      let(:scanned_resource) { FactoryBot.create_for_repository(:scanned_resource, member_ids: [member_resource.id]) }
+
+      before do
+        scanned_resource
+      end
+
+      it "does not render a collections form field" do
+        get :edit, params: { id: member_resource.id.to_s }
+
+        expect(response.body).not_to have_select "Collections", name: "scanned_resource[member_of_collection_ids][]"
+      end
+    end
+  end
+
   describe "html update" do
     let(:user) { FactoryBot.create(:admin) }
 

--- a/spec/controllers/vector_resources_controller_spec.rb
+++ b/spec/controllers/vector_resources_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe VectorResourcesController do
         expect(response.body).to have_field "Rights Note"
         expect(response.body).to have_field "Local identifier"
         expect(response.body).to have_selector "#vector_resource_append_id[value='#{parent.id}']", visible: false
-        expect(response.body).to have_select "Collections", name: "vector_resource[member_of_collection_ids][]", options: [collection.title.first]
+        expect(response.body).not_to have_select "Collections", name: "vector_resource[member_of_collection_ids][]", options: [collection.title.first]
         expect(response.body).to have_field "Place Name"
         expect(response.body).to have_field "Temporal"
         expect(response.body).to have_select "Rights Statement", name: "vector_resource[rights_statement]", options: [""] + ControlledVocabulary.for(:rights_statement).all.map(&:label)

--- a/spec/shared_specs/controllers/base_resource_controller.rb
+++ b/spec/shared_specs/controllers/base_resource_controller.rb
@@ -38,7 +38,7 @@ RSpec.shared_examples "a BaseResourceController" do
         expect(response.body).to have_field "Portion Note"
         expect(response.body).to have_field "Navigation Date", class: "timepicker"
         expect(response.body).to have_selector "##{model_name}_append_id[value='#{parent.id}']", visible: false
-        expect(response.body).to have_select "Collections", name: "#{model_name}[member_of_collection_ids][]", options: [collection.title.first]
+        expect(response.body).not_to have_select "Collections", name: "#{model_name}[member_of_collection_ids][]", options: [collection.title.first]
         expect(response.body).to have_select "Rights Statement", name: "#{model_name}[rights_statement]", options: [""] + ControlledVocabulary.for(:rights_statement).all.map(&:label)
         expect(response.body).to have_select "PDF Type", name: "#{model_name}[pdf_type]", options: ["Color PDF", "Grayscale PDF", "Bitonal PDF", "No PDF"]
         languages = Tesseract.languages


### PR DESCRIPTION
Resolves https://github.com/pulibrary/pomegranate/issues/362 by extending ManifestBuilder::CollectionNode in order to hide member resources when both the parent and members belong to the same Collection