### PR TITLE
Imports Voyager metadata using a cron job

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -86,6 +86,7 @@ Metrics/MethodLength:
     - 'app/controllers/base_resource_controller.rb'
     - 'app/services/pdf_generator.rb'
     - 'app/services/file_appender.rb'
+    - 'app/jobs/voyager_update_job.rb'
 Metrics/ModuleLength:
   Exclude:
     - 'app/models/schema/marc_relators.rb'
@@ -107,6 +108,8 @@ RSpec/AnyInstance:
     - 'spec/jobs/check_fixity_recursive_job_spec.rb'
     - 'spec/controllers/fixity_dashboard_controller_spec.rb'
     - 'spec/change_sets/archival_media_collection_change_set_spec.rb'
+    - 'spec/services/voyager_updater/event_spec.rb'
+    - 'spec/jobs/voyager_update_job_spec.rb'
 RSpec/DescribeClass:
   Exclude:
     - 'spec/abilities/**/*'

--- a/Capfile
+++ b/Capfile
@@ -10,6 +10,7 @@ require "capistrano/rails/assets"
 require "capistrano/rails/migrations"
 require "capistrano/passenger"
 require "capistrano/rails/console"
+require "whenever/capistrano"
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -107,5 +107,6 @@ gem "jquery-datatables-rails", "~> 3.4.0"
 gem "json-schema"
 gem "leaflet-rails", "~> 0.7"
 gem "prawn"
+gem "whenever", "~> 0.10"
 
 gem "graphiql-rails", group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,6 +234,7 @@ GEM
     chromedriver-helper (1.1.0)
       archive-zip (~> 0.7.0)
       nokogiri (~> 1.6)
+    chronic (0.10.2)
     coderay (1.1.1)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -790,6 +791,8 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    whenever (0.10.0)
+      chronic (>= 0.6.3)
     xml-simple (1.1.5)
     xpath (2.1.0)
       nokogiri (~> 1.3)
@@ -889,6 +892,7 @@ DEPENDENCIES
   web-console
   webmock
   webpacker (~> 3.3)
+  whenever (~> 0.10)
 
 BUNDLED WITH
    1.16.2

--- a/app/change_set_persisters/change_set_persister/apply_remote_metadata.rb
+++ b/app/change_set_persisters/change_set_persister/apply_remote_metadata.rb
@@ -18,9 +18,30 @@ class ChangeSetPersister
 
     private
 
+      # Determines whether or not the resource in the ChangeSet is a geospatial resource
+      # @return [Boolean]
+      def geo_resource?
+        change_set.model.respond_to?(:geo_resource?) && change_set.model.geo_resource?
+      end
+
+      # Determines whether or not an identifier value is an ARK identifier
+      # @param identifier [String]
+      # @return [Boolean]
+      def ark?(identifier)
+        identifier.start_with?(Ark.new(identifier).uri)
+      end
+
+      # Determines whether or not an identifier has been modified in the ChangeSet
+      # @return [Boolean]
+      def identifier_exists?
+        change_set.model.identifier.present?
+      end
+
+      # Sets the remote metadata for the resource in the ChangeSet
+      # @param attributes [Hash]
       def apply(attributes)
         change_set.model.imported_metadata = ImportedMetadata.new(attributes)
-        return unless change_set.model.identifier.blank? && attributes[:identifier] && attributes[:identifier].start_with?(Ark.new(attributes[:identifier]).uri)
+        return unless attributes[:identifier] && !geo_resource? && !identifier_exists? && ark?(attributes[:identifier])
         change_set.model.identifier = Ark.new(attributes[:identifier]).identifier
       end
   end

