### PR TITLE
Ensures that MVW thumbnails are rendered by using member FileSets rather than just member resources

### DIFF
--- a/app/services/manifest_builder/manifest_service_locator.rb
+++ b/app/services/manifest_builder/manifest_service_locator.rb
@@ -31,6 +31,7 @@ class ManifestBuilder
           child_manifest_builder_factory,
           see_also_builder,
           license_builder,
+          thumbnail_builder,
           rendering_builder,
           composite_builder: composite_builder
         )

--- a/app/services/manifest_builder/thumbnail_builder.rb
+++ b/app/services/manifest_builder/thumbnail_builder.rb
@@ -27,23 +27,34 @@ class ManifestBuilder
         @helper ||= ManifestHelper.new
       end
 
-      # Retrieve the member resources (for multi-volume works)
-      # @return [Array<Valkyrie::Resource>]
-      def nearest_member_thumbnail_uri
-        members = query_service.find_members(resource: resource, model: resource.class)
-        members.find { |member| !member.thumbnail_id.empty? }
+      def nearest_member
+        members = query_service.find_members(resource: resource, model: resource.resource.class)
+        members.find { |member| member.thumbnail_id.present? }
+      end
+
+      def nearest_member_thumbnail_id
+        return unless nearest_member
+        @nearest_member_thumbnail_id ||= Array.wrap(nearest_member.thumbnail_id).first
+      end
+
+      def nearest_member_file_set
+        member_file_set = find_thumbnail_file_set(nearest_member_thumbnail_id)
+        return unless member_file_set && member_file_set.derivative_file
+        member_file_set
+      rescue Valkyrie::Persistence::ObjectNotFoundError
+        nil
       end
 
       # Generate the Hash for structuring thumbnail URIs
       # @see http://iiif.io/api/presentation/2.1/#resource-structure
-      # @param member [FileSet, Valkyrie::Resource]
+      # @param file_set [FileSet]
       # @return [Hash]
-      def build_thumbnail_values(member)
+      def build_thumbnail_values(file_set)
         {
-          "@id" => helper.manifest_image_thumbnail_path(member.id),
+          "@id" => helper.manifest_image_thumbnail_path(file_set.id),
           "service" => {
             "@context" => "http://iiiif.io/api/image/2/context.json",
-            "@id" => helper.manifest_image_path(member),
+            "@id" => helper.manifest_image_path(file_set),
             "profile" => "http;//iiiif.io/api/image/2/level2.json"
           }
         }
@@ -58,7 +69,7 @@ class ManifestBuilder
       # Generate the value Hash modeling the thumbnail resource for the Manifest
       # @return [Hash, nil]
       def thumbnail
-        member = resource_has_thumbnail_file_set? ? file_set : nearest_member_thumbnail_uri
+        member = resource_has_thumbnail_file_set? ? file_set : nearest_member_file_set
         return nil unless member
         build_thumbnail_values(member)
       end

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -292,6 +292,9 @@ RSpec.describe ManifestBuilder do
       expect(output).to be_kind_of Hash
       expect(output["@type"]).to eq "sc:Collection"
       expect(output["viewingHint"]).to eq "multi-part"
+
+      expect(output["thumbnail"]).to include "@id" => "http://www.example.com/image-service/#{child.member_ids.first.id}/full/!200,150/0/default.jpg"
+
       expect(output["manifests"].length).to eq 1
       expect(output["manifests"][0]["@id"]).to eq "http://www.example.com/concern/scanned_resources/#{child.id}/manifest"
       expect(output["manifests"][0]["viewingHint"]).to be_nil
@@ -302,6 +305,17 @@ RSpec.describe ManifestBuilder do
       # not allowed in collections until iiif presentation api v3
       expect(output["viewingDirection"]).to eq nil
       expect(output["manifests"][0]["thumbnail"]["@id"]).to eq "http://www.example.com/image-service/#{child.member_ids.first}/full/!200,150/0/default.jpg"
+    end
+    context "when the nested child does't have a valid thumbnail" do
+      let(:child) { FactoryBot.create_for_repository(:scanned_resource, thumbnail_id: ["invalid-id"]) }
+
+      it "does not generate the thumbnail" do
+        output = manifest_builder.build
+        expect(output).to be_kind_of Hash
+        expect(output["@type"]).to eq "sc:Collection"
+        expect(output["viewingHint"]).to eq "multi-part"
+        expect(output).not_to include "thumbnail"
+      end
     end
   end
 


### PR DESCRIPTION
Fixes a bug discovered in https://github.com/pulibrary/figgy/pull/1425