### PR TITLE
Fix FileSet IDs in Canvas Resources.

### DIFF
--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -310,7 +310,11 @@ class ManifestBuilder
       @parent_node = parent_node
     end
 
-    delegate :id, :local_identifier, :ocr_content, :to_model, to: :resource
+    delegate :local_identifier, :ocr_content, :to_model, to: :resource
+
+    def id
+      resource.id.to_s
+    end
 
     ##
     # Stringify the image using the decorator

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -108,6 +108,7 @@ RSpec.describe ManifestBuilder do
       structure_canvas_id = output["structures"][2]["canvases"][0]
       expect(canvas_id).to eq structure_canvas_id
       first_image = output["sequences"][0]["canvases"][0]["images"][0]
+      expect(first_image["resource"]["@id"]).to eq scanned_resource.member_ids.first.to_s
       expect(output["sequences"][0]["canvases"][0]["local_identifier"]).to eq "p79409x97p"
 
       canvas_renderings = output["sequences"][0]["canvases"][0]["rendering"]


### PR DESCRIPTION
It was displaying them as
```json
{
   "@id": {"id": "bla"}
}
```

instead of 
```json
{
  "@id": "bla"
}
```

and this fixes that.