### PR TITLE
Improve GeoServer delete message behavior

### DIFF
--- a/app/services/geoserver_message_generator.rb
+++ b/app/services/geoserver_message_generator.rb
@@ -22,11 +22,19 @@ class GeoserverMessageGenerator
 
   private
 
+    # GeoServer workspace for restricted content that requires authentication
+    # @return [String]
+    def authenticated_workspace
+      Figgy.config["geoserver"]["authenticated"]["workspace"]
+    end
+
     # Generate the file path for the first derivative appended to the resource
     # @return [String]
     def derivative_file_path
       derivative_id = resource.derivative_file.file_identifiers.first
       Valkyrie::StorageAdapter.find_by(id: derivative_id).io.path
+    rescue Valkyrie::StorageAdapter::FileNotFound
+      return ""
     end
 
     # Access the path used for GeoServer derivatives
@@ -51,14 +59,13 @@ class GeoserverMessageGenerator
     # Provide the type of geospatial layer type (Shapefile or GeoTIFF)
     # @return [Symbol]
     def layer_type
-      return :shapefile if vector_resource_parent?
+      return :shapefile if vector_file?
       :geotiff
     end
 
     # Retrieve the parent resource
     # @return [Valkyrie::Resource]
     def parent
-      raise(Valkyrie::Persistence::ObjectNotFoundError, "Failed to retrieve the parent resource for the FileSet #{resource.id}") if resource.decorate.parent.nil?
       @parent ||= resource.decorate.parent
     end
 
@@ -66,8 +73,14 @@ class GeoserverMessageGenerator
     #   GeoTiff
     # @return [String]
     def path
-      return shapefile_path if vector_resource_parent?
+      return shapefile_path if vector_file?
       geotiff_path
+    end
+
+    # GeoServer workspace for open public content
+    # @return [String]
+    def public_workspace
+      Figgy.config["geoserver"]["open"]["workspace"]
     end
 
     # Provide the default public visibility value for the resource
@@ -86,23 +99,24 @@ class GeoserverMessageGenerator
     # Retrieve the title from the parent resource
     # @return [String]
     def title
+      return "" unless parent
       Array(parent.title).first.to_s
     end
 
-    # Determines whether or not a vector resource is the parent of the current
-    #   resource
+    # Determines whether or the resource is a vector file
     # @return [Boolean]
-    def vector_resource_parent?
-      parent.is_a?(VectorResource)
+    def vector_file?
+      ControlledVocabulary::GeoVectorFormat.new.include?(resource.mime_type.first)
     end
 
-    # Retrieve the GeoServer workspace using the visibility from the parent
-    #   resource
+    # Generate a GeoServer workspace for the file set
     # @see http://docs.geoserver.org/stable/en/user/rest/workspaces.html
     # @return [String]
     def workspace
+      # Return a default workspace value if there is no parent resource
+      return authenticated_workspace unless parent
+      # Generate a workspace value from the visibility of the parent resource
       visibility = parent.model.visibility.try(:first)
-      return Figgy.config["geoserver"]["open"]["workspace"] if visibility == public_visibility
-      Figgy.config["geoserver"]["authenticated"]["workspace"]
+      visibility == public_visibility ? public_workspace : authenticated_workspace
     end
 end

--- a/spec/services/event_generator/geoserver_event_generator_spec.rb
+++ b/spec/services/event_generator/geoserver_event_generator_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe EventGenerator::GeoserverEventGenerator do
   end
 
   describe "#derivatives_deleted" do
-    it "publishes a persistent JSON message" do
+    it "publishes two persistent JSON messages, one for each workspace" do
       event_generator.derivatives_deleted(record)
-      expect(rabbit_connection).to have_received(:publish)
+      expect(rabbit_connection).to have_received(:publish).twice
     end
   end
 


### PR DESCRIPTION
- Better handles conditions where a vector file set's parent resource no longer exists or when the member files are missing.
- Sends two messages to GeoServer on every delete. One for the public workspace and one for the restricted workspace. This will help to reduce manual cleanup on GeoServer because of anomalous events in Figgy. 

Tested this in staging, and was able to delete Vector Resources without error as well as a FileSet that had become separated from it's parent.

Closes #1669 