### PR TITLE
Scale down PDF image sizes.

### DIFF
--- a/app/services/pdf_generator/canvas_downloader.rb
+++ b/app/services/pdf_generator/canvas_downloader.rb
@@ -51,7 +51,7 @@ class PDFGenerator
       end
 
       def scale_factor
-        3.0
+        2.0
       end
 
       def bitonal?


### PR DESCRIPTION
Tests show that it's still readable, and the PDFs are smaller.