--- a/app/jobs/voyager_update_job.rb
+++ b/app/jobs/voyager_update_job.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class VoyagerUpdateJob < ApplicationJob
+  # Update all resources with Voyager metadata
+  # @param ids [Array<String>]
+  def perform(ids)
+    Rails.logger.info "Processing updates for IDs: #{ids.join(', ')}" unless ids.empty?
+
+    change_set_persister.buffer_into_index do |buffered_change_set_persister|
+      ids.each do |id|
+        begin
+          results = query_service.custom_queries.find_by_string_property(property: "source_metadata_identifier", value: id).to_a
+          next if results.empty?
+
+          resource = results.first
+          change_set = DynamicChangeSet.new(resource)
+          next unless change_set.respond_to?(:apply_remote_metadata?) && change_set.respond_to?(:source_metadata_identifier)
+
+          change_set.prepopulate!
+          change_set.validate(refresh_remote_metadata: true)
+
+          buffered_change_set_persister.save(change_set: change_set)
+        rescue StandardError => error
+          Rails.logger.warn "#{self.class}: Unable to process the changed Voyager record #{id}: #{error}"
+        end
+      end
+    end
+  end
+
+  private
+
+    # Retrieves the query service from the metadata adapter
+    # @return [Valkyrie::Persistence::Postgres::QueryService]
+    def query_service
+      Valkyrie.config.metadata_adapter.query_service
+    end
+
+    # Construct the persister for saving Resources
+    # @return [ChangeSetPersister]
+    def change_set_persister
+      ChangeSetPersister.new(
+        metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister),
+        storage_adapter: Valkyrie.config.storage_adapter
+      )
+    end
+end

--- a/app/services/voyager_updater.rb
+++ b/app/services/voyager_updater.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+module VoyagerUpdater
+end

--- a/app/services/voyager_updater/dump.rb
+++ b/app/services/voyager_updater/dump.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+module VoyagerUpdater
+  class Dump
+    attr_reader :url
+
+    # Constructor
+    # @param url [String]
+    def initialize(url)
+      @url = url
+    end
+
+    # Retrieve the bib. IDs from the Voyager data dump marked as updated
+    # @return [Array<String>]
+    def update_ids
+      parsed_json["ids"]["update_ids"].map { |x| x["id"] }
+    end
+
+    # Retrieve the bib. IDs from the Voyager data dump marked as created
+    # @return [Array<String>]
+    def create_ids
+      parsed_json["ids"]["create_ids"].map { |x| x["id"] }
+    end
+
+    # Retrieve the resource IDs for those resources marked for update
+    # @return [Array<String>]
+    def ids_needing_updated
+      @ids_needing_updated ||=
+        begin
+          relevant_ids.each_slice(100).flat_map do |ids|
+            ids.map { |bib_id| resource(bib_id) }.compact.map { |resource| resource.id.to_s }
+          end
+        end
+    end
+
+    private
+
+      # Retrieve the bib. IDs used for the resource updates
+      # @return [Array<String>]
+      def relevant_ids
+        update_ids + create_ids
+      end
+
+      # Retrieve the JSON from Voyager and parse the values into a Hash
+      # @return [Hash]
+      def parsed_json
+        @parsed_json ||= JSON.parse(open(url).read)
+      end
+
+      # Retrieves a resource using a Voyager bib. ID
+      # @param bib_id [String]
+      # @return [Resource, nil]
+      def resource(bib_id)
+        results = query_service.custom_queries.find_by_string_property(property: "source_metadata_identifier", value: bib_id).to_a
+        return if results.empty?
+        results.first
+      end
+
+      # Retrieves the query service from the metadata adapter
+      # @return [Valkyrie::Persistence::Postgres::QueryService]
+      def query_service
+        Valkyrie.config.metadata_adapter.query_service
+      end
+  end
+end

--- a/app/services/voyager_updater/event.rb
+++ b/app/services/voyager_updater/event.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+module VoyagerUpdater
+  class Event
+    PROCESSABLE_EVENT_TYPE = "CHANGED_RECORDS"
+
+    attr_reader :id, :dump_url, :dump_type
+    delegate :ids_needing_updated, to: :dump
+
+    # Constructor
+    # @param init_hsh [Hash] the values for the serialized event resource
+    def initialize(init_hsh)
+      @id = init_hsh["id"].to_i
+      @dump_url = init_hsh["dump_url"]
+      @dump_type = init_hsh["dump_type"]
+    end
+
+    # Determine whether or not the Event has been processed
+    # @return [Boolean]
+    def enqueued?
+      !ActiveJob::Base.queue_adapter.enqueued_jobs.find do |enqueued|
+        enqueued[:job] == job_klass && enqueued[:args].first.include?(id.to_s)
+      end.nil?
+    end
+
+    # Construct the data Dump object (using values retrieved from the endpoint)
+    # @return [Dump]
+    def dump
+      @dump ||= Dump.new(dump_url)
+    end
+
+    # Using the type of data dump, determine whether or not the data can be processed
+    # @return [Boolean]
+    def unprocessable?
+      dump_type != PROCESSABLE_EVENT_TYPE
+    end
+
+    # Process the event
+    # @return [ProcessedEvent]
+    def process!
+      return if enqueued? || unprocessable?
+      job_klass.perform_later(ids_needing_updated)
+    end
+
+    private
+
+      # The ActiveJob Class used to update remote metadata
+      # @return [Class]
+      def job_klass
+        VoyagerUpdateJob
+      end
+  end
+end

