### PR TITLE
Add a test for the case when find_by_string_property has no results

### DIFF
--- a/spec/queries/find_by_string_property_spec.rb
+++ b/spec/queries/find_by_string_property_spec.rb
@@ -11,5 +11,12 @@ RSpec.describe FindByStringProperty do
       output = query.find_by_string_property(property: :barcode, value: box.barcode.first).first
       expect(output.id).to eq box.id
     end
+
+    context "when no objects have the string in that property" do
+      it "returns no results" do
+        output = query.find_by_string_property(property: :barcode, value: "notabarcode")
+        expect(output.to_a).to be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
refs #1676

There wasn't a bug (just a mock that was throwing off my other test) but do we still want this test?