### PR TITLE
Add portion note to title of scanned maps with remote metadata

### DIFF
--- a/app/services/geo_discovery/document_builder/basic_metadata_builder.rb
+++ b/app/services/geo_discovery/document_builder/basic_metadata_builder.rb
@@ -63,7 +63,7 @@ module GeoDiscovery
         end
 
         # Returns an array of attributes to add to document.
-        # @return Array<Symbol> attributes
+        # @return [Array<Symbol>] attributes
         def simple_attributes
           [:creator, :spatial, :temporal,
            :provenance, :language, :publisher]
@@ -71,15 +71,16 @@ module GeoDiscovery
 
         # Returns an array of subject strings. For Vector and Raster Resources,
         # non ISO 19115 topic category subjects are filtered out.
-        # @return Array<String> subjects
+        # @return [Array<String>] subjects
         def subject
           return resource_decorator.subject if resource_decorator.model.is_a?(ScannedMap)
           resource_decorator.subject.select { |v| topic_categories.value?(v) }
         end
 
+        # Use the standard resource decorator to retreive title.
+        # @return [String] title
         def title
-          titles = resource_decorator.title
-          titles&.first.to_s
+          resource_decorator.model.decorate.title.try(:first)
         end
 
         def topic_categories

--- a/spec/services/geo_discovery/document_builder_spec.rb
+++ b/spec/services/geo_discovery/document_builder_spec.rb
@@ -105,12 +105,15 @@ describe GeoDiscovery::DocumentBuilder do
     context "with remote metadata" do
       let(:geo_work) do
         FactoryBot.create_for_repository(:scanned_map,
+                                         title: [],
                                          source_metadata_identifier: "5144620",
                                          coverage: coverage.to_s,
                                          subject: ["Sanborn", "Mount Holly (N.J.)—Maps"],
                                          visibility: visibility,
                                          identifier: "ark:/99999/fk4",
+                                         portion_note: "Sheet 1",
                                          imported_metadata: [{
+                                           title: ["Mount Holly, N.J."],
                                            subject: ["Mount Holly (N.J.)—Maps"],
                                            identifier: "http://arks.princeton.edu/ark:/99999/fk4",
                                            call_number: [
@@ -124,6 +127,7 @@ describe GeoDiscovery::DocumentBuilder do
         expect(document["dc_subject_sm"]).to eq ["Mount Holly (N.J.)—Maps", "Sanborn"]
         expect(document["dc_identifier_s"]).to eq "ark:/99999/fk4"
         expect(document["layer_slug_s"]).to eq "princeton-fk4"
+        expect(document["dc_title_s"]).to eq "Mount Holly, N.J. (Sheet 1)"
       end
 
       it "has url reference to the catalog record and a call number field" do


### PR DESCRIPTION
Fixes issue where portion note is not displayed in the GeoBlacklight document title for scanned maps with imported metadata.

Partially addresses #1453