### PR TITLE
Add viewing hint to canvases.

### DIFF
--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -310,7 +310,7 @@ class ManifestBuilder
       @parent_node = parent_node
     end
 
-    delegate :local_identifier, :ocr_content, :to_model, to: :resource
+    delegate :local_identifier, :viewing_hint, :ocr_content, :to_model, to: :resource
 
     def id
       resource.id.to_s

--- a/app/services/manifest_builder/canvas_builder.rb
+++ b/app/services/manifest_builder/canvas_builder.rb
@@ -4,6 +4,7 @@ class ManifestBuilder
     def apply_record_properties
       super
       canvas["local_identifier"] = record.local_identifier.first if record.try(:local_identifier).present?
+      canvas["viewingHint"] = record.viewing_hint.first if record.try(:viewing_hint).present?
       rendering_builder.new(record).apply(canvas)
     end
 

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -85,6 +85,7 @@ RSpec.describe ManifestBuilder do
       file_set_id = output.member_ids.first
       file_set = query_service.find_by(id: file_set_id)
       file_set.local_identifier = "p79409x97p"
+      file_set.viewing_hint = ["non-paged"]
       metadata_adapter.persister.save(resource: file_set)
       change_set = ScannedResourceChangeSet.new(output)
       change_set.validate(logical_structure: logical_structure(file_set_id), start_canvas: start_canvas || file_set_id)
@@ -105,6 +106,7 @@ RSpec.describe ManifestBuilder do
       expect(output["sequences"][0]["viewingHint"]).to eq "individuals"
       canvas_id = output["sequences"][0]["canvases"][0]["@id"]
       expect(output["structures"].length).to eq 3
+      expect(output["sequences"][0]["canvases"][0]["viewingHint"]).to eq "non-paged"
       structure_canvas_id = output["structures"][2]["canvases"][0]
       expect(canvas_id).to eq structure_canvas_id
       expect(output["sequences"][0]["canvases"][0]["width"]).to be_a Integer


### PR DESCRIPTION
I'm not sure if UV uses these, but we store things like "non-paged" via the order manager and should utilize that in the manifest. If UV -does- use these, this might be a good way to do photo albums.