### PR TITLE
Fix resource URL and canvas width/height type.

### DIFF
--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -327,11 +327,17 @@ class ManifestBuilder
     # Retrieve an instance of the IIIFManifest::DisplayImage for the image
     # @return [IIIFManifest::DisplayImage]
     def display_image
-      @display_image ||= IIIFManifest::DisplayImage.new(helper.manifest_image_medium_path(id),
-                                                        width: width,
-                                                        height: height,
+      @display_image ||= IIIFManifest::DisplayImage.new(display_image_url,
+                                                        width: width.to_i,
+                                                        height: height.to_i,
                                                         format: "image/jpeg",
                                                         iiif_endpoint: endpoint)
+    end
+
+    def display_image_url
+      helper.manifest_image_medium_path(id)
+    rescue
+      ""
     end
 
     private

--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -327,11 +327,11 @@ class ManifestBuilder
     # Retrieve an instance of the IIIFManifest::DisplayImage for the image
     # @return [IIIFManifest::DisplayImage]
     def display_image
-      IIIFManifest::DisplayImage.new(id,
-                                     width: width,
-                                     height: height,
-                                     format: "image/jpeg",
-                                     iiif_endpoint: endpoint)
+      @display_image ||= IIIFManifest::DisplayImage.new(helper.manifest_image_medium_path(id),
+                                                        width: width,
+                                                        height: height,
+                                                        format: "image/jpeg",
+                                                        iiif_endpoint: endpoint)
     end
 
     private
@@ -433,6 +433,11 @@ class ManifestBuilder
     def manifest_image_thumbnail_path(id)
       file_set = query_service.find_by(id: Valkyrie::ID.new(id))
       "#{manifest_image_path(file_set)}/full/!200,150/0/default.jpg"
+    end
+
+    def manifest_image_medium_path(id)
+      file_set = query_service.find_by(id: Valkyrie::ID.new(id))
+      "#{manifest_image_path(file_set)}/full/!1000,/0/default.jpg"
     end
 
     def query_service

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -108,7 +108,8 @@ RSpec.describe ManifestBuilder do
       structure_canvas_id = output["structures"][2]["canvases"][0]
       expect(canvas_id).to eq structure_canvas_id
       first_image = output["sequences"][0]["canvases"][0]["images"][0]
-      expect(first_image["resource"]["@id"]).to eq scanned_resource.member_ids.first.to_s
+
+      expect(first_image["resource"]["@id"]).to eq "http://www.example.com/image-service/#{scanned_resource.member_ids.first}/full/!1000,/0/default.jpg"
       expect(output["sequences"][0]["canvases"][0]["local_identifier"]).to eq "p79409x97p"
 
       canvas_renderings = output["sequences"][0]["canvases"][0]["rendering"]

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -107,6 +107,7 @@ RSpec.describe ManifestBuilder do
       expect(output["structures"].length).to eq 3
       structure_canvas_id = output["structures"][2]["canvases"][0]
       expect(canvas_id).to eq structure_canvas_id
+      expect(output["sequences"][0]["canvases"][0]["width"]).to be_a Integer
       first_image = output["sequences"][0]["canvases"][0]["images"][0]
 
       expect(first_image["resource"]["@id"]).to eq "http://www.example.com/image-service/#{scanned_resource.member_ids.first}/full/!1000,/0/default.jpg"


### PR DESCRIPTION
Necessary for manifests to be considered valid.