--- a/app/services/voyager_updater/event_stream.rb
+++ b/app/services/voyager_updater/event_stream.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+module VoyagerUpdater
+  class EventStream
+    attr_reader :url
+
+    # Constructor
+    # @param url [String]
+    def initialize(url)
+      @url = url
+    end
+
+    # Retrieve and deserialize all events from the service endpoint
+    # @return [Array<Event>]
+    def events
+      @events ||= parsed_json.map do |json_record|
+        Event.new(json_record)
+      end
+    end
+
+    # Process each event which has been populated
+    def process!
+      events.each(&:process!)
+    end
+
+    private
+
+      # Retrieve the event values and parse the response from JSON
+      # @return [Hash]
+      def parsed_json
+        @parsed_json ||= JSON.parse(open(url).read)
+      end
+  end
+end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -37,6 +37,8 @@ set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/derivatives', 'tmp/up
 # set :keep_releases, 5
 set :passenger_restart_with_touch, true
 
+set :whenever_update_flags, "--update-crontab #{fetch :whenever_identifier} --set #{fetch :whenever_variables} --user deploy"
+
 desc "Write the current version to public/version.txt"
 task :write_version do
   on roles(:app), in: :sequence do
@@ -74,4 +76,3 @@ namespace :deploy do
     end
   end
 end
-

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+set :output, "/tmp/figgy_update_bib_ids.log"
+every :day, at: "2:00 am", roles: [:db] do
+  rake "figgy:update_bib_ids"
+end
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever

--- a/lib/tasks/figgy.rake
+++ b/lib/tasks/figgy.rake
@@ -6,4 +6,11 @@ namespace :figgy do
       CheckFixityRecursiveJob.set(queue: :super_low).perform_later
     end
   end
+  desc "updates the remote metadata from Voyager"
+  task update_bib_ids: :environment do
+    if defined?(Rails) && (Rails.env == "development")
+      Rails.logger = Logger.new(STDOUT)
+    end
+    VoyagerUpdater::EventStream.new("https://bibdata.princeton.edu/events.json").process!
+  end
 end

--- a/spec/change_set_persisters/change_set_persister_spec.rb
+++ b/spec/change_set_persisters/change_set_persister_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe ChangeSetPersister do
       expect(output.primary_imported_metadata.subject).to include "Administrative and political divisions—Maps"
       expect(output.primary_imported_metadata.spatial).to eq ["Cameroon", "Nigeria"]
       expect(output.primary_imported_metadata.coverage).to eq ["northlimit=12.500000; eastlimit=014.620000; southlimit=03.890000; westlimit=008.550000; units=degrees; projection=EPSG:4326"]
-      expect(output.identifier).to eq(["ark:/88435/jq085p05h"])
+      expect(output.identifier).to be nil
     end
     it "doesn't override an existing identifier" do
       resource = FactoryBot.build(:scanned_map, title: [], identifier: ["something"])

--- a/spec/jobs/voyager_update_job_spec.rb
+++ b/spec/jobs/voyager_update_job_spec.rb
@@ -1,0 +1,56 @@
+
+# frozen_string_literal: true
+require "rails_helper"
+
+describe VoyagerUpdateJob do
+  with_queue_adapter :inline
+
+  let(:ids) { ["123456", "4609321"] }
+
+  before do
+    stub_bibdata(bib_id: "123456")
+    stub_bibdata(bib_id: "4609321")
+  end
+
+  describe "#perform" do
+    let(:resources) do
+      [
+        FactoryBot.create_for_repository(:scanned_resource, source_metadata_identifier: ids.first),
+        FactoryBot.create_for_repository(:scanned_resource, source_metadata_identifier: ids.last)
+      ]
+    end
+    let(:buffered_change_set_persister) { instance_double(ChangeSetPersister::Basic) }
+
+    before do
+      resources
+      allow(buffered_change_set_persister).to receive(:save)
+      allow_any_instance_of(ChangeSetPersister::Basic).to receive(:buffer_into_index).and_yield(buffered_change_set_persister)
+      described_class.perform_now(ids)
+    end
+
+    it "queries for all resources and updates them asynchronously" do
+      expect(buffered_change_set_persister).to have_received(:save).exactly(2).times
+    end
+  end
+
+  context "when given invalid IDs" do
+    let(:logger) { instance_double(ActiveSupport::Logger) }
+    let(:resource) { FactoryBot.create_for_repository(:scanned_resource, source_metadata_identifier: ids.first) }
+    let(:buffered_change_set_persister) { instance_double(ChangeSetPersister::Basic) }
+
+    before do
+      resource
+      allow(buffered_change_set_persister).to receive(:save).and_raise(StandardError, "persistence error message")
+      allow_any_instance_of(ChangeSetPersister::Basic).to receive(:buffer_into_index).and_yield(buffered_change_set_persister)
+      allow(logger).to receive(:info)
+      allow(logger).to receive(:warn)
+      allow(Rails).to receive(:logger).and_return(logger)
+
+      described_class.perform_now([ids.first])
+    end
+
+    it "logs a warning" do
+      expect(logger).to have_received(:warn).with("VoyagerUpdateJob: Unable to process the changed Voyager record 123456: persistence error message")
+    end
+  end
+end

--- a/spec/services/voyager_updater/dump_spec.rb
+++ b/spec/services/voyager_updater/dump_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe VoyagerUpdater::Dump do
+  subject(:dump) { described_class.new(url) }
+  let(:url) { "http://localhost.localdomain" }
+  let(:data) do
+    {
+      "ids" => {
+        "update_ids" => [
+          { "id" => "123456" }
+        ],
+        "create_ids" => [
+          { "id" => "4609321" }
+        ]
+      }
+    }
+  end
+
+  before do
+    stub_request(:get, url)
+      .to_return(body: data.to_json)
+  end
+
+  describe ".new" do
+    it "constructs the object" do
+      expect(dump.url).to eq(url)
+    end
+  end
+
+  describe "#update_ids" do
+    it "retrieves the bib. IDs for records which Voyager marked as updated" do
+      expect(dump.update_ids).to eq(["123456"])
+    end
+  end
+
+  describe "#create_ids" do
+    it "retrieves the bib. IDs for records which Voyager marked as created" do
+      expect(dump.create_ids).to eq(["4609321"])
+    end
+  end
+
+  describe "#ids_needing_updated" do
+    let(:resource1) { FactoryBot.create_for_repository(:scanned_resource, source_metadata_identifier: "123456") }
+    let(:resource2) { FactoryBot.create_for_repository(:scanned_resource, source_metadata_identifier: "4609321") }
+
+    before do
+      stub_bibdata(bib_id: "123456")
+      stub_bibdata(bib_id: "4609321")
+
+      resource1
+      resource2
+    end
+    it "retrieves the IDs for the resources which have the bib. IDs in their metadata" do
+      expect(dump.ids_needing_updated).to eq([resource1.id.to_s, resource2.id.to_s])
+    end
+  end
+end

--- a/spec/services/voyager_updater/event_spec.rb
+++ b/spec/services/voyager_updater/event_spec.rb
@@ -1,0 +1,120 @@
+
+# frozen_string_literal: true
+require "rails_helper"
+
+describe VoyagerUpdater::Event do
+  subject(:event) { described_class.new(values) }
+  let(:id) { "123456" }
+  let(:dump_url) { "http://localhost.localdomain" }
+  let(:dump_type) { "CHANGED_RECORDS" }
+  let(:values) do
+    {
+      "id" => id,
+      "dump_url" => dump_url,
+      "dump_type" => dump_type
+    }
+  end
+  let(:dump_data) do
+    {
+      "ids" => {
+        "update_ids" => [
+          { "id" => "123456" }
+        ],
+        "create_ids" => [
+          { "id" => "4609321" }
+        ]
+      }
+    }
+  end
+
+  after do
+    ActiveJob::Base.queue_adapter.enqueued_jobs = []
+  end
+
+  describe ".new" do
+    it "constructs the Event with a Hash" do
+      expect(event.id).to eq(1_234_56)
+      expect(event.dump_url).to eq(dump_url)
+      expect(event.dump_type).to eq(dump_type)
+    end
+  end
+
+  describe "#enqueued?" do
+    before do
+      VoyagerUpdateJob.perform_later([id])
+    end
+    it "determines if a processing job has been enqueued" do
+      expect(event.enqueued?).to be true
+    end
+  end
+
+  describe "#dump" do
+    it "constructs the data dump object" do
+      expect(event.dump).to be_a VoyagerUpdater::Dump
+    end
+  end
+
+  describe "#unprocessable?" do
+    it "allows supported data dump types to be processed" do
+      expect(event.unprocessable?).to be false
+    end
+
+    context "when the data dump type is unsupported" do
+      let(:dump_type) { "INVALID" }
+
+      it "does not allow the data dump to be processed" do
+        expect(event.unprocessable?).to be true
+      end
+    end
+  end
+
+  describe "#process!" do
+    let(:resource1) { FactoryBot.create_for_repository(:scanned_resource, source_metadata_identifier: "123456") }
+    let(:resource2) { FactoryBot.create_for_repository(:scanned_resource, source_metadata_identifier: "4609321") }
+
+    before do
+      allow(VoyagerUpdateJob).to receive(:perform_later)
+      stub_bibdata(bib_id: "123456")
+      stub_bibdata(bib_id: "4609321")
+      resource1
+      resource2
+      stub_request(:get, dump_url).to_return(body: dump_data.to_json)
+
+      event.process!
+    end
+
+    it "enqueues an ActiveJob for updating resources with changed records in Voyager" do
+      expect(VoyagerUpdateJob).to have_received(:perform_later).with([resource1.id.to_s, resource2.id.to_s])
+    end
+  end
+
+  context "when the Voyager data dump is not processable" do
+    let(:dump_type) { "INVALID" }
+
+    before do
+      allow(VoyagerUpdateJob).to receive(:perform_later)
+      event.process!
+    end
+
+    describe "#process!" do
+      it "does not enqueue the job" do
+        expect(VoyagerUpdateJob).not_to have_received(:perform_later)
+      end
+    end
+  end
+
+  context "when the job has been enqueued" do
+    describe "#process!" do
+      before do
+        VoyagerUpdateJob.perform_later([id])
+        allow(VoyagerUpdateJob).to receive(:perform_later)
+
+        event.process!
+      end
+
+      it "does not enqueue the job" do
+        expect(VoyagerUpdateJob).not_to have_received(:perform_later)
+      end
+    end
+  end
+end

--- a/spec/services/voyager_updater/event_stream_spec.rb
+++ b/spec/services/voyager_updater/event_stream_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe VoyagerUpdater::EventStream do
+  subject(:event_stream) { described_class.new(url) }
+  let(:url) { "http://localhost.localdomain" }
+  let(:id) { "1234567" }
+  let(:dump_url) { "http://localhost.localdomain" }
+  let(:dump_type) { "CHANGED_RECORDS" }
+  let(:data) do
+    [
+      {
+        "id" => id,
+        "dump_url" => dump_url,
+        "dump_type" => dump_type
+      }
+    ]
+  end
+
+  before do
+    stub_request(:get, "http://localhost.localdomain/").to_return(body: data.to_json)
+  end
+
+  describe ".new" do
+    it "constructs the object for handling streams of events" do
+      expect(event_stream.url).to eq(url)
+    end
+  end
+
+  describe "#events" do
+    it "constructs Event objects using the Voyager update data" do
+      expect(event_stream.events).not_to be_empty
+      expect(event_stream.events.first).to be_a VoyagerUpdater::Event
+    end
+  end
+
+  describe "#process!" do
+    let(:event) { instance_double(VoyagerUpdater::Event) }
+    before do
+      allow(event).to receive(:process!)
+      allow(VoyagerUpdater::Event).to receive(:new).and_return(event)
+      event_stream.process!
+    end
+    it "processes each event" do
+      expect(event).to have_received(:process!)
+    end
+  end
+end


### PR DESCRIPTION
Resolves #696 and #1461 

- Implements the following:
  - `VoyagerUpdateJob`
  - `VoyagerUpdater::Dump`
  - `VoyagerUpdater::Event`
  - `VoyagerUpdater::EventStream`
  - `figgy:update_bib_ids` (Rake Task)
- Integrates the `whenever` Gem in order support creating cron tasks for these updates using Capistrano
- Ensures that ARKs are not imported for new or existing geospatial resources
- Ensures that ARKs are not imported if they have already been stored for a Resource