### PR TITLE
Implements PDFGenerator::Canvas#validate! to validate IIIF Manifest structure

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,7 @@ Metrics/AbcSize:
     - 'app/models/concerns/linked_data/linked_ephemera_folder.rb'
     - 'app/models/ability.rb'
     - 'app/services/file_appender.rb'
+    - 'app/services/pdf_generator.rb'
 Metrics/BlockLength:
   Exclude:
     - 'app/controllers/catalog_controller.rb'
@@ -68,6 +69,7 @@ Metrics/CyclomaticComplexity:
   Exclude:
     - 'app/models/concerns/linked_data/linked_resource_factory.rb'
     - 'app/services/file_appender.rb'
+    - 'app/services/pdf_generator/canvas.rb'
 Metrics/MethodLength:
   Exclude:
     - 'db/migrate/**/*'
@@ -95,6 +97,9 @@ Metrics/ModuleLength:
 Metrics/ParameterLists:
   Exclude:
     - 'app/change_set_persisters/change_set_persister.rb'
+Metrics/PerceivedComplexity:
+  Exclude:
+    - 'app/services/pdf_generator/canvas.rb'
 Rails/OutputSafety:
   Exclude:
     - 'app/decorators/**/*'

--- a/app/services/pdf_generator/canvas.rb
+++ b/app/services/pdf_generator/canvas.rb
@@ -5,19 +5,41 @@ class PDFGenerator
     LETTER_WIDTH = PDF::Core::PageGeometry::SIZES["LETTER"].first
     LETTER_HEIGHT = PDF::Core::PageGeometry::SIZES["LETTER"].last
     BITONAL_SIZE = 2000
+
+    # Error raised when IIIF Manifests have an invalid structure
+    class InvalidIIIFManifestError < StandardError; end
+
     attr_reader :canvas
+
+    # @param [Hash] canvas
     def initialize(canvas)
       @canvas = canvas
+      validate!
     end
 
+    # Ensure that the IIIF Manifest canvas has a valid structure
+    # @raise [InvalidIIIFManifestError]
+    def validate!
+      raise(InvalidIIIFManifestError, "IIIF Manifest canvas does not reference a resource") unless canvas.key?("resource")
+      raise(InvalidIIIFManifestError, "IIIF Manifest canvas does not specify a width") unless canvas["resource"].key?("width") && canvas["resource"]["width"]
+      raise(InvalidIIIFManifestError, "IIIF Manifest canvas does not specify a height") unless canvas["resource"].key?("height") && canvas["resource"]["height"]
+      raise(InvalidIIIFManifestError, "IIIF Manifest canvas does not specify a service URL") unless canvas["resource"].key?("service") && canvas["resource"]["service"].key?("@id")
+    end
+
+    # Access the width for the canvas
+    # @return [Integer]
     def width
       canvas["resource"]["width"].to_i
     end
 
+    # Access the height for the canvas
+    # @return [Integer]
     def height
       canvas["resource"]["height"].to_i
     end
 
+    # Access the URL for the IIIF image server
+    # @return [String]
     def url
       canvas["resource"]["service"]["@id"]
     end

--- a/spec/services/pdf_generator_spec.rb
+++ b/spec/services/pdf_generator_spec.rb
@@ -36,6 +36,227 @@ RSpec.describe PDFGenerator do
       end
     end
 
+    context "when a IIIF Manifest does not have a canvas image service referenced" do
+      let(:manifest) do
+        {
+          "@type" => "sc:Manifest",
+          "sequences" => [
+            {
+              "@type" => "sc:Sequence",
+              "@id" => "http://www.example.com/concern/scanned_resources/c240f04d-d779-45ad-b7e4-acb28e7b8da6/manifest/sequence/normal",
+              "canvases" => [
+                {
+                  "@type" => "sc:Canvas",
+                  "images" => [
+                    {
+                      "@type" => "oa:Annotation",
+                      "motivation" => "sc:painting",
+                      "resource" => {
+                        "@type" => "dctypes:Image",
+                        "@id" => "http://www.example.com/image-service/9292c8c2-8480-42b7-8714-e7e6b45a3bee/full/!1000,/0/default.jpg",
+                        "height" => 200,
+                        "width" => 287,
+                        "service" => {}
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      let(:manifest_builder) { instance_double(ManifestBuilder) }
+
+      before do
+        stub_request(
+          :any,
+          "http://www.example.com/image-service/#{file_set.id}/full/287,/0/gray.jpg"
+        ).to_return(
+          body: File.open(Rails.root.join("spec", "fixtures", "files", "derivatives", "grey-landscape-pdf.jpg")),
+          status: 200
+        )
+
+        file_set.original_file.width = 287
+        file_set.original_file.height = 200
+
+        persister.save(resource: file_set)
+
+        allow(Valkyrie.logger).to receive(:error)
+        allow(manifest_builder).to receive(:build).and_return(manifest)
+        allow(ManifestBuilder).to receive(:new).and_return(manifest_builder)
+      end
+
+      it "logs the error" do
+        expect { generator.render }.to raise_error(PDFGenerator::Error)
+        expect(Valkyrie.logger).to have_received(:error).with("PDFGenerator: Failed to generate a PDF for the resource #{resource.id}: IIIF Manifest canvas does not specify a service URL")
+      end
+    end
+
+    context "when a IIIF Manifest does not have a width" do
+      let(:manifest) do
+        {
+          "@type" => "sc:Manifest",
+          "sequences" => [
+            {
+              "@type" => "sc:Sequence",
+              "@id" => "http://www.example.com/concern/scanned_resources/c240f04d-d779-45ad-b7e4-acb28e7b8da6/manifest/sequence/normal",
+              "canvases" => [
+                {
+                  "@type" => "sc:Canvas",
+                  "images" => [
+                    {
+                      "@type" => "oa:Annotation",
+                      "motivation" => "sc:painting",
+                      "resource" => {
+                        "@type" => "dctypes:Image",
+                        "@id" => "http://www.example.com/image-service/9292c8c2-8480-42b7-8714-e7e6b45a3bee/full/!1000,/0/default.jpg",
+                        "height" => 200
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      let(:manifest_builder) { instance_double(ManifestBuilder) }
+
+      before do
+        stub_request(
+          :any,
+          "http://www.example.com/image-service/#{file_set.id}/full/287,/0/gray.jpg"
+        ).to_return(
+          body: File.open(Rails.root.join("spec", "fixtures", "files", "derivatives", "grey-landscape-pdf.jpg")),
+          status: 200
+        )
+
+        file_set.original_file.width = 287
+        file_set.original_file.height = 200
+
+        persister.save(resource: file_set)
+
+        allow(Valkyrie.logger).to receive(:error)
+        allow(manifest_builder).to receive(:build).and_return(manifest)
+        allow(ManifestBuilder).to receive(:new).and_return(manifest_builder)
+      end
+
+      it "logs the error" do
+        expect { generator.render }.to raise_error(PDFGenerator::Error)
+        expect(Valkyrie.logger).to have_received(:error).with("PDFGenerator: Failed to generate a PDF for the resource #{resource.id}: IIIF Manifest canvas does not specify a width")
+      end
+    end
+
+    context "when a IIIF Manifest does not have a height" do
+      let(:manifest) do
+        {
+          "@type" => "sc:Manifest",
+          "sequences" => [
+            {
+              "@type" => "sc:Sequence",
+              "@id" => "http://www.example.com/concern/scanned_resources/c240f04d-d779-45ad-b7e4-acb28e7b8da6/manifest/sequence/normal",
+              "canvases" => [
+                {
+                  "@type" => "sc:Canvas",
+                  "images" => [
+                    {
+                      "@type" => "oa:Annotation",
+                      "motivation" => "sc:painting",
+                      "resource" => {
+                        "@type" => "dctypes:Image",
+                        "@id" => "http://www.example.com/image-service/9292c8c2-8480-42b7-8714-e7e6b45a3bee/full/!1000,/0/default.jpg",
+                        "width" => 287
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      let(:manifest_builder) { instance_double(ManifestBuilder) }
+
+      before do
+        stub_request(
+          :any,
+          "http://www.example.com/image-service/#{file_set.id}/full/287,/0/gray.jpg"
+        ).to_return(
+          body: File.open(Rails.root.join("spec", "fixtures", "files", "derivatives", "grey-landscape-pdf.jpg")),
+          status: 200
+        )
+
+        file_set.original_file.width = 287
+        file_set.original_file.height = 200
+
+        persister.save(resource: file_set)
+
+        allow(Valkyrie.logger).to receive(:error)
+        allow(manifest_builder).to receive(:build).and_return(manifest)
+        allow(ManifestBuilder).to receive(:new).and_return(manifest_builder)
+      end
+
+      it "logs the error" do
+        expect { generator.render }.to raise_error(PDFGenerator::Error)
+        expect(Valkyrie.logger).to have_received(:error).with("PDFGenerator: Failed to generate a PDF for the resource #{resource.id}: IIIF Manifest canvas does not specify a height")
+      end
+    end
+
+    context "when a IIIF Manifest does not have a canvas image resource referenced" do
+      let(:manifest) do
+        {
+          "@type" => "sc:Manifest",
+          "sequences" => [
+            {
+              "@type" => "sc:Sequence",
+              "@id" => "http://www.example.com/concern/scanned_resources/c240f04d-d779-45ad-b7e4-acb28e7b8da6/manifest/sequence/normal",
+              "canvases" => [
+                {
+                  "@type" => "sc:Canvas",
+                  "images" => [
+                    {
+                      "@type" => "oa:Annotation",
+                      "motivation" => "sc:painting"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      let(:manifest_builder) { instance_double(ManifestBuilder) }
+
+      before do
+        stub_request(
+          :any,
+          "http://www.example.com/image-service/#{file_set.id}/full/287,/0/gray.jpg"
+        ).to_return(
+          body: File.open(Rails.root.join("spec", "fixtures", "files", "derivatives", "grey-landscape-pdf.jpg")),
+          status: 200
+        )
+
+        file_set.original_file.width = 287
+        file_set.original_file.height = 200
+
+        persister.save(resource: file_set)
+
+        allow(Valkyrie.logger).to receive(:error)
+        allow(manifest_builder).to receive(:build).and_return(manifest)
+        allow(ManifestBuilder).to receive(:new).and_return(manifest_builder)
+      end
+
+      it "logs the error" do
+        expect { generator.render }.to raise_error(PDFGenerator::Error)
+        expect(Valkyrie.logger).to have_received(:error).with("PDFGenerator: Failed to generate a PDF for the resource #{resource.id}: IIIF Manifest canvas does not reference a resource")
+      end
+    end
+
     context "when set to gray" do
       before do
         stub_request(:any, "http://www.example.com/image-service/#{file_set.id}/full/287,/0/gray.jpg")


### PR DESCRIPTION
Resolves #1662 