### PR TITLE
Fire GeoServer events when parent resource is updated

### DIFF
--- a/app/services/event_generator/composite_generator.rb
+++ b/app/services/event_generator/composite_generator.rb
@@ -33,10 +33,12 @@ class EventGenerator
 
     private
 
-      # Send method with record argument to first valid generator
+      # Send method with record argument to all valid generators
       def delegate_to_generator(method_name, record)
-        generator = generators.find { |g| g.valid?(record) }
-        generator.send(method_name, record) if generator
+        valid_generators = generators.select { |g| g.valid?(record) }
+        valid_generators.each do |generator|
+          generator.send(method_name, record)
+        end
       end
   end
 end

--- a/spec/services/event_generator/geoserver_event_generator_spec.rb
+++ b/spec/services/event_generator/geoserver_event_generator_spec.rb
@@ -29,6 +29,13 @@ RSpec.describe EventGenerator::GeoserverEventGenerator do
     end
   end
 
+  describe "#record_updated" do
+    it "publishes a persistent JSON message" do
+      event_generator.record_updated(resource)
+      expect(rabbit_connection).to have_received(:publish)
+    end
+  end
+
   describe "#valid?" do
     context "with a raster file set with a derivative" do
       let(:file) { fixture_file_upload("files/raster/geotiff.tif", "image/tif") }
@@ -36,6 +43,14 @@ RSpec.describe EventGenerator::GeoserverEventGenerator do
       let(:resource) { FactoryBot.create_for_repository(:raster_resource, files: [file]) }
 
       it "publishes a persistent JSON message" do
+        expect(event_generator.valid?(record)).to be true
+      end
+    end
+
+    context "with a geo resource" do
+      let(:record) { FactoryBot.create_for_repository(:vector_resource) }
+
+      it "is valid" do
         expect(event_generator.valid?(record)).to be true
       end
     end


### PR DESCRIPTION
- Fires a GeoServer event for every child geo FileSet when a when a geo resource is updated.
- Allows message to propagate to all valid generators instead of just the first. This allows GeoBlacklight and GeoServer messages to both be generated when a resource is updated.

Closes #1348 

Also see: https://github.com/pulibrary/geoserver-worker/pull/3