### PR TITLE
Prefix geo derivative names and ids

### DIFF
--- a/app/derivative-services/raster_resource_derivative_service.rb
+++ b/app/derivative-services/raster_resource_derivative_service.rb
@@ -81,7 +81,7 @@ class RasterResourceDerivativeService
     {
       input_format: original_file.mime_type.first,
       label: :display_raster,
-      id: resource.id,
+      id: prefixed_id,
       format: "tif",
       srid: "EPSG:3857",
       url: URI("file://#{temporary_display_output.path}")
@@ -102,6 +102,12 @@ class RasterResourceDerivativeService
   def parent
     decorator = FileSetDecorator.new(change_set)
     decorator.parent
+  end
+
+  # Resource id prefixed with letter to avoid restrictions on
+  # numbers in QNames from GeoServer generated WFS GML.
+  def prefixed_id
+    "p-#{resource.id}"
   end
 
   def run_derivatives

--- a/app/derivative-services/vector_resource_derivative_service.rb
+++ b/app/derivative-services/vector_resource_derivative_service.rb
@@ -89,7 +89,7 @@ class VectorResourceDerivativeService
       label: :display_vector,
       id: resource.id,
       format: "zip",
-      srid: "EPSG:3857",
+      srid: "EPSG:4326",
       url: URI("file://#{temporary_display_output.path}")
     }
   end

--- a/app/derivative-services/vector_resource_derivative_service.rb
+++ b/app/derivative-services/vector_resource_derivative_service.rb
@@ -87,7 +87,7 @@ class VectorResourceDerivativeService
     {
       input_format: original_file.mime_type.first,
       label: :display_vector,
-      id: resource.id,
+      id: prefixed_id,
       format: "zip",
       srid: "EPSG:4326",
       url: URI("file://#{temporary_display_output.path}")
@@ -108,6 +108,12 @@ class VectorResourceDerivativeService
   def parent
     decorator = FileSetDecorator.new(change_set)
     decorator.parent
+  end
+
+  # Resource id prefixed with letter to avoid restrictions on
+  # numbers in QNames from GeoServer generated WFS GML.
+  def prefixed_id
+    "p-#{resource.id}"
   end
 
   def run_derivatives

--- a/app/services/geo_discovery/document_builder/wxs.rb
+++ b/app/services/geo_discovery/document_builder/wxs.rb
@@ -13,7 +13,7 @@ module GeoDiscovery
       def identifier
         return unless file_set
         return file_set.id.to_s unless @config && visibility
-        "#{@config[visibility][:workspace]}:#{file_set.id}" if @config[visibility][:workspace]
+        "#{@config[visibility][:workspace]}:p-#{file_set.id}" if @config[visibility][:workspace]
       end
 
       # Returns the wms server url.

--- a/app/services/geoserver_message_generator.rb
+++ b/app/services/geoserver_message_generator.rb
@@ -31,8 +31,10 @@ class GeoserverMessageGenerator
       Figgy.config["geoserver"]["derivatives_path"]
     end
 
+    # Resource id prefixed with letter to avoid restrictions on
+    # numbers in QNames from GeoServer generated WFS GML.
     def id
-      resource.id.to_s
+      "p-#{resource.id}"
     end
 
     def layer_type

--- a/spec/services/geo_discovery/document_builder/wxs_spec.rb
+++ b/spec/services/geo_discovery/document_builder/wxs_spec.rb
@@ -27,7 +27,7 @@ describe GeoDiscovery::DocumentBuilder::Wxs do
     context "public document" do
       it "returns a public identifier" do
         file_set_id = geo_work.member_ids[0]
-        expect(wxs_builder.identifier).to eq "public-figgy:#{file_set_id}"
+        expect(wxs_builder.identifier).to eq "public-figgy:p-#{file_set_id}"
       end
     end
 

--- a/spec/services/geoserver_message_generator_spec.rb
+++ b/spec/services/geoserver_message_generator_spec.rb
@@ -28,11 +28,11 @@ RSpec.describe GeoserverMessageGenerator do
           visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
         )
       end
-      let(:shapefile_name) { "display_vector/#{file_set.id}.shp" }
+      let(:shapefile_name) { "display_vector/p-#{file_set.id}.shp" }
 
       it "returns a valid message hash" do
         output = generator.generate
-        expect(output["id"]).to eq(file_set.id.to_s)
+        expect(output["id"]).to eq("p-#{file_set.id}")
         expect(output["layer_type"]).to eq(:shapefile)
         expect(output["workspace"]).to eq(Figgy.config["geoserver"]["open"]["workspace"])
         expect(output["path"]).to include(shapefile_name, geoserver_derivatives_path)
@@ -55,7 +55,7 @@ RSpec.describe GeoserverMessageGenerator do
 
       it "returns a valid message hash" do
         output = generator.generate
-        expect(output["id"]).to eq(file_set.id.to_s)
+        expect(output["id"]).to eq("p-#{file_set.id}")
         expect(output["layer_type"]).to eq(:geotiff)
         expect(output["workspace"]).to eq(Figgy.config["geoserver"]["authenticated"]["workspace"])
         expect(output["path"]).to include(geo_tiff_name, geoserver_derivatives_path)


### PR DESCRIPTION
- Sets the output projection for vector derivatives to EPSG:4326 to avoid shapefile projection issues in GeoServer. The modest gains in performance when using 3857 are mitigated by increased complexity in setting up new layers.
- Prefixes geo derivative names and ids with a letter to avoid XML validation errors with GeoServer WFS generated GML.

Closes #1659