### PR TITLE
Implements the METSDocument::MODSDocument Class for appending MODS metadata attributes within IngestMETSJob

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,7 @@ Metrics/AbcSize:
     - 'app/models/ability.rb'
     - 'app/services/file_appender.rb'
     - 'app/services/pdf_generator.rb'
+    - 'app/jobs/ingest_mets_job.rb'
 Metrics/BlockLength:
   Exclude:
     - 'app/controllers/catalog_controller.rb'
@@ -65,6 +66,7 @@ Metrics/ClassLength:
     - 'app/controllers/ephemera_folders_controller.rb'
     - 'app/derivative-services/jp2_derivative_service.rb'
     - 'app/services/file_appender.rb'
+    - 'app/models/mets_document.rb'
 Metrics/CyclomaticComplexity:
   Exclude:
     - 'app/models/concerns/linked_data/linked_resource_factory.rb'
@@ -90,6 +92,7 @@ Metrics/MethodLength:
     - 'app/services/pdf_generator.rb'
     - 'app/services/file_appender.rb'
     - 'app/jobs/voyager_update_job.rb'
+    - 'app/models/mets_document.rb'
 Metrics/ModuleLength:
   Exclude:
     - 'app/models/schema/marc_relators.rb'

--- a/app/jobs/ingest_mets_job.rb
+++ b/app/jobs/ingest_mets_job.rb
@@ -3,20 +3,21 @@ class IngestMETSJob < ApplicationJob
   attr_reader :mets
 
   # @param [String] mets_file Filename of a METS file to ingest
-  # @param [String] user User to ingest as
-  def perform(mets_file, user)
+  # @param [User] user User to ingest as
+  def perform(mets_file, user, import_mods = false)
     logger.info "Ingesting METS #{mets_file}"
     @mets = METSDocument::Factory.new(mets_file).new
     @user = user
-    changeset_persister.buffer_into_index do |buffered_persister|
-      Ingester.for(mets: @mets, user: @user, changeset_persister: buffered_persister).ingest
+    @import_mods = import_mods
+    change_set_persister.buffer_into_index do |buffered_persister|
+      Ingester.for(mets: @mets, user: @user, change_set_persister: buffered_persister, import_mods: @import_mods).ingest
     end
   end
 
-  def changeset_persister
-    @changeset_persister ||= ChangeSetPersister.new(metadata_adapter: metadata_adapter,
-                                                    storage_adapter: storage_adapter,
-                                                    queue: queue_name)
+  def change_set_persister
+    @change_set_persister ||= ChangeSetPersister.new(metadata_adapter: metadata_adapter,
+                                                     storage_adapter: storage_adapter,
+                                                     queue: queue_name)
   end
 
   def metadata_adapter
@@ -28,63 +29,110 @@ class IngestMETSJob < ApplicationJob
   end
 
   class Ingester
-    delegate :metadata_adapter, to: :changeset_persister
+    delegate :metadata_adapter, to: :change_set_persister
     delegate :query_service, to: :metadata_adapter
-    def self.for(mets:, user:, changeset_persister:)
+    def self.for(mets:, user:, change_set_persister:, import_mods:)
       if mets.multi_volume?
-        HierarchicalIngester.new(mets: mets, user: user, changeset_persister: changeset_persister)
+        HierarchicalIngester.new(mets: mets, user: user, change_set_persister: change_set_persister, import_mods: import_mods)
       else
-        new(mets: mets, user: user, changeset_persister: changeset_persister)
+        new(mets: mets, user: user, change_set_persister: change_set_persister, import_mods: import_mods)
       end
     end
 
-    attr_reader :mets, :user, :changeset_persister
-    def initialize(mets:, user:, changeset_persister:)
+    attr_reader :mets, :user, :change_set_persister
+    # @param [METSDocument] mets
+    # @param [User] user
+    # @param [ChangeSetPersister] change_set_persister
+    def initialize(mets:, user:, change_set_persister:, import_mods: false)
       @mets = mets
       @user = user
-      @changeset_persister = changeset_persister
+      @change_set_persister = change_set_persister
+      @import_mods = import_mods
     end
 
+    def import_mods?
+      @import_mods
+    end
+
+    # Ingest the resource using a METS Document object
+    # @return [ScannedResource] the persisted resource
     def ingest
-      resource.source_metadata_identifier = mets.bib_id
-      resource.title = mets.label
-      resource.files = files.to_a
-      resource.member_of_collection_ids = [find_or_create_collection(mets.collection_slug)] if mets.respond_to?(:collection_slug)
-      output = changeset_persister.save(change_set: resource)
+      # Only import the MODS metadata from the METS Document if a MARC record is
+      #   not provided
+      change_set.source_metadata_identifier = mets.bib_id unless mets.bib_id.blank?
+      change_set.title = mets.label
+      change_set.files = files.to_a
+      change_set.member_of_collection_ids = [find_or_create_collection(mets.collection_slug)] if mets.respond_to?(:collection_slug)
+      persisted = change_set_persister.save(change_set: change_set)
       files.each_with_index do |file, index|
-        mets_to_repo_map[file.id.to_s] = output.member_ids[index]
+        mets_to_repo_map[file.id.to_s] = persisted.member_ids[index]
       end
-      assign_logical_structure(output)
+      logical_persisted = assign_logical_structure(persisted)
+      assign_attributes(logical_persisted) if import_mods?
+      logical_persisted
     end
 
-    def assign_logical_structure(output)
-      new_resource = DynamicChangeSet.new(output)
-      new_resource.logical_structure = [{ label: "Main Structure", nodes: map_fileids(mets.structure)[:nodes] }]
-      changeset_persister.save(change_set: new_resource)
+    # Assigns the logical structure used to generate the IIIF Presentation Manifest
+    # @param [ScannedResource] the resource being modified
+    # @return [ScannedResource] the persisted resource with the logical structure assigned
+    def assign_logical_structure(resource)
+      new_change_set = DynamicChangeSet.new(resource)
+      new_change_set.logical_structure = [{ label: "Main Structure", nodes: map_fileids(mets.structure)[:nodes] }]
+      change_set_persister.save(change_set: new_change_set)
     end
 
+    # Assigns the metadata attributes from the METS Document (which are not
+    #   featured in the bib. source record
+    # @param [ScannedResource] the resource being modified
+    # @return [ScannedResource] the persisted resource with the logical structure assigned
+    def assign_attributes(resource)
+      new_change_set = DynamicChangeSet.new(resource)
+      new_change_set.prepopulate!
+      return resource unless new_change_set.validate(mets.attributes)
+      new_change_set.sync
+      change_set_persister.save(change_set: new_change_set)
+    end
+
+    # Generate Hashes for each file linked to the described resource in the
+    #   METS Document
+    # @return [Array<Hash>]
     def files
       mets.files.lazy.map do |file|
         mets.decorated_file(file)
       end
     end
 
+    # Finds an existing or creates a new Collection for the imported Resource
     # @param [String] slug
     # @return [Valkyrie::ID]
     def find_or_create_collection(slug)
-      collection =
-        query_service.custom_queries.find_by_string_property(property: :slug, value: slug).first ||
-        changeset_persister.save(change_set: CollectionChangeSet.new(Collection.new(title: slug, slug: slug)))
+      existing_collections = query_service.custom_queries.find_by_string_property(property: :slug, value: slug)
+      return existing_collections.first.id unless existing_collections.to_a.empty?
+
+      new_collection = Collection.new(title: slug, slug: slug)
+      new_collection_change_set = CollectionChangeSet.new(new_collection)
+      collection = change_set_persister.save(change_set: new_collection_change_set)
       collection.id
     end
 
-    def resource
-      @resource ||=
+    # Provide the resource class used for ingesting Resources using a METS Document
+    # @return [Class]
+    def resource_klass
+      ScannedResource
+    end
+
+    # Construct the ChangeSet object for the new resource
+    # @return [ChangeSet]
+    def change_set
+      @change_set ||=
         begin
-          DynamicChangeSet.new(ScannedResource.new)
+          DynamicChangeSet.new(resource_klass.new)
         end
     end
 
+    # Map a Hash recursively keyed to each FileSet ID
+    # @param [Hash] hsh source of Hash values (usually generated from METSDocument#structure)
+    # @return [Hash]
     def map_fileids(hsh)
       hsh.each do |k, v|
         hsh[k] = v.each { |node| map_fileids(node) } if k == :nodes
@@ -92,6 +140,8 @@ class IngestMETSJob < ApplicationJob
       end
     end
 
+    # Generate the internal Hash used to store the mapping
+    # @return [Hash]
     def mets_to_repo_map
       @mets_to_repo_map ||= {}
     end
@@ -99,38 +149,65 @@ class IngestMETSJob < ApplicationJob
 
   class HierarchicalIngester < Ingester
     def ingest
-      resource.source_metadata_identifier = mets.bib_id
+      change_set.source_metadata_identifier = mets.bib_id
       mets.volume_ids.each do |volume_id|
         volume_mets = VolumeMets.new(parent_mets: mets, volume_id: volume_id)
-        volume = Ingester.new(mets: volume_mets, user: user, changeset_persister: changeset_persister).ingest
-        resource.member_ids = resource.member_ids + [volume.id]
+        volume = Ingester.new(mets: volume_mets, user: user, change_set_persister: change_set_persister, import_mods: import_mods?).ingest
+        change_set.member_ids = change_set.member_ids + [volume.id]
       end
-      changeset_persister.save(change_set: resource)
+      change_set_persister.save(change_set: change_set)
     end
   end
 
+  # Class modeling the METS Document for child volumes within multi-volume
+  #   works
   class VolumeMets
     attr_reader :parent_mets, :volume_id
     delegate :decorated_file, to: :parent_mets
+
+    # @param [METS::Document] parent_mets
+    # @param [String] volume_id
     def initialize(parent_mets:, volume_id:)
       @parent_mets = parent_mets
       @volume_id = volume_id
     end
 
+    # Access the bib. ID
+    # @see METSDocument#bib_id
+    # (There are no bib. IDs for child volumes, these are retrieved from the
+    #   parent resource)
+    # @return [nil]
     def bib_id
       nil
     end
 
+    # Retrieve the information for the files from the METS for the parent
+    #   resource
+    # @see METSDocument#files
+    # @return [Hash<Array>]
     def files
       parent_mets.files_for_volume(volume_id)
     end
 
+    # Retrieve the structure from the METS for the parent resource
+    # @see MetsStructure#structure_for_volume
+    # @return [Hash]
     def structure
       parent_mets.structure_for_volume(volume_id)
     end
 
+    # Retrieve the label for the volume
+    # @see METSDocument#label_for_volume
+    # @return [String]
     def label
       parent_mets.label_for_volume(volume_id)
+    end
+
+    # Merge the metadata attributes with those of the parent resource
+    # @see METSDocument#attributes
+    # @return [Hash]
+    def attributes
+      parent_mets.attributes.merge(title: [label])
     end
   end
 end

--- a/app/models/mets_document.rb
+++ b/app/models/mets_document.rb
@@ -1,81 +1,140 @@
 # frozen_string_literal: true
+
+# Class modeling METS Documents
+# @see https://www.loc.gov/standards/mets/
 class METSDocument
   include MetsStructure
+  METS_XML_NAMESPACE = "http://www.loc.gov/METS/"
+
   attr_reader :source_file, :mets
 
+  # @param [String] mets_file
   def initialize(mets_file)
     @source_file = mets_file
     @mets = File.open(@source_file) { |f| Nokogiri::XML(f) }
   end
 
+  # Access the ARK ID
+  # @return [String]
   def ark_id
-    @mets.xpath("/mets:mets/@OBJID").to_s
+    element = @mets.xpath("/mets:mets/@OBJID")
+    element.to_s
   end
 
+  # Access the bib. ID
+  # @return [String]
   def bib_id
-    @mets.xpath("/mets:mets/mets:dmdSec/mets:mdRef/@xlink:href").to_s.gsub(/.*\//, "")
+    element = @mets.xpath("/mets:mets/mets:dmdSec/mets:mdRef/@xlink:href")
+    content = element.to_s
+    content.gsub(/.*\//, "")
   end
 
+  # Access the slug for the Collection
+  # @return [String]
   def collection_slug
-    @mets.xpath("/mets:mets/mets:structMap[@TYPE='RelatedObjects']//mets:div[@TYPE='IsPartOf']/@CONTENTIDS").to_s
+    element = @mets.xpath("/mets:mets/mets:structMap[@TYPE='RelatedObjects']//mets:div[@TYPE='IsPartOf']/@CONTENTIDS")
+    element.to_s
   end
 
+  # Access the ID for the PUDL resource
+  # @return [String]
   def pudl_id
-    @mets.xpath("/mets:mets/mets:metsHdr/mets:metsDocumentID").first.content.gsub(/\.mets/, "")
+    elements = @mets.xpath("/mets:mets/mets:metsHdr/mets:metsDocumentID")
+    element = elements.first
+    content = element.content
+    content.gsub(/\.mets/, "")
   end
 
+  # Access the file path to the thumbnail image
+  # @return [String]
   def thumbnail_path
     xp = "/mets:mets/mets:fileSec/mets:fileGrp[@USE='thumbnail']/mets:file/mets:FLocat/@xlink:href"
-    @mets.xpath(xp).to_s.gsub(/file:\/\//, "")
+    element = @mets.xpath(xp)
+    content = element.to_s
+    content.gsub(/file:\/\//, "")
   end
 
+  # Determine whether or not the resource described by the METS is
+  #   right-to-left or left-to-right in viewing direction
+  # @return [Boolean]
   def viewing_direction
     right_to_left ? "right-to-left" : "left-to-right"
   end
 
+  # Determine whether or not the viewing direction for the described resource
+  #   is right-to-left in viewing direction
+  # @return [Boolean]
   def right_to_left
-    @mets.xpath("/mets:mets/mets:structMap[@TYPE='Physical']/mets:div/@TYPE").to_s.start_with? "RTL"
+    element = @mets.xpath("/mets:mets/mets:structMap[@TYPE='Physical']/mets:div/@TYPE")
+    content = element.to_s
+    content.start_with? "RTL"
   end
 
+  # Access the viewing hint encoded in the METS Document
+  # @return [String]
   def viewing_hint
-    type = @mets.xpath("/mets:mets/mets:structMap[@TYPE='Physical']/mets:div/@TYPE").to_s
+    attribute = @mets.xpath("/mets:mets/mets:structMap[@TYPE='Physical']/mets:div/@TYPE")
+    type = attribute.to_s
     return if ["TightBoundManuscript", "ScrollSet", "BoundArt"].any? { |w| type.include?(w) }
     "paged"
   end
 
+  # Determine if the described resource is a multi-volume work
+  # @return [Boolean]
   def multi_volume?
     volume_nodes.length > 1
   end
 
+  # Retrieve the IDs for the volumes encoded in the METS Document
+  # @return [Array<String>]
   def volume_ids
     volume_nodes.map do |vol|
       vol.attribute("ID").value
     end
   end
 
+  # Provide the label for the described resource
+  # (This defaults to an empty array)
+  # @return [Array]
   def label
     []
   end
 
+  # For a given volume ID, retrieve the label for that volume
+  # @param [String] volume_id ID for the volume
+  # @return [String]
   def label_for_volume(volume_id)
     volume_node = volume_nodes.find { |vol| vol.attribute("ID").value == volume_id }
     return volume_node.attribute("LABEL").value if volume_node
   end
 
+  # For a given volume ID, retrieve the information for each file associated
+  #   with the volume
+  # @param [String] volume_id ID for the volume
+  # @return [Array<Hash>]
   def files_for_volume(volume_id)
     @mets.xpath("//mets:div[@ID='#{volume_id}']//mets:fptr/@FILEID").map(&:value).uniq.map do |file_id|
       file_info(@mets.xpath("//mets:file[@ID='#{file_id}']"), volume_id)
     end
   end
 
+  # Retrieve all information for files encoded in the METS
+  # @return [Hash<Array>]
   def files
     @mets.xpath("/mets:mets/mets:fileSec/mets:fileGrp[@USE='masters']/mets:file").map do |f|
       file_info(f)
     end
   end
 
+  # For a given XML element encoding a file description (and an optional ID for
+  #   a volume), construct a Hash containing information about the file
+  # @param [Nokogiri::XML::Node] file the file XML element
+  # @param [String] volume_id the ID for the volume
+  # @return [Hash]
   def file_info(file, volume_id = nil)
-    path = file.xpath("mets:FLocat/@xlink:href").to_s.gsub(/file:\/\//, "")
+    element = file.xpath("mets:FLocat/@xlink:href")
+    content = element.to_s
+    path = content.gsub(/file:\/\//, "")
     replaces = volume_id ? "#{volume_id}/" : ""
     replaces += File.basename(path, File.extname(path))
     {
@@ -87,11 +146,17 @@ class METSDocument
     }
   end
 
+  # Retrieve options relating to the encoded file
+  # @param [Nokogiri::XML::Node] file the file XML element
+  # @return [Hash]
   def file_opts(file)
     return {} if @mets.xpath("count(//mets:div/mets:fptr[@FILEID='#{file[:id]}'])").positive?
     { viewing_hint: "non-paged" }
   end
 
+  # Construct an IngestableFile object given a Hash containing file attributes
+  # @param [Hash] f file attributes
+  # @return [IngestableFile]
   def decorated_file(f)
     IngestableFile.new(
       file_path: f[:path],
@@ -103,19 +168,55 @@ class METSDocument
     )
   end
 
+  # Generate the attributes for the container resource given a Hash of file
+  #   attributes
+  # @param [Hash] file file attributes
+  # @param [Hash]
   def container_attributes(file)
     {
       title: file_label(file[:id])
     }
   end
 
+  # Construct the MODS Document object using the METS XML Document and an XPath
+  # @return [MODSDocument]
+  def mods
+    @mods ||= MODSDocument.from(mets: @mets, xpath: "/mets:mets/mets:dmdSec/mets:mdWrap/mets:xmlData/mods:mods")
+  end
+
+  # Generate the metadata attributes for the resource being described
+  # @return [Hash]
+  def attributes
+    return {} if mods.nil?
+    {
+      title: mods.title,
+      alternative_title: mods.alternative_title,
+      uniform_title: mods.uniform_title,
+      date_created: mods.date_created,
+      extent: mods.extent,
+      license: mods.access_condition,
+      resource_type: mods.type_of_resource,
+      subject: mods.subject,
+      rights_note: mods.restriction_on_access,
+      description: mods.note,
+      abstract: mods.abstract,
+      contents: mods.table_of_contents
+    }
+  end
+
   private
 
+    # Access the XML elements encoding information about volumes in the METS
+    #   Document
+    # @return [Nokogiri::XML::NodeSet]
     def volume_nodes
       xp = "/mets:mets/mets:structMap[@TYPE='Physical']/mets:div[@TYPE='MultiVolumeSet']/mets:div"
       @volume_nodes ||= logical_volumes || @mets.xpath(xp)
     end
 
+    # Access the XML elements encoding information about volumes in the METS
+    #   Document if they are encoded as a logical structural map (structMap)
+    # @return [Nokogiri::XML::NodeSet]
     def logical_volumes
       xp = "/mets:mets/mets:structMap[@TYPE='Logical']/mets:div/mets:div[starts-with(@TYPE, 'Bound')]"
       log = @mets.xpath(xp)

--- a/app/models/mets_document/mods_document.rb
+++ b/app/models/mets_document/mods_document.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+# Class modeling the MODS metadata within a METS Document
+# @see https://www.loc.gov/standards/mods/
+class METSDocument
+  class MODSDocument
+    MODS_XML_NAMESPACE = "http://www.loc.gov/mods/v3"
+    XLINK_XML_NAMESPACE = "http://www.w3.org/1999/xlink"
+
+    def self.from(mets:, xpath:)
+      elements = mets.xpath(xpath, mets: METS_XML_NAMESPACE, mods: MODS_XML_NAMESPACE)
+      return if elements.empty?
+
+      new(elements.first)
+    end
+
+    def initialize(element)
+      @element = element
+    end
+
+    def title
+      value_from xpath: "mods:titleInfo/mods:title"
+    end
+
+    def alternative_title
+      value_from xpath: "mods:titleInfo[@type=\"alternative\"]/mods:title"
+    end
+
+    def uniform_title
+      value_from xpath: "mods:titleInfo[@type=\"uniform\"]/mods:title"
+    end
+
+    def date_created
+      values = value_from xpath: "mods:originInfo/mods:dateCreated"
+      joined = values.join(" - ")
+      Array.wrap(joined)
+    end
+
+    def type_of_resource
+      value_from xpath: "mods:typeOfResource"
+    end
+
+    def extent
+      value_from xpath: "mods:physicalDescription/mods:extent"
+    end
+
+    def note
+      value_from xpath: "mods:note"
+    end
+
+    def subject
+      subject_names
+    end
+
+    def access_condition
+      uris = value_from xpath: "mods:accessCondition[@type=\"useAndReproduction\"]/@xlink:href"
+      return uris unless uris.empty?
+      value_from xpath: "mods:accessCondition[@type=\"useAndReproduction\"]"
+    end
+
+    def restriction_on_access
+      uris = value_from xpath: "mods:accessCondition[@type=\"restrictionOnAccess\"]/@xlink:href"
+      return uris unless uris.empty?
+      value_from xpath: "mods:accessCondition[@type=\"restrictionOnAccess\"]"
+    end
+
+    def abstract
+      value_from xpath: "mods:abstract"
+    end
+
+    def table_of_contents
+      value_from xpath: "mods:tableOfContents"
+    end
+
+    private
+
+      def find_elements(xpath)
+        @element.xpath(xpath, mods: MODS_XML_NAMESPACE, xlink: XLINK_XML_NAMESPACE)
+      end
+
+      def content(elements)
+        elements.map(&:content)
+      end
+
+      def value_from(xpath:)
+        elements = find_elements(xpath)
+        content(elements)
+      end
+
+      def subject_names
+        value_from xpath: "mods:subject/mods:name/mods:namePart"
+      end
+  end
+end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -13,13 +13,14 @@ namespace :import do
     file = ENV["FILE"]
     user = User.find_by_user_key(ENV["USER"]) if ENV["USER"]
     user = User.all.select(&:admin?).first unless user
+    import_mods = ENV["IMPORT_MODS"] && ENV["IMPORT_MODS"].capitalize == "TRUE"
 
-    abort "usage: rake import:mets FILE=/path/to/file.mets [USER=aperson]" unless file && File.file?(file)
+    abort "usage: rake import:mets FILE=/path/to/file.mets [USER=aperson] [IMPORT_MODS=TRUE]" unless file && File.file?(file)
 
     @logger = Logger.new(STDOUT)
     @logger.info "ingesting as: #{user.user_key} (override with USER=foo)"
     @logger.info "queuing job to ingest file: #{file}"
 
-    IngestMETSJob.set(queue: :low).perform_later(file, user)
+    IngestMETSJob.set(queue: :low).perform_later(file, user, import_mods)
   end
 end

--- a/spec/fixtures/mets/scrapbooks.mets
+++ b/spec/fixtures/mets/scrapbooks.mets
@@ -1,0 +1,12573 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" OBJID="ark:/88435/sf268784s" TYPE="CompiledDigitalObject" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd">
+<mets:metsHdr CREATEDATE="2018-08-04T11:56:25.172-04:00" LASTMODDATE="2018-08-04T11:56:25.172-04:00">
+<mets:metsDocumentID TYPE="PUDL">pudl0044/831958/scrapbooks.mets</mets:metsDocumentID>
+</mets:metsHdr>
+<mets:dmdSec ID="nagzi">
+<mets:mdWrap MDTYPE="MODS">
+<mets:xmlData>
+<mods xmlns="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods//v3/mods-3-3.xsd">
+
+
+   <titleInfo>
+
+      <title>F. Scott Fitzgerald scrapbooks</title>
+
+   </titleInfo>
+   <name authority="naf" type="personal">
+
+      <namePart type="family">Fitzgerald</namePart>
+      <namePart type="given">F. Scott (Francis Scott)</namePart>
+      <namePart type="date">1896-1940</namePart>
+      <role>
+         <roleTerm authority="marcrelator" type="code">aut</roleTerm>
+      </role>
+   </name>
+   <typeOfResource manuscript="yes">still image</typeOfResource>
+   <originInfo>
+      <dateCreated encoding="w3cdtf" keyDate="yes" point="start">1896</dateCreated>
+      <dateCreated encoding="w3cdtf" point="end">1935</dateCreated>
+   </originInfo>
+   <language>
+      <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+   </language>
+   <physicalDescription>
+      <extent>7 volumes</extent>
+   </physicalDescription>
+   <abstract>Scrapbooks. Seven bound volumes of about the life and work of F. Scott Fitzgerald. Includes newspaper clippings, book reviews, and interviews relating to Fitzgerald and his work; dust covers of books and tearsheets of magazine articles and short stories; promotional announcements and other printed ephemera; photographs, including formal studio portraits of Fitzgerald, photographs of friends and acquaintances, and family snapshoots (Scott, Zelda, Scottie); memorabilia, such as Valentines and locks of hair; and correspondence, including scattered letters, mostly from personal friends. Fitzgerald kept and compiled five of the volumes, largely pertaining to his published novels and collections, as well as magazine articles and short stories. Fitzgerald compiled "A Scrap Book Record" around 1920 to cover his earlier life, ca. 1900-1919, through the acceptance of his short story "Head and Shoulders" for publication in The Saturday Evening Post (1920). Mary "Mollie" McQuillan Fitzgerald (1859-1936), his mother, compiled the "Baby Book." For preservation reasons, physical access to the original scrapbooks is restricted. The best resource for identifying and dating scrapbook contents is Matthew J. Bruccoli, Scottie Fitzgerald Smith and Joan P. Kerr, eds., The Romantic Egoists: A Pictorial Autobiography from the Scrapbooks and Albums of F. Scott Fitzgerald and Zelda Fitzgerald (New York: Charles Scribner's Sons, 1974). </abstract>
+   <note>Gift of Scottie Fitzgerald Lanahan.</note>
+   <tableOfContents>I. This Side of Paradise (1920).</tableOfContents>
+   <tableOfContents>II. This Side of Paradise (1920), to The Beautiful and Damned (1922). </tableOfContents>
+   <tableOfContents>III. Tales of the Jazz Age (1922), to All the Sad Young Men (1926).  </tableOfContents>
+   <tableOfContents>IV. The Great Gatsby (1925), to silent-film version of Gatsby (1926). </tableOfContents>
+   <tableOfContents>V. Tender Is the Night (1934), to Taps at Reveille (1935). </tableOfContents>
+   <tableOfContents>VI. F. Scott Fitzgerald's "Baby Book" (1896-1915).</tableOfContents>
+   <tableOfContents>VII. "A Scrap Book Record, compiled from many sources of interest to and concerning one F. Scott Fitzgerald" (ca. 1900-1919). </tableOfContents>
+   <subject authority="lcsh">
+      <name authority="naf" type="personal">
+         <namePart type="family">Fitzgerald</namePart>
+         <namePart type="given">F. Scott (Francis Scott)</namePart>
+         <namePart type="date">1896-1940</namePart>
+      </name>
+      <genre>Manuscripts</genre>
+   </subject>
+   <relatedItem type="host">
+      <typeOfResource collection="yes">text</typeOfResource>
+      <titleInfo>
+         <title>F. Scott Fitzgerald papers, 1897-1944</title>
+      </titleInfo>
+      <!--<location>
+         <url note="Digital Collection">http://pudl.princeton.edu/collections/pudl0044</url>
+      </location>-->
+   </relatedItem>
+   <location>
+      <physicalLocation type="text">Princeton University Library. Department of Rare Books and Special Collections</physicalLocation>
+      <physicalLocation authority="marcorg" type="code">NjP</physicalLocation>
+      <holdingSimple>
+         <copyInformation>
+            <subLocation>mss</subLocation>
+            <shelfLocator>C0187, series 10, Oversize I-VII</shelfLocator>
+         </copyInformation>
+      </holdingSimple>
+   </location>
+   <accessCondition type="useAndReproduction">Not to be published, reproduced, or broadcast without the written permission of the Princeton University Library.  Selected items in the F. Scott Fitzgerald Papers can
+      be photoduplicated at the expense of the researcher requesting photoduplication. Advanced
+      estimates and payment are required. For general information on photoduplication and
+      permissions, go to http://www.princeton.edu/~rbsc Requests to to reproduce, publish, or
+      broadcast material from the F. Scott Fitzgerald Papers should be addressed Public Services
+      staff, rbsc@princeton.edu The correct form of citation includes the name of the collection,
+      box and folder numbers, and an indication that the originals are in the "Manuscripts Division,
+      Department of Rare Books and Special Collections, Princeton University Library." The
+      manuscript of The Great Gatsby and other writings of F. Scott Fitzgerald are not to be quoted,
+      published, reproduced, or broadcast without the written permission of the Princeton University
+      Library as owner of the physical object, and of the Fitzgerald Literary Trust (copyright
+      holder), c/o Harold Ober Associates, 425 Madison Avenue, New York, New York 10017 (Telephone:
+      212-759-8600; FAX: 212-759-9428). The Library is not responsible for copyright infringement or
+      other legal problems resulting from unauthorized publication of the words of F. Scott
+      Fitzgerald.</accessCondition>
+   <accessCondition type="restrictionOnAccess">For legal and conservation reasons, access to F.
+      Scott Fitzgerald’s original manuscripts (including corrected galleys and scrapbooks) is
+      strictly restricted. Scottie Fitzgerald Lanahan, daughter of F. Scott Fitzgerald and Zelda
+      Fitzgerald, donated the Fitzgerald Papers to the Princeton University Library in 1950,
+      stipulating that surrogates of the original manuscripts were to be made available to
+      researchers instead of the originals. This was done to preserve the originals, which are not
+      on good paper. Originally, the surrogates were in the form of microfilm. Facsimiles editions of This Side of Paradise and 
+      other manuscripts of books and short
+      stories followed a multi-volume series: F. Scott Fitzgerald Manuscripts, edited by Matthew J.
+      Bruccoli and Alan Margolies (New York: Garland Publishing Company, 1990). Complete sets of the
+      facsimile edition are available at more than 50 research libraries (including Firestone
+      Library). </accessCondition>
+
+   <!--<location>
+         <url note="Digital Collection">http://pudl.princeton.edu/collections/pudl0044</url>
+      </location>-->
+   <recordInfo>
+      <recordContentSource authority="marcorg">NjP</recordContentSource>
+      <!-- <recordOrigin>http://catalog.princeton.edu/cgi-bin/Pwebrecon.cgi?BBID=</recordOrigin>-->
+      <recordIdentifier>http://diglib.princeton.edu/mdata/pudl0044/831958/scrapbooks.mods</recordIdentifier>
+      <languageOfCataloging>
+         <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+      </languageOfCataloging>
+   </recordInfo>
+</mods>
+</mets:xmlData>
+</mets:mdWrap>
+</mets:dmdSec>
+<mets:fileSec>
+<mets:fileGrp USE="thumbnail">
+<mets:file ID="nw2qg" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000001.tif"/>
+</mets:file>
+</mets:fileGrp>
+<mets:fileGrp USE="masters">
+<mets:file CHECKSUM="c722694328e628859aafee4252841c32" CHECKSUMTYPE="MD5" ID="l5baq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000001.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ee42fcf0208c22838c86e5615f9d3d3a" CHECKSUMTYPE="MD5" ID="b7zl3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000002.tif"/>
+</mets:file>
+<mets:file CHECKSUM="137f0a71c0df4e3a419685c0c51a96bc" CHECKSUMTYPE="MD5" ID="x6tb4" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000003.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2f3906cd8d26f08b97000d65d56e5f72" CHECKSUMTYPE="MD5" ID="d7rez" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000004.tif"/>
+</mets:file>
+<mets:file CHECKSUM="60fe44b89190fbe6a6e2bfa3645a56f3" CHECKSUMTYPE="MD5" ID="avxb5" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000005.tif"/>
+</mets:file>
+<mets:file CHECKSUM="194de79265b568e0da585f8477a2a941" CHECKSUMTYPE="MD5" ID="kji8y" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000006.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ff4af2d727021b001a0bd9acb9f3eab8" CHECKSUMTYPE="MD5" ID="qx8bu" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000007.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7136e0bfddf0be39a47b565bf9a203e6" CHECKSUMTYPE="MD5" ID="utkd3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000008.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a51f6a746fa736d751a855c9e6087be0" CHECKSUMTYPE="MD5" ID="px9u1" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000009.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8c4ef2711d5bfbf3fc160d671509dbf" CHECKSUMTYPE="MD5" ID="fujgx" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000010.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d41fb1da167855afa07dc9e9b0d3b37b" CHECKSUMTYPE="MD5" ID="no9dy" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000011.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d77b1d243a0a988b627fbf9dbad28539" CHECKSUMTYPE="MD5" ID="fy2zm" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000012.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f8b65a7c1ab9bdbf1f3a9de4246c96b0" CHECKSUMTYPE="MD5" ID="shc5u" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000013.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8efc890cdb60896b8282466502dbd715" CHECKSUMTYPE="MD5" ID="kysvi" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000014.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f3feb2faa7517cb4aafaa97d17d345f0" CHECKSUMTYPE="MD5" ID="t9a8m" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000015.tif"/>
+</mets:file>
+<mets:file CHECKSUM="72cff30fafc003da12f58bfd1555996b" CHECKSUMTYPE="MD5" ID="oz7pl" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000016.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7447842a0d515f4b71c724d3ec8ae890" CHECKSUMTYPE="MD5" ID="z4dm9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000017.tif"/>
+</mets:file>
+<mets:file CHECKSUM="cbd65ae422d824f99c17c76e2da673e3" CHECKSUMTYPE="MD5" ID="p3txt" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000018.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c0cd799104bd5ad751ca42e32cab73d5" CHECKSUMTYPE="MD5" ID="b6g6h" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000019.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6933543f132d1e67df576f853aa66039" CHECKSUMTYPE="MD5" ID="lkang" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000020.tif"/>
+</mets:file>
+<mets:file CHECKSUM="956d7e6b1e0011c28f7b098580393cf8" CHECKSUMTYPE="MD5" ID="t9m8s" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000021.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d237affabfbe21c32e0dd41132b0a1ac" CHECKSUMTYPE="MD5" ID="fdozy" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000022.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9f6a2f93921abe4bd326834a7ddb57df" CHECKSUMTYPE="MD5" ID="d1yqw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000023.tif"/>
+</mets:file>
+<mets:file CHECKSUM="93315fc6a08adb5e0d293b78454f91b8" CHECKSUMTYPE="MD5" ID="y9jjj" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000024.tif"/>
+</mets:file>
+<mets:file CHECKSUM="85685633cb3a5349fcf37ffa3c3f119b" CHECKSUMTYPE="MD5" ID="gnrbg" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000025.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a1a6128535d39b0f0c6ad4ed8cf4b6a1" CHECKSUMTYPE="MD5" ID="f3tg4" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000026.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b1e4ad89d473ca3392749f364355d925" CHECKSUMTYPE="MD5" ID="scrtl" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000027.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8bc65be27f726adbaef9dd0e6a88c3d9" CHECKSUMTYPE="MD5" ID="zkae8" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000028.tif"/>
+</mets:file>
+<mets:file CHECKSUM="dc90a7888e2bcce5f8728621e6528ccd" CHECKSUMTYPE="MD5" ID="hi82a" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000029.tif"/>
+</mets:file>
+<mets:file CHECKSUM="115660f311293e3c8b8b947e67585599" CHECKSUMTYPE="MD5" ID="e4hwb" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000030.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b88dc7ba32f15b47e41642b926f4c770" CHECKSUMTYPE="MD5" ID="ick68" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000031.tif"/>
+</mets:file>
+<mets:file CHECKSUM="629a69ed21161e35cf5ca185457c0a21" CHECKSUMTYPE="MD5" ID="xno7n" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000032.tif"/>
+</mets:file>
+<mets:file CHECKSUM="91c2a49329700207fdf6597cf9345e14" CHECKSUMTYPE="MD5" ID="uir9m" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000033.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6b653e3c1adff1cc28448960906265e4" CHECKSUMTYPE="MD5" ID="gvmjb" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000034.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ac91c6c3609a7fc1b427de2b27d1f477" CHECKSUMTYPE="MD5" ID="f5boc" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000035.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6afa789f1d3ee0f96f8b789d46ad0222" CHECKSUMTYPE="MD5" ID="owo44" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000036.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bde5cd87baea77c9554cb155e6a6e8d2" CHECKSUMTYPE="MD5" ID="npc2a" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000037.tif"/>
+</mets:file>
+<mets:file CHECKSUM="af9454805c9d9447d7c6fadaa7eb6931" CHECKSUMTYPE="MD5" ID="y05o2" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000038.tif"/>
+</mets:file>
+<mets:file CHECKSUM="cff5624aa2c3cd97304017bf290afcdf" CHECKSUMTYPE="MD5" ID="ilpzx" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000039.tif"/>
+</mets:file>
+<mets:file CHECKSUM="fcf41e79afee00dd94335abacec25d09" CHECKSUMTYPE="MD5" ID="ayryk" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000040.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2ae6787ded84bcc49f15bd165ba857c5" CHECKSUMTYPE="MD5" ID="mnmdv" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000041.tif"/>
+</mets:file>
+<mets:file CHECKSUM="454d1345552c1343b3c6d7628700101f" CHECKSUMTYPE="MD5" ID="tbvw9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000042.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c9e318d93e150c58d3479085c336c12b" CHECKSUMTYPE="MD5" ID="n90tt" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000043.tif"/>
+</mets:file>
+<mets:file CHECKSUM="49aca14a7652b935b24e6ed559703427" CHECKSUMTYPE="MD5" ID="wmky0" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000044.tif"/>
+</mets:file>
+<mets:file CHECKSUM="71e8cc86823e3a9d411a623a5483830d" CHECKSUMTYPE="MD5" ID="aioqq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000045.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d23650beb5997a0d157dcad483c861b3" CHECKSUMTYPE="MD5" ID="t1gez" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000046.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8fb31c6d02105aa8def678435fd7479b" CHECKSUMTYPE="MD5" ID="hu1ty" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000047.tif"/>
+</mets:file>
+<mets:file CHECKSUM="303381da2cd44852bb84c603994c6a4" CHECKSUMTYPE="MD5" ID="r530k" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000048.tif"/>
+</mets:file>
+<mets:file CHECKSUM="458639d618bbcd67c19585cba06b5a4d" CHECKSUMTYPE="MD5" ID="shlfg" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000049.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c58e5bfdc46d78c1016af0ea17053e64" CHECKSUMTYPE="MD5" ID="q4eqv" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000050.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bf2353a141e07e8735f7924249024a5f" CHECKSUMTYPE="MD5" ID="a1int" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000051.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b2f4a281ad9dbe78356c9b2ec7bfbb06" CHECKSUMTYPE="MD5" ID="cixxw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000052.tif"/>
+</mets:file>
+<mets:file CHECKSUM="68b1928de4e32c978cfa57b182569252" CHECKSUMTYPE="MD5" ID="zeagq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000053.tif"/>
+</mets:file>
+<mets:file CHECKSUM="74bd2c06c68086c255564fe3b02b63af" CHECKSUMTYPE="MD5" ID="xp6se" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000054.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3e154608e3a2852b42f116d8efc8b0e5" CHECKSUMTYPE="MD5" ID="q5pwa" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000055.tif"/>
+</mets:file>
+<mets:file CHECKSUM="28a76c9a54fbdef35622a7df412a3b4" CHECKSUMTYPE="MD5" ID="lez6y" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000056.tif"/>
+</mets:file>
+<mets:file CHECKSUM="638d53426202a11987b6e4521d0bfe03" CHECKSUMTYPE="MD5" ID="cazkp" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000057.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6af7916dc309081d512dfcdc9c523408" CHECKSUMTYPE="MD5" ID="l19ce" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000058.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bdefaa482384d6b522ce7a01d78fbed3" CHECKSUMTYPE="MD5" ID="sbec1" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000059.tif"/>
+</mets:file>
+<mets:file CHECKSUM="306ef5df086b1e23fd6a452c611d2008" CHECKSUMTYPE="MD5" ID="liulp" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000060.tif"/>
+</mets:file>
+<mets:file CHECKSUM="390fd9ae7914a9dc612e0e41a7a163ff" CHECKSUMTYPE="MD5" ID="l85k7" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000061.tif"/>
+</mets:file>
+<mets:file CHECKSUM="97a5ea2b615644fda30fbdd7b572d601" CHECKSUMTYPE="MD5" ID="u68l8" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000062.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bdc590cb5cc384099263794eedffc501" CHECKSUMTYPE="MD5" ID="j180l" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000063.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6a562e52180c2cb717753d9e1c86a16b" CHECKSUMTYPE="MD5" ID="zohoz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000064.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a21dce33c961326cb2ef8903e703207a" CHECKSUMTYPE="MD5" ID="kgusw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000065.tif"/>
+</mets:file>
+<mets:file CHECKSUM="57827977ad55ea5abc512b856ad5c975" CHECKSUMTYPE="MD5" ID="t1hbj" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000066.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3b46056353f00f458bf8417a65d3f38b" CHECKSUMTYPE="MD5" ID="u9pjh" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000067.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ef99368b0fff840a08847e4c0f58f809" CHECKSUMTYPE="MD5" ID="hruzn" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000068.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d645703e6b2e45a726f82326550e332" CHECKSUMTYPE="MD5" ID="qs479" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000069.tif"/>
+</mets:file>
+<mets:file CHECKSUM="48c76dc8d6d7760c27bf86d743ff609c" CHECKSUMTYPE="MD5" ID="pnv2x" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000070.tif"/>
+</mets:file>
+<mets:file CHECKSUM="68dd7270e2a28bafcf5eaf1101e102d0" CHECKSUMTYPE="MD5" ID="zk9zd" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000071.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4c63a76bfeb615deb3ae2fc08d0f7703" CHECKSUMTYPE="MD5" ID="b6asb" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000072.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c14d1b556993613b08526b9d23e1a386" CHECKSUMTYPE="MD5" ID="qyd9w" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000073.tif"/>
+</mets:file>
+<mets:file CHECKSUM="29b14ad0fba5a0f4f420f6923d37e362" CHECKSUMTYPE="MD5" ID="c5g3p" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000074.tif"/>
+</mets:file>
+<mets:file CHECKSUM="69220178898a9eeb79f309dca72fc619" CHECKSUMTYPE="MD5" ID="dd3jp" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000075.tif"/>
+</mets:file>
+<mets:file CHECKSUM="fdef560c2acbc5907d008a8b24af3539" CHECKSUMTYPE="MD5" ID="geyd4" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000076.tif"/>
+</mets:file>
+<mets:file CHECKSUM="66c6acbc1b72460a252ef82587728799" CHECKSUMTYPE="MD5" ID="nuysl" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000077.tif"/>
+</mets:file>
+<mets:file CHECKSUM="138146f38d210f30d85efae24f776759" CHECKSUMTYPE="MD5" ID="wyi47" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000078.tif"/>
+</mets:file>
+<mets:file CHECKSUM="aaecd9c48321cdf9ff4788d6de3ebd01" CHECKSUMTYPE="MD5" ID="v1jwi" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000079.tif"/>
+</mets:file>
+<mets:file CHECKSUM="45e2db48c4e951098c24e0480f2096b2" CHECKSUMTYPE="MD5" ID="le4jg" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000080.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f77220b574a2d75699f4ae58455cd204" CHECKSUMTYPE="MD5" ID="u6e51" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000081.tif"/>
+</mets:file>
+<mets:file CHECKSUM="529863a1ac585a1e019a580c1a67ba63" CHECKSUMTYPE="MD5" ID="h2yh5" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000082.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e5098c5c44d94c4d005ee2ac43b4948d" CHECKSUMTYPE="MD5" ID="sfkqu" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000083.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ea2ed37400d3d5165528e682b9fd52b2" CHECKSUMTYPE="MD5" ID="eb68m" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000084.tif"/>
+</mets:file>
+<mets:file CHECKSUM="86e33bb770efb95e4b28a9dd18d82fbd" CHECKSUMTYPE="MD5" ID="ba7pj" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000085.tif"/>
+</mets:file>
+<mets:file CHECKSUM="20091e33ef69ebbf1a4d386eb95a153d" CHECKSUMTYPE="MD5" ID="gmrzp" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000086.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d308f09be59cbc3c668d7b8919b38722" CHECKSUMTYPE="MD5" ID="yvmh8" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000087.tif"/>
+</mets:file>
+<mets:file CHECKSUM="41375885bf18f7848fb368f25b17cb00" CHECKSUMTYPE="MD5" ID="y6nyp" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000088.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4d83c43c40c6565656771c6cb2bdddde" CHECKSUMTYPE="MD5" ID="ow1zi" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000089.tif"/>
+</mets:file>
+<mets:file CHECKSUM="548f3f72f36cfccb932a853ec541d84" CHECKSUMTYPE="MD5" ID="bkg58" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000090.tif"/>
+</mets:file>
+<mets:file CHECKSUM="41ebc6e20b165708e7c64e513efa686a" CHECKSUMTYPE="MD5" ID="d856l" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000091.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9c692f777a57a3356a9ced9dd046babb" CHECKSUMTYPE="MD5" ID="aragj" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000092.tif"/>
+</mets:file>
+<mets:file CHECKSUM="63799469c5b5f8ba52b7264c05ea42c5" CHECKSUMTYPE="MD5" ID="c7ca7" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000093.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bf2d8f00750da7f1bde55b559063c1a7" CHECKSUMTYPE="MD5" ID="charw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000094.tif"/>
+</mets:file>
+<mets:file CHECKSUM="feece20816e274edfb66d139681ff212" CHECKSUMTYPE="MD5" ID="crsxc" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000095.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8e2e821203b89d8ecd0d74644286ec85" CHECKSUMTYPE="MD5" ID="r9y6g" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000096.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7f1f07734cbae3e6be71ad305bbb6661" CHECKSUMTYPE="MD5" ID="itq91" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000097.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e5991f9fa57075b8c073f8bfbc540a5e" CHECKSUMTYPE="MD5" ID="xnxhm" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000098.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e0a86b8f1ac01b6fa28d1d2028cd9168" CHECKSUMTYPE="MD5" ID="vzziq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000099.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b5dbd38698fc1b318050663c20c90e0" CHECKSUMTYPE="MD5" ID="jmgdg" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000100.tif"/>
+</mets:file>
+<mets:file CHECKSUM="877b4c30864743fc3dca59602cc4e1c9" CHECKSUMTYPE="MD5" ID="p2qk7" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000101.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2c26ffb82a5e15ad3c76764c1b86c8cc" CHECKSUMTYPE="MD5" ID="hvz24" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000102.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d520ca8431cb2d7a72e4f89f92d59fbc" CHECKSUMTYPE="MD5" ID="ull2i" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000103.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2fe04097ba7d36320295f5ce53ff80b3" CHECKSUMTYPE="MD5" ID="cpn5w" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000104.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a52878c8096ce6dc31ac0282647ff59c" CHECKSUMTYPE="MD5" ID="xsa6f" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000105.tif"/>
+</mets:file>
+<mets:file CHECKSUM="54be13a4c9ba6b20bad46b5e2a279d2b" CHECKSUMTYPE="MD5" ID="zhprw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000106.tif"/>
+</mets:file>
+<mets:file CHECKSUM="83f6e65e1e8cfa3214d10faf12a4eb5a" CHECKSUMTYPE="MD5" ID="rf115" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000107.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b8c70ffa5339f95b42ef903d0e6a683" CHECKSUMTYPE="MD5" ID="cc019" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000108.tif"/>
+</mets:file>
+<mets:file CHECKSUM="66a26e90d0eda5769f69d4a23e2fa6e1" CHECKSUMTYPE="MD5" ID="knl23" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000109.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8f031f6d32ea80df08ca9584714cf30a" CHECKSUMTYPE="MD5" ID="yk3nf" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000110.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4760b19c5bb47bcb6c582fe8c69a126b" CHECKSUMTYPE="MD5" ID="k6h3b" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000111.tif"/>
+</mets:file>
+<mets:file CHECKSUM="38dd6700d240365acca3e3a3c92f6b80" CHECKSUMTYPE="MD5" ID="pu2re" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000112.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5b6d36abefeb07a898c5a6d6e0a5cfc7" CHECKSUMTYPE="MD5" ID="zodsq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000113.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e2fa5b3cb2d9725166ea04c1f4a9e345" CHECKSUMTYPE="MD5" ID="f8gf6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000114.tif"/>
+</mets:file>
+<mets:file CHECKSUM="61bcf712a6eeba3d86875c8f60ed31fc" CHECKSUMTYPE="MD5" ID="bu548" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000115.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b1aef21048b137ba384a7a73aa43b113" CHECKSUMTYPE="MD5" ID="e8mee" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000116.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9b74f12e952206c060ae089e4f2e26b0" CHECKSUMTYPE="MD5" ID="hjan6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000117.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a0132b1f1a85a7ba69e2fbf016b5ae" CHECKSUMTYPE="MD5" ID="tobgg" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000118.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b0314b2a44240ec09f3b54083374bc71" CHECKSUMTYPE="MD5" ID="zuoqn" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000119.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f35f1c9876cf48e2b8b32236fd0325a9" CHECKSUMTYPE="MD5" ID="rlb1z" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000120.tif"/>
+</mets:file>
+<mets:file CHECKSUM="cda2b8c1b1eb13712c9dc3b400709303" CHECKSUMTYPE="MD5" ID="brwmw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000121.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b3c1230b6eb8d2fa18e963f3388a41f" CHECKSUMTYPE="MD5" ID="zwylh" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000122.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b91cfb7d5b334dab6122bda2e8ab8953" CHECKSUMTYPE="MD5" ID="ivnzm" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000123.tif"/>
+</mets:file>
+<mets:file CHECKSUM="260cc04a4d55b206c6668135d6749c45" CHECKSUMTYPE="MD5" ID="yn3bj" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000124.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7933daa324ee492e9226fa7cb18bbfa" CHECKSUMTYPE="MD5" ID="cistq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000125.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a780e15289325383c3849e73dfb08432" CHECKSUMTYPE="MD5" ID="faekk" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000126.tif"/>
+</mets:file>
+<mets:file CHECKSUM="68c0fecc02681cbf1bcd3e7a64798ed6" CHECKSUMTYPE="MD5" ID="x3kaz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000127.tif"/>
+</mets:file>
+<mets:file CHECKSUM="69422333dda1b36e80c3561e58e5aebd" CHECKSUMTYPE="MD5" ID="f5crn" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000128.tif"/>
+</mets:file>
+<mets:file CHECKSUM="505601f1ea019058bccf0568742d6af4" CHECKSUMTYPE="MD5" ID="hv0zw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000129.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1c7bbd616463d1ec8844883afdf5a9bd" CHECKSUMTYPE="MD5" ID="gmhd5" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000130.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5dae2481ade47928c6681771467178ca" CHECKSUMTYPE="MD5" ID="jzwgk" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000131.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6ce13c579b4fa95ef81be0de48aaee14" CHECKSUMTYPE="MD5" ID="nss32" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000132.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f371f7045ea26dade1635bfc33edced8" CHECKSUMTYPE="MD5" ID="e1ev8" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000133.tif"/>
+</mets:file>
+<mets:file CHECKSUM="143a9f2b63d049e901702ab2d4b4c70a" CHECKSUMTYPE="MD5" ID="uze97" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000134.tif"/>
+</mets:file>
+<mets:file CHECKSUM="be7d63afc9321f446909cdfc6af6c013" CHECKSUMTYPE="MD5" ID="gkc4z" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000135.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5cd94bd02c37b414b74111248ccf96e0" CHECKSUMTYPE="MD5" ID="ycc7i" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_01/00000136.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f76c81cba59236ae9cbe9bb5e57bfa95" CHECKSUMTYPE="MD5" ID="gbw01" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000001.tif"/>
+</mets:file>
+<mets:file CHECKSUM="64c1264c8a5c35d8791ca9463177ea5f" CHECKSUMTYPE="MD5" ID="nmsij" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000002.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9064c1b712aa7369e8ca89070334e0d1" CHECKSUMTYPE="MD5" ID="vzbuy" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000003.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ae9c4bfab39a837aad1391b210456025" CHECKSUMTYPE="MD5" ID="uessr" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000004.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5aec3061a88bf21ea2c8f445a4f96008" CHECKSUMTYPE="MD5" ID="sc6n7" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000005.tif"/>
+</mets:file>
+<mets:file CHECKSUM="846bd7dd6015c8aa056c53a7a997136" CHECKSUMTYPE="MD5" ID="y77dv" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000006.tif"/>
+</mets:file>
+<mets:file CHECKSUM="87e687b2817d846d296a54052669bbab" CHECKSUMTYPE="MD5" ID="ey6xg" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000007.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a0e7287646e26d2143000ab2e94285ad" CHECKSUMTYPE="MD5" ID="ytgv2" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000008.tif"/>
+</mets:file>
+<mets:file CHECKSUM="20303f8d5484f2c81ad592f1100a36ab" CHECKSUMTYPE="MD5" ID="p6m1g" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000009.tif"/>
+</mets:file>
+<mets:file CHECKSUM="98e95c020fe1a87a0e79fd73e2f25319" CHECKSUMTYPE="MD5" ID="pksi3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000010.tif"/>
+</mets:file>
+<mets:file CHECKSUM="205f8540bd71247d5dd4a436d67346c4" CHECKSUMTYPE="MD5" ID="y766a" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000011.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a4b56392df7a3c7e5f9895c0fffbff09" CHECKSUMTYPE="MD5" ID="yv4sv" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000012.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ae2332a291e5b29c7f2de2ecef15a035" CHECKSUMTYPE="MD5" ID="a0yrw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000013.tif"/>
+</mets:file>
+<mets:file CHECKSUM="993031653eea5f01fe15de1fe78a4d7c" CHECKSUMTYPE="MD5" ID="xc1c6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000014.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2fe6627f4323afce1362774945b7986e" CHECKSUMTYPE="MD5" ID="kk92r" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000015.tif"/>
+</mets:file>
+<mets:file CHECKSUM="795834c85b9cedc8546bc11ea6ddb672" CHECKSUMTYPE="MD5" ID="jr55e" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000016.tif"/>
+</mets:file>
+<mets:file CHECKSUM="280c5ed09f0d11ff4c90e3264b5b6ad9" CHECKSUMTYPE="MD5" ID="ll9fu" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000017.tif"/>
+</mets:file>
+<mets:file CHECKSUM="82990c4db5b8872f43eb717a49e494c1" CHECKSUMTYPE="MD5" ID="st3j2" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000018.tif"/>
+</mets:file>
+<mets:file CHECKSUM="77ca327f0f2f885c848088294bf7d1e4" CHECKSUMTYPE="MD5" ID="mglo7" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000019.tif"/>
+</mets:file>
+<mets:file CHECKSUM="31214e219de680c47a81886fa5b8bfdb" CHECKSUMTYPE="MD5" ID="x613p" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000020.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d34ba03a656dc61536db9783744eb319" CHECKSUMTYPE="MD5" ID="l5mqk" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000021.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c13c07464f11f9e8849aa903da8654b7" CHECKSUMTYPE="MD5" ID="hstfn" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000022.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9ead63541684b814bfaa0a1fcf146428" CHECKSUMTYPE="MD5" ID="omvdz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000023.tif"/>
+</mets:file>
+<mets:file CHECKSUM="dd6b745cc9f04539270846a4936503e9" CHECKSUMTYPE="MD5" ID="gj6lz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000024.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3b9bcd23513992fd91b8cf67d80bcd2b" CHECKSUMTYPE="MD5" ID="zdvyi" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000025.tif"/>
+</mets:file>
+<mets:file CHECKSUM="92fec356f197eed2029dfa4b96cfe653" CHECKSUMTYPE="MD5" ID="jj7kw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000026.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3273ee62ee758527d6c0143b33a8c191" CHECKSUMTYPE="MD5" ID="vadp6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000027.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9b06889c7b93befb8b0caf6fb54411fd" CHECKSUMTYPE="MD5" ID="g1ja2" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000028.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2f1bd55d5427350be9a511bf6867f895" CHECKSUMTYPE="MD5" ID="dsfnb" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000029.tif"/>
+</mets:file>
+<mets:file CHECKSUM="adabef3f1b834216dcfadd6efa98fd54" CHECKSUMTYPE="MD5" ID="i1o1x" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000030.tif"/>
+</mets:file>
+<mets:file CHECKSUM="93b920e6b175afc971a74ae6b193b8a7" CHECKSUMTYPE="MD5" ID="zdj6t" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000031.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4c46d86b2587fa98e66728c8afc83770" CHECKSUMTYPE="MD5" ID="sldpu" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000032.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6e62bf8f18264f60e364ce365dac4703" CHECKSUMTYPE="MD5" ID="o6kby" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000033.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f9a9f269cff410ddf9e5100eebdc503e" CHECKSUMTYPE="MD5" ID="pzq3d" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000034.tif"/>
+</mets:file>
+<mets:file CHECKSUM="cb7ce98a95c38ba3339b40da362a9632" CHECKSUMTYPE="MD5" ID="p5d50" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000035.tif"/>
+</mets:file>
+<mets:file CHECKSUM="85fad7254e63f3a3050d26d73704cf28" CHECKSUMTYPE="MD5" ID="fa3o8" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000036.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f6a6164e5091664054b28d42e1fdf1fa" CHECKSUMTYPE="MD5" ID="h5lsi" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000037.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ab022b6e801c1de7276186136d245e7f" CHECKSUMTYPE="MD5" ID="w35tq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000038.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d3adf47b4051f2928335e9a5e570297a" CHECKSUMTYPE="MD5" ID="wff2e" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000039.tif"/>
+</mets:file>
+<mets:file CHECKSUM="18e740d52112fc1a0366a1066f6ac5ee" CHECKSUMTYPE="MD5" ID="zvrun" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000040.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1166290a582fdcfae10cf11522b72ef4" CHECKSUMTYPE="MD5" ID="tbg6m" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000041.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b6cfc748ef47949ed0aa1ecb62758a4a" CHECKSUMTYPE="MD5" ID="lqszf" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000042.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8312134aa6c6c58d9444e1b9809f93d5" CHECKSUMTYPE="MD5" ID="erre9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000043.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c511fb57d9f01d15a5ea584e7a68b79a" CHECKSUMTYPE="MD5" ID="vt6zp" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000044.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5c705827e6215ce842e3b6131ae5169d" CHECKSUMTYPE="MD5" ID="mlgzw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000045.tif"/>
+</mets:file>
+<mets:file CHECKSUM="26528b88fa7475f5b7ae1345ecd55387" CHECKSUMTYPE="MD5" ID="z0uxp" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000046.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f1b79a1cf445e03dc2d8d8a774983e01" CHECKSUMTYPE="MD5" ID="e8yob" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000047.tif"/>
+</mets:file>
+<mets:file CHECKSUM="567b7205910545310adedb70bc344637" CHECKSUMTYPE="MD5" ID="zoq1z" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000048.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3ef9765ae5110cee161dd374d2acc91e" CHECKSUMTYPE="MD5" ID="jkgp6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000049.tif"/>
+</mets:file>
+<mets:file CHECKSUM="891585980f2823dd2f65ff725d910a63" CHECKSUMTYPE="MD5" ID="f8a7y" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000050.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b63af430f3dc5c510a40bd013217e6b" CHECKSUMTYPE="MD5" ID="vzjv5" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000051.tif"/>
+</mets:file>
+<mets:file CHECKSUM="36d1ea55fb0a6e272641c2b82bc1826a" CHECKSUMTYPE="MD5" ID="cwj2o" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000052.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5150ab29f352d1596d0b3b962ed59520" CHECKSUMTYPE="MD5" ID="i0mso" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000053.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5220c479882275e3698ed72082f3894f" CHECKSUMTYPE="MD5" ID="ca7oe" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000054.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e311bedfb0a503e3b526baba6c6140e0" CHECKSUMTYPE="MD5" ID="r2d8z" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000055.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8f68480771e2351a634687c74786883a" CHECKSUMTYPE="MD5" ID="z1tr9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000056.tif"/>
+</mets:file>
+<mets:file CHECKSUM="904b29e43bb48c16aca2f69d32a57ea2" CHECKSUMTYPE="MD5" ID="j6gen" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000057.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a8d529fbdf4a210998d3399e22039ef" CHECKSUMTYPE="MD5" ID="xln4i" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000058.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ee74a0b0f1f7256091cbe1aa93175114" CHECKSUMTYPE="MD5" ID="vn9l5" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000059.tif"/>
+</mets:file>
+<mets:file CHECKSUM="40ecf0a3374d7a542f8b0528dbf9d9f0" CHECKSUMTYPE="MD5" ID="t1gc0" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000060.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8a131d73dbba98843fe6dba73c17e57f" CHECKSUMTYPE="MD5" ID="xnyc5" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000061.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3a1046ce21698a735b4f6313553086a4" CHECKSUMTYPE="MD5" ID="g4cnz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000062.tif"/>
+</mets:file>
+<mets:file CHECKSUM="cc9d4bdcd160e405404c370da5e85837" CHECKSUMTYPE="MD5" ID="i8m2c" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000063.tif"/>
+</mets:file>
+<mets:file CHECKSUM="88a4aa207c1b439f5ed06603e52ffd31" CHECKSUMTYPE="MD5" ID="aisvb" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000064.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a2fc655ec981b8b5c9998cacbf02507e" CHECKSUMTYPE="MD5" ID="pdd45" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000065.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b15bb24fa8286e9e2c9b8dd590a91a35" CHECKSUMTYPE="MD5" ID="byq68" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000066.tif"/>
+</mets:file>
+<mets:file CHECKSUM="125089cbb9e2ccb498067da988445f6e" CHECKSUMTYPE="MD5" ID="sdqg6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000067.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c957cfa00458bd16d04d97624b3e6a0f" CHECKSUMTYPE="MD5" ID="e2kbq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000068.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d02cbba6f2702b372b996769a79cf216" CHECKSUMTYPE="MD5" ID="ym1mf" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000069.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a16c885085d6c2965ef87fc49152aa0" CHECKSUMTYPE="MD5" ID="xpanh" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000070.tif"/>
+</mets:file>
+<mets:file CHECKSUM="60f769bbafcb1eed7d72aa1e6d507cfa" CHECKSUMTYPE="MD5" ID="d7ne5" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000071.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c271090e5168047033a069b3b58f90b8" CHECKSUMTYPE="MD5" ID="s5yaa" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000072.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7e52c0d6840facc5ed3ff02d6f7d31fb" CHECKSUMTYPE="MD5" ID="zdkxu" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000073.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3e99be9afe63b82d2e2a8a7feaac2b88" CHECKSUMTYPE="MD5" ID="scqf7" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000074.tif"/>
+</mets:file>
+<mets:file CHECKSUM="84dff3433ef5aa533b4503167f5e0d5a" CHECKSUMTYPE="MD5" ID="vdzak" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000075.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a28230d199f73499ba80f9968d0043a4" CHECKSUMTYPE="MD5" ID="gjlie" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000076.tif"/>
+</mets:file>
+<mets:file CHECKSUM="28023d17139755fa39d12269083e7872" CHECKSUMTYPE="MD5" ID="hqsxz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000077.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1bf348e9b49c59fb80287ffa6ef31226" CHECKSUMTYPE="MD5" ID="hqqcu" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000078.tif"/>
+</mets:file>
+<mets:file CHECKSUM="83e0962c77776c46319753cd9d71cf2c" CHECKSUMTYPE="MD5" ID="xfa6r" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000079.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3114517bc69abbde720018152c3f2d3f" CHECKSUMTYPE="MD5" ID="rstpt" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000080.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a541198c0cdd89db734eb7d8c90a1009" CHECKSUMTYPE="MD5" ID="ubcs8" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000081.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b5cc072a1444d8ef8bdd86784b64c79f" CHECKSUMTYPE="MD5" ID="svn96" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000082.tif"/>
+</mets:file>
+<mets:file CHECKSUM="509e2b75aba8c8cf2336b76d3f2fa81e" CHECKSUMTYPE="MD5" ID="o4cys" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000083.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9f3307bfb3f80e9bbba0a6d0d97ff8df" CHECKSUMTYPE="MD5" ID="l5yu1" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000084.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6e011a829c9b481b890ad5cb4d2a7188" CHECKSUMTYPE="MD5" ID="xv323" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000085.tif"/>
+</mets:file>
+<mets:file CHECKSUM="dc1d8434f2835102ea5e8999b87328b9" CHECKSUMTYPE="MD5" ID="imzjt" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000086.tif"/>
+</mets:file>
+<mets:file CHECKSUM="621a19d08c6d5b3c709ae9a03df4df30" CHECKSUMTYPE="MD5" ID="kholk" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000087.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8119dacd921338b88d7211899f0c56ab" CHECKSUMTYPE="MD5" ID="rqh5x" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000088.tif"/>
+</mets:file>
+<mets:file CHECKSUM="431ce5bfb4cbd43abd57142010dbc4be" CHECKSUMTYPE="MD5" ID="owvra" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000089.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4c34b01c70dd799bdcd2cedd8187e6bb" CHECKSUMTYPE="MD5" ID="t73z8" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000090.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2af414287bb5fdf86a196ebcfaaebcb0" CHECKSUMTYPE="MD5" ID="u1hx1" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000091.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8635fd553ce1f6fc5a95824f245b14cc" CHECKSUMTYPE="MD5" ID="a4dnn" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000092.tif"/>
+</mets:file>
+<mets:file CHECKSUM="94f5b9f001f741a00d589515b5212a09" CHECKSUMTYPE="MD5" ID="irbal" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000093.tif"/>
+</mets:file>
+<mets:file CHECKSUM="970922f38748ab076894bc0837aa340" CHECKSUMTYPE="MD5" ID="t5roh" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000094.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f32cbb8b3741e55209b398fe09d0b3e" CHECKSUMTYPE="MD5" ID="a9glf" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000095.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f104a6a95c1e5720115852999e9d1250" CHECKSUMTYPE="MD5" ID="zyahj" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000096.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f8a964962632e1a97085159ff3ee1451" CHECKSUMTYPE="MD5" ID="yw0hr" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000097.tif"/>
+</mets:file>
+<mets:file CHECKSUM="fe39e855edcbe52894075e5bbe9cf528" CHECKSUMTYPE="MD5" ID="v6tzx" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000098.tif"/>
+</mets:file>
+<mets:file CHECKSUM="237f5cf1ce8e07a8f1c47e0f79e04cd8" CHECKSUMTYPE="MD5" ID="vvj31" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000099.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d97ff5c6b05122f77c5b0886a72b1f49" CHECKSUMTYPE="MD5" ID="zt1z1" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000100.tif"/>
+</mets:file>
+<mets:file CHECKSUM="dcad28ccab30e43d0e5b099c257001d3" CHECKSUMTYPE="MD5" ID="anj9n" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000101.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6ee6360be69b2791f5665d72bc4cd163" CHECKSUMTYPE="MD5" ID="yra7f" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000102.tif"/>
+</mets:file>
+<mets:file CHECKSUM="40afa92d0beaa4e9af9bb2c7e5f1f603" CHECKSUMTYPE="MD5" ID="v5rlk" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000103.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a9fb107ebc0f2689c5435d014ae670cc" CHECKSUMTYPE="MD5" ID="w16r2" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000104.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3fc3cb9b03b1fdfe3da9776b63036578" CHECKSUMTYPE="MD5" ID="hjddo" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000105.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d3a47dbe8376ba04d237224b779254b6" CHECKSUMTYPE="MD5" ID="vnysn" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000106.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9abed72de2358d30cb67d70c55e0cea" CHECKSUMTYPE="MD5" ID="u1z1k" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000107.tif"/>
+</mets:file>
+<mets:file CHECKSUM="646ed3a1e45d3274a69487fae1df0bc4" CHECKSUMTYPE="MD5" ID="ygg14" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000108.tif"/>
+</mets:file>
+<mets:file CHECKSUM="366755ea5069251a96e13525732fb0ff" CHECKSUMTYPE="MD5" ID="yotr5" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000109.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e76b5722542cc1fa369d04d67480fe76" CHECKSUMTYPE="MD5" ID="clkeo" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000110.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bbc15ecb234eafc1851a4e8e9fed6780" CHECKSUMTYPE="MD5" ID="cvyv5" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000111.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d1aa9e0232aa9459251283add051fafb" CHECKSUMTYPE="MD5" ID="c3ohx" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000112.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1acbfd5e6e109c5a1bb0d519fe250e6f" CHECKSUMTYPE="MD5" ID="buqgu" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000113.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4080282d9b0730a62bdb856c2b04b735" CHECKSUMTYPE="MD5" ID="ggrpe" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000114.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3c6a5c33f180f0e65ba1e7a43ef87d00" CHECKSUMTYPE="MD5" ID="gvk7z" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000115.tif"/>
+</mets:file>
+<mets:file CHECKSUM="65aa45d33e2d78ecdca9a61f40d71ea9" CHECKSUMTYPE="MD5" ID="x26y3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000116.tif"/>
+</mets:file>
+<mets:file CHECKSUM="37526a81379fd0756c1165fc4da3fa79" CHECKSUMTYPE="MD5" ID="reuys" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000117.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9f2865439808988f8597cdec5dec6162" CHECKSUMTYPE="MD5" ID="mr2cf" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000118.tif"/>
+</mets:file>
+<mets:file CHECKSUM="902a44d08ea72d35897a303274b9b91d" CHECKSUMTYPE="MD5" ID="yy2up" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000119.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7f3120739c43fda17cc71f29e3907ca1" CHECKSUMTYPE="MD5" ID="l2132" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000120.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a1c35a5c40e2b0883748d816efaead21" CHECKSUMTYPE="MD5" ID="qerhs" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000121.tif"/>
+</mets:file>
+<mets:file CHECKSUM="27c5921913ed5b802bec6f7e8f9998c0" CHECKSUMTYPE="MD5" ID="dfd89" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000122.tif"/>
+</mets:file>
+<mets:file CHECKSUM="85be81595b3b5d9c1fedbdf723f94e9f" CHECKSUMTYPE="MD5" ID="nad7m" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000123.tif"/>
+</mets:file>
+<mets:file CHECKSUM="da5f5ec71b0eca09686bf410e8a582c2" CHECKSUMTYPE="MD5" ID="yim2w" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000124.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a1f90ecca4f757b21fed94d1f6b1a9a2" CHECKSUMTYPE="MD5" ID="iylx4" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000125.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c5bf1a4ed7c10c20fccc0577ce5983bd" CHECKSUMTYPE="MD5" ID="nag3e" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000126.tif"/>
+</mets:file>
+<mets:file CHECKSUM="24ec038d53c4ba0a8cdaffd1b3e41d85" CHECKSUMTYPE="MD5" ID="jhio2" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000127.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f85cbf4b30465d1a640f56a8096cc3e1" CHECKSUMTYPE="MD5" ID="sdun3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000128.tif"/>
+</mets:file>
+<mets:file CHECKSUM="765e017a0cf73ac5d58ed2dd3fd117a1" CHECKSUMTYPE="MD5" ID="ajto8" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000129.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ce4ffba23e6e4596ffab9744c1ee3aa2" CHECKSUMTYPE="MD5" ID="ggrib" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000130.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5303daf796d918f9a2b02effced798" CHECKSUMTYPE="MD5" ID="q40sl" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000131.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6f8a9b5b5679af48ccfc2ce399a41b13" CHECKSUMTYPE="MD5" ID="nz7ra" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000132.tif"/>
+</mets:file>
+<mets:file CHECKSUM="fd0a2c85ec77473a805383b832d212e2" CHECKSUMTYPE="MD5" ID="flfya" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000133.tif"/>
+</mets:file>
+<mets:file CHECKSUM="27af53152aff96f9eceb563503c483ba" CHECKSUMTYPE="MD5" ID="pn8ht" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000134.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a45af99a9e1671df3827240311198345" CHECKSUMTYPE="MD5" ID="flzoo" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000135.tif"/>
+</mets:file>
+<mets:file CHECKSUM="abba9686a7e7a33af38ce9577b3f2c46" CHECKSUMTYPE="MD5" ID="ilv71" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000136.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e146524dd5e226dc1ca5ec75674999ad" CHECKSUMTYPE="MD5" ID="k60at" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_02/00000137.tif"/>
+</mets:file>
+<mets:file CHECKSUM="343f188246eb0d1467c21e71755428e6" CHECKSUMTYPE="MD5" ID="v8a82" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000001.tif"/>
+</mets:file>
+<mets:file CHECKSUM="45402aa4e9e3a49fa61ea6e2dcadfc9" CHECKSUMTYPE="MD5" ID="rf6zl" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000002.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5375cb522f9d2549d979f089cbc8fa1d" CHECKSUMTYPE="MD5" ID="msgw3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000003.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7bde24ffc7962a42d44e5f2e004661d5" CHECKSUMTYPE="MD5" ID="q90z9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000004.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f5b7a5f8874781605ecc7389ac9e4b5d" CHECKSUMTYPE="MD5" ID="rphap" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000005.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3760bf823cd8c01d64784205ae7abe2a" CHECKSUMTYPE="MD5" ID="sae8v" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000006.tif"/>
+</mets:file>
+<mets:file CHECKSUM="aece9eec13a0fcff6b000cc5226f27a7" CHECKSUMTYPE="MD5" ID="na812" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000007.tif"/>
+</mets:file>
+<mets:file CHECKSUM="657cfafc6379a9f5d3f73f13a19860f7" CHECKSUMTYPE="MD5" ID="tt15e" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000008.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ce14076b49e3843dae95b5a3e24517bd" CHECKSUMTYPE="MD5" ID="i6ijp" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000009.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e0d02b2a039690e84891eb9686db68e2" CHECKSUMTYPE="MD5" ID="addcz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000010.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3aa3afc8c2904cdb205ad4e0f50941e7" CHECKSUMTYPE="MD5" ID="pq6u7" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000011.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ce45467a5d1a84b67b8d9895e8840463" CHECKSUMTYPE="MD5" ID="kmm4w" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000012.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5d78b66e7af7c0b1a6cf614b79beeb6a" CHECKSUMTYPE="MD5" ID="jeznt" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000013.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5f0aeb72c5d2c52413a9c8e0a54ef7c4" CHECKSUMTYPE="MD5" ID="it3aw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000014.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e125e464d7f05d744d3fd344c36fb3ea" CHECKSUMTYPE="MD5" ID="jqadt" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000015.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5ef379705a706907c8cc3b4343f7107a" CHECKSUMTYPE="MD5" ID="q1ltt" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000016.tif"/>
+</mets:file>
+<mets:file CHECKSUM="119b977e71a60532190b2b9033748a49" CHECKSUMTYPE="MD5" ID="mgp2i" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000017.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e6a707630d3480b9fb91b4d2031efed5" CHECKSUMTYPE="MD5" ID="k9wp3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000018.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e744d77fdf62c190f438f7933983faf2" CHECKSUMTYPE="MD5" ID="eg9ti" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000019.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e0c8ff84055699eb6ffbd706d21cf1a1" CHECKSUMTYPE="MD5" ID="sdpla" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000020.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2703806dfc1cfbe1493adc235374062f" CHECKSUMTYPE="MD5" ID="hcsg3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000021.tif"/>
+</mets:file>
+<mets:file CHECKSUM="85c099d0c31056666ba5d1a011760a87" CHECKSUMTYPE="MD5" ID="e6vm7" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000022.tif"/>
+</mets:file>
+<mets:file CHECKSUM="cb2d6c77aeeeed4a1e43ab670303bc4f" CHECKSUMTYPE="MD5" ID="hrylu" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000023.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7b9c267f9eecbbdc801a98a49fe43e0d" CHECKSUMTYPE="MD5" ID="e2ngf" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000024.tif"/>
+</mets:file>
+<mets:file CHECKSUM="60fa83b412735583aea88684fa90d33f" CHECKSUMTYPE="MD5" ID="yafgs" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000025.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a175d72af897b614ac9c2beee97a9f76" CHECKSUMTYPE="MD5" ID="oiccp" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000026.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3f838e57b004e729c5886cf78d43d586" CHECKSUMTYPE="MD5" ID="x553l" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000027.tif"/>
+</mets:file>
+<mets:file CHECKSUM="dfc6314a240cd25a33a5de4d10538ae7" CHECKSUMTYPE="MD5" ID="sakj7" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000028.tif"/>
+</mets:file>
+<mets:file CHECKSUM="27928f986022a08788eb86ea0feefb2c" CHECKSUMTYPE="MD5" ID="fk967" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000029.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6c768b5c67872c19a484a06402b190ae" CHECKSUMTYPE="MD5" ID="ezaho" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000030.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3b5f92d1943fabe80280c7084b18228a" CHECKSUMTYPE="MD5" ID="k4kj8" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000031.tif"/>
+</mets:file>
+<mets:file CHECKSUM="33366db6f74d6b2c2bbcfa0a4f0c0a26" CHECKSUMTYPE="MD5" ID="d0xo9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000032.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f6c95c7dadeb6fda823937fc20b515d7" CHECKSUMTYPE="MD5" ID="n1g65" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000033.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f31640cc2fc56cf88e0df53ca1f7713e" CHECKSUMTYPE="MD5" ID="sbxsa" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000034.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d7bbf0ac3b891a74336ed24f061f83b1" CHECKSUMTYPE="MD5" ID="yrxbt" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000035.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4e13f3f76569471bbae3dcb9370aa16a" CHECKSUMTYPE="MD5" ID="m3dwo" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000036.tif"/>
+</mets:file>
+<mets:file CHECKSUM="13ad01fe5f54a54ccaba7382ad077a5b" CHECKSUMTYPE="MD5" ID="oiw85" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000037.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1637d26f301044debdcb8648ad70640f" CHECKSUMTYPE="MD5" ID="c2xvy" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000038.tif"/>
+</mets:file>
+<mets:file CHECKSUM="859416f3dccc181e8443447d747165ce" CHECKSUMTYPE="MD5" ID="xkgya" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000039.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b28ed77eb38e9d29f09aeae7fa07645e" CHECKSUMTYPE="MD5" ID="k56b0" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000040.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f8fee561a636511252509d9475fda597" CHECKSUMTYPE="MD5" ID="np848" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000041.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f139715f5ac8f97687d5938e17370ced" CHECKSUMTYPE="MD5" ID="btxon" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000042.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3060a67e9f20eca188ebc58428c7a3ae" CHECKSUMTYPE="MD5" ID="zgua9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000043.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2a9e3307b6e96619e6e69b132c3bc40a" CHECKSUMTYPE="MD5" ID="i9w2q" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000044.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c8f0881a59d3948e028cd06770ab5b89" CHECKSUMTYPE="MD5" ID="cdn97" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000045.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a99fc8072e5eb897f476307acec469a7" CHECKSUMTYPE="MD5" ID="cyk5m" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000046.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a6af24b73e1f22c44664f3b11cc75bf9" CHECKSUMTYPE="MD5" ID="msgcu" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000047.tif"/>
+</mets:file>
+<mets:file CHECKSUM="54a1038f064110257ba6a92bad6a65" CHECKSUMTYPE="MD5" ID="h7g54" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000048.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c833240c3b9f961a67ecd175aa88b748" CHECKSUMTYPE="MD5" ID="h7wff" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000049.tif"/>
+</mets:file>
+<mets:file CHECKSUM="19b2be423c8a4a0510b52ed4efdee291" CHECKSUMTYPE="MD5" ID="a2j6w" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000050.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ee5b83265f8f96151649428128618446" CHECKSUMTYPE="MD5" ID="lc0gq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000051.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1b9a8e625c2433187d0c03cdc5853dd0" CHECKSUMTYPE="MD5" ID="mpuzm" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000052.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bca72362a1477a41f8665abd926aaa74" CHECKSUMTYPE="MD5" ID="c43f8" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000053.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e989dcac4f6111cc53121820cf3be9c6" CHECKSUMTYPE="MD5" ID="hqors" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000054.tif"/>
+</mets:file>
+<mets:file CHECKSUM="be5a2851407183391f45a8e4102d2b24" CHECKSUMTYPE="MD5" ID="pwz0y" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000055.tif"/>
+</mets:file>
+<mets:file CHECKSUM="38529b9e5b5bc92c529522d1a7addffe" CHECKSUMTYPE="MD5" ID="jpfw9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000056.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2a76f0e4819b6072ffaba54375a55d0a" CHECKSUMTYPE="MD5" ID="xxu34" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000057.tif"/>
+</mets:file>
+<mets:file CHECKSUM="35659b38bd06db7b438972bf9e64fa69" CHECKSUMTYPE="MD5" ID="cj88e" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000058.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3c1ae54dbd1f1d5c930893b908f73765" CHECKSUMTYPE="MD5" ID="edhjy" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000059.tif"/>
+</mets:file>
+<mets:file CHECKSUM="29b3e2677333e65eef9030f1678e7afc" CHECKSUMTYPE="MD5" ID="wovmb" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000060.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b88ffc145ca711d7afab3b09d44729c0" CHECKSUMTYPE="MD5" ID="wdw0w" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000061.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c2474be3a06e8ff6e07b27a12be3f2e6" CHECKSUMTYPE="MD5" ID="xftm6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000062.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e599f71c71934f1e216c63c097decc46" CHECKSUMTYPE="MD5" ID="jem8q" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000063.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e88f52096d2b190620b2b5bcc758a31a" CHECKSUMTYPE="MD5" ID="euvrk" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000064.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e509fa41305ac8b72879d8d4a9007e87" CHECKSUMTYPE="MD5" ID="jo42w" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000065.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8df01d82720c00aebab443107130c7c2" CHECKSUMTYPE="MD5" ID="ddcxk" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000066.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c9328f360c7fa79dcc1a792a6807b3f" CHECKSUMTYPE="MD5" ID="ol623" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000067.tif"/>
+</mets:file>
+<mets:file CHECKSUM="76467889febf5d576fb4a1bfb51072bd" CHECKSUMTYPE="MD5" ID="pgzme" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000068.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b6ff2179c24ceb40f640241db0344006" CHECKSUMTYPE="MD5" ID="c42ke" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000069.tif"/>
+</mets:file>
+<mets:file CHECKSUM="50c2f201e9ca1f0a344798e556b1ad54" CHECKSUMTYPE="MD5" ID="b5gpt" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000070.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9a61fca589f5b1cd06bab5af93f834d" CHECKSUMTYPE="MD5" ID="p8p2e" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000071.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2dac7324397d39055dda7126f4054030" CHECKSUMTYPE="MD5" ID="p05ft" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000072.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bdda3e10edf1a3083dad6e45376792cd" CHECKSUMTYPE="MD5" ID="s9gmi" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000073.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d3aa4796a6f635390b243c76e9df89a2" CHECKSUMTYPE="MD5" ID="rqsvs" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000074.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7ceaf7f34818518cdd4d72411d13682b" CHECKSUMTYPE="MD5" ID="qysu4" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000075.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a6f28c7ae01e6775ef029d5f027bd097" CHECKSUMTYPE="MD5" ID="k58hg" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000076.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bd1d3255a4eccfae9f6336a9b84661d2" CHECKSUMTYPE="MD5" ID="q52s0" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000077.tif"/>
+</mets:file>
+<mets:file CHECKSUM="57c92f23716b947d42c252aa5bccd671" CHECKSUMTYPE="MD5" ID="r2l7i" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000078.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a71b7c5b553b5148477c154053971dd0" CHECKSUMTYPE="MD5" ID="liqys" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000079.tif"/>
+</mets:file>
+<mets:file CHECKSUM="56d9dca669e6f045f2092c1e2104be24" CHECKSUMTYPE="MD5" ID="mp1np" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000080.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bb22c567006551ca93fd3d490480e3d1" CHECKSUMTYPE="MD5" ID="hmam0" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000081.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2023c3b1e067b7be34f129dd17e7d340" CHECKSUMTYPE="MD5" ID="mu9ue" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000082.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bfb064f8e073ce40fd5fdcba98a44dfa" CHECKSUMTYPE="MD5" ID="fsr8g" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000083.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5d52cb98e6092bb487253923a92db712" CHECKSUMTYPE="MD5" ID="mh9il" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000084.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1c349da090ee394523c38e3622a7cb69" CHECKSUMTYPE="MD5" ID="ph9o0" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000085.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3ed48af645c792d2933ddf86206a8c2d" CHECKSUMTYPE="MD5" ID="s0tzp" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000086.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a0e6ce312776f998f058e40ca681f11a" CHECKSUMTYPE="MD5" ID="fgwqb" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000087.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bf417d60f08de790bca1eaf692b06494" CHECKSUMTYPE="MD5" ID="r91qd" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000088.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4284ad7724d3cea4bea3684b7ed6b8a4" CHECKSUMTYPE="MD5" ID="hqbdd" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000089.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3159a1e063b089a29bc01b2b04251d18" CHECKSUMTYPE="MD5" ID="j2vyn" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000090.tif"/>
+</mets:file>
+<mets:file CHECKSUM="528254c0398988d3095688ba23d1fe85" CHECKSUMTYPE="MD5" ID="x0sww" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000091.tif"/>
+</mets:file>
+<mets:file CHECKSUM="868b327e154f1505911dac99fc91014a" CHECKSUMTYPE="MD5" ID="muvut" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000092.tif"/>
+</mets:file>
+<mets:file CHECKSUM="fb8a0a08d820dd5e525e50ceccab6aee" CHECKSUMTYPE="MD5" ID="qkept" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000093.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6aa2fdee0ca9bf927634e335a97e7cb2" CHECKSUMTYPE="MD5" ID="l6su7" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000094.tif"/>
+</mets:file>
+<mets:file CHECKSUM="15ea4fbb745059b95ce12379afe1bfd9" CHECKSUMTYPE="MD5" ID="v3o0d" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000095.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2df5116e3eb0a5cab3321c61a3687234" CHECKSUMTYPE="MD5" ID="ypnf1" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000096.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c46f6d18a9dead8d1deaa4d35a3fdc53" CHECKSUMTYPE="MD5" ID="icr4e" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000097.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d37757ba03927fed2c394c4be48a70f0" CHECKSUMTYPE="MD5" ID="u9a0j" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000098.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4c49f7ca1fbf1b0c8468d3861b1125fa" CHECKSUMTYPE="MD5" ID="bagdc" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000099.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2a956fd0ddd5f04e762baa9edc047445" CHECKSUMTYPE="MD5" ID="y2r1y" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000100.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4e27118d6c120a1dc56faddedb1d7749" CHECKSUMTYPE="MD5" ID="j7f6y" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000101.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b83cfb00d12921cdce5fc6d69472a04f" CHECKSUMTYPE="MD5" ID="z6rzx" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000102.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c0c36650ad4fded75b1c31a5b19e1789" CHECKSUMTYPE="MD5" ID="rofj9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000103.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a21d41aa12e2c57ce1ff6b3891c2b943" CHECKSUMTYPE="MD5" ID="hohj1" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000104.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c351da2eacccdb3fab865ac4b3f5bd37" CHECKSUMTYPE="MD5" ID="livvw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000105.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bdf0c038e85ccff1b7e76b04f5e5ce9f" CHECKSUMTYPE="MD5" ID="jy4la" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000106.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c47820672185a4c5662ccc59c00d8a9a" CHECKSUMTYPE="MD5" ID="f3u75" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000107.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f94f104f304e769c5448acabd29f852f" CHECKSUMTYPE="MD5" ID="ftxer" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000108.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6ba628b1f7a9160917f898123c85f3d" CHECKSUMTYPE="MD5" ID="d3z6p" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000109.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9a959bc40aab68fb1be636d595704e84" CHECKSUMTYPE="MD5" ID="u3m5u" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000110.tif"/>
+</mets:file>
+<mets:file CHECKSUM="dd53a8c4b93280720e26b4d539ed6b9e" CHECKSUMTYPE="MD5" ID="k215o" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000111.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a3b45600242655df564bbfbd08ee917f" CHECKSUMTYPE="MD5" ID="f0sim" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000112.tif"/>
+</mets:file>
+<mets:file CHECKSUM="803a0bb37699fa66a4b79ed397f1f28" CHECKSUMTYPE="MD5" ID="wqfwg" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000113.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6dfe1d74ea51fc7d0a9e04856b88be3d" CHECKSUMTYPE="MD5" ID="zzj9h" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000114.tif"/>
+</mets:file>
+<mets:file CHECKSUM="23c8d93b2b81e09d7841bcfe3b21719" CHECKSUMTYPE="MD5" ID="f77v3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000115.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a2dd8e02b0e6e9d62b07cd3d18a07c4c" CHECKSUMTYPE="MD5" ID="qlqti" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000116.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ed3fdb7387ae7f2136e041e99616bafe" CHECKSUMTYPE="MD5" ID="valzj" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000117.tif"/>
+</mets:file>
+<mets:file CHECKSUM="815bacb1ba6e2441fd9d1a2ccee9529a" CHECKSUMTYPE="MD5" ID="r4d2z" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000118.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2dd34edb944475a8acbf50f6a01a5260" CHECKSUMTYPE="MD5" ID="tcmhj" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000119.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e15d105e47462f3b357096138b8f3abc" CHECKSUMTYPE="MD5" ID="j4k24" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000120.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b988071e0be59c3b0a5384a9d1580350" CHECKSUMTYPE="MD5" ID="ecn91" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000121.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e38408cabbe61743d92746ae6cad6c0" CHECKSUMTYPE="MD5" ID="x3qo9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000122.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e3982a8a8246f8ff1f823e322628912a" CHECKSUMTYPE="MD5" ID="uzt4f" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000123.tif"/>
+</mets:file>
+<mets:file CHECKSUM="872edd74233eee3f10b2799d2d497fa8" CHECKSUMTYPE="MD5" ID="frxra" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000124.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d5084100d8d1b6a29eae60f857abffa3" CHECKSUMTYPE="MD5" ID="vc74u" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000125.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9b22385b1b0d8ba152a266ec8b279bf5" CHECKSUMTYPE="MD5" ID="waq1u" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000126.tif"/>
+</mets:file>
+<mets:file CHECKSUM="cb7f86c83a65c9abf58fa026ebe2076" CHECKSUMTYPE="MD5" ID="wbrp1" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000127.tif"/>
+</mets:file>
+<mets:file CHECKSUM="eb656102ce934c1451d996039e290f80" CHECKSUMTYPE="MD5" ID="ablkt" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000128.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4b1f08f32a85a597b22c7905edfb4575" CHECKSUMTYPE="MD5" ID="d959w" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000129.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2bff8981387b9d408d736d24ec193aa0" CHECKSUMTYPE="MD5" ID="vow3a" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000130.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7a00b0de857fa0fef7074b9a686f934b" CHECKSUMTYPE="MD5" ID="d6qle" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000131.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e29e026475c7ebfaf20692a079ea63f8" CHECKSUMTYPE="MD5" ID="vklm5" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000132.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b225812b419b78d3a30ed44a27d264ed" CHECKSUMTYPE="MD5" ID="bfqit" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000133.tif"/>
+</mets:file>
+<mets:file CHECKSUM="11f201f909dce1f3c21385d095353a4d" CHECKSUMTYPE="MD5" ID="vx5ox" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000134.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ef911453c0f6801c4c41ec7ec447ec17" CHECKSUMTYPE="MD5" ID="cntk1" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000135.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f1ef1d32ca4d312009839c6d98233356" CHECKSUMTYPE="MD5" ID="ofvd3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000136.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2527b293687967790f090ffa4e5c055f" CHECKSUMTYPE="MD5" ID="lg46u" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000137.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9b8fd5f05c4c0ace2ef32bd7c510e84e" CHECKSUMTYPE="MD5" ID="g0br0" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000138.tif"/>
+</mets:file>
+<mets:file CHECKSUM="29cd78f40379ec7b4d07415e6ab020d6" CHECKSUMTYPE="MD5" ID="mfobf" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000139.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b45e599cf2d725f009c1f108fd729ac5" CHECKSUMTYPE="MD5" ID="khw76" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000140.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6545800feb42aee99271a05bb9ce079e" CHECKSUMTYPE="MD5" ID="k17e9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000141.tif"/>
+</mets:file>
+<mets:file CHECKSUM="43ef7750aaa34af74bc0226794b5d75c" CHECKSUMTYPE="MD5" ID="uny9n" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000142.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d2d5cdf491940aaa239703015ff28f82" CHECKSUMTYPE="MD5" ID="uyww5" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000143.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e2cfae064bde14a0ec6dc59b4e88e86c" CHECKSUMTYPE="MD5" ID="tf461" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000144.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5528ce0c2bc792f77087ed2da98cd457" CHECKSUMTYPE="MD5" ID="nwufz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000145.tif"/>
+</mets:file>
+<mets:file CHECKSUM="52f939397fee3af875a432d345e314ed" CHECKSUMTYPE="MD5" ID="y7xj9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000146.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6611b377cf15a0777c888ec4195cc62e" CHECKSUMTYPE="MD5" ID="st4yo" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000147.tif"/>
+</mets:file>
+<mets:file CHECKSUM="de2a56dd6397b1c385152a46ab7514d1" CHECKSUMTYPE="MD5" ID="g5sem" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000148.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c1ab696cd0dd477f321104b8b8a27426" CHECKSUMTYPE="MD5" ID="mxzg7" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000149.tif"/>
+</mets:file>
+<mets:file CHECKSUM="925ea380f35cbbfd1c9cdd9ddceb6959" CHECKSUMTYPE="MD5" ID="xut8u" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000150.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c3f8896c7f2df813f4f5eaa7ac53a5c4" CHECKSUMTYPE="MD5" ID="syhcf" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000151.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f63b0db9ca88b16ab9db15a4f4a60ac0" CHECKSUMTYPE="MD5" ID="g0cyu" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000152.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8113d45a44d32067fad78ad2bd85d47a" CHECKSUMTYPE="MD5" ID="lfevo" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000153.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bb2d31b05cb0c19cccd621ad9dea8035" CHECKSUMTYPE="MD5" ID="je1hs" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000154.tif"/>
+</mets:file>
+<mets:file CHECKSUM="295a8554e33e3278d348131687c78e83" CHECKSUMTYPE="MD5" ID="y1dxx" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000155.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d81aeacf93145b56701c90a886ee9cd" CHECKSUMTYPE="MD5" ID="lll96" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000156.tif"/>
+</mets:file>
+<mets:file CHECKSUM="acfa9b0f75d03bb9051607fa90925dd7" CHECKSUMTYPE="MD5" ID="zmqge" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000157.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a74e3a68d293c929f9b74a31665104cf" CHECKSUMTYPE="MD5" ID="jl8fl" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000158.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a3e6953f3159aa5d97d1176521bfce97" CHECKSUMTYPE="MD5" ID="wrf2o" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000159.tif"/>
+</mets:file>
+<mets:file CHECKSUM="41303b3cdd9d7096a14c4312f0df75f1" CHECKSUMTYPE="MD5" ID="d64fn" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000160.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e820a611240076143845d1640ef30068" CHECKSUMTYPE="MD5" ID="ov5v9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000161.tif"/>
+</mets:file>
+<mets:file CHECKSUM="918cb1fa53ffb060fec1f66c1d2b744e" CHECKSUMTYPE="MD5" ID="wgmk6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000162.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ef89599eb1992faca3b9f8e06c89b7de" CHECKSUMTYPE="MD5" ID="delsa" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000163.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e555df25443555b0d4671bfdca90891" CHECKSUMTYPE="MD5" ID="gugru" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000164.tif"/>
+</mets:file>
+<mets:file CHECKSUM="37a86ef78d172e8456496916e6bf51aa" CHECKSUMTYPE="MD5" ID="ylshw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000165.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8f481c0b7959db97472e92d48911a8e7" CHECKSUMTYPE="MD5" ID="m6fnq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000166.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d437b9378c9ec43cbf13d4035c6336de" CHECKSUMTYPE="MD5" ID="b1ww7" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000167.tif"/>
+</mets:file>
+<mets:file CHECKSUM="aa4a3530c251593f21684afef91671f2" CHECKSUMTYPE="MD5" ID="ljz80" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000168.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2ef327ca5f2fc4fa5daba8bcfb51e42d" CHECKSUMTYPE="MD5" ID="hrk7z" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000169.tif"/>
+</mets:file>
+<mets:file CHECKSUM="40168adad2ca853ed0d61d39ed69c2e2" CHECKSUMTYPE="MD5" ID="j81nz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000170.tif"/>
+</mets:file>
+<mets:file CHECKSUM="24d8afd2e665e223bca6d7cafd08b649" CHECKSUMTYPE="MD5" ID="mro4g" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000171.tif"/>
+</mets:file>
+<mets:file CHECKSUM="785c22e61b558800aafec70feba6dfdc" CHECKSUMTYPE="MD5" ID="kltin" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000172.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8f360a2a22b99331e4990684afda4d51" CHECKSUMTYPE="MD5" ID="y5a89" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000173.tif"/>
+</mets:file>
+<mets:file CHECKSUM="925f7de647d1b3aac343982273b1c8f5" CHECKSUMTYPE="MD5" ID="b86dc" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000174.tif"/>
+</mets:file>
+<mets:file CHECKSUM="410f64544ff7c34d0478e3b6830a5801" CHECKSUMTYPE="MD5" ID="q1szc" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000175.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5638aa47a302db88d1e0615764833e06" CHECKSUMTYPE="MD5" ID="d26fb" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000176.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6da012c66244eb82e1f1c2152415e3ba" CHECKSUMTYPE="MD5" ID="bqf06" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000177.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d74e9bc0d3dd25015c389df00e52a167" CHECKSUMTYPE="MD5" ID="d0301" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000178.tif"/>
+</mets:file>
+<mets:file CHECKSUM="743752ae5c6bd02ca6c4c54cf4481d9a" CHECKSUMTYPE="MD5" ID="s2d2j" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000179.tif"/>
+</mets:file>
+<mets:file CHECKSUM="918c64f7d3e1ebc4fad7b3d51c523d99" CHECKSUMTYPE="MD5" ID="bt4wx" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000180.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9a17a89a34422b12cf9563f7b126920e" CHECKSUMTYPE="MD5" ID="c9wkq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000181.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6cf395d4887ad7f756e1adb186c213aa" CHECKSUMTYPE="MD5" ID="hepla" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000182.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2f778ba583a721737b4d203536f7d51" CHECKSUMTYPE="MD5" ID="sgwme" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000183.tif"/>
+</mets:file>
+<mets:file CHECKSUM="efd6c0608fecf9279939eb987317e591" CHECKSUMTYPE="MD5" ID="bwjr6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000184.tif"/>
+</mets:file>
+<mets:file CHECKSUM="324bce444fdb52538cf2e5435538e1c4" CHECKSUMTYPE="MD5" ID="e3bbr" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000185.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bbdd3dba6e126f6a5b550113bafc7a91" CHECKSUMTYPE="MD5" ID="i7vxv" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000186.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9a0b37c9235475688db150bfe25ee5b7" CHECKSUMTYPE="MD5" ID="iun5g" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000187.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6b430b6ca3bebb2d024b9adaa3e81b67" CHECKSUMTYPE="MD5" ID="tsq5t" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000188.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a14e98a9c6aba2bb82307bcd9299c914" CHECKSUMTYPE="MD5" ID="wcgvm" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000189.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a6e11da61e59fc171287197dabad4473" CHECKSUMTYPE="MD5" ID="j9qcw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000190.tif"/>
+</mets:file>
+<mets:file CHECKSUM="14bddbaf8f5c089f83643bd83e3a130f" CHECKSUMTYPE="MD5" ID="e50nk" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000191.tif"/>
+</mets:file>
+<mets:file CHECKSUM="122cd97ba2ed99fe12621e54cc51a828" CHECKSUMTYPE="MD5" ID="vplvg" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000192.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d1feb9806153b02ddfacb6b6049350ba" CHECKSUMTYPE="MD5" ID="oeg72" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000193.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8560a1e9f0b7dae96334dcdcfa866415" CHECKSUMTYPE="MD5" ID="hvvhq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000194.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d48ffb6bf7959ca724cfc61d46f99e90" CHECKSUMTYPE="MD5" ID="t8l8z" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000195.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c3086a7bff9ec49af09660f882c03781" CHECKSUMTYPE="MD5" ID="f8dyi" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000196.tif"/>
+</mets:file>
+<mets:file CHECKSUM="deb7cebefd209633e48df1bb0fa55eff" CHECKSUMTYPE="MD5" ID="fflxv" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000197.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9af2b6ba3809868236190bf6e8f4355c" CHECKSUMTYPE="MD5" ID="kpoyk" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000198.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6d0ddcb3da069f2bcecf9dd68befdde7" CHECKSUMTYPE="MD5" ID="yf81i" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000199.tif"/>
+</mets:file>
+<mets:file CHECKSUM="cdf1adf6a3633ceaeb3927cd079390e4" CHECKSUMTYPE="MD5" ID="vv8gg" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000200.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8028c609902e74db05ac36e2e6ca5c0f" CHECKSUMTYPE="MD5" ID="x432s" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000201.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f51da4eb272b39effa516a7a9b00a9ec" CHECKSUMTYPE="MD5" ID="g7fbr" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000202.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c10f321188e7d81f0321d8f561833a6a" CHECKSUMTYPE="MD5" ID="t5091" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000203.tif"/>
+</mets:file>
+<mets:file CHECKSUM="efd99c870dde77e11893b3778286d337" CHECKSUMTYPE="MD5" ID="fx3mf" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000204.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5de3db95673a8faf7b43f207ac3b1257" CHECKSUMTYPE="MD5" ID="zqfsx" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000205.tif"/>
+</mets:file>
+<mets:file CHECKSUM="37cd79d24d9ca947814e7f3cb0fe0360" CHECKSUMTYPE="MD5" ID="m4pwy" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000206.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a4be49dd2973355403a3b2bea368aeca" CHECKSUMTYPE="MD5" ID="fjpe1" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000207.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bf48482591170408ba7f0675718012cc" CHECKSUMTYPE="MD5" ID="vty53" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000208.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b92a849ef4359d648b690c17b79b69d1" CHECKSUMTYPE="MD5" ID="kukwl" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000209.tif"/>
+</mets:file>
+<mets:file CHECKSUM="46bc9080db0577bd72201b550bff6647" CHECKSUMTYPE="MD5" ID="xo04e" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000210.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6101715fc68a36d6cb9ecdfe8ff6cf63" CHECKSUMTYPE="MD5" ID="m2v63" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000211.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8e2a4f6c7f06f9b35bfe18f2f6751de2" CHECKSUMTYPE="MD5" ID="zl6fi" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000212.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6fb6e4bf18a4cc39c1038e51b565f522" CHECKSUMTYPE="MD5" ID="x3sdg" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000213.tif"/>
+</mets:file>
+<mets:file CHECKSUM="22377620a8d86b68064ca69d11b34eec" CHECKSUMTYPE="MD5" ID="ykwee" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000214.tif"/>
+</mets:file>
+<mets:file CHECKSUM="af28f318375481bca22b0cb8fdb360ee" CHECKSUMTYPE="MD5" ID="jlwyi" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000215.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c02c6f43d58eca48004f1caf715140e1" CHECKSUMTYPE="MD5" ID="bgjq9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000216.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b8252c51195939c66725a91931dff55a" CHECKSUMTYPE="MD5" ID="icbda" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000217.tif"/>
+</mets:file>
+<mets:file CHECKSUM="61124107de10cc2ee5f3fe3f22430106" CHECKSUMTYPE="MD5" ID="z2t4z" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000218.tif"/>
+</mets:file>
+<mets:file CHECKSUM="76dd074fc03499ab99e7433cc89f984d" CHECKSUMTYPE="MD5" ID="c2dic" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000219.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6eca6b7a107858b5036ad337981dcd99" CHECKSUMTYPE="MD5" ID="kmtlu" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000220.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c9b63607236e28a9bda71cbcab30e5dd" CHECKSUMTYPE="MD5" ID="l04hq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000221.tif"/>
+</mets:file>
+<mets:file CHECKSUM="716b6f44875d3f8cc6bc469644353b67" CHECKSUMTYPE="MD5" ID="ksbop" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000222.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bc3658cd50aafee141b7acca50dedefe" CHECKSUMTYPE="MD5" ID="njtkd" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000223.tif"/>
+</mets:file>
+<mets:file CHECKSUM="408511479458ff9e0f3a89e3c1157c04" CHECKSUMTYPE="MD5" ID="zg7r3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000224.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6ed4a182d74d051e2adebb47ca6169e0" CHECKSUMTYPE="MD5" ID="mb6u3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000225.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d4dde08b4e002ba8070d13d3f5565f7a" CHECKSUMTYPE="MD5" ID="tkoln" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000226.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c717b5b72c56726194321bab6c5ef771" CHECKSUMTYPE="MD5" ID="jepo2" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000227.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ae2aa34dceab764853047bfe7e8ee3b0" CHECKSUMTYPE="MD5" ID="dbvpd" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000228.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4511664e400827a8c6b41ba24e2d7024" CHECKSUMTYPE="MD5" ID="pfs81" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000229.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3d467caaec1a5d8a9a5440866b5c0ca" CHECKSUMTYPE="MD5" ID="m35oz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000230.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e157c32b70aa3021184f62829a3f7256" CHECKSUMTYPE="MD5" ID="mj8jr" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000231.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c95c3f9ee49a4b49ef240b5fb7f03248" CHECKSUMTYPE="MD5" ID="b7ztq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000232.tif"/>
+</mets:file>
+<mets:file CHECKSUM="53bff1eb37f0a3c6aa722b7d7b94ef3a" CHECKSUMTYPE="MD5" ID="mewnx" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000233.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f2e54e5cd092fccc34784b81485c76f4" CHECKSUMTYPE="MD5" ID="cv5pz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000234.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6563dbe1b9e4a5f2ba2c524fc180b861" CHECKSUMTYPE="MD5" ID="v7k65" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000235.tif"/>
+</mets:file>
+<mets:file CHECKSUM="af9aa19ca7543cf50cb038daf32380eb" CHECKSUMTYPE="MD5" ID="ombf5" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000236.tif"/>
+</mets:file>
+<mets:file CHECKSUM="74c50cd029f57569b06e51bd26444d42" CHECKSUMTYPE="MD5" ID="ssfi4" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000237.tif"/>
+</mets:file>
+<mets:file CHECKSUM="cebac3a49cecd4a333796a369753174" CHECKSUMTYPE="MD5" ID="syg1s" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000238.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8c3e68ab0cc6429046f81f3f96b292ee" CHECKSUMTYPE="MD5" ID="os6pg" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000239.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6f1c773bb44054a3ebb99f8e2e927327" CHECKSUMTYPE="MD5" ID="n0fxi" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000240.tif"/>
+</mets:file>
+<mets:file CHECKSUM="47217a4b09c0b7ed2c189b840b04bf52" CHECKSUMTYPE="MD5" ID="ezb2s" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000241.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3de04290485856e13b09db36176fc351" CHECKSUMTYPE="MD5" ID="bq00n" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000242.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7c940a0f7f17876c868a8becf7531cff" CHECKSUMTYPE="MD5" ID="j1ayh" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_03/00000243.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f8574c1d565dbb6e4df12572cfeea448" CHECKSUMTYPE="MD5" ID="dl10y" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000001.tif"/>
+</mets:file>
+<mets:file CHECKSUM="249f561d372136191c7042d555af77ac" CHECKSUMTYPE="MD5" ID="uhjtm" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000002.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a8527e6c188f3b2f583dece7f367b650" CHECKSUMTYPE="MD5" ID="dl7a3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000003.tif"/>
+</mets:file>
+<mets:file CHECKSUM="cf38ac22fc85ccf473e48f5cf29998cc" CHECKSUMTYPE="MD5" ID="tt0tc" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000004.tif"/>
+</mets:file>
+<mets:file CHECKSUM="596e90601272aff25efdc8f05734dbc0" CHECKSUMTYPE="MD5" ID="g4whn" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000005.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3ff06e48b0ef648000d511cf33f364ce" CHECKSUMTYPE="MD5" ID="g66hd" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000006.tif"/>
+</mets:file>
+<mets:file CHECKSUM="dab2abc99976d85a9ad5d3a2dd9e8cd0" CHECKSUMTYPE="MD5" ID="t432o" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000007.tif"/>
+</mets:file>
+<mets:file CHECKSUM="aa391f06739e6a4742986a51331c308e" CHECKSUMTYPE="MD5" ID="nt0fb" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000008.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4c215f5fabca95973a5139f0d298c511" CHECKSUMTYPE="MD5" ID="c8yjt" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000009.tif"/>
+</mets:file>
+<mets:file CHECKSUM="37472fad611fcb0251558dc8a4dbd7ad" CHECKSUMTYPE="MD5" ID="pkwol" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000010.tif"/>
+</mets:file>
+<mets:file CHECKSUM="243dfd0b460019c4aaf135692ab70c67" CHECKSUMTYPE="MD5" ID="vtw7x" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000011.tif"/>
+</mets:file>
+<mets:file CHECKSUM="876d22a698172cd1c91e8f76106b874b" CHECKSUMTYPE="MD5" ID="c0e5o" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000012.tif"/>
+</mets:file>
+<mets:file CHECKSUM="53bc267e4a7bf195e4a59bed858ec19b" CHECKSUMTYPE="MD5" ID="kn3xy" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000013.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1a3cde3f3f2754e11dcc1e3edd884e4c" CHECKSUMTYPE="MD5" ID="tw6bz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000014.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e481f133b04c331adabe76e30c841860" CHECKSUMTYPE="MD5" ID="cfw4l" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000015.tif"/>
+</mets:file>
+<mets:file CHECKSUM="176a396cb57aaae16e0955815c44f48d" CHECKSUMTYPE="MD5" ID="k3icz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000016.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d248f2e7d7a5c71bb66865b3f4bbb62d" CHECKSUMTYPE="MD5" ID="wlrmm" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000017.tif"/>
+</mets:file>
+<mets:file CHECKSUM="dcbecf38114f3678cd38d04fb168d889" CHECKSUMTYPE="MD5" ID="zcqhr" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000018.tif"/>
+</mets:file>
+<mets:file CHECKSUM="103dacb6ab3817d9faaea376eb408a17" CHECKSUMTYPE="MD5" ID="b2aeu" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000019.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ed2fbf2a4f0c11081a59ab09a3d3bc24" CHECKSUMTYPE="MD5" ID="mnhgp" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000020.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8096d3233016a10f23a1552a15ba22a" CHECKSUMTYPE="MD5" ID="mzzbj" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000021.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4ef98fa5090abadb1bca7a3b110273eb" CHECKSUMTYPE="MD5" ID="fosql" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000022.tif"/>
+</mets:file>
+<mets:file CHECKSUM="15c818397f9f51946647f517ce74ec72" CHECKSUMTYPE="MD5" ID="c9qfc" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000023.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e1a59389080f2b6c3538daadf420654f" CHECKSUMTYPE="MD5" ID="cjp3e" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000024.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8ecb21c5f87e94caee292ca2ae81ad80" CHECKSUMTYPE="MD5" ID="mywpu" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000025.tif"/>
+</mets:file>
+<mets:file CHECKSUM="44ae4019a5978903cbcc7f61510f05de" CHECKSUMTYPE="MD5" ID="g7iej" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000026.tif"/>
+</mets:file>
+<mets:file CHECKSUM="11ea92c9d5e4b33a8dcd5ebd4fb5f400" CHECKSUMTYPE="MD5" ID="amui8" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000027.tif"/>
+</mets:file>
+<mets:file CHECKSUM="86e97607e2914aeac44ac378f40b184b" CHECKSUMTYPE="MD5" ID="t188v" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000028.tif"/>
+</mets:file>
+<mets:file CHECKSUM="88bbac9557c0bcfdffb8ff0dac469728" CHECKSUMTYPE="MD5" ID="iby1r" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000029.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1543df1910c08250bc1227bbbdc19cdf" CHECKSUMTYPE="MD5" ID="phc22" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000030.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3483324d1791dbade16c60440c46eb6e" CHECKSUMTYPE="MD5" ID="xapi9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000031.tif"/>
+</mets:file>
+<mets:file CHECKSUM="14c9cf56d7b547fb373f6a7c2ea2e4d7" CHECKSUMTYPE="MD5" ID="s0deg" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000032.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d8daf0cc7cf2a26b1a5658bf1d23fc13" CHECKSUMTYPE="MD5" ID="smqhh" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000033.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ed6615c0d007362fc607fe5e97dff002" CHECKSUMTYPE="MD5" ID="n4cj8" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000034.tif"/>
+</mets:file>
+<mets:file CHECKSUM="49453306c5f2f16103177f556f9d31b2" CHECKSUMTYPE="MD5" ID="pnic8" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000035.tif"/>
+</mets:file>
+<mets:file CHECKSUM="cab0ed154fe5dd82797d38e2bbc565b0" CHECKSUMTYPE="MD5" ID="og5kn" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000036.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2b5070e36eb617802b2f1fc9ed81c8f9" CHECKSUMTYPE="MD5" ID="nwk2z" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000037.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c0b45564ca2a5a8686a32a97eda5a664" CHECKSUMTYPE="MD5" ID="uxrzz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000038.tif"/>
+</mets:file>
+<mets:file CHECKSUM="53f84c2dae552f85ed2668150b161265" CHECKSUMTYPE="MD5" ID="usw4x" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000039.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d38572f179f5adcf981588ee2eb4eaec" CHECKSUMTYPE="MD5" ID="g7vcm" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000040.tif"/>
+</mets:file>
+<mets:file CHECKSUM="41f8951685e2c4c29fe73c10a6db78a1" CHECKSUMTYPE="MD5" ID="ur8p7" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000041.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bd4e9d6e51b5af2b3224db03667186bd" CHECKSUMTYPE="MD5" ID="aipxr" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000042.tif"/>
+</mets:file>
+<mets:file CHECKSUM="360caf44b42987259a61c090eed26d6e" CHECKSUMTYPE="MD5" ID="vo06f" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000043.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5164afd0575ea14e1ab689275ab173d3" CHECKSUMTYPE="MD5" ID="mzxyp" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000044.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5c6511c4aaa02b3409d7577d92fe71ce" CHECKSUMTYPE="MD5" ID="q71s3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000045.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b5f414bad80c5e77c747bb43f0d041f9" CHECKSUMTYPE="MD5" ID="mv1av" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000046.tif"/>
+</mets:file>
+<mets:file CHECKSUM="57dbdeb062a081f1f8e3552943ff74dd" CHECKSUMTYPE="MD5" ID="d896r" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000047.tif"/>
+</mets:file>
+<mets:file CHECKSUM="50cbe5144abcc0825622174f9ed7964f" CHECKSUMTYPE="MD5" ID="zjs4p" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000048.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5b78d7684233f2bfd1e9acd54553c111" CHECKSUMTYPE="MD5" ID="n0p8e" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000049.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2cbbb26602d44b3ceb347a4602e9cee8" CHECKSUMTYPE="MD5" ID="gqmg9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000050.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9759590e4672848fb452184a05133726" CHECKSUMTYPE="MD5" ID="ak6qp" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000051.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bb5d635594e84350c799427f79bc685" CHECKSUMTYPE="MD5" ID="b96hq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000052.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b0127596580134b9ea285449c8069f2a" CHECKSUMTYPE="MD5" ID="ckp2v" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000053.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a71555a92394936cbd676f56b275736b" CHECKSUMTYPE="MD5" ID="k0ro9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000054.tif"/>
+</mets:file>
+<mets:file CHECKSUM="febf7320e9450c4db1fe06a54c1cbf08" CHECKSUMTYPE="MD5" ID="gi3oe" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000055.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2abd961c1e63dbcd2ccb6ecaa338de42" CHECKSUMTYPE="MD5" ID="bzno0" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000056.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ea19ce245756243722f5951c95ad278" CHECKSUMTYPE="MD5" ID="qrfg2" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000057.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e4caaf18cdcbe2dce0f769a158d5735f" CHECKSUMTYPE="MD5" ID="y8792" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000058.tif"/>
+</mets:file>
+<mets:file CHECKSUM="847b395995bcdcf7e980e853e705990b" CHECKSUMTYPE="MD5" ID="tc1m3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000059.tif"/>
+</mets:file>
+<mets:file CHECKSUM="688f9b56c9df6b1f24bbda6cb27a0318" CHECKSUMTYPE="MD5" ID="tszb9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000060.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c857f9254f543fbf3b9e520eafcb11bb" CHECKSUMTYPE="MD5" ID="ianjz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000061.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ad3fe5c6510a374a51d027983a9972ab" CHECKSUMTYPE="MD5" ID="sk8ck" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000062.tif"/>
+</mets:file>
+<mets:file CHECKSUM="cb01e984522e484af27233e567502042" CHECKSUMTYPE="MD5" ID="gsg0w" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000063.tif"/>
+</mets:file>
+<mets:file CHECKSUM="efe434529bd756655095076a6e9dee0d" CHECKSUMTYPE="MD5" ID="m9dep" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000064.tif"/>
+</mets:file>
+<mets:file CHECKSUM="39e6fa4978f0c80ceb2b27c6ec89d232" CHECKSUMTYPE="MD5" ID="kqsjy" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000065.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5cbf1e91423ba88284d374776afe32b3" CHECKSUMTYPE="MD5" ID="rtsza" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000066.tif"/>
+</mets:file>
+<mets:file CHECKSUM="38c6c343a30bef1c20aee9b0dcad8f48" CHECKSUMTYPE="MD5" ID="ucgi6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000067.tif"/>
+</mets:file>
+<mets:file CHECKSUM="27d6275aed6427a38b208fc6868205c8" CHECKSUMTYPE="MD5" ID="ua7bc" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000068.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f5dac107fed065bd0ba2fe94e6a17157" CHECKSUMTYPE="MD5" ID="xtlk6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000069.tif"/>
+</mets:file>
+<mets:file CHECKSUM="82c95e783e52c9010aca505b34747bdd" CHECKSUMTYPE="MD5" ID="bqbs0" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000070.tif"/>
+</mets:file>
+<mets:file CHECKSUM="87543b276b815cc16e3737b3ae0f749" CHECKSUMTYPE="MD5" ID="d1xg3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000071.tif"/>
+</mets:file>
+<mets:file CHECKSUM="dc7d35ffdeefc22ca5e2e5721486a36d" CHECKSUMTYPE="MD5" ID="q8wdo" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000072.tif"/>
+</mets:file>
+<mets:file CHECKSUM="11afa70af33d7356d6ddaa8677f264f6" CHECKSUMTYPE="MD5" ID="h909k" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000073.tif"/>
+</mets:file>
+<mets:file CHECKSUM="29852bfeae11cbb410caa03acc70e10c" CHECKSUMTYPE="MD5" ID="phmlq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000074.tif"/>
+</mets:file>
+<mets:file CHECKSUM="453a3718715390aefc4ab501862093ec" CHECKSUMTYPE="MD5" ID="dlw45" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000075.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f974a5e08f3c608995407d5b6b7e4693" CHECKSUMTYPE="MD5" ID="gavkf" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000076.tif"/>
+</mets:file>
+<mets:file CHECKSUM="91da2b35d184d0e205152c8b1ea9cf8e" CHECKSUMTYPE="MD5" ID="oqg92" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000077.tif"/>
+</mets:file>
+<mets:file CHECKSUM="236547dad562f98e2daad0f00ce58348" CHECKSUMTYPE="MD5" ID="pemfv" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000078.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a5fd18ff7b61f4c706178f1665ff60d4" CHECKSUMTYPE="MD5" ID="l3wo6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000079.tif"/>
+</mets:file>
+<mets:file CHECKSUM="fe4e9d237b6de945d2410ea6c3d5666a" CHECKSUMTYPE="MD5" ID="vqmwl" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000080.tif"/>
+</mets:file>
+<mets:file CHECKSUM="534f955d760fdc8ae98d2357206fc574" CHECKSUMTYPE="MD5" ID="zu4np" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000081.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2fb32a890370e6f821c0cea086713021" CHECKSUMTYPE="MD5" ID="fhtd2" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000082.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c9b17d1a0b8b624c4f2a179bc062171" CHECKSUMTYPE="MD5" ID="bbehu" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000083.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5f5ceb5c3e86899f5dcfc8e710942f48" CHECKSUMTYPE="MD5" ID="c78v3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000084.tif"/>
+</mets:file>
+<mets:file CHECKSUM="67a2cd5d62077c477d5c923d3a748e0a" CHECKSUMTYPE="MD5" ID="ck93t" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000085.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5c86c44bd2e484ea162a154cc661b709" CHECKSUMTYPE="MD5" ID="axwvk" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000086.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5c166659558aaad3e7bcf7edac3ac14f" CHECKSUMTYPE="MD5" ID="s54gg" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000087.tif"/>
+</mets:file>
+<mets:file CHECKSUM="302dc7bed1612bdf8bb6859b756c7971" CHECKSUMTYPE="MD5" ID="zmxdx" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000088.tif"/>
+</mets:file>
+<mets:file CHECKSUM="595b736bca9dbc2e2ca58aaba226d850" CHECKSUMTYPE="MD5" ID="if0kg" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000089.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c8f2f530aea49ff258accd20e5078b20" CHECKSUMTYPE="MD5" ID="hdipo" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000090.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a2024e82f87fa02cea36dd855ada53cf" CHECKSUMTYPE="MD5" ID="dg2ew" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000091.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7126be31293d2294e0b3e689d6f0c54b" CHECKSUMTYPE="MD5" ID="njufs" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000092.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9cd0bf9dc7093157749c16b9fd266fa5" CHECKSUMTYPE="MD5" ID="faxuy" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000093.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8d0b55022808a5fb9654e21ab451d3df" CHECKSUMTYPE="MD5" ID="gtb81" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000094.tif"/>
+</mets:file>
+<mets:file CHECKSUM="26a2dc937de390c346e6a02ad5c954e5" CHECKSUMTYPE="MD5" ID="rlw5z" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000095.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b3cde4cbbfc0abdb3723443e1f85d50c" CHECKSUMTYPE="MD5" ID="geyq8" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000096.tif"/>
+</mets:file>
+<mets:file CHECKSUM="47abe903ae58365cdaac5bc8559f6c32" CHECKSUMTYPE="MD5" ID="avg3i" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000097.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9d9d3aade7ee1d59dd12d1d6ea692811" CHECKSUMTYPE="MD5" ID="fzmh3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000098.tif"/>
+</mets:file>
+<mets:file CHECKSUM="14eaa199e1751da32432780b7f613cdf" CHECKSUMTYPE="MD5" ID="qj5jw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000099.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8f874c84bf6b712d291ae0e3f8067102" CHECKSUMTYPE="MD5" ID="r8qvb" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000100.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c8a36af5b59b28af1e24e920dbec2fbd" CHECKSUMTYPE="MD5" ID="wlnfj" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000101.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bbea423d1f4292b9857cdfedda9cf1ea" CHECKSUMTYPE="MD5" ID="aftmq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000102.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5e36a186c5dfbb4f25eb369e5f231868" CHECKSUMTYPE="MD5" ID="ndx8x" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000103.tif"/>
+</mets:file>
+<mets:file CHECKSUM="673d7a5e429cd530753d22bf5f8dc117" CHECKSUMTYPE="MD5" ID="a5czr" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000104.tif"/>
+</mets:file>
+<mets:file CHECKSUM="33d6fadfb6964f18c6c23a957279c291" CHECKSUMTYPE="MD5" ID="q0qis" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000105.tif"/>
+</mets:file>
+<mets:file CHECKSUM="69b491b3ba71423c05bfd0f73033f274" CHECKSUMTYPE="MD5" ID="nphyw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000106.tif"/>
+</mets:file>
+<mets:file CHECKSUM="836286d6792561a1594cf1eb394b69fc" CHECKSUMTYPE="MD5" ID="kx0g8" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000107.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3a31ee3df038201f05a88a7109875293" CHECKSUMTYPE="MD5" ID="mpbts" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000108.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c1bf9e92295ca13ef2d030464261139b" CHECKSUMTYPE="MD5" ID="nmtmc" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000109.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4189e5d798bf3da0d8c44845477ac3bc" CHECKSUMTYPE="MD5" ID="zjbmq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000110.tif"/>
+</mets:file>
+<mets:file CHECKSUM="87983a5e772d42cd92954ecb1eb0a651" CHECKSUMTYPE="MD5" ID="mtooq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000111.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1abef5b8a130f6482ad36a7c488a263d" CHECKSUMTYPE="MD5" ID="nclt6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000112.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4ad439ee8f0a09728cfcf84b2fbe1783" CHECKSUMTYPE="MD5" ID="olxbi" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000113.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5cb438bde62ee3d1c0885be2a177518" CHECKSUMTYPE="MD5" ID="clrsb" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000114.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7b570066a3e4303e097b9d52df5e379e" CHECKSUMTYPE="MD5" ID="vt2ka" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000115.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7220fac79154bf285bcfc7a92115e46d" CHECKSUMTYPE="MD5" ID="vkf8r" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000116.tif"/>
+</mets:file>
+<mets:file CHECKSUM="fdfb91f3c7c60366cf07a797b244ae41" CHECKSUMTYPE="MD5" ID="rxzsd" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000117.tif"/>
+</mets:file>
+<mets:file CHECKSUM="99cf4b14e1f3d4db6c1c49f0fa8d01c" CHECKSUMTYPE="MD5" ID="hrnts" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000118.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ef25003ab56dbfd87ed38cb80224cbef" CHECKSUMTYPE="MD5" ID="yuoze" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000119.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bfbb2b8cd02477d5a5f475062aa36d3" CHECKSUMTYPE="MD5" ID="h0syv" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000120.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ebaa1eafde180701fcd5025bfa38f6e4" CHECKSUMTYPE="MD5" ID="pwmml" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000121.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7455ad25cb6ffe2773c77f68f8a1502e" CHECKSUMTYPE="MD5" ID="k8h8u" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000122.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6eeed90be9f9afdf515921ad88b6c46f" CHECKSUMTYPE="MD5" ID="abo4t" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000123.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e9fc60b60c3b1a03b8d592186c4c3ef6" CHECKSUMTYPE="MD5" ID="d46z1" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000124.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2e5fd2bc73dd64f6bfdca2d4a0aeada7" CHECKSUMTYPE="MD5" ID="yx8ds" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000125.tif"/>
+</mets:file>
+<mets:file CHECKSUM="23f7517ff1e4e2dca50ffbb99c770bf0" CHECKSUMTYPE="MD5" ID="nelem" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000126.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e21447bbc017d114c3a1edc4f301e664" CHECKSUMTYPE="MD5" ID="rz75f" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000127.tif"/>
+</mets:file>
+<mets:file CHECKSUM="227def9907cbdcfad074759ee03a457c" CHECKSUMTYPE="MD5" ID="oub70" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000128.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a630bec75f02731990d77170e8f3f1a8" CHECKSUMTYPE="MD5" ID="r8ugl" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000129.tif"/>
+</mets:file>
+<mets:file CHECKSUM="befd8ba9ee72f26b735eacef2bb9a7e6" CHECKSUMTYPE="MD5" ID="li7po" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000130.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f3713ae6d72ac7522cac8c84a58348fb" CHECKSUMTYPE="MD5" ID="qcjvs" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000131.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a193cf66a4debcb773e90287bdc8e360" CHECKSUMTYPE="MD5" ID="z88bb" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_04/00000132.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e3d7ec85d747c29f619ff54b6ec02385" CHECKSUMTYPE="MD5" ID="l6bv7" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000001.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ffd9462ea0fd253f59594ee779c59e26" CHECKSUMTYPE="MD5" ID="dq6jq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000002.tif"/>
+</mets:file>
+<mets:file CHECKSUM="14dd861c39468833f64b70d418761637" CHECKSUMTYPE="MD5" ID="cz5nc" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000003.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8fe275943bd206d321765172494ea40c" CHECKSUMTYPE="MD5" ID="asesw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000004.tif"/>
+</mets:file>
+<mets:file CHECKSUM="daccd3b839a19d38527bf3a662b72944" CHECKSUMTYPE="MD5" ID="snpci" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000005.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7a9c79832e1f24934e35db433ed4cf70" CHECKSUMTYPE="MD5" ID="vum6x" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000006.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f1bbc1be727df49063dff6eedd49d061" CHECKSUMTYPE="MD5" ID="w6r8n" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000007.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d11e49e7e2e9dfa5653f7ab619755482" CHECKSUMTYPE="MD5" ID="iq7jx" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000008.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ecb981d050de2c3b2bce79546363121" CHECKSUMTYPE="MD5" ID="y5nkh" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000009.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e0af63e49f01dfbcfd9c74e94a0fddf3" CHECKSUMTYPE="MD5" ID="dp9np" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000010.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a4dc622e18c683432d10ebee01ee45f" CHECKSUMTYPE="MD5" ID="l43ke" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000011.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4790142e2c6e6200fffc41ad2e42806e" CHECKSUMTYPE="MD5" ID="sq0th" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000012.tif"/>
+</mets:file>
+<mets:file CHECKSUM="677bd3ad62670d6fa3d74ccc339813ac" CHECKSUMTYPE="MD5" ID="nsrh6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000013.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a546cb7af63f4787d734529e5d12b055" CHECKSUMTYPE="MD5" ID="xjrxs" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000014.tif"/>
+</mets:file>
+<mets:file CHECKSUM="115d8564bedf114595ba83edb27c159f" CHECKSUMTYPE="MD5" ID="ld924" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000015.tif"/>
+</mets:file>
+<mets:file CHECKSUM="65595cf312da1a4f7dda1bf89cc31006" CHECKSUMTYPE="MD5" ID="boamg" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000016.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a4fb20273557080ca3f3685a9afe944b" CHECKSUMTYPE="MD5" ID="f1pzl" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000017.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8f096b9b5b1298d12574b69ff9ed3a5" CHECKSUMTYPE="MD5" ID="n3y9e" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000018.tif"/>
+</mets:file>
+<mets:file CHECKSUM="93bc129963f09a7811d9163f291077b4" CHECKSUMTYPE="MD5" ID="s58ay" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000019.tif"/>
+</mets:file>
+<mets:file CHECKSUM="69690fef2a91a0df528ec3526316ff98" CHECKSUMTYPE="MD5" ID="c9s4a" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000020.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4885074f8a2cbff1965c2abaf1aec69e" CHECKSUMTYPE="MD5" ID="c5mgk" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000021.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9f023d73fb2182a27e96a22bbb94d0e4" CHECKSUMTYPE="MD5" ID="jridz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000022.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6a5c8557cebb66129e74f4e55763c045" CHECKSUMTYPE="MD5" ID="d7lp7" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000023.tif"/>
+</mets:file>
+<mets:file CHECKSUM="79037939cd40fe27418589b73906b1f2" CHECKSUMTYPE="MD5" ID="e9emc" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000024.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a9390f1a215593d5faf3f153cb96fdc4" CHECKSUMTYPE="MD5" ID="lpiug" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000025.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c5857466d705e1667cb61ecc16736b50" CHECKSUMTYPE="MD5" ID="kl9ar" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000026.tif"/>
+</mets:file>
+<mets:file CHECKSUM="298c0867648476e9eceaee0e636c2d02" CHECKSUMTYPE="MD5" ID="fcigj" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000027.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1cc1e92b13188c1d5dcecb0a54a1d2a8" CHECKSUMTYPE="MD5" ID="m1tbi" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000028.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3e4c841bb5bad2da18364133b50ee4fe" CHECKSUMTYPE="MD5" ID="dthum" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000029.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6310a6c550301b21ff60323101a6dd6d" CHECKSUMTYPE="MD5" ID="axnw8" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000030.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3ef555060d6a71a85689bdec73a017e9" CHECKSUMTYPE="MD5" ID="avkzj" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000031.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2433d09e80c4cacdd0f35f6469f0b986" CHECKSUMTYPE="MD5" ID="xwk2l" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000032.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a1d2335133256a54067442ffbbb593a2" CHECKSUMTYPE="MD5" ID="p79g6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000033.tif"/>
+</mets:file>
+<mets:file CHECKSUM="239c04063214081ae3a2ec704720700" CHECKSUMTYPE="MD5" ID="fiaa7" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000034.tif"/>
+</mets:file>
+<mets:file CHECKSUM="51f6de8a9b33607a35c0732e3c0d61f0" CHECKSUMTYPE="MD5" ID="zjpdw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000035.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5e275d2a0b8425d48517c1b7f925f63e" CHECKSUMTYPE="MD5" ID="f3vui" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000036.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1249a70eac88236f0827f632415c176e" CHECKSUMTYPE="MD5" ID="nutfr" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000037.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a26176275e50b1734536b3fed00f260d" CHECKSUMTYPE="MD5" ID="b4jgf" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000038.tif"/>
+</mets:file>
+<mets:file CHECKSUM="55b77d227684463ddda835e931bb28ff" CHECKSUMTYPE="MD5" ID="wiafv" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000039.tif"/>
+</mets:file>
+<mets:file CHECKSUM="eacceef0b349f4ab3f90b9b30c5a169a" CHECKSUMTYPE="MD5" ID="x28xs" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000040.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c22c12dd891475b75728bcbeee20c547" CHECKSUMTYPE="MD5" ID="apsww" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000041.tif"/>
+</mets:file>
+<mets:file CHECKSUM="240460df7f67bf33ea5c6f0b37e333dd" CHECKSUMTYPE="MD5" ID="xwrv3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000042.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ae2fecf459be3f62333096a3bc4ae1e6" CHECKSUMTYPE="MD5" ID="tetm3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000043.tif"/>
+</mets:file>
+<mets:file CHECKSUM="fcc766ef4e1ce17ec6fa53a5087a1c90" CHECKSUMTYPE="MD5" ID="aag2e" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000044.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ba5d76a26e461965fa037f45b2154327" CHECKSUMTYPE="MD5" ID="pznb4" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000045.tif"/>
+</mets:file>
+<mets:file CHECKSUM="12351df5588352b3e377c1e1cc4d8e6f" CHECKSUMTYPE="MD5" ID="hxmh0" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000046.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ffb37d6ef81f1d635f167a62854dd16a" CHECKSUMTYPE="MD5" ID="pzgqm" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000047.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1505e0bc0fd685eb69831b98499f91f2" CHECKSUMTYPE="MD5" ID="bz2kn" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000048.tif"/>
+</mets:file>
+<mets:file CHECKSUM="79787780dac3ecd8ae1ac93e611180dd" CHECKSUMTYPE="MD5" ID="namvv" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000049.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c53251b452ff8ff9e2caed7d2d27181e" CHECKSUMTYPE="MD5" ID="o7zf5" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000050.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ce3e43f3fee4472a87d0dcfc2258fe37" CHECKSUMTYPE="MD5" ID="aeo3u" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000051.tif"/>
+</mets:file>
+<mets:file CHECKSUM="eb90b583a41bfca8c5b2bd82ca0fb6b5" CHECKSUMTYPE="MD5" ID="p1ku7" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000052.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c9b24c5194ccd43ab9870776a34f6d23" CHECKSUMTYPE="MD5" ID="r2n0e" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000053.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4a31216e1d0535e85ad26b1ee5fbbeaa" CHECKSUMTYPE="MD5" ID="mo9g4" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000054.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8c93d3e26aa1d5ac7f8cb7c7a1a31c80" CHECKSUMTYPE="MD5" ID="eaa6t" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000055.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5e2bd61ae59f54f60933311e5ef867cb" CHECKSUMTYPE="MD5" ID="zpbmo" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000056.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e5f12c77e2229e3e80100aa4b8384b23" CHECKSUMTYPE="MD5" ID="ktlcq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000057.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d924988e90dce12c2a66c0c36a509ad4" CHECKSUMTYPE="MD5" ID="wk7hn" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000058.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d76ffcdae6cb20507e8cd0c955f620e7" CHECKSUMTYPE="MD5" ID="hqoix" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000059.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e47f88da57748d4ddf758ab88418225f" CHECKSUMTYPE="MD5" ID="jrzk6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000060.tif"/>
+</mets:file>
+<mets:file CHECKSUM="944d3f9619ae821fdb5ac71b4f60399b" CHECKSUMTYPE="MD5" ID="haql9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000061.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d57bf36818ed2d93710d82589e4de5b3" CHECKSUMTYPE="MD5" ID="r75cw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000062.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e907b448a5ec25ccfdc1d9def887648" CHECKSUMTYPE="MD5" ID="fggxk" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000063.tif"/>
+</mets:file>
+<mets:file CHECKSUM="dcb226727a6f0e8db32ff638688a3027" CHECKSUMTYPE="MD5" ID="naka0" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000064.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6e8116bc74cf3f32a31395010fa44f3d" CHECKSUMTYPE="MD5" ID="icc37" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000065.tif"/>
+</mets:file>
+<mets:file CHECKSUM="fc8972446f1abf56cc2bc79a502eefbe" CHECKSUMTYPE="MD5" ID="hjwzr" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000066.tif"/>
+</mets:file>
+<mets:file CHECKSUM="12be19044f805bf7cbca088a92e98167" CHECKSUMTYPE="MD5" ID="jlkm4" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000067.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f1b8650d104d60955a5f6b48d742c8ec" CHECKSUMTYPE="MD5" ID="yxebu" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000068.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8386e1d6a39b27336270e4738ab06361" CHECKSUMTYPE="MD5" ID="a1wby" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000069.tif"/>
+</mets:file>
+<mets:file CHECKSUM="36d7de53f07048080d028e1c745abfe2" CHECKSUMTYPE="MD5" ID="ozyc8" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000070.tif"/>
+</mets:file>
+<mets:file CHECKSUM="37f6cb78b7a859377a8adb4401d7a3c9" CHECKSUMTYPE="MD5" ID="dcsyg" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000071.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4c60693f02e23c4d6d238b6cc83c83c9" CHECKSUMTYPE="MD5" ID="tidfl" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000072.tif"/>
+</mets:file>
+<mets:file CHECKSUM="cdc100ca8b45df533a99863e70e54e0f" CHECKSUMTYPE="MD5" ID="xxxw2" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000073.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1fa8e7959076f96fae424d8b280b4191" CHECKSUMTYPE="MD5" ID="md3o9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000074.tif"/>
+</mets:file>
+<mets:file CHECKSUM="76926fae43cf6dd61a45bfc800feb102" CHECKSUMTYPE="MD5" ID="sh7sc" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000075.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f1b75f9f2f6c3fa5dadb77d02e3854a3" CHECKSUMTYPE="MD5" ID="vm529" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000076.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4815d92fc53e5c305b85122bb812509d" CHECKSUMTYPE="MD5" ID="rupn1" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000077.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e2cc1a8d74cd961d505128d38b8e366b" CHECKSUMTYPE="MD5" ID="ql0i0" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000078.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b74feab77df2ba46c45cde239da745cd" CHECKSUMTYPE="MD5" ID="f4yeh" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000079.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2dff68d8005b9425ae54b462550d49a6" CHECKSUMTYPE="MD5" ID="dlnqz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000080.tif"/>
+</mets:file>
+<mets:file CHECKSUM="33d19c3c92eabeb48edf8ec6ec7e111f" CHECKSUMTYPE="MD5" ID="ofo0v" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000081.tif"/>
+</mets:file>
+<mets:file CHECKSUM="dd0ace0c113d795ee4e7d915afa0e482" CHECKSUMTYPE="MD5" ID="y5fnf" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000082.tif"/>
+</mets:file>
+<mets:file CHECKSUM="71f53a46e2e2615ff5e1409d1d3aa365" CHECKSUMTYPE="MD5" ID="z5n8y" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000083.tif"/>
+</mets:file>
+<mets:file CHECKSUM="dd46e0367cc0fcb032bbbcaa1bb2ba2b" CHECKSUMTYPE="MD5" ID="odt3y" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000084.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c9bea5e72f35ba6e4f027f8c42e7d3ec" CHECKSUMTYPE="MD5" ID="knrhz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000085.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6078d6723b1c76384af21e13158c6c38" CHECKSUMTYPE="MD5" ID="aeo5d" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000086.tif"/>
+</mets:file>
+<mets:file CHECKSUM="efaf9d0039b1ba5aa7e79e2c6d3bc341" CHECKSUMTYPE="MD5" ID="ejy60" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000087.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9472126132c066d448980427fcb1f99" CHECKSUMTYPE="MD5" ID="zklad" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000088.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e5b974be7433e73983d977159fc7ce64" CHECKSUMTYPE="MD5" ID="lplo0" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000089.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2b5eaa233980f2e43017fa446f2cdae" CHECKSUMTYPE="MD5" ID="o115b" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000090.tif"/>
+</mets:file>
+<mets:file CHECKSUM="152dea865bbcd7c16303bab1d5dbef8d" CHECKSUMTYPE="MD5" ID="ojeo2" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000091.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8173fac22896f221cb93209f93b68c95" CHECKSUMTYPE="MD5" ID="tgax3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000092.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d1d25f42b0427a505791ca375e406cea" CHECKSUMTYPE="MD5" ID="oj1t4" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000093.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6312f425fc477a63d77d9b476e60bc59" CHECKSUMTYPE="MD5" ID="ndyzb" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000094.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bc3f13086754ccb2eff4eedeae027b8a" CHECKSUMTYPE="MD5" ID="l7dmh" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000095.tif"/>
+</mets:file>
+<mets:file CHECKSUM="beb2a27e2e0fe5ef26002e16ef23a23c" CHECKSUMTYPE="MD5" ID="yw9m6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000096.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ebfecb3b3de586482304e346e65933a2" CHECKSUMTYPE="MD5" ID="vx12f" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000097.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f8ec47eefd5a70687e6bad7cd966ac14" CHECKSUMTYPE="MD5" ID="qp5ir" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000098.tif"/>
+</mets:file>
+<mets:file CHECKSUM="25078784b07b0a1e646156603ae38d46" CHECKSUMTYPE="MD5" ID="b2r2t" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000099.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5609d1da36d48c9c3e343bcc6a95f82b" CHECKSUMTYPE="MD5" ID="jqd9z" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000100.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6d8246038da1319c032649af611d9337" CHECKSUMTYPE="MD5" ID="gho5w" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000101.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d528f6898385f8dcfaadc42002af6f7f" CHECKSUMTYPE="MD5" ID="xwveo" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000102.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a60da30ad98e4d4ed9ddbfcb76027037" CHECKSUMTYPE="MD5" ID="xrmfl" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000103.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ecfd0fbf1cba1eabd638bbfc013812de" CHECKSUMTYPE="MD5" ID="igbls" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_05/00000104.tif"/>
+</mets:file>
+<mets:file CHECKSUM="31ca9aecf024667cc1ddaac15b2441b1" CHECKSUMTYPE="MD5" ID="qhdeb" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000001.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1533a2f5f46d4d43af64299ba2870abf" CHECKSUMTYPE="MD5" ID="nutcv" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000002.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f5941ad1129115a4494f538cb0a0a97d" CHECKSUMTYPE="MD5" ID="pnhhq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000003.tif"/>
+</mets:file>
+<mets:file CHECKSUM="690e23e1841ea8197de64d77d406e681" CHECKSUMTYPE="MD5" ID="hhivk" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000004.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4e540741ac828844757e285221fcfd3f" CHECKSUMTYPE="MD5" ID="byg39" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000005.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4dd0800be1b31a062d89c9cec464d53a" CHECKSUMTYPE="MD5" ID="ju0a7" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000006.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7fe21787f491db0c6c4cc3c394991300" CHECKSUMTYPE="MD5" ID="muc9s" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000007.tif"/>
+</mets:file>
+<mets:file CHECKSUM="351ad91ddba0afab9f2f2c5b62ee2c82" CHECKSUMTYPE="MD5" ID="ezk09" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000008.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a7eb0afe224b30e8c23e9065fa7204a8" CHECKSUMTYPE="MD5" ID="h0o6b" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000009.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e50110beb01038c68b17f7d5a328209f" CHECKSUMTYPE="MD5" ID="mrhlc" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000010.tif"/>
+</mets:file>
+<mets:file CHECKSUM="704ccc5b5c4673c5d2a9c4d186b172cb" CHECKSUMTYPE="MD5" ID="tfpo8" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000011.tif"/>
+</mets:file>
+<mets:file CHECKSUM="eb32b1ebd9b36b45a3fd2c24d3b8c2bb" CHECKSUMTYPE="MD5" ID="abr5m" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000012.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e1d041946bb6b9aa47ac5dc462a0fe88" CHECKSUMTYPE="MD5" ID="bl7vm" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000013.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d25f72e13b836690d114958ec21b38f4" CHECKSUMTYPE="MD5" ID="xhwg9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000014.tif"/>
+</mets:file>
+<mets:file CHECKSUM="28869ff65fe8faa4f5e4d0ae21a2e4f9" CHECKSUMTYPE="MD5" ID="nuu5z" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000015.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a23b49e48b92e455db7887022c15dcb2" CHECKSUMTYPE="MD5" ID="me7q5" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000016.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7266110f17e181c1cd32b096b6c3fee4" CHECKSUMTYPE="MD5" ID="shgs4" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000017.tif"/>
+</mets:file>
+<mets:file CHECKSUM="de51bd98d8aa7cb9eb3e85deff99b14f" CHECKSUMTYPE="MD5" ID="yblsu" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000018.tif"/>
+</mets:file>
+<mets:file CHECKSUM="972948d3c82033ff5285d2a9865065b8" CHECKSUMTYPE="MD5" ID="fu8kd" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000019.tif"/>
+</mets:file>
+<mets:file CHECKSUM="83234da0bde8b295b9b008dd14e95f11" CHECKSUMTYPE="MD5" ID="asy6a" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000020.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4ac443e98adfe9de0848c55c1b63ef0a" CHECKSUMTYPE="MD5" ID="pphid" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000021.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f3aabf4d7fdd6960c930c0a5115778da" CHECKSUMTYPE="MD5" ID="lo1fn" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000022.tif"/>
+</mets:file>
+<mets:file CHECKSUM="926cf14f5fdd3d5de8e79da70c48c17f" CHECKSUMTYPE="MD5" ID="y40nj" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000023.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b1c152d3e26bd29c87aadb9ab9c2f8d0" CHECKSUMTYPE="MD5" ID="t1ffw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000024.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9f1ac6f6d2fdb6bbb3d9fcc9354f7d93" CHECKSUMTYPE="MD5" ID="eq8ru" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000025.tif"/>
+</mets:file>
+<mets:file CHECKSUM="973e3bc56fa68da82e38890ae4f16045" CHECKSUMTYPE="MD5" ID="pcd72" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000026.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7d018c65309ff0249ec0ec33c5bfc9a5" CHECKSUMTYPE="MD5" ID="ukely" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000027.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8b75e5ad1ca2d402343f4f1f1fb74df7" CHECKSUMTYPE="MD5" ID="z617f" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000028.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5896ddc7d86c2ab145c06c4b42ae4de2" CHECKSUMTYPE="MD5" ID="r4dbx" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000029.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9572bb5799289de43cc0f61fd0e1835a" CHECKSUMTYPE="MD5" ID="pt7yk" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000030.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9bf78213aaa3bf64ebab5fff6dc7a141" CHECKSUMTYPE="MD5" ID="lxwff" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000031.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5198c023ee129f72ea416deffffff9d7" CHECKSUMTYPE="MD5" ID="f2mjo" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000032.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6a2329609d8d562796e77420aecba715" CHECKSUMTYPE="MD5" ID="khuxu" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000033.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a6542f8a3cd9dc17f715d0ad2260e7e6" CHECKSUMTYPE="MD5" ID="bp2ah" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000034.tif"/>
+</mets:file>
+<mets:file CHECKSUM="98582df343ffdb170e1a882598aad0cc" CHECKSUMTYPE="MD5" ID="hfjhl" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000035.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ee726657497f5e30c9741314dfb49ed3" CHECKSUMTYPE="MD5" ID="dzw4u" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000036.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b56081172eb7a84742303fae85b4d519" CHECKSUMTYPE="MD5" ID="w199v" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000037.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d480ba33e50eb8faff03bc4cfd3cace4" CHECKSUMTYPE="MD5" ID="ogr8y" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000038.tif"/>
+</mets:file>
+<mets:file CHECKSUM="556694e2ad9907e751e5b366c56f0caa" CHECKSUMTYPE="MD5" ID="qzmgo" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000039.tif"/>
+</mets:file>
+<mets:file CHECKSUM="369541f26eca28c1710e3c1fa44912cf" CHECKSUMTYPE="MD5" ID="z7yig" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000040.tif"/>
+</mets:file>
+<mets:file CHECKSUM="69c37f0a8f065f7b5b5201d1ab7f4f12" CHECKSUMTYPE="MD5" ID="rh2ll" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000041.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d85cd56bf7c209d21286c743634651ea" CHECKSUMTYPE="MD5" ID="oreht" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000042.tif"/>
+</mets:file>
+<mets:file CHECKSUM="74a91f79378ec2616f510991ffa138a1" CHECKSUMTYPE="MD5" ID="amget" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000043.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d24b969deaf53ae1c13f85a80ac97286" CHECKSUMTYPE="MD5" ID="ax17o" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000044.tif"/>
+</mets:file>
+<mets:file CHECKSUM="370ef408bc01c2ffd9240e4595a436ca" CHECKSUMTYPE="MD5" ID="mmy64" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000045.tif"/>
+</mets:file>
+<mets:file CHECKSUM="695ba8c249c374bd8c940a1b00c157cb" CHECKSUMTYPE="MD5" ID="d141t" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_06/00000046.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3b374bc6614605e50a09e32a9404aba6" CHECKSUMTYPE="MD5" ID="xjpzg" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000001.tif"/>
+</mets:file>
+<mets:file CHECKSUM="77cf7e7b5608071d816bd0f949dc76ab" CHECKSUMTYPE="MD5" ID="vbm3m" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000002.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8fb25da20d9dc626177b78671e77120f" CHECKSUMTYPE="MD5" ID="hlsda" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000003.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ad045dd7a5e42915b19409abbc3485a7" CHECKSUMTYPE="MD5" ID="t2r9q" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000004.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c485b3105a8f09e347c06208c28f5591" CHECKSUMTYPE="MD5" ID="yvhwk" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000005.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ebee06c9f5cdee6ea79ccdfb720fe05c" CHECKSUMTYPE="MD5" ID="m4uf6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000006.tif"/>
+</mets:file>
+<mets:file CHECKSUM="747c171028d3f5b11c8813d7d7d6911f" CHECKSUMTYPE="MD5" ID="jqjgw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000007.tif"/>
+</mets:file>
+<mets:file CHECKSUM="15c4abf3561e6bc7224953e792bbe020" CHECKSUMTYPE="MD5" ID="t98md" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000008.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7650bdfeb23f3d5c39fd39b78a057679" CHECKSUMTYPE="MD5" ID="z0szl" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000009.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f06eb1aaaded0c489f3e3dbef820f63d" CHECKSUMTYPE="MD5" ID="q5dnx" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000010.tif"/>
+</mets:file>
+<mets:file CHECKSUM="dd25ccf82c9ccd7e0791386efebff389" CHECKSUMTYPE="MD5" ID="vjg9z" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000011.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5de75c177b5fe90cd23210a0fd19984e" CHECKSUMTYPE="MD5" ID="w0fnp" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000012.tif"/>
+</mets:file>
+<mets:file CHECKSUM="21359bbbaf384de62d48ef7e9112d729" CHECKSUMTYPE="MD5" ID="epsr9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000013.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c118c562171b8180f907de019c99ea9a" CHECKSUMTYPE="MD5" ID="x9dpw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000014.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2cf976425c869b591f9fb97333b3c1a1" CHECKSUMTYPE="MD5" ID="ejpro" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000015.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8ec525160be25329a98547d362670dad" CHECKSUMTYPE="MD5" ID="rcm5k" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000016.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8256fe1bbc1f740cf84ba40e83af904d" CHECKSUMTYPE="MD5" ID="x1qfl" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000017.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1b30014c194b41bbd4418f28597e1862" CHECKSUMTYPE="MD5" ID="tjd5u" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000018.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f8715b29f34a9484aaf63e545d95841e" CHECKSUMTYPE="MD5" ID="mh998" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000019.tif"/>
+</mets:file>
+<mets:file CHECKSUM="cd4618000104cf5e4e639530ae894fb5" CHECKSUMTYPE="MD5" ID="xomqh" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000020.tif"/>
+</mets:file>
+<mets:file CHECKSUM="fb3772c37bc1b54ff92bff5642e57813" CHECKSUMTYPE="MD5" ID="dlc0x" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000021.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7eadf0c696c43561fc4b7e76e4a28425" CHECKSUMTYPE="MD5" ID="x4z1d" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000022.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a43042c1712fca8c3845a9710910f1d5" CHECKSUMTYPE="MD5" ID="jkko8" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000023.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9869d4c799897e4f48abbbb931588e8c" CHECKSUMTYPE="MD5" ID="lng8l" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000024.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9a8fd60d43531972cfb71f69ecf574a0" CHECKSUMTYPE="MD5" ID="plzdt" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000025.tif"/>
+</mets:file>
+<mets:file CHECKSUM="463d5371f8d4fb2bad817c5f3fe17fa2" CHECKSUMTYPE="MD5" ID="zfcpi" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000026.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ac257357cd0c83ae8815fe5f203f1906" CHECKSUMTYPE="MD5" ID="e7llx" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000027.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b97663e3aaced886907aeb2d88f2101c" CHECKSUMTYPE="MD5" ID="e4dsi" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000028.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a44b31440611503518c2fd69a8432434" CHECKSUMTYPE="MD5" ID="rk6os" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000029.tif"/>
+</mets:file>
+<mets:file CHECKSUM="16e2d3b06ca889b43321fc36635cc25" CHECKSUMTYPE="MD5" ID="kmb94" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000030.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a5890fc26535e8b615e3095b6c018d0d" CHECKSUMTYPE="MD5" ID="n4eat" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000031.tif"/>
+</mets:file>
+<mets:file CHECKSUM="87b8e6339e375914648e87f5ef0d17d4" CHECKSUMTYPE="MD5" ID="siapl" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000032.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d59fbfc01a2f944af86e2598e2f4802" CHECKSUMTYPE="MD5" ID="zyd0k" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000033.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e984f8bcf874fb5cae74ac464ec05865" CHECKSUMTYPE="MD5" ID="l46r4" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000034.tif"/>
+</mets:file>
+<mets:file CHECKSUM="18b48208c19e6d94af68afccb09e245d" CHECKSUMTYPE="MD5" ID="jyt4v" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000035.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6f21d223da029c0733d3938a4f992e2b" CHECKSUMTYPE="MD5" ID="ky080" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000036.tif"/>
+</mets:file>
+<mets:file CHECKSUM="14eed36aeed14e5ee4aa39fb93baa1e7" CHECKSUMTYPE="MD5" ID="kqyef" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000037.tif"/>
+</mets:file>
+<mets:file CHECKSUM="48edb5f16df8cb03282a1ea8d66a1237" CHECKSUMTYPE="MD5" ID="lmrck" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000038.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a5e09df701f6ee92548326bfe2b9c97d" CHECKSUMTYPE="MD5" ID="aoqob" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000039.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e006cb3f51df09a8efe0de53a22cc287" CHECKSUMTYPE="MD5" ID="aykzw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000040.tif"/>
+</mets:file>
+<mets:file CHECKSUM="91c98fde411008ff7d3ea294d9fd5fce" CHECKSUMTYPE="MD5" ID="hiviw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000041.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b3c8da60fedd1063b55c92b578986f3f" CHECKSUMTYPE="MD5" ID="swcbj" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000042.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3548ee8a868dc1583b698beb9389b56d" CHECKSUMTYPE="MD5" ID="qc203" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000043.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d4bf2357682a21bbc7bd6948c5372f29" CHECKSUMTYPE="MD5" ID="w28gk" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000044.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a516e5fb86e4e3135b45520e47d56596" CHECKSUMTYPE="MD5" ID="vn2l3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000045.tif"/>
+</mets:file>
+<mets:file CHECKSUM="90618b3c88c375e72175c88fead179fc" CHECKSUMTYPE="MD5" ID="crmfq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000046.tif"/>
+</mets:file>
+<mets:file CHECKSUM="db2d767bf461a5874f7fdbf73da99818" CHECKSUMTYPE="MD5" ID="kj946" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000047.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ad864b741ee40a696256408cfad12481" CHECKSUMTYPE="MD5" ID="psnh7" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000048.tif"/>
+</mets:file>
+<mets:file CHECKSUM="54b930911d724738a2879ce135d17814" CHECKSUMTYPE="MD5" ID="po3pl" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000049.tif"/>
+</mets:file>
+<mets:file CHECKSUM="55331dd74190fa2d24c94bbc95cda3fa" CHECKSUMTYPE="MD5" ID="ynh4h" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000050.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b3e11b3ad1b3523e5058aef2262fa246" CHECKSUMTYPE="MD5" ID="a616s" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000051.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c973ab65eddbd445d6a4b19f5880b1d2" CHECKSUMTYPE="MD5" ID="xdl46" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000052.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5738f15ce3d337a6eaf65e88a008b4be" CHECKSUMTYPE="MD5" ID="qmkaw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000053.tif"/>
+</mets:file>
+<mets:file CHECKSUM="63e3bbde172fc938bbddec92ef21d468" CHECKSUMTYPE="MD5" ID="ckmq2" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000054.tif"/>
+</mets:file>
+<mets:file CHECKSUM="db2d250131b0624f41e22dfcaa2a73c0" CHECKSUMTYPE="MD5" ID="ucgcs" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000055.tif"/>
+</mets:file>
+<mets:file CHECKSUM="67d908e8561be6ade0f903f8e5ae5a5a" CHECKSUMTYPE="MD5" ID="v7omr" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000056.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c36347a5560d8cee499ce2bd09942999" CHECKSUMTYPE="MD5" ID="gug1q" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000057.tif"/>
+</mets:file>
+<mets:file CHECKSUM="190b490111425ddb8a819bc0beb7bb9c" CHECKSUMTYPE="MD5" ID="bufjw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000058.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5e3695130cc58150ac08f8dc423bae91" CHECKSUMTYPE="MD5" ID="dwpv8" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000059.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5f6463cda535a5b8361cc12a7add2061" CHECKSUMTYPE="MD5" ID="tav4j" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000060.tif"/>
+</mets:file>
+<mets:file CHECKSUM="362c6ec6252a39c8283f2bfb7ba403e" CHECKSUMTYPE="MD5" ID="m3v1n" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000061.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ebae44ead40d40a077b264e6caaeaac1" CHECKSUMTYPE="MD5" ID="rujkd" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000062.tif"/>
+</mets:file>
+<mets:file CHECKSUM="62de54aaf59512f2ac1a721196f3e8c0" CHECKSUMTYPE="MD5" ID="z9frs" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000063.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a4de9c9ac894946d1657191091dd8b6c" CHECKSUMTYPE="MD5" ID="oprak" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000064.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6e62408bbaf6ef15dfa591472d086099" CHECKSUMTYPE="MD5" ID="w77k6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000065.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2332943b6b9da66e60f713a5e6ec5f6a" CHECKSUMTYPE="MD5" ID="ojy89" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000066.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7d52306528c69b85de0b80ead1452d12" CHECKSUMTYPE="MD5" ID="dugwz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000067.tif"/>
+</mets:file>
+<mets:file CHECKSUM="461c57ba3b1628b02d20e76a12eab8a8" CHECKSUMTYPE="MD5" ID="osk5f" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000068.tif"/>
+</mets:file>
+<mets:file CHECKSUM="880a8b4252eca425e8a8c57e0fc2fec2" CHECKSUMTYPE="MD5" ID="yvzsk" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000069.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a17ee0e56f29618428974bc8ac26463b" CHECKSUMTYPE="MD5" ID="eg1hw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000070.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c8f7cad8df7a5eddab7f92e5473a2ad5" CHECKSUMTYPE="MD5" ID="ryno3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000071.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b3ee61c8d52b65dfaa5da5ecbff1ad9a" CHECKSUMTYPE="MD5" ID="ndsim" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000072.tif"/>
+</mets:file>
+<mets:file CHECKSUM="90f85ff2fa2e028a40e49f85455c1aa2" CHECKSUMTYPE="MD5" ID="vei4g" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000073.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7a836550be9d042ce81523c94d4b0c9c" CHECKSUMTYPE="MD5" ID="kff0a" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000074.tif"/>
+</mets:file>
+<mets:file CHECKSUM="355f2c4a5855acf0ac153741a99ccb6e" CHECKSUMTYPE="MD5" ID="duekt" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000075.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b972339037db042b5cdb7f929f593a00" CHECKSUMTYPE="MD5" ID="qc7cu" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000076.tif"/>
+</mets:file>
+<mets:file CHECKSUM="788903a92f75665dc1007ccd7a7280e5" CHECKSUMTYPE="MD5" ID="uk3av" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000077.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e0b4cba0fa210ca744c0f6982a49f49b" CHECKSUMTYPE="MD5" ID="b1s6e" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000078.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7c57be381390bdb1df5fcb9b60d54f48" CHECKSUMTYPE="MD5" ID="q74m3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000079.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8bfd7b2930ec07420c7fa903754aef70" CHECKSUMTYPE="MD5" ID="px8ki" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000080.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bcaf41fde55584556a30dc082ea7c76a" CHECKSUMTYPE="MD5" ID="n8znw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000081.tif"/>
+</mets:file>
+<mets:file CHECKSUM="87e2be1cc7e3a9bb341509c21cbbd863" CHECKSUMTYPE="MD5" ID="ni2i6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000082.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bd0a03c5bf793ecf8b1881ed6a6ba88" CHECKSUMTYPE="MD5" ID="ra7lj" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000083.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5406ad049a58d8e3d2738e5a51cd16bd" CHECKSUMTYPE="MD5" ID="wr2gu" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000084.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8b371dfe1ab07ab610b11c137bfb60ae" CHECKSUMTYPE="MD5" ID="u4xo5" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000085.tif"/>
+</mets:file>
+<mets:file CHECKSUM="dae0fb53d218422afab8e876db9b3aa2" CHECKSUMTYPE="MD5" ID="hfq4h" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000086.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7890a5ffebbf7c71d7d51fa3e1ce7ff6" CHECKSUMTYPE="MD5" ID="toi1y" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000087.tif"/>
+</mets:file>
+<mets:file CHECKSUM="58a627c5c8746b0d60acd375c3ed8477" CHECKSUMTYPE="MD5" ID="fgv25" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000088.tif"/>
+</mets:file>
+<mets:file CHECKSUM="afa18c0d6fc66524b3f94b16421b5d51" CHECKSUMTYPE="MD5" ID="j5gdk" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000089.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ab5e5fe7d5a50670063a9594bf4e58bc" CHECKSUMTYPE="MD5" ID="zo7ix" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000090.tif"/>
+</mets:file>
+<mets:file CHECKSUM="13a663138c2d0e2037efe9de5a77d143" CHECKSUMTYPE="MD5" ID="b2opi" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000091.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c432d53e5babbb6341e4f1a76744e92e" CHECKSUMTYPE="MD5" ID="wtcvb" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000092.tif"/>
+</mets:file>
+<mets:file CHECKSUM="961f7b6ed3090c1a1c217ee3bfb188ed" CHECKSUMTYPE="MD5" ID="ppx2j" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000093.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5380fb4c7b1e78a154b926991aafe874" CHECKSUMTYPE="MD5" ID="ehnek" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000094.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4ac0aaaad69cff2997e61b0f185558e" CHECKSUMTYPE="MD5" ID="gvbey" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000095.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f0df96c206b2dabaca6c06fee99e55ad" CHECKSUMTYPE="MD5" ID="i02uz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000096.tif"/>
+</mets:file>
+<mets:file CHECKSUM="177c95bb05053bb081db58c4dc1d24ed" CHECKSUMTYPE="MD5" ID="zqers" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000097.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d5319dc97646774e14a9097e3814818f" CHECKSUMTYPE="MD5" ID="s6rga" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000098.tif"/>
+</mets:file>
+<mets:file CHECKSUM="15ff6e9b0a49c5fcf95b2490cfed50ba" CHECKSUMTYPE="MD5" ID="rzh99" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000099.tif"/>
+</mets:file>
+<mets:file CHECKSUM="710a509540d8b051b23cc4018a6e638d" CHECKSUMTYPE="MD5" ID="defod" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000100.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f1e56b1c257cde589c479229f7971d86" CHECKSUMTYPE="MD5" ID="xrnh5" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000101.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a86ca6287991746ad2ed127def493645" CHECKSUMTYPE="MD5" ID="dtbzd" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000102.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e52ee4f7915353056ee39dfd6291ac3e" CHECKSUMTYPE="MD5" ID="zne2z" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000103.tif"/>
+</mets:file>
+<mets:file CHECKSUM="dc8b28d8f57d1f49b123269ad01f2dca" CHECKSUMTYPE="MD5" ID="mh2w0" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000104.tif"/>
+</mets:file>
+<mets:file CHECKSUM="50615adff27efec6b453a3dfa4371389" CHECKSUMTYPE="MD5" ID="cjc1w" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000105.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ce4299ffeb7d5265afe5b10e5442ec1d" CHECKSUMTYPE="MD5" ID="vcz1c" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000106.tif"/>
+</mets:file>
+<mets:file CHECKSUM="136d7493ee3720f9b334d9a210271c71" CHECKSUMTYPE="MD5" ID="i0f5u" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000107.tif"/>
+</mets:file>
+<mets:file CHECKSUM="948d3be1ae27f7e3b5c7dd674675dd2a" CHECKSUMTYPE="MD5" ID="k4quw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000108.tif"/>
+</mets:file>
+<mets:file CHECKSUM="27a93b9f0fc921f88e4226c65604aa8" CHECKSUMTYPE="MD5" ID="p70xr" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000109.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7cb513486d9780178464a9aeca7e7fab" CHECKSUMTYPE="MD5" ID="qd684" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000110.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f520b0f77dac7c0edfbe491b451d8322" CHECKSUMTYPE="MD5" ID="ubc16" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000111.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f7945413fdecb6b51c67930ad146967" CHECKSUMTYPE="MD5" ID="cn2tp" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000112.tif"/>
+</mets:file>
+<mets:file CHECKSUM="56b64e367d73f1bb3c1463a0800b7890" CHECKSUMTYPE="MD5" ID="sufwl" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000113.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a515aac523a07d4140bf3fc1b8050081" CHECKSUMTYPE="MD5" ID="lkr9d" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000114.tif"/>
+</mets:file>
+<mets:file CHECKSUM="327a24a96ba5a18a77f7171360bd92b6" CHECKSUMTYPE="MD5" ID="yb2ct" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000115.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c082c56a109d79fa81d9764223f6d51b" CHECKSUMTYPE="MD5" ID="pq6me" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000116.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a28831c525d4dee9dccac1d252a869eb" CHECKSUMTYPE="MD5" ID="w8l42" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000117.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8790f70a914efa8882d5ea8c727d2817" CHECKSUMTYPE="MD5" ID="oxzlx" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000118.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2c18c53d940290430d1901169898899b" CHECKSUMTYPE="MD5" ID="foe73" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000119.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c3ace2e17fd9aa86a45e6fe84224864a" CHECKSUMTYPE="MD5" ID="iesca" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000120.tif"/>
+</mets:file>
+<mets:file CHECKSUM="dc520e89dba513e03ba535efb49c82f1" CHECKSUMTYPE="MD5" ID="cyhg3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000121.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e88ebf84db078fc7a02efc9a2c7ea680" CHECKSUMTYPE="MD5" ID="khjsf" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000122.tif"/>
+</mets:file>
+<mets:file CHECKSUM="21298d9f6eef0594dbbaa76bf5335441" CHECKSUMTYPE="MD5" ID="evg9a" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000123.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f3d10b9e1a9a4244c35fe60e5f5ee40d" CHECKSUMTYPE="MD5" ID="k14sf" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000124.tif"/>
+</mets:file>
+<mets:file CHECKSUM="76c48ef6ac895ab2b1c89c55c62e1a35" CHECKSUMTYPE="MD5" ID="htxd3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000125.tif"/>
+</mets:file>
+<mets:file CHECKSUM="364d1783d085f4923e58ff34ba60441d" CHECKSUMTYPE="MD5" ID="rv3kd" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000126.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3768c674eb64441810512d56009df37a" CHECKSUMTYPE="MD5" ID="f5shi" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000127.tif"/>
+</mets:file>
+<mets:file CHECKSUM="90bf241f35e373c3733fe5d5c2ffae34" CHECKSUMTYPE="MD5" ID="qt0k5" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000128.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3b07fa7ccdcec92e8dc0ce93bc6c57d7" CHECKSUMTYPE="MD5" ID="n8423" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000129.tif"/>
+</mets:file>
+<mets:file CHECKSUM="eb9ceac44d0ac6c32bf3239c20da2d81" CHECKSUMTYPE="MD5" ID="ygg5u" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000130.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e850806697f8372090fa090609576bb8" CHECKSUMTYPE="MD5" ID="yfbf2" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000131.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b6837653de4ee511e0b7370081e6dc2e" CHECKSUMTYPE="MD5" ID="k2spy" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000132.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3929c1fb6b7e36b24a6624e671d1e065" CHECKSUMTYPE="MD5" ID="qgvda" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000133.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7cafca89326fb22e9e9a1da22f71cfb3" CHECKSUMTYPE="MD5" ID="rd5w4" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000134.tif"/>
+</mets:file>
+<mets:file CHECKSUM="139c09cebdde8c03e539c05075ee0efc" CHECKSUMTYPE="MD5" ID="cpm1t" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000135.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f51fa230da2aa6f658d8703e6e8d3ddf" CHECKSUMTYPE="MD5" ID="omujt" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000136.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7f4f40d8c0e1c4954b4fdbbf9e8404c2" CHECKSUMTYPE="MD5" ID="qse11" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000137.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c91a0c7225c596dbbb4f3503edc23958" CHECKSUMTYPE="MD5" ID="lxzhy" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000138.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1aea61af879deabe3e3d5555522c9abd" CHECKSUMTYPE="MD5" ID="npaje" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000139.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1c14b071e303774479e8141e926d6498" CHECKSUMTYPE="MD5" ID="jlqd2" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000140.tif"/>
+</mets:file>
+<mets:file CHECKSUM="54096b275e296b6d9c1c6f5c8e5885d0" CHECKSUMTYPE="MD5" ID="v49s0" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000141.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8065a7423a615de5750552f74706b47" CHECKSUMTYPE="MD5" ID="e5h3z" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000142.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8ecde9430c0197f02f0775ff569a6044" CHECKSUMTYPE="MD5" ID="d7u5r" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000143.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ff07f6222034b7c220dd8e8a3b275cb3" CHECKSUMTYPE="MD5" ID="qynoj" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000144.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ee587efe59b1f134a88ea0803c8d740f" CHECKSUMTYPE="MD5" ID="p3f0i" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000145.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d986822ce4fd43f6ac85f18e9a910719" CHECKSUMTYPE="MD5" ID="lt0oh" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000146.tif"/>
+</mets:file>
+<mets:file CHECKSUM="428bacc836fa868fecdd304d492a9ab7" CHECKSUMTYPE="MD5" ID="v485l" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000147.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9fe494dc3c5c7bdf3d964bd880f6140f" CHECKSUMTYPE="MD5" ID="gakux" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000148.tif"/>
+</mets:file>
+<mets:file CHECKSUM="216354ce4c9d26f2d592cfd38b376530" CHECKSUMTYPE="MD5" ID="jfgwc" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000149.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6debf8e9a29baa1b5958a75627432e7a" CHECKSUMTYPE="MD5" ID="er8bv" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000150.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6e34966ffaf70fb078eca4b1a192b8e8" CHECKSUMTYPE="MD5" ID="gor76" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000151.tif"/>
+</mets:file>
+<mets:file CHECKSUM="30f2c935e6de4e4a32a2c1253003e741" CHECKSUMTYPE="MD5" ID="bmo8c" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000152.tif"/>
+</mets:file>
+<mets:file CHECKSUM="fed0e6e2059f38da5584f261ae35b6e3" CHECKSUMTYPE="MD5" ID="thg9a" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000153.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ad6eceb70b708c88595a2526caadf355" CHECKSUMTYPE="MD5" ID="hdojr" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000154.tif"/>
+</mets:file>
+<mets:file CHECKSUM="534b24792b0e112eef4fd9670272b634" CHECKSUMTYPE="MD5" ID="f1pih" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000155.tif"/>
+</mets:file>
+<mets:file CHECKSUM="afa6129dfe51afd76d3910c46eedffec" CHECKSUMTYPE="MD5" ID="sbunq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000156.tif"/>
+</mets:file>
+<mets:file CHECKSUM="608d4696c7bca65dc55e2074099bb6ef" CHECKSUMTYPE="MD5" ID="jfuz0" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000157.tif"/>
+</mets:file>
+<mets:file CHECKSUM="baf7d49037da1a0c326591145ef27be3" CHECKSUMTYPE="MD5" ID="zo1zv" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000158.tif"/>
+</mets:file>
+<mets:file CHECKSUM="27a41910eb512de30962f10c6133dd4c" CHECKSUMTYPE="MD5" ID="nviid" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000159.tif"/>
+</mets:file>
+<mets:file CHECKSUM="120f356070833f3571dfdf356ea96cb1" CHECKSUMTYPE="MD5" ID="ajtwz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000160.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4fcdc6a5cf1ee84006a3434119a1d52b" CHECKSUMTYPE="MD5" ID="m8qf2" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000161.tif"/>
+</mets:file>
+<mets:file CHECKSUM="db9fd176fbde74ea1f298c75b0a52125" CHECKSUMTYPE="MD5" ID="et3er" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000162.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7573c04a343c17db116dc3a617da9f7f" CHECKSUMTYPE="MD5" ID="hgzay" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000163.tif"/>
+</mets:file>
+<mets:file CHECKSUM="91c69d495535f8b6ef40dcd469657223" CHECKSUMTYPE="MD5" ID="c6nh0" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000164.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e216e1addfcbf2a9d3aa8c82a59dd0f0" CHECKSUMTYPE="MD5" ID="z4yps" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000165.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7b1f68cf9f04fb2fba70cf9717806c54" CHECKSUMTYPE="MD5" ID="p8hmx" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000166.tif"/>
+</mets:file>
+<mets:file CHECKSUM="fd957431129d72b2575ee06bf67087bb" CHECKSUMTYPE="MD5" ID="t38xa" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000167.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5c76ec321b4502012f8a122230c6e3f4" CHECKSUMTYPE="MD5" ID="ewmca" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000168.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e9f9013e16a5b094b9bf917d4c7f3ae5" CHECKSUMTYPE="MD5" ID="e20ki" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000169.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c0e216d8b951e3456a57dce5845e7800" CHECKSUMTYPE="MD5" ID="pgdmj" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000170.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f2413a3e066fd97729341740f2a3caee" CHECKSUMTYPE="MD5" ID="krams" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000171.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2f8824b8f7057048acdbf6ac8c3ec3bc" CHECKSUMTYPE="MD5" ID="ljyjn" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000172.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8063b00652e820fdae2996d46c98eb9b" CHECKSUMTYPE="MD5" ID="yfpat" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000173.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a3576b53549efed06c78ded447246cbe" CHECKSUMTYPE="MD5" ID="ushd8" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000174.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ff2647ae175aa068fc98ec5ac95ffb9d" CHECKSUMTYPE="MD5" ID="evhyk" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000175.tif"/>
+</mets:file>
+<mets:file CHECKSUM="cddee8dc53586f0917c39dad0fc0b9d9" CHECKSUMTYPE="MD5" ID="m3vx1" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000176.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9d3bd16bce66fad69e3a4144832bfae" CHECKSUMTYPE="MD5" ID="dqj33" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000177.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4b090fc393363a5a1ccaa60d4a5f011b" CHECKSUMTYPE="MD5" ID="zevnb" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000178.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5af5fe9a47001be742de51c88426e2bf" CHECKSUMTYPE="MD5" ID="ipuys" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000179.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3a236ea780f5857bf2fdee45e19667b5" CHECKSUMTYPE="MD5" ID="mj5xl" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000180.tif"/>
+</mets:file>
+<mets:file CHECKSUM="88c3fa4f385adced905e67b054afdf03" CHECKSUMTYPE="MD5" ID="w8szf" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000181.tif"/>
+</mets:file>
+<mets:file CHECKSUM="82d2246c66a40cab7b14a9bb56a17ce3" CHECKSUMTYPE="MD5" ID="gfddm" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000182.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2fbe97b15c2b0378d0c1b6e7a2fd2cd0" CHECKSUMTYPE="MD5" ID="u46vg" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000183.tif"/>
+</mets:file>
+<mets:file CHECKSUM="964ff6945cd43a2613e7c97ba7c2d809" CHECKSUMTYPE="MD5" ID="ivjjk" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000184.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7c5e780070eb9b6abca1cee4f57e85da" CHECKSUMTYPE="MD5" ID="omw6y" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000185.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ffc226ad56c4b617ef1d59fce345a087" CHECKSUMTYPE="MD5" ID="yoq6k" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000186.tif"/>
+</mets:file>
+<mets:file CHECKSUM="128836e629e05d9b0cd506b99e4e55da" CHECKSUMTYPE="MD5" ID="r7kk7" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000187.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ca38771b904b0f0e69c9283d19444616" CHECKSUMTYPE="MD5" ID="ptioh" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000188.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6b7dadfa332c2bba0abab8af28ee1f83" CHECKSUMTYPE="MD5" ID="joi92" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000189.tif"/>
+</mets:file>
+<mets:file CHECKSUM="98ae1fe46949c9b581f7262be004f25a" CHECKSUMTYPE="MD5" ID="zpaiv" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000190.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ca2df2d5bcd9f5acbb4edbe05104ce42" CHECKSUMTYPE="MD5" ID="yqq07" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000191.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3224adc09a13f139bac1ddaddb89c2f3" CHECKSUMTYPE="MD5" ID="xmgq5" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000192.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a97de4bf268da21ca3e3613ba35eff2b" CHECKSUMTYPE="MD5" ID="jh7w2" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000193.tif"/>
+</mets:file>
+<mets:file CHECKSUM="39a8aae1865d27edc3dba919244917ed" CHECKSUMTYPE="MD5" ID="g1tve" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000194.tif"/>
+</mets:file>
+<mets:file CHECKSUM="56aa24270e861f868701bb75938b9614" CHECKSUMTYPE="MD5" ID="jdtaw" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000195.tif"/>
+</mets:file>
+<mets:file CHECKSUM="cc0816e2a5bc24d8220da3ebfde4eb74" CHECKSUMTYPE="MD5" ID="t8qu0" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000196.tif"/>
+</mets:file>
+<mets:file CHECKSUM="fa049c60d1959dbc13618bf84b171e84" CHECKSUMTYPE="MD5" ID="he1jr" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000197.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5996d2f1716bc8e730be2f51659e9941" CHECKSUMTYPE="MD5" ID="luhbr" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000198.tif"/>
+</mets:file>
+<mets:file CHECKSUM="204cecab77ee79e167575450243ec7aa" CHECKSUMTYPE="MD5" ID="zi46d" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000199.tif"/>
+</mets:file>
+<mets:file CHECKSUM="68c67c1768d9f71592c2de1effed1ebf" CHECKSUMTYPE="MD5" ID="nn7cn" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000200.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e1a67831a251057553b1520b62260fcc" CHECKSUMTYPE="MD5" ID="zqhb0" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000201.tif"/>
+</mets:file>
+<mets:file CHECKSUM="cde9211c6bd2f600e1d25e5da436dcf8" CHECKSUMTYPE="MD5" ID="uz3nx" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000202.tif"/>
+</mets:file>
+<mets:file CHECKSUM="68eafc024efad0f1a14aeb8648ad6f55" CHECKSUMTYPE="MD5" ID="mdk3l" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000203.tif"/>
+</mets:file>
+<mets:file CHECKSUM="aa559363b5d329d2b1ca755ca9316281" CHECKSUMTYPE="MD5" ID="wyo40" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000204.tif"/>
+</mets:file>
+<mets:file CHECKSUM="73bf6ab2852665c4ef5ef38158917861" CHECKSUMTYPE="MD5" ID="cd9nr" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000205.tif"/>
+</mets:file>
+<mets:file CHECKSUM="aed213e138486419d014febce66c1c89" CHECKSUMTYPE="MD5" ID="ay98v" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000206.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6e367542bd3759d117bdeb7e397991a1" CHECKSUMTYPE="MD5" ID="j3isb" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000207.tif"/>
+</mets:file>
+<mets:file CHECKSUM="da94bc4bef4abb94a286d61a50e35439" CHECKSUMTYPE="MD5" ID="ksq0a" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000208.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ec2510bbe9b57d6a54f1982dba337675" CHECKSUMTYPE="MD5" ID="xjqaq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000209.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b2b0c799de068063b9cd19ce02133d0f" CHECKSUMTYPE="MD5" ID="eiiqf" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000210.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5d725253e44d656cba1a12d74ca7344f" CHECKSUMTYPE="MD5" ID="hu71u" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000211.tif"/>
+</mets:file>
+<mets:file CHECKSUM="487af81f58afacac20a1aa468fd7ab6f" CHECKSUMTYPE="MD5" ID="uhxe7" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000212.tif"/>
+</mets:file>
+<mets:file CHECKSUM="82f7d07c914321830f564eb3db132d57" CHECKSUMTYPE="MD5" ID="ujeh6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000213.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7724691893708a005a661bdb3bb19d0e" CHECKSUMTYPE="MD5" ID="j70y7" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000214.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7c0196f1f53feacddde19acb769779ec" CHECKSUMTYPE="MD5" ID="scadl" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000215.tif"/>
+</mets:file>
+<mets:file CHECKSUM="12bf6862d31d470969c2828f9a68db0d" CHECKSUMTYPE="MD5" ID="mko05" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000216.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e6bcf59218b362dc7bc28cd13a381be9" CHECKSUMTYPE="MD5" ID="whria" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000217.tif"/>
+</mets:file>
+<mets:file CHECKSUM="be1fc22b8c5585df7533ee4202f26e7a" CHECKSUMTYPE="MD5" ID="yasdz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000218.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3a393d717e5e4d897e6daf62b6a5b2e0" CHECKSUMTYPE="MD5" ID="fd9jf" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000219.tif"/>
+</mets:file>
+<mets:file CHECKSUM="234099035307fea3bd83b4cd9d3f4967" CHECKSUMTYPE="MD5" ID="pt9fn" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000220.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5416981198633e378f038fedc5220d8f" CHECKSUMTYPE="MD5" ID="c22e4" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000221.tif"/>
+</mets:file>
+<mets:file CHECKSUM="59dcc99fe7d706022f7ea6dd86a727bd" CHECKSUMTYPE="MD5" ID="w819o" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000222.tif"/>
+</mets:file>
+<mets:file CHECKSUM="cf0bc21421ba64a6133122ce1bccdd09" CHECKSUMTYPE="MD5" ID="tckbr" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000223.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c91e8844ba6c1e20c4d0d9238c58ed6e" CHECKSUMTYPE="MD5" ID="lmy6e" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000224.tif"/>
+</mets:file>
+<mets:file CHECKSUM="506b7fe49e861553f27f7ab9f48c2bf9" CHECKSUMTYPE="MD5" ID="ptswy" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000225.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b7de91a276322447a8786a4344e68740" CHECKSUMTYPE="MD5" ID="dgtk6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000226.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3a9d3303316875ac1db8b33c88e6c235" CHECKSUMTYPE="MD5" ID="o2wnl" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000227.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c32b10387ea8110f3cf4954dcf351c8e" CHECKSUMTYPE="MD5" ID="pfiex" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000228.tif"/>
+</mets:file>
+<mets:file CHECKSUM="847d0c17dcf382c7945c093c5c21bd1a" CHECKSUMTYPE="MD5" ID="hy4wa" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000229.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2efbab3cabd9d4003ea7d869faed03a7" CHECKSUMTYPE="MD5" ID="k3ud6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000230.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7158089916643b1217b12a90a42869a9" CHECKSUMTYPE="MD5" ID="p8xsz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000231.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8deb892a976c355cacec94bc1020796d" CHECKSUMTYPE="MD5" ID="wjsur" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000232.tif"/>
+</mets:file>
+<mets:file CHECKSUM="566b8ea5229014581064e23979ea3a40" CHECKSUMTYPE="MD5" ID="xg2pz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000233.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6992050de948fe163505f4918a8f1589" CHECKSUMTYPE="MD5" ID="clpgh" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000234.tif"/>
+</mets:file>
+<mets:file CHECKSUM="48a826ca014193cd3e45b8a72012796d" CHECKSUMTYPE="MD5" ID="fj8s9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/scrapbooks/scrapbook_07/00000235.tif"/>
+</mets:file>
+</mets:fileGrp>
+</mets:fileSec>
+<mets:structMap TYPE="RelatedObjects">
+<mets:div DMDID="nagzi nagzi" ID="mhw19" LABEL="Default">
+<mets:div CONTENTIDS="pudl0044" TYPE="IsPartOf"/>
+<mets:div ID="aggregates" TYPE="OrderedList">
+<mets:div ID="sykjy" LABEL="image 1" ORDER="1" TYPE="Static">
+<mets:fptr FILEID="l5baq"/>
+</mets:div>
+<mets:div ID="cbxqi" LABEL="image 2" ORDER="2" TYPE="Static">
+<mets:fptr FILEID="b7zl3"/>
+</mets:div>
+<mets:div ID="n1fw8" LABEL="image 3" ORDER="3" TYPE="Static">
+<mets:fptr FILEID="x6tb4"/>
+</mets:div>
+<mets:div ID="w4j3y" LABEL="image 4" ORDER="4" TYPE="Static">
+<mets:fptr FILEID="d7rez"/>
+</mets:div>
+<mets:div ID="owf5j" LABEL="image 5" ORDER="5" TYPE="Static">
+<mets:fptr FILEID="avxb5"/>
+</mets:div>
+<mets:div ID="v9qj7" LABEL="image 6" ORDER="6" TYPE="Static">
+<mets:fptr FILEID="kji8y"/>
+</mets:div>
+<mets:div ID="k8fxn" LABEL="image 7" ORDER="7" TYPE="Static">
+<mets:fptr FILEID="qx8bu"/>
+</mets:div>
+<mets:div ID="t7ddn" LABEL="image 8" ORDER="8" TYPE="Static">
+<mets:fptr FILEID="utkd3"/>
+</mets:div>
+<mets:div ID="u1364" LABEL="image 9" ORDER="9" TYPE="Static">
+<mets:fptr FILEID="px9u1"/>
+</mets:div>
+<mets:div ID="yzr5a" LABEL="image 10" ORDER="10" TYPE="Static">
+<mets:fptr FILEID="fujgx"/>
+</mets:div>
+<mets:div ID="uzojc" LABEL="image 11" ORDER="11" TYPE="Static">
+<mets:fptr FILEID="no9dy"/>
+</mets:div>
+<mets:div ID="kegqz" LABEL="image 12" ORDER="12" TYPE="Static">
+<mets:fptr FILEID="fy2zm"/>
+</mets:div>
+<mets:div ID="o2chc" LABEL="image 13" ORDER="13" TYPE="Static">
+<mets:fptr FILEID="shc5u"/>
+</mets:div>
+<mets:div ID="oqnlp" LABEL="image 14" ORDER="14" TYPE="Static">
+<mets:fptr FILEID="kysvi"/>
+</mets:div>
+<mets:div ID="xn15y" LABEL="image 15" ORDER="15" TYPE="Static">
+<mets:fptr FILEID="t9a8m"/>
+</mets:div>
+<mets:div ID="k5rsp" LABEL="image 16" ORDER="16" TYPE="Static">
+<mets:fptr FILEID="oz7pl"/>
+</mets:div>
+<mets:div ID="abxth" LABEL="image 17" ORDER="17" TYPE="Static">
+<mets:fptr FILEID="z4dm9"/>
+</mets:div>
+<mets:div ID="hhzai" LABEL="image 18" ORDER="18" TYPE="Static">
+<mets:fptr FILEID="p3txt"/>
+</mets:div>
+<mets:div ID="yudto" LABEL="image 19" ORDER="19" TYPE="Static">
+<mets:fptr FILEID="b6g6h"/>
+</mets:div>
+<mets:div ID="ghdcn" LABEL="image 20" ORDER="20" TYPE="Static">
+<mets:fptr FILEID="lkang"/>
+</mets:div>
+<mets:div ID="aayu9" LABEL="image 21" ORDER="21" TYPE="Static">
+<mets:fptr FILEID="t9m8s"/>
+</mets:div>
+<mets:div ID="vvkq0" LABEL="image 22" ORDER="22" TYPE="Static">
+<mets:fptr FILEID="fdozy"/>
+</mets:div>
+<mets:div ID="p3lzl" LABEL="image 23" ORDER="23" TYPE="Static">
+<mets:fptr FILEID="d1yqw"/>
+</mets:div>
+<mets:div ID="im6fm" LABEL="image 24" ORDER="24" TYPE="Static">
+<mets:fptr FILEID="y9jjj"/>
+</mets:div>
+<mets:div ID="p9nkm" LABEL="image 25" ORDER="25" TYPE="Static">
+<mets:fptr FILEID="gnrbg"/>
+</mets:div>
+<mets:div ID="mkl2d" LABEL="image 26" ORDER="26" TYPE="Static">
+<mets:fptr FILEID="f3tg4"/>
+</mets:div>
+<mets:div ID="pga0h" LABEL="image 27" ORDER="27" TYPE="Static">
+<mets:fptr FILEID="scrtl"/>
+</mets:div>
+<mets:div ID="v5hu5" LABEL="image 28" ORDER="28" TYPE="Static">
+<mets:fptr FILEID="zkae8"/>
+</mets:div>
+<mets:div ID="c6ker" LABEL="image 29" ORDER="29" TYPE="Static">
+<mets:fptr FILEID="hi82a"/>
+</mets:div>
+<mets:div ID="qcf16" LABEL="image 30" ORDER="30" TYPE="Static">
+<mets:fptr FILEID="e4hwb"/>
+</mets:div>
+<mets:div ID="a2ps4" LABEL="image 31" ORDER="31" TYPE="Static">
+<mets:fptr FILEID="ick68"/>
+</mets:div>
+<mets:div ID="vs5n4" LABEL="image 32" ORDER="32" TYPE="Static">
+<mets:fptr FILEID="xno7n"/>
+</mets:div>
+<mets:div ID="nm18a" LABEL="image 33" ORDER="33" TYPE="Static">
+<mets:fptr FILEID="uir9m"/>
+</mets:div>
+<mets:div ID="gl9ta" LABEL="image 34" ORDER="34" TYPE="Static">
+<mets:fptr FILEID="gvmjb"/>
+</mets:div>
+<mets:div ID="edk0o" LABEL="image 35" ORDER="35" TYPE="Static">
+<mets:fptr FILEID="f5boc"/>
+</mets:div>
+<mets:div ID="u8eg3" LABEL="image 36" ORDER="36" TYPE="Static">
+<mets:fptr FILEID="owo44"/>
+</mets:div>
+<mets:div ID="kutli" LABEL="image 37" ORDER="37" TYPE="Static">
+<mets:fptr FILEID="npc2a"/>
+</mets:div>
+<mets:div ID="r5u54" LABEL="image 38" ORDER="38" TYPE="Static">
+<mets:fptr FILEID="y05o2"/>
+</mets:div>
+<mets:div ID="pku05" LABEL="image 39" ORDER="39" TYPE="Static">
+<mets:fptr FILEID="ilpzx"/>
+</mets:div>
+<mets:div ID="u52va" LABEL="image 40" ORDER="40" TYPE="Static">
+<mets:fptr FILEID="ayryk"/>
+</mets:div>
+<mets:div ID="in9m0" LABEL="image 41" ORDER="41" TYPE="Static">
+<mets:fptr FILEID="mnmdv"/>
+</mets:div>
+<mets:div ID="gp8hn" LABEL="image 42" ORDER="42" TYPE="Static">
+<mets:fptr FILEID="tbvw9"/>
+</mets:div>
+<mets:div ID="lskx6" LABEL="image 43" ORDER="43" TYPE="Static">
+<mets:fptr FILEID="n90tt"/>
+</mets:div>
+<mets:div ID="kyucg" LABEL="image 44" ORDER="44" TYPE="Static">
+<mets:fptr FILEID="wmky0"/>
+</mets:div>
+<mets:div ID="arj8g" LABEL="image 45" ORDER="45" TYPE="Static">
+<mets:fptr FILEID="aioqq"/>
+</mets:div>
+<mets:div ID="iutl2" LABEL="image 46" ORDER="46" TYPE="Static">
+<mets:fptr FILEID="t1gez"/>
+</mets:div>
+<mets:div ID="muz0n" LABEL="image 47" ORDER="47" TYPE="Static">
+<mets:fptr FILEID="hu1ty"/>
+</mets:div>
+<mets:div ID="cf49u" LABEL="image 48" ORDER="48" TYPE="Static">
+<mets:fptr FILEID="r530k"/>
+</mets:div>
+<mets:div ID="op9o2" LABEL="image 49" ORDER="49" TYPE="Static">
+<mets:fptr FILEID="shlfg"/>
+</mets:div>
+<mets:div ID="vnjlz" LABEL="image 50" ORDER="50" TYPE="Static">
+<mets:fptr FILEID="q4eqv"/>
+</mets:div>
+<mets:div ID="hgl8y" LABEL="image 51" ORDER="51" TYPE="Static">
+<mets:fptr FILEID="a1int"/>
+</mets:div>
+<mets:div ID="recme" LABEL="image 52" ORDER="52" TYPE="Static">
+<mets:fptr FILEID="cixxw"/>
+</mets:div>
+<mets:div ID="p41mf" LABEL="image 53" ORDER="53" TYPE="Static">
+<mets:fptr FILEID="zeagq"/>
+</mets:div>
+<mets:div ID="k91du" LABEL="image 54" ORDER="54" TYPE="Static">
+<mets:fptr FILEID="xp6se"/>
+</mets:div>
+<mets:div ID="fb2v4" LABEL="image 55" ORDER="55" TYPE="Static">
+<mets:fptr FILEID="q5pwa"/>
+</mets:div>
+<mets:div ID="r7lcr" LABEL="image 56" ORDER="56" TYPE="Static">
+<mets:fptr FILEID="lez6y"/>
+</mets:div>
+<mets:div ID="q0kmv" LABEL="image 57" ORDER="57" TYPE="Static">
+<mets:fptr FILEID="cazkp"/>
+</mets:div>
+<mets:div ID="thhyt" LABEL="image 58" ORDER="58" TYPE="Static">
+<mets:fptr FILEID="l19ce"/>
+</mets:div>
+<mets:div ID="ecuay" LABEL="image 59" ORDER="59" TYPE="Static">
+<mets:fptr FILEID="sbec1"/>
+</mets:div>
+<mets:div ID="fyjip" LABEL="image 60" ORDER="60" TYPE="Static">
+<mets:fptr FILEID="liulp"/>
+</mets:div>
+<mets:div ID="wjxxi" LABEL="image 61" ORDER="61" TYPE="Static">
+<mets:fptr FILEID="l85k7"/>
+</mets:div>
+<mets:div ID="w9ivy" LABEL="image 62" ORDER="62" TYPE="Static">
+<mets:fptr FILEID="u68l8"/>
+</mets:div>
+<mets:div ID="himb6" LABEL="image 63" ORDER="63" TYPE="Static">
+<mets:fptr FILEID="j180l"/>
+</mets:div>
+<mets:div ID="rl56n" LABEL="image 64" ORDER="64" TYPE="Static">
+<mets:fptr FILEID="zohoz"/>
+</mets:div>
+<mets:div ID="sswxt" LABEL="image 65" ORDER="65" TYPE="Static">
+<mets:fptr FILEID="kgusw"/>
+</mets:div>
+<mets:div ID="qrxl2" LABEL="image 66" ORDER="66" TYPE="Static">
+<mets:fptr FILEID="t1hbj"/>
+</mets:div>
+<mets:div ID="ycx2h" LABEL="image 67" ORDER="67" TYPE="Static">
+<mets:fptr FILEID="u9pjh"/>
+</mets:div>
+<mets:div ID="eehw6" LABEL="image 68" ORDER="68" TYPE="Static">
+<mets:fptr FILEID="hruzn"/>
+</mets:div>
+<mets:div ID="dw518" LABEL="image 69" ORDER="69" TYPE="Static">
+<mets:fptr FILEID="qs479"/>
+</mets:div>
+<mets:div ID="mkdva" LABEL="image 70" ORDER="70" TYPE="Static">
+<mets:fptr FILEID="pnv2x"/>
+</mets:div>
+<mets:div ID="pltph" LABEL="image 71" ORDER="71" TYPE="Static">
+<mets:fptr FILEID="zk9zd"/>
+</mets:div>
+<mets:div ID="j1cvw" LABEL="image 72" ORDER="72" TYPE="Static">
+<mets:fptr FILEID="b6asb"/>
+</mets:div>
+<mets:div ID="qf1ob" LABEL="image 73" ORDER="73" TYPE="Static">
+<mets:fptr FILEID="qyd9w"/>
+</mets:div>
+<mets:div ID="aewm1" LABEL="image 74" ORDER="74" TYPE="Static">
+<mets:fptr FILEID="c5g3p"/>
+</mets:div>
+<mets:div ID="rqc26" LABEL="image 75" ORDER="75" TYPE="Static">
+<mets:fptr FILEID="dd3jp"/>
+</mets:div>
+<mets:div ID="ev1er" LABEL="image 76" ORDER="76" TYPE="Static">
+<mets:fptr FILEID="geyd4"/>
+</mets:div>
+<mets:div ID="tvt27" LABEL="image 77" ORDER="77" TYPE="Static">
+<mets:fptr FILEID="nuysl"/>
+</mets:div>
+<mets:div ID="t5l1n" LABEL="image 78" ORDER="78" TYPE="Static">
+<mets:fptr FILEID="wyi47"/>
+</mets:div>
+<mets:div ID="haa02" LABEL="image 79" ORDER="79" TYPE="Static">
+<mets:fptr FILEID="v1jwi"/>
+</mets:div>
+<mets:div ID="efisi" LABEL="image 80" ORDER="80" TYPE="Static">
+<mets:fptr FILEID="le4jg"/>
+</mets:div>
+<mets:div ID="vpzrr" LABEL="image 81" ORDER="81" TYPE="Static">
+<mets:fptr FILEID="u6e51"/>
+</mets:div>
+<mets:div ID="ehatt" LABEL="image 82" ORDER="82" TYPE="Static">
+<mets:fptr FILEID="h2yh5"/>
+</mets:div>
+<mets:div ID="z6y5m" LABEL="image 83" ORDER="83" TYPE="Static">
+<mets:fptr FILEID="sfkqu"/>
+</mets:div>
+<mets:div ID="flpvw" LABEL="image 84" ORDER="84" TYPE="Static">
+<mets:fptr FILEID="eb68m"/>
+</mets:div>
+<mets:div ID="iliu1" LABEL="image 85" ORDER="85" TYPE="Static">
+<mets:fptr FILEID="ba7pj"/>
+</mets:div>
+<mets:div ID="dqhxr" LABEL="image 86" ORDER="86" TYPE="Static">
+<mets:fptr FILEID="gmrzp"/>
+</mets:div>
+<mets:div ID="jgfhk" LABEL="image 87" ORDER="87" TYPE="Static">
+<mets:fptr FILEID="yvmh8"/>
+</mets:div>
+<mets:div ID="uq6o2" LABEL="image 88" ORDER="88" TYPE="Static">
+<mets:fptr FILEID="y6nyp"/>
+</mets:div>
+<mets:div ID="olnqo" LABEL="image 89" ORDER="89" TYPE="Static">
+<mets:fptr FILEID="ow1zi"/>
+</mets:div>
+<mets:div ID="xy5zt" LABEL="image 90" ORDER="90" TYPE="Static">
+<mets:fptr FILEID="bkg58"/>
+</mets:div>
+<mets:div ID="nc219" LABEL="image 91" ORDER="91" TYPE="Static">
+<mets:fptr FILEID="d856l"/>
+</mets:div>
+<mets:div ID="atr03" LABEL="image 92" ORDER="92" TYPE="Static">
+<mets:fptr FILEID="aragj"/>
+</mets:div>
+<mets:div ID="gav7t" LABEL="image 93" ORDER="93" TYPE="Static">
+<mets:fptr FILEID="c7ca7"/>
+</mets:div>
+<mets:div ID="veolr" LABEL="image 94" ORDER="94" TYPE="Static">
+<mets:fptr FILEID="charw"/>
+</mets:div>
+<mets:div ID="n60g1" LABEL="image 95" ORDER="95" TYPE="Static">
+<mets:fptr FILEID="crsxc"/>
+</mets:div>
+<mets:div ID="zgatv" LABEL="image 96" ORDER="96" TYPE="Static">
+<mets:fptr FILEID="r9y6g"/>
+</mets:div>
+<mets:div ID="fi9q0" LABEL="image 97" ORDER="97" TYPE="Static">
+<mets:fptr FILEID="itq91"/>
+</mets:div>
+<mets:div ID="gl85m" LABEL="image 98" ORDER="98" TYPE="Static">
+<mets:fptr FILEID="xnxhm"/>
+</mets:div>
+<mets:div ID="y9axw" LABEL="image 99" ORDER="99" TYPE="Static">
+<mets:fptr FILEID="vzziq"/>
+</mets:div>
+<mets:div ID="die6j" LABEL="image 100" ORDER="100" TYPE="Static">
+<mets:fptr FILEID="jmgdg"/>
+</mets:div>
+<mets:div ID="zfnk1" LABEL="image 101" ORDER="101" TYPE="Static">
+<mets:fptr FILEID="p2qk7"/>
+</mets:div>
+<mets:div ID="urzlb" LABEL="image 102" ORDER="102" TYPE="Static">
+<mets:fptr FILEID="hvz24"/>
+</mets:div>
+<mets:div ID="p2wv9" LABEL="image 103" ORDER="103" TYPE="Static">
+<mets:fptr FILEID="ull2i"/>
+</mets:div>
+<mets:div ID="eyfiw" LABEL="image 104" ORDER="104" TYPE="Static">
+<mets:fptr FILEID="cpn5w"/>
+</mets:div>
+<mets:div ID="h2ebp" LABEL="image 105" ORDER="105" TYPE="Static">
+<mets:fptr FILEID="xsa6f"/>
+</mets:div>
+<mets:div ID="ci4rb" LABEL="image 106" ORDER="106" TYPE="Static">
+<mets:fptr FILEID="zhprw"/>
+</mets:div>
+<mets:div ID="v5gfq" LABEL="image 107" ORDER="107" TYPE="Static">
+<mets:fptr FILEID="rf115"/>
+</mets:div>
+<mets:div ID="uatu9" LABEL="image 108" ORDER="108" TYPE="Static">
+<mets:fptr FILEID="cc019"/>
+</mets:div>
+<mets:div ID="sx1d4" LABEL="image 109" ORDER="109" TYPE="Static">
+<mets:fptr FILEID="knl23"/>
+</mets:div>
+<mets:div ID="t0t9r" LABEL="image 110" ORDER="110" TYPE="Static">
+<mets:fptr FILEID="yk3nf"/>
+</mets:div>
+<mets:div ID="veadx" LABEL="image 111" ORDER="111" TYPE="Static">
+<mets:fptr FILEID="k6h3b"/>
+</mets:div>
+<mets:div ID="i5adj" LABEL="image 112" ORDER="112" TYPE="Static">
+<mets:fptr FILEID="pu2re"/>
+</mets:div>
+<mets:div ID="afrun" LABEL="image 113" ORDER="113" TYPE="Static">
+<mets:fptr FILEID="zodsq"/>
+</mets:div>
+<mets:div ID="tzplb" LABEL="image 114" ORDER="114" TYPE="Static">
+<mets:fptr FILEID="f8gf6"/>
+</mets:div>
+<mets:div ID="alvvv" LABEL="image 115" ORDER="115" TYPE="Static">
+<mets:fptr FILEID="bu548"/>
+</mets:div>
+<mets:div ID="ru6vg" LABEL="image 116" ORDER="116" TYPE="Static">
+<mets:fptr FILEID="e8mee"/>
+</mets:div>
+<mets:div ID="jkx11" LABEL="image 117" ORDER="117" TYPE="Static">
+<mets:fptr FILEID="hjan6"/>
+</mets:div>
+<mets:div ID="g7p6x" LABEL="image 118" ORDER="118" TYPE="Static">
+<mets:fptr FILEID="tobgg"/>
+</mets:div>
+<mets:div ID="ky4sk" LABEL="image 119" ORDER="119" TYPE="Static">
+<mets:fptr FILEID="zuoqn"/>
+</mets:div>
+<mets:div ID="h68ef" LABEL="image 120" ORDER="120" TYPE="Static">
+<mets:fptr FILEID="rlb1z"/>
+</mets:div>
+<mets:div ID="c1bf4" LABEL="image 121" ORDER="121" TYPE="Static">
+<mets:fptr FILEID="brwmw"/>
+</mets:div>
+<mets:div ID="w7otl" LABEL="image 122" ORDER="122" TYPE="Static">
+<mets:fptr FILEID="zwylh"/>
+</mets:div>
+<mets:div ID="mx6xg" LABEL="image 123" ORDER="123" TYPE="Static">
+<mets:fptr FILEID="ivnzm"/>
+</mets:div>
+<mets:div ID="ux82c" LABEL="image 124" ORDER="124" TYPE="Static">
+<mets:fptr FILEID="yn3bj"/>
+</mets:div>
+<mets:div ID="zckpa" LABEL="image 125" ORDER="125" TYPE="Static">
+<mets:fptr FILEID="cistq"/>
+</mets:div>
+<mets:div ID="v7d0c" LABEL="image 126" ORDER="126" TYPE="Static">
+<mets:fptr FILEID="faekk"/>
+</mets:div>
+<mets:div ID="fjl3d" LABEL="image 127" ORDER="127" TYPE="Static">
+<mets:fptr FILEID="x3kaz"/>
+</mets:div>
+<mets:div ID="t00lm" LABEL="image 128" ORDER="128" TYPE="Static">
+<mets:fptr FILEID="f5crn"/>
+</mets:div>
+<mets:div ID="md9mx" LABEL="image 129" ORDER="129" TYPE="Static">
+<mets:fptr FILEID="hv0zw"/>
+</mets:div>
+<mets:div ID="vqluu" LABEL="image 130" ORDER="130" TYPE="Static">
+<mets:fptr FILEID="gmhd5"/>
+</mets:div>
+<mets:div ID="rqjiv" LABEL="image 131" ORDER="131" TYPE="Static">
+<mets:fptr FILEID="jzwgk"/>
+</mets:div>
+<mets:div ID="nk8za" LABEL="image 132" ORDER="132" TYPE="Static">
+<mets:fptr FILEID="nss32"/>
+</mets:div>
+<mets:div ID="iaojt" LABEL="image 133" ORDER="133" TYPE="Static">
+<mets:fptr FILEID="e1ev8"/>
+</mets:div>
+<mets:div ID="mhwk1" LABEL="image 134" ORDER="134" TYPE="Static">
+<mets:fptr FILEID="uze97"/>
+</mets:div>
+<mets:div ID="p877a" LABEL="image 135" ORDER="135" TYPE="Static">
+<mets:fptr FILEID="gkc4z"/>
+</mets:div>
+<mets:div ID="bp8ku" LABEL="image 136" ORDER="136" TYPE="Static">
+<mets:fptr FILEID="ycc7i"/>
+</mets:div>
+<mets:div ID="tsat7" LABEL="image 1" ORDER="137" TYPE="Static">
+<mets:fptr FILEID="gbw01"/>
+</mets:div>
+<mets:div ID="irfp1" LABEL="image 2" ORDER="138" TYPE="Static">
+<mets:fptr FILEID="nmsij"/>
+</mets:div>
+<mets:div ID="p0cv4" LABEL="image 3" ORDER="139" TYPE="Static">
+<mets:fptr FILEID="vzbuy"/>
+</mets:div>
+<mets:div ID="zf7wd" LABEL="image 4" ORDER="140" TYPE="Static">
+<mets:fptr FILEID="uessr"/>
+</mets:div>
+<mets:div ID="paeu9" LABEL="image 5" ORDER="141" TYPE="Static">
+<mets:fptr FILEID="sc6n7"/>
+</mets:div>
+<mets:div ID="ajwjw" LABEL="image 6" ORDER="142" TYPE="Static">
+<mets:fptr FILEID="y77dv"/>
+</mets:div>
+<mets:div ID="wfl1u" LABEL="image 7" ORDER="143" TYPE="Static">
+<mets:fptr FILEID="ey6xg"/>
+</mets:div>
+<mets:div ID="ss7pn" LABEL="image 8" ORDER="144" TYPE="Static">
+<mets:fptr FILEID="ytgv2"/>
+</mets:div>
+<mets:div ID="h4e0a" LABEL="image 9" ORDER="145" TYPE="Static">
+<mets:fptr FILEID="p6m1g"/>
+</mets:div>
+<mets:div ID="lgybd" LABEL="image 10" ORDER="146" TYPE="Static">
+<mets:fptr FILEID="pksi3"/>
+</mets:div>
+<mets:div ID="y0sfp" LABEL="image 11" ORDER="147" TYPE="Static">
+<mets:fptr FILEID="y766a"/>
+</mets:div>
+<mets:div ID="gc9pv" LABEL="image 12" ORDER="148" TYPE="Static">
+<mets:fptr FILEID="yv4sv"/>
+</mets:div>
+<mets:div ID="hyjk1" LABEL="image 13" ORDER="149" TYPE="Static">
+<mets:fptr FILEID="a0yrw"/>
+</mets:div>
+<mets:div ID="fnz0j" LABEL="image 14" ORDER="150" TYPE="Static">
+<mets:fptr FILEID="xc1c6"/>
+</mets:div>
+<mets:div ID="u89py" LABEL="image 15" ORDER="151" TYPE="Static">
+<mets:fptr FILEID="kk92r"/>
+</mets:div>
+<mets:div ID="njfzm" LABEL="image 16" ORDER="152" TYPE="Static">
+<mets:fptr FILEID="jr55e"/>
+</mets:div>
+<mets:div ID="o8iem" LABEL="image 17" ORDER="153" TYPE="Static">
+<mets:fptr FILEID="ll9fu"/>
+</mets:div>
+<mets:div ID="pnqbt" LABEL="image 18" ORDER="154" TYPE="Static">
+<mets:fptr FILEID="st3j2"/>
+</mets:div>
+<mets:div ID="o3m0k" LABEL="image 19" ORDER="155" TYPE="Static">
+<mets:fptr FILEID="mglo7"/>
+</mets:div>
+<mets:div ID="ve6iv" LABEL="image 20" ORDER="156" TYPE="Static">
+<mets:fptr FILEID="x613p"/>
+</mets:div>
+<mets:div ID="fszny" LABEL="image 21" ORDER="157" TYPE="Static">
+<mets:fptr FILEID="l5mqk"/>
+</mets:div>
+<mets:div ID="q3ds5" LABEL="image 22" ORDER="158" TYPE="Static">
+<mets:fptr FILEID="hstfn"/>
+</mets:div>
+<mets:div ID="zcqvj" LABEL="image 23" ORDER="159" TYPE="Static">
+<mets:fptr FILEID="omvdz"/>
+</mets:div>
+<mets:div ID="ganh3" LABEL="image 24" ORDER="160" TYPE="Static">
+<mets:fptr FILEID="gj6lz"/>
+</mets:div>
+<mets:div ID="q4y66" LABEL="image 25" ORDER="161" TYPE="Static">
+<mets:fptr FILEID="zdvyi"/>
+</mets:div>
+<mets:div ID="u3ure" LABEL="image 26" ORDER="162" TYPE="Static">
+<mets:fptr FILEID="jj7kw"/>
+</mets:div>
+<mets:div ID="uowtc" LABEL="image 27" ORDER="163" TYPE="Static">
+<mets:fptr FILEID="vadp6"/>
+</mets:div>
+<mets:div ID="gvs3f" LABEL="image 28" ORDER="164" TYPE="Static">
+<mets:fptr FILEID="g1ja2"/>
+</mets:div>
+<mets:div ID="c3q6o" LABEL="image 29" ORDER="165" TYPE="Static">
+<mets:fptr FILEID="dsfnb"/>
+</mets:div>
+<mets:div ID="ngg4n" LABEL="image 30" ORDER="166" TYPE="Static">
+<mets:fptr FILEID="i1o1x"/>
+</mets:div>
+<mets:div ID="e761t" LABEL="image 31" ORDER="167" TYPE="Static">
+<mets:fptr FILEID="zdj6t"/>
+</mets:div>
+<mets:div ID="st2cv" LABEL="image 32" ORDER="168" TYPE="Static">
+<mets:fptr FILEID="sldpu"/>
+</mets:div>
+<mets:div ID="ugsrn" LABEL="image 33" ORDER="169" TYPE="Static">
+<mets:fptr FILEID="o6kby"/>
+</mets:div>
+<mets:div ID="cncsn" LABEL="image 34" ORDER="170" TYPE="Static">
+<mets:fptr FILEID="pzq3d"/>
+</mets:div>
+<mets:div ID="xkscj" LABEL="image 35" ORDER="171" TYPE="Static">
+<mets:fptr FILEID="p5d50"/>
+</mets:div>
+<mets:div ID="lqx6u" LABEL="image 36" ORDER="172" TYPE="Static">
+<mets:fptr FILEID="fa3o8"/>
+</mets:div>
+<mets:div ID="yeuwh" LABEL="image 37" ORDER="173" TYPE="Static">
+<mets:fptr FILEID="h5lsi"/>
+</mets:div>
+<mets:div ID="g9t9l" LABEL="image 38" ORDER="174" TYPE="Static">
+<mets:fptr FILEID="w35tq"/>
+</mets:div>
+<mets:div ID="gtgi4" LABEL="image 39" ORDER="175" TYPE="Static">
+<mets:fptr FILEID="wff2e"/>
+</mets:div>
+<mets:div ID="lxp0t" LABEL="image 40" ORDER="176" TYPE="Static">
+<mets:fptr FILEID="zvrun"/>
+</mets:div>
+<mets:div ID="d4ml4" LABEL="image 41" ORDER="177" TYPE="Static">
+<mets:fptr FILEID="tbg6m"/>
+</mets:div>
+<mets:div ID="xpb0o" LABEL="image 42" ORDER="178" TYPE="Static">
+<mets:fptr FILEID="lqszf"/>
+</mets:div>
+<mets:div ID="r89ok" LABEL="image 43" ORDER="179" TYPE="Static">
+<mets:fptr FILEID="erre9"/>
+</mets:div>
+<mets:div ID="qsxeb" LABEL="image 44" ORDER="180" TYPE="Static">
+<mets:fptr FILEID="vt6zp"/>
+</mets:div>
+<mets:div ID="nqaaw" LABEL="image 45" ORDER="181" TYPE="Static">
+<mets:fptr FILEID="mlgzw"/>
+</mets:div>
+<mets:div ID="afde5" LABEL="image 46" ORDER="182" TYPE="Static">
+<mets:fptr FILEID="z0uxp"/>
+</mets:div>
+<mets:div ID="rr3zl" LABEL="image 47" ORDER="183" TYPE="Static">
+<mets:fptr FILEID="e8yob"/>
+</mets:div>
+<mets:div ID="qnruc" LABEL="image 48" ORDER="184" TYPE="Static">
+<mets:fptr FILEID="zoq1z"/>
+</mets:div>
+<mets:div ID="a2zuw" LABEL="image 49" ORDER="185" TYPE="Static">
+<mets:fptr FILEID="jkgp6"/>
+</mets:div>
+<mets:div ID="jikq9" LABEL="image 50" ORDER="186" TYPE="Static">
+<mets:fptr FILEID="f8a7y"/>
+</mets:div>
+<mets:div ID="bte36" LABEL="image 51" ORDER="187" TYPE="Static">
+<mets:fptr FILEID="vzjv5"/>
+</mets:div>
+<mets:div ID="rhd4n" LABEL="image 52" ORDER="188" TYPE="Static">
+<mets:fptr FILEID="cwj2o"/>
+</mets:div>
+<mets:div ID="ijggi" LABEL="image 53" ORDER="189" TYPE="Static">
+<mets:fptr FILEID="i0mso"/>
+</mets:div>
+<mets:div ID="onhg2" LABEL="image 54" ORDER="190" TYPE="Static">
+<mets:fptr FILEID="ca7oe"/>
+</mets:div>
+<mets:div ID="ruclt" LABEL="image 55" ORDER="191" TYPE="Static">
+<mets:fptr FILEID="r2d8z"/>
+</mets:div>
+<mets:div ID="k6ofu" LABEL="image 56" ORDER="192" TYPE="Static">
+<mets:fptr FILEID="z1tr9"/>
+</mets:div>
+<mets:div ID="xti6e" LABEL="image 57" ORDER="193" TYPE="Static">
+<mets:fptr FILEID="j6gen"/>
+</mets:div>
+<mets:div ID="i0yqe" LABEL="image 58" ORDER="194" TYPE="Static">
+<mets:fptr FILEID="xln4i"/>
+</mets:div>
+<mets:div ID="rqld6" LABEL="image 59" ORDER="195" TYPE="Static">
+<mets:fptr FILEID="vn9l5"/>
+</mets:div>
+<mets:div ID="cb8hi" LABEL="image 60" ORDER="196" TYPE="Static">
+<mets:fptr FILEID="t1gc0"/>
+</mets:div>
+<mets:div ID="y3j0j" LABEL="image 61" ORDER="197" TYPE="Static">
+<mets:fptr FILEID="xnyc5"/>
+</mets:div>
+<mets:div ID="nlndx" LABEL="image 62" ORDER="198" TYPE="Static">
+<mets:fptr FILEID="g4cnz"/>
+</mets:div>
+<mets:div ID="xeq84" LABEL="image 63" ORDER="199" TYPE="Static">
+<mets:fptr FILEID="i8m2c"/>
+</mets:div>
+<mets:div ID="qbw3p" LABEL="image 64" ORDER="200" TYPE="Static">
+<mets:fptr FILEID="aisvb"/>
+</mets:div>
+<mets:div ID="qv4sf" LABEL="image 65" ORDER="201" TYPE="Static">
+<mets:fptr FILEID="pdd45"/>
+</mets:div>
+<mets:div ID="c6dju" LABEL="image 66" ORDER="202" TYPE="Static">
+<mets:fptr FILEID="byq68"/>
+</mets:div>
+<mets:div ID="nx4qr" LABEL="image 67" ORDER="203" TYPE="Static">
+<mets:fptr FILEID="sdqg6"/>
+</mets:div>
+<mets:div ID="ei55u" LABEL="image 68" ORDER="204" TYPE="Static">
+<mets:fptr FILEID="e2kbq"/>
+</mets:div>
+<mets:div ID="bwdlo" LABEL="image 69" ORDER="205" TYPE="Static">
+<mets:fptr FILEID="ym1mf"/>
+</mets:div>
+<mets:div ID="laij2" LABEL="image 70" ORDER="206" TYPE="Static">
+<mets:fptr FILEID="xpanh"/>
+</mets:div>
+<mets:div ID="or8wr" LABEL="image 71" ORDER="207" TYPE="Static">
+<mets:fptr FILEID="d7ne5"/>
+</mets:div>
+<mets:div ID="d44ed" LABEL="image 72" ORDER="208" TYPE="Static">
+<mets:fptr FILEID="s5yaa"/>
+</mets:div>
+<mets:div ID="dvtf2" LABEL="image 73" ORDER="209" TYPE="Static">
+<mets:fptr FILEID="zdkxu"/>
+</mets:div>
+<mets:div ID="mleby" LABEL="image 74" ORDER="210" TYPE="Static">
+<mets:fptr FILEID="scqf7"/>
+</mets:div>
+<mets:div ID="adbb5" LABEL="image 75" ORDER="211" TYPE="Static">
+<mets:fptr FILEID="vdzak"/>
+</mets:div>
+<mets:div ID="jdadl" LABEL="image 76" ORDER="212" TYPE="Static">
+<mets:fptr FILEID="gjlie"/>
+</mets:div>
+<mets:div ID="r5cwq" LABEL="image 77" ORDER="213" TYPE="Static">
+<mets:fptr FILEID="hqsxz"/>
+</mets:div>
+<mets:div ID="fbuhr" LABEL="image 78" ORDER="214" TYPE="Static">
+<mets:fptr FILEID="hqqcu"/>
+</mets:div>
+<mets:div ID="x3gje" LABEL="image 79" ORDER="215" TYPE="Static">
+<mets:fptr FILEID="xfa6r"/>
+</mets:div>
+<mets:div ID="hbx43" LABEL="image 80" ORDER="216" TYPE="Static">
+<mets:fptr FILEID="rstpt"/>
+</mets:div>
+<mets:div ID="r2uhe" LABEL="image 81" ORDER="217" TYPE="Static">
+<mets:fptr FILEID="ubcs8"/>
+</mets:div>
+<mets:div ID="aqgeq" LABEL="image 82" ORDER="218" TYPE="Static">
+<mets:fptr FILEID="svn96"/>
+</mets:div>
+<mets:div ID="as6hg" LABEL="image 83" ORDER="219" TYPE="Static">
+<mets:fptr FILEID="o4cys"/>
+</mets:div>
+<mets:div ID="ayl56" LABEL="image 84" ORDER="220" TYPE="Static">
+<mets:fptr FILEID="l5yu1"/>
+</mets:div>
+<mets:div ID="utrxl" LABEL="image 85" ORDER="221" TYPE="Static">
+<mets:fptr FILEID="xv323"/>
+</mets:div>
+<mets:div ID="qznhb" LABEL="image 86" ORDER="222" TYPE="Static">
+<mets:fptr FILEID="imzjt"/>
+</mets:div>
+<mets:div ID="up5w4" LABEL="image 87" ORDER="223" TYPE="Static">
+<mets:fptr FILEID="kholk"/>
+</mets:div>
+<mets:div ID="jrlk2" LABEL="image 88" ORDER="224" TYPE="Static">
+<mets:fptr FILEID="rqh5x"/>
+</mets:div>
+<mets:div ID="b1fh5" LABEL="image 89" ORDER="225" TYPE="Static">
+<mets:fptr FILEID="owvra"/>
+</mets:div>
+<mets:div ID="bk2o3" LABEL="image 90" ORDER="226" TYPE="Static">
+<mets:fptr FILEID="t73z8"/>
+</mets:div>
+<mets:div ID="hlivx" LABEL="image 91" ORDER="227" TYPE="Static">
+<mets:fptr FILEID="u1hx1"/>
+</mets:div>
+<mets:div ID="pih6o" LABEL="image 92" ORDER="228" TYPE="Static">
+<mets:fptr FILEID="a4dnn"/>
+</mets:div>
+<mets:div ID="i55us" LABEL="image 93" ORDER="229" TYPE="Static">
+<mets:fptr FILEID="irbal"/>
+</mets:div>
+<mets:div ID="vv1m3" LABEL="image 94" ORDER="230" TYPE="Static">
+<mets:fptr FILEID="t5roh"/>
+</mets:div>
+<mets:div ID="u2aph" LABEL="image 95" ORDER="231" TYPE="Static">
+<mets:fptr FILEID="a9glf"/>
+</mets:div>
+<mets:div ID="dj0kq" LABEL="image 96" ORDER="232" TYPE="Static">
+<mets:fptr FILEID="zyahj"/>
+</mets:div>
+<mets:div ID="y4mht" LABEL="image 97" ORDER="233" TYPE="Static">
+<mets:fptr FILEID="yw0hr"/>
+</mets:div>
+<mets:div ID="ndxf0" LABEL="image 98" ORDER="234" TYPE="Static">
+<mets:fptr FILEID="v6tzx"/>
+</mets:div>
+<mets:div ID="x613s" LABEL="image 99" ORDER="235" TYPE="Static">
+<mets:fptr FILEID="vvj31"/>
+</mets:div>
+<mets:div ID="tfh8w" LABEL="image 100" ORDER="236" TYPE="Static">
+<mets:fptr FILEID="zt1z1"/>
+</mets:div>
+<mets:div ID="axl2z" LABEL="image 101" ORDER="237" TYPE="Static">
+<mets:fptr FILEID="anj9n"/>
+</mets:div>
+<mets:div ID="wcjqn" LABEL="image 102" ORDER="238" TYPE="Static">
+<mets:fptr FILEID="yra7f"/>
+</mets:div>
+<mets:div ID="eqkh3" LABEL="image 103" ORDER="239" TYPE="Static">
+<mets:fptr FILEID="v5rlk"/>
+</mets:div>
+<mets:div ID="ksg2v" LABEL="image 104" ORDER="240" TYPE="Static">
+<mets:fptr FILEID="w16r2"/>
+</mets:div>
+<mets:div ID="osesi" LABEL="image 105" ORDER="241" TYPE="Static">
+<mets:fptr FILEID="hjddo"/>
+</mets:div>
+<mets:div ID="whh25" LABEL="image 106" ORDER="242" TYPE="Static">
+<mets:fptr FILEID="vnysn"/>
+</mets:div>
+<mets:div ID="rqoci" LABEL="image 107" ORDER="243" TYPE="Static">
+<mets:fptr FILEID="u1z1k"/>
+</mets:div>
+<mets:div ID="ys8jm" LABEL="image 108" ORDER="244" TYPE="Static">
+<mets:fptr FILEID="ygg14"/>
+</mets:div>
+<mets:div ID="rbk9f" LABEL="image 109" ORDER="245" TYPE="Static">
+<mets:fptr FILEID="yotr5"/>
+</mets:div>
+<mets:div ID="da60t" LABEL="image 110" ORDER="246" TYPE="Static">
+<mets:fptr FILEID="clkeo"/>
+</mets:div>
+<mets:div ID="ybypf" LABEL="image 111" ORDER="247" TYPE="Static">
+<mets:fptr FILEID="cvyv5"/>
+</mets:div>
+<mets:div ID="hq71l" LABEL="image 112" ORDER="248" TYPE="Static">
+<mets:fptr FILEID="c3ohx"/>
+</mets:div>
+<mets:div ID="plwgm" LABEL="image 113" ORDER="249" TYPE="Static">
+<mets:fptr FILEID="buqgu"/>
+</mets:div>
+<mets:div ID="epkeu" LABEL="image 114" ORDER="250" TYPE="Static">
+<mets:fptr FILEID="ggrpe"/>
+</mets:div>
+<mets:div ID="nf3ks" LABEL="image 115" ORDER="251" TYPE="Static">
+<mets:fptr FILEID="gvk7z"/>
+</mets:div>
+<mets:div ID="hd6xg" LABEL="image 116" ORDER="252" TYPE="Static">
+<mets:fptr FILEID="x26y3"/>
+</mets:div>
+<mets:div ID="m5dqf" LABEL="image 117" ORDER="253" TYPE="Static">
+<mets:fptr FILEID="reuys"/>
+</mets:div>
+<mets:div ID="w29zw" LABEL="image 118" ORDER="254" TYPE="Static">
+<mets:fptr FILEID="mr2cf"/>
+</mets:div>
+<mets:div ID="cwj59" LABEL="image 119" ORDER="255" TYPE="Static">
+<mets:fptr FILEID="yy2up"/>
+</mets:div>
+<mets:div ID="p6gj2" LABEL="image 120" ORDER="256" TYPE="Static">
+<mets:fptr FILEID="l2132"/>
+</mets:div>
+<mets:div ID="kzbrn" LABEL="image 121" ORDER="257" TYPE="Static">
+<mets:fptr FILEID="qerhs"/>
+</mets:div>
+<mets:div ID="w0wwv" LABEL="image 122" ORDER="258" TYPE="Static">
+<mets:fptr FILEID="dfd89"/>
+</mets:div>
+<mets:div ID="atg7l" LABEL="image 123" ORDER="259" TYPE="Static">
+<mets:fptr FILEID="nad7m"/>
+</mets:div>
+<mets:div ID="ohwlk" LABEL="image 124" ORDER="260" TYPE="Static">
+<mets:fptr FILEID="yim2w"/>
+</mets:div>
+<mets:div ID="wyubh" LABEL="image 125" ORDER="261" TYPE="Static">
+<mets:fptr FILEID="iylx4"/>
+</mets:div>
+<mets:div ID="qojve" LABEL="image 126" ORDER="262" TYPE="Static">
+<mets:fptr FILEID="nag3e"/>
+</mets:div>
+<mets:div ID="tahjr" LABEL="image 127" ORDER="263" TYPE="Static">
+<mets:fptr FILEID="jhio2"/>
+</mets:div>
+<mets:div ID="z8dcw" LABEL="image 128" ORDER="264" TYPE="Static">
+<mets:fptr FILEID="sdun3"/>
+</mets:div>
+<mets:div ID="w4r67" LABEL="image 129" ORDER="265" TYPE="Static">
+<mets:fptr FILEID="ajto8"/>
+</mets:div>
+<mets:div ID="l8w3z" LABEL="image 130" ORDER="266" TYPE="Static">
+<mets:fptr FILEID="ggrib"/>
+</mets:div>
+<mets:div ID="ww5l7" LABEL="image 131" ORDER="267" TYPE="Static">
+<mets:fptr FILEID="q40sl"/>
+</mets:div>
+<mets:div ID="ujvxw" LABEL="image 132" ORDER="268" TYPE="Static">
+<mets:fptr FILEID="nz7ra"/>
+</mets:div>
+<mets:div ID="ypfe8" LABEL="image 133" ORDER="269" TYPE="Static">
+<mets:fptr FILEID="flfya"/>
+</mets:div>
+<mets:div ID="b1ei1" LABEL="image 134" ORDER="270" TYPE="Static">
+<mets:fptr FILEID="pn8ht"/>
+</mets:div>
+<mets:div ID="wyjjg" LABEL="image 135" ORDER="271" TYPE="Static">
+<mets:fptr FILEID="flzoo"/>
+</mets:div>
+<mets:div ID="jepon" LABEL="image 136" ORDER="272" TYPE="Static">
+<mets:fptr FILEID="ilv71"/>
+</mets:div>
+<mets:div ID="gn44e" LABEL="image 137" ORDER="273" TYPE="Static">
+<mets:fptr FILEID="k60at"/>
+</mets:div>
+<mets:div ID="rlfib" LABEL="image 1" ORDER="274" TYPE="Static">
+<mets:fptr FILEID="v8a82"/>
+</mets:div>
+<mets:div ID="qwevd" LABEL="image 2" ORDER="275" TYPE="Static">
+<mets:fptr FILEID="rf6zl"/>
+</mets:div>
+<mets:div ID="thn8p" LABEL="image 3" ORDER="276" TYPE="Static">
+<mets:fptr FILEID="msgw3"/>
+</mets:div>
+<mets:div ID="hb2bf" LABEL="image 4" ORDER="277" TYPE="Static">
+<mets:fptr FILEID="q90z9"/>
+</mets:div>
+<mets:div ID="u1dsc" LABEL="image 5" ORDER="278" TYPE="Static">
+<mets:fptr FILEID="rphap"/>
+</mets:div>
+<mets:div ID="y0wkt" LABEL="image 6" ORDER="279" TYPE="Static">
+<mets:fptr FILEID="sae8v"/>
+</mets:div>
+<mets:div ID="vyq5w" LABEL="image 7" ORDER="280" TYPE="Static">
+<mets:fptr FILEID="na812"/>
+</mets:div>
+<mets:div ID="aifr1" LABEL="image 8" ORDER="281" TYPE="Static">
+<mets:fptr FILEID="tt15e"/>
+</mets:div>
+<mets:div ID="vfmvn" LABEL="image 9" ORDER="282" TYPE="Static">
+<mets:fptr FILEID="i6ijp"/>
+</mets:div>
+<mets:div ID="kn09h" LABEL="image 10" ORDER="283" TYPE="Static">
+<mets:fptr FILEID="addcz"/>
+</mets:div>
+<mets:div ID="e1dcn" LABEL="image 11" ORDER="284" TYPE="Static">
+<mets:fptr FILEID="pq6u7"/>
+</mets:div>
+<mets:div ID="kgoag" LABEL="image 12" ORDER="285" TYPE="Static">
+<mets:fptr FILEID="kmm4w"/>
+</mets:div>
+<mets:div ID="c521h" LABEL="image 13" ORDER="286" TYPE="Static">
+<mets:fptr FILEID="jeznt"/>
+</mets:div>
+<mets:div ID="bg9wr" LABEL="image 14" ORDER="287" TYPE="Static">
+<mets:fptr FILEID="it3aw"/>
+</mets:div>
+<mets:div ID="ij0df" LABEL="image 15" ORDER="288" TYPE="Static">
+<mets:fptr FILEID="jqadt"/>
+</mets:div>
+<mets:div ID="j8tas" LABEL="image 16" ORDER="289" TYPE="Static">
+<mets:fptr FILEID="q1ltt"/>
+</mets:div>
+<mets:div ID="hc90s" LABEL="image 17" ORDER="290" TYPE="Static">
+<mets:fptr FILEID="mgp2i"/>
+</mets:div>
+<mets:div ID="rd98e" LABEL="image 18" ORDER="291" TYPE="Static">
+<mets:fptr FILEID="k9wp3"/>
+</mets:div>
+<mets:div ID="fn8wd" LABEL="image 19" ORDER="292" TYPE="Static">
+<mets:fptr FILEID="eg9ti"/>
+</mets:div>
+<mets:div ID="fqp0p" LABEL="image 20" ORDER="293" TYPE="Static">
+<mets:fptr FILEID="sdpla"/>
+</mets:div>
+<mets:div ID="k5fa4" LABEL="image 21" ORDER="294" TYPE="Static">
+<mets:fptr FILEID="hcsg3"/>
+</mets:div>
+<mets:div ID="t7d3i" LABEL="image 22" ORDER="295" TYPE="Static">
+<mets:fptr FILEID="e6vm7"/>
+</mets:div>
+<mets:div ID="vzr79" LABEL="image 23" ORDER="296" TYPE="Static">
+<mets:fptr FILEID="hrylu"/>
+</mets:div>
+<mets:div ID="irpyo" LABEL="image 24" ORDER="297" TYPE="Static">
+<mets:fptr FILEID="e2ngf"/>
+</mets:div>
+<mets:div ID="kmi02" LABEL="image 25" ORDER="298" TYPE="Static">
+<mets:fptr FILEID="yafgs"/>
+</mets:div>
+<mets:div ID="wuy0a" LABEL="image 26" ORDER="299" TYPE="Static">
+<mets:fptr FILEID="oiccp"/>
+</mets:div>
+<mets:div ID="xkidn" LABEL="image 27" ORDER="300" TYPE="Static">
+<mets:fptr FILEID="x553l"/>
+</mets:div>
+<mets:div ID="l7ga5" LABEL="image 28" ORDER="301" TYPE="Static">
+<mets:fptr FILEID="sakj7"/>
+</mets:div>
+<mets:div ID="epc3q" LABEL="image 29" ORDER="302" TYPE="Static">
+<mets:fptr FILEID="fk967"/>
+</mets:div>
+<mets:div ID="hifum" LABEL="image 30" ORDER="303" TYPE="Static">
+<mets:fptr FILEID="ezaho"/>
+</mets:div>
+<mets:div ID="utrit" LABEL="image 31" ORDER="304" TYPE="Static">
+<mets:fptr FILEID="k4kj8"/>
+</mets:div>
+<mets:div ID="eytow" LABEL="image 32" ORDER="305" TYPE="Static">
+<mets:fptr FILEID="d0xo9"/>
+</mets:div>
+<mets:div ID="dcciy" LABEL="image 33" ORDER="306" TYPE="Static">
+<mets:fptr FILEID="n1g65"/>
+</mets:div>
+<mets:div ID="ozfa8" LABEL="image 34" ORDER="307" TYPE="Static">
+<mets:fptr FILEID="sbxsa"/>
+</mets:div>
+<mets:div ID="k7r0x" LABEL="image 35" ORDER="308" TYPE="Static">
+<mets:fptr FILEID="yrxbt"/>
+</mets:div>
+<mets:div ID="gy2oe" LABEL="image 36" ORDER="309" TYPE="Static">
+<mets:fptr FILEID="m3dwo"/>
+</mets:div>
+<mets:div ID="a3jhq" LABEL="image 37" ORDER="310" TYPE="Static">
+<mets:fptr FILEID="oiw85"/>
+</mets:div>
+<mets:div ID="ap2dp" LABEL="image 38" ORDER="311" TYPE="Static">
+<mets:fptr FILEID="c2xvy"/>
+</mets:div>
+<mets:div ID="jsn7e" LABEL="image 39" ORDER="312" TYPE="Static">
+<mets:fptr FILEID="xkgya"/>
+</mets:div>
+<mets:div ID="cmxhw" LABEL="image 40" ORDER="313" TYPE="Static">
+<mets:fptr FILEID="k56b0"/>
+</mets:div>
+<mets:div ID="v1csv" LABEL="image 41" ORDER="314" TYPE="Static">
+<mets:fptr FILEID="np848"/>
+</mets:div>
+<mets:div ID="voknv" LABEL="image 42" ORDER="315" TYPE="Static">
+<mets:fptr FILEID="btxon"/>
+</mets:div>
+<mets:div ID="xbg1k" LABEL="image 43" ORDER="316" TYPE="Static">
+<mets:fptr FILEID="zgua9"/>
+</mets:div>
+<mets:div ID="oi6u8" LABEL="image 44" ORDER="317" TYPE="Static">
+<mets:fptr FILEID="i9w2q"/>
+</mets:div>
+<mets:div ID="u728z" LABEL="image 45" ORDER="318" TYPE="Static">
+<mets:fptr FILEID="cdn97"/>
+</mets:div>
+<mets:div ID="m9b8m" LABEL="image 46" ORDER="319" TYPE="Static">
+<mets:fptr FILEID="cyk5m"/>
+</mets:div>
+<mets:div ID="d952m" LABEL="image 47" ORDER="320" TYPE="Static">
+<mets:fptr FILEID="msgcu"/>
+</mets:div>
+<mets:div ID="q850s" LABEL="image 48" ORDER="321" TYPE="Static">
+<mets:fptr FILEID="h7g54"/>
+</mets:div>
+<mets:div ID="jr20h" LABEL="image 49" ORDER="322" TYPE="Static">
+<mets:fptr FILEID="h7wff"/>
+</mets:div>
+<mets:div ID="i27j8" LABEL="image 50" ORDER="323" TYPE="Static">
+<mets:fptr FILEID="a2j6w"/>
+</mets:div>
+<mets:div ID="ki541" LABEL="image 51" ORDER="324" TYPE="Static">
+<mets:fptr FILEID="lc0gq"/>
+</mets:div>
+<mets:div ID="bgipo" LABEL="image 52" ORDER="325" TYPE="Static">
+<mets:fptr FILEID="mpuzm"/>
+</mets:div>
+<mets:div ID="tdflz" LABEL="image 53" ORDER="326" TYPE="Static">
+<mets:fptr FILEID="c43f8"/>
+</mets:div>
+<mets:div ID="a159m" LABEL="image 54" ORDER="327" TYPE="Static">
+<mets:fptr FILEID="hqors"/>
+</mets:div>
+<mets:div ID="hoic4" LABEL="image 55" ORDER="328" TYPE="Static">
+<mets:fptr FILEID="pwz0y"/>
+</mets:div>
+<mets:div ID="hkum0" LABEL="image 56" ORDER="329" TYPE="Static">
+<mets:fptr FILEID="jpfw9"/>
+</mets:div>
+<mets:div ID="lw0y4" LABEL="image 57" ORDER="330" TYPE="Static">
+<mets:fptr FILEID="xxu34"/>
+</mets:div>
+<mets:div ID="h17hr" LABEL="image 58" ORDER="331" TYPE="Static">
+<mets:fptr FILEID="cj88e"/>
+</mets:div>
+<mets:div ID="wmav3" LABEL="image 59" ORDER="332" TYPE="Static">
+<mets:fptr FILEID="edhjy"/>
+</mets:div>
+<mets:div ID="lgymc" LABEL="image 60" ORDER="333" TYPE="Static">
+<mets:fptr FILEID="wovmb"/>
+</mets:div>
+<mets:div ID="gm28g" LABEL="image 61" ORDER="334" TYPE="Static">
+<mets:fptr FILEID="wdw0w"/>
+</mets:div>
+<mets:div ID="kn3r9" LABEL="image 62" ORDER="335" TYPE="Static">
+<mets:fptr FILEID="xftm6"/>
+</mets:div>
+<mets:div ID="hqvy6" LABEL="image 63" ORDER="336" TYPE="Static">
+<mets:fptr FILEID="jem8q"/>
+</mets:div>
+<mets:div ID="xfxgm" LABEL="image 64" ORDER="337" TYPE="Static">
+<mets:fptr FILEID="euvrk"/>
+</mets:div>
+<mets:div ID="pjon9" LABEL="image 65" ORDER="338" TYPE="Static">
+<mets:fptr FILEID="jo42w"/>
+</mets:div>
+<mets:div ID="n6t8p" LABEL="image 66" ORDER="339" TYPE="Static">
+<mets:fptr FILEID="ddcxk"/>
+</mets:div>
+<mets:div ID="ybw60" LABEL="image 67" ORDER="340" TYPE="Static">
+<mets:fptr FILEID="ol623"/>
+</mets:div>
+<mets:div ID="h78sx" LABEL="image 68" ORDER="341" TYPE="Static">
+<mets:fptr FILEID="pgzme"/>
+</mets:div>
+<mets:div ID="uqky1" LABEL="image 69" ORDER="342" TYPE="Static">
+<mets:fptr FILEID="c42ke"/>
+</mets:div>
+<mets:div ID="kbok2" LABEL="image 70" ORDER="343" TYPE="Static">
+<mets:fptr FILEID="b5gpt"/>
+</mets:div>
+<mets:div ID="xv5jy" LABEL="image 71" ORDER="344" TYPE="Static">
+<mets:fptr FILEID="p8p2e"/>
+</mets:div>
+<mets:div ID="wxkah" LABEL="image 72" ORDER="345" TYPE="Static">
+<mets:fptr FILEID="p05ft"/>
+</mets:div>
+<mets:div ID="fvl64" LABEL="image 73" ORDER="346" TYPE="Static">
+<mets:fptr FILEID="s9gmi"/>
+</mets:div>
+<mets:div ID="spl3i" LABEL="image 74" ORDER="347" TYPE="Static">
+<mets:fptr FILEID="rqsvs"/>
+</mets:div>
+<mets:div ID="y69kw" LABEL="image 75" ORDER="348" TYPE="Static">
+<mets:fptr FILEID="qysu4"/>
+</mets:div>
+<mets:div ID="ia91j" LABEL="image 76" ORDER="349" TYPE="Static">
+<mets:fptr FILEID="k58hg"/>
+</mets:div>
+<mets:div ID="c193h" LABEL="image 77" ORDER="350" TYPE="Static">
+<mets:fptr FILEID="q52s0"/>
+</mets:div>
+<mets:div ID="j2daq" LABEL="image 78" ORDER="351" TYPE="Static">
+<mets:fptr FILEID="r2l7i"/>
+</mets:div>
+<mets:div ID="mlbp0" LABEL="image 79" ORDER="352" TYPE="Static">
+<mets:fptr FILEID="liqys"/>
+</mets:div>
+<mets:div ID="j639v" LABEL="image 80" ORDER="353" TYPE="Static">
+<mets:fptr FILEID="mp1np"/>
+</mets:div>
+<mets:div ID="ypetu" LABEL="image 81" ORDER="354" TYPE="Static">
+<mets:fptr FILEID="hmam0"/>
+</mets:div>
+<mets:div ID="xvpvb" LABEL="image 82" ORDER="355" TYPE="Static">
+<mets:fptr FILEID="mu9ue"/>
+</mets:div>
+<mets:div ID="en7k3" LABEL="image 83" ORDER="356" TYPE="Static">
+<mets:fptr FILEID="fsr8g"/>
+</mets:div>
+<mets:div ID="epq9u" LABEL="image 84" ORDER="357" TYPE="Static">
+<mets:fptr FILEID="mh9il"/>
+</mets:div>
+<mets:div ID="ihash" LABEL="image 85" ORDER="358" TYPE="Static">
+<mets:fptr FILEID="ph9o0"/>
+</mets:div>
+<mets:div ID="kntog" LABEL="image 86" ORDER="359" TYPE="Static">
+<mets:fptr FILEID="s0tzp"/>
+</mets:div>
+<mets:div ID="zybkp" LABEL="image 87" ORDER="360" TYPE="Static">
+<mets:fptr FILEID="fgwqb"/>
+</mets:div>
+<mets:div ID="dswtv" LABEL="image 88" ORDER="361" TYPE="Static">
+<mets:fptr FILEID="r91qd"/>
+</mets:div>
+<mets:div ID="t2cdz" LABEL="image 89" ORDER="362" TYPE="Static">
+<mets:fptr FILEID="hqbdd"/>
+</mets:div>
+<mets:div ID="qlgc8" LABEL="image 90" ORDER="363" TYPE="Static">
+<mets:fptr FILEID="j2vyn"/>
+</mets:div>
+<mets:div ID="m6o0u" LABEL="image 91" ORDER="364" TYPE="Static">
+<mets:fptr FILEID="x0sww"/>
+</mets:div>
+<mets:div ID="f07x7" LABEL="image 92" ORDER="365" TYPE="Static">
+<mets:fptr FILEID="muvut"/>
+</mets:div>
+<mets:div ID="fdauu" LABEL="image 93" ORDER="366" TYPE="Static">
+<mets:fptr FILEID="qkept"/>
+</mets:div>
+<mets:div ID="ntkuq" LABEL="image 94" ORDER="367" TYPE="Static">
+<mets:fptr FILEID="l6su7"/>
+</mets:div>
+<mets:div ID="sdcc0" LABEL="image 95" ORDER="368" TYPE="Static">
+<mets:fptr FILEID="v3o0d"/>
+</mets:div>
+<mets:div ID="u2unj" LABEL="image 96" ORDER="369" TYPE="Static">
+<mets:fptr FILEID="ypnf1"/>
+</mets:div>
+<mets:div ID="z6fsk" LABEL="image 97" ORDER="370" TYPE="Static">
+<mets:fptr FILEID="icr4e"/>
+</mets:div>
+<mets:div ID="b6zrv" LABEL="image 98" ORDER="371" TYPE="Static">
+<mets:fptr FILEID="u9a0j"/>
+</mets:div>
+<mets:div ID="ldr2t" LABEL="image 99" ORDER="372" TYPE="Static">
+<mets:fptr FILEID="bagdc"/>
+</mets:div>
+<mets:div ID="aw4ga" LABEL="image 100" ORDER="373" TYPE="Static">
+<mets:fptr FILEID="y2r1y"/>
+</mets:div>
+<mets:div ID="s38og" LABEL="image 101" ORDER="374" TYPE="Static">
+<mets:fptr FILEID="j7f6y"/>
+</mets:div>
+<mets:div ID="qiqwo" LABEL="image 102" ORDER="375" TYPE="Static">
+<mets:fptr FILEID="z6rzx"/>
+</mets:div>
+<mets:div ID="tggm0" LABEL="image 103" ORDER="376" TYPE="Static">
+<mets:fptr FILEID="rofj9"/>
+</mets:div>
+<mets:div ID="ia2ca" LABEL="image 104" ORDER="377" TYPE="Static">
+<mets:fptr FILEID="hohj1"/>
+</mets:div>
+<mets:div ID="zd19t" LABEL="image 105" ORDER="378" TYPE="Static">
+<mets:fptr FILEID="livvw"/>
+</mets:div>
+<mets:div ID="mrel2" LABEL="image 106" ORDER="379" TYPE="Static">
+<mets:fptr FILEID="jy4la"/>
+</mets:div>
+<mets:div ID="erz7p" LABEL="image 107" ORDER="380" TYPE="Static">
+<mets:fptr FILEID="f3u75"/>
+</mets:div>
+<mets:div ID="etv8x" LABEL="image 108" ORDER="381" TYPE="Static">
+<mets:fptr FILEID="ftxer"/>
+</mets:div>
+<mets:div ID="pjz3y" LABEL="image 109" ORDER="382" TYPE="Static">
+<mets:fptr FILEID="d3z6p"/>
+</mets:div>
+<mets:div ID="jfz2z" LABEL="image 110" ORDER="383" TYPE="Static">
+<mets:fptr FILEID="u3m5u"/>
+</mets:div>
+<mets:div ID="p6yfb" LABEL="image 111" ORDER="384" TYPE="Static">
+<mets:fptr FILEID="k215o"/>
+</mets:div>
+<mets:div ID="vfsv6" LABEL="image 112" ORDER="385" TYPE="Static">
+<mets:fptr FILEID="f0sim"/>
+</mets:div>
+<mets:div ID="eohnz" LABEL="image 113" ORDER="386" TYPE="Static">
+<mets:fptr FILEID="wqfwg"/>
+</mets:div>
+<mets:div ID="uxfps" LABEL="image 114" ORDER="387" TYPE="Static">
+<mets:fptr FILEID="zzj9h"/>
+</mets:div>
+<mets:div ID="j5ayz" LABEL="image 115" ORDER="388" TYPE="Static">
+<mets:fptr FILEID="f77v3"/>
+</mets:div>
+<mets:div ID="sgnp3" LABEL="image 116" ORDER="389" TYPE="Static">
+<mets:fptr FILEID="qlqti"/>
+</mets:div>
+<mets:div ID="v5ooc" LABEL="image 117" ORDER="390" TYPE="Static">
+<mets:fptr FILEID="valzj"/>
+</mets:div>
+<mets:div ID="yiip6" LABEL="image 118" ORDER="391" TYPE="Static">
+<mets:fptr FILEID="r4d2z"/>
+</mets:div>
+<mets:div ID="dqsqk" LABEL="image 119" ORDER="392" TYPE="Static">
+<mets:fptr FILEID="tcmhj"/>
+</mets:div>
+<mets:div ID="w29tl" LABEL="image 120" ORDER="393" TYPE="Static">
+<mets:fptr FILEID="j4k24"/>
+</mets:div>
+<mets:div ID="svcki" LABEL="image 121" ORDER="394" TYPE="Static">
+<mets:fptr FILEID="ecn91"/>
+</mets:div>
+<mets:div ID="vhtpn" LABEL="image 122" ORDER="395" TYPE="Static">
+<mets:fptr FILEID="x3qo9"/>
+</mets:div>
+<mets:div ID="tka8e" LABEL="image 123" ORDER="396" TYPE="Static">
+<mets:fptr FILEID="uzt4f"/>
+</mets:div>
+<mets:div ID="re28h" LABEL="image 124" ORDER="397" TYPE="Static">
+<mets:fptr FILEID="frxra"/>
+</mets:div>
+<mets:div ID="x9awf" LABEL="image 125" ORDER="398" TYPE="Static">
+<mets:fptr FILEID="vc74u"/>
+</mets:div>
+<mets:div ID="nn4ys" LABEL="image 126" ORDER="399" TYPE="Static">
+<mets:fptr FILEID="waq1u"/>
+</mets:div>
+<mets:div ID="dpthl" LABEL="image 127" ORDER="400" TYPE="Static">
+<mets:fptr FILEID="wbrp1"/>
+</mets:div>
+<mets:div ID="u8t6n" LABEL="image 128" ORDER="401" TYPE="Static">
+<mets:fptr FILEID="ablkt"/>
+</mets:div>
+<mets:div ID="ikem3" LABEL="image 129" ORDER="402" TYPE="Static">
+<mets:fptr FILEID="d959w"/>
+</mets:div>
+<mets:div ID="kqhc2" LABEL="image 130" ORDER="403" TYPE="Static">
+<mets:fptr FILEID="vow3a"/>
+</mets:div>
+<mets:div ID="c83pl" LABEL="image 131" ORDER="404" TYPE="Static">
+<mets:fptr FILEID="d6qle"/>
+</mets:div>
+<mets:div ID="dyywb" LABEL="image 132" ORDER="405" TYPE="Static">
+<mets:fptr FILEID="vklm5"/>
+</mets:div>
+<mets:div ID="alsqj" LABEL="image 133" ORDER="406" TYPE="Static">
+<mets:fptr FILEID="bfqit"/>
+</mets:div>
+<mets:div ID="jlsl3" LABEL="image 134" ORDER="407" TYPE="Static">
+<mets:fptr FILEID="vx5ox"/>
+</mets:div>
+<mets:div ID="p344w" LABEL="image 135" ORDER="408" TYPE="Static">
+<mets:fptr FILEID="cntk1"/>
+</mets:div>
+<mets:div ID="m62d6" LABEL="image 136" ORDER="409" TYPE="Static">
+<mets:fptr FILEID="ofvd3"/>
+</mets:div>
+<mets:div ID="hiwov" LABEL="image 137" ORDER="410" TYPE="Static">
+<mets:fptr FILEID="lg46u"/>
+</mets:div>
+<mets:div ID="f27k7" LABEL="image 138" ORDER="411" TYPE="Static">
+<mets:fptr FILEID="g0br0"/>
+</mets:div>
+<mets:div ID="nqazd" LABEL="image 139" ORDER="412" TYPE="Static">
+<mets:fptr FILEID="mfobf"/>
+</mets:div>
+<mets:div ID="n2bbv" LABEL="image 140" ORDER="413" TYPE="Static">
+<mets:fptr FILEID="khw76"/>
+</mets:div>
+<mets:div ID="kwwos" LABEL="image 141" ORDER="414" TYPE="Static">
+<mets:fptr FILEID="k17e9"/>
+</mets:div>
+<mets:div ID="fmevh" LABEL="image 142" ORDER="415" TYPE="Static">
+<mets:fptr FILEID="uny9n"/>
+</mets:div>
+<mets:div ID="xlqnt" LABEL="image 143" ORDER="416" TYPE="Static">
+<mets:fptr FILEID="uyww5"/>
+</mets:div>
+<mets:div ID="gnuzj" LABEL="image 144" ORDER="417" TYPE="Static">
+<mets:fptr FILEID="tf461"/>
+</mets:div>
+<mets:div ID="nmb68" LABEL="image 145" ORDER="418" TYPE="Static">
+<mets:fptr FILEID="nwufz"/>
+</mets:div>
+<mets:div ID="pwply" LABEL="image 146" ORDER="419" TYPE="Static">
+<mets:fptr FILEID="y7xj9"/>
+</mets:div>
+<mets:div ID="x1iy6" LABEL="image 147" ORDER="420" TYPE="Static">
+<mets:fptr FILEID="st4yo"/>
+</mets:div>
+<mets:div ID="neip3" LABEL="image 148" ORDER="421" TYPE="Static">
+<mets:fptr FILEID="g5sem"/>
+</mets:div>
+<mets:div ID="ws15r" LABEL="image 149" ORDER="422" TYPE="Static">
+<mets:fptr FILEID="mxzg7"/>
+</mets:div>
+<mets:div ID="kaeoh" LABEL="image 150" ORDER="423" TYPE="Static">
+<mets:fptr FILEID="xut8u"/>
+</mets:div>
+<mets:div ID="cgjcl" LABEL="image 151" ORDER="424" TYPE="Static">
+<mets:fptr FILEID="syhcf"/>
+</mets:div>
+<mets:div ID="agkbf" LABEL="image 152" ORDER="425" TYPE="Static">
+<mets:fptr FILEID="g0cyu"/>
+</mets:div>
+<mets:div ID="ysnbi" LABEL="image 153" ORDER="426" TYPE="Static">
+<mets:fptr FILEID="lfevo"/>
+</mets:div>
+<mets:div ID="tmefj" LABEL="image 154" ORDER="427" TYPE="Static">
+<mets:fptr FILEID="je1hs"/>
+</mets:div>
+<mets:div ID="h4i6h" LABEL="image 155" ORDER="428" TYPE="Static">
+<mets:fptr FILEID="y1dxx"/>
+</mets:div>
+<mets:div ID="nvvia" LABEL="image 156" ORDER="429" TYPE="Static">
+<mets:fptr FILEID="lll96"/>
+</mets:div>
+<mets:div ID="c09zt" LABEL="image 157" ORDER="430" TYPE="Static">
+<mets:fptr FILEID="zmqge"/>
+</mets:div>
+<mets:div ID="nx4s3" LABEL="image 158" ORDER="431" TYPE="Static">
+<mets:fptr FILEID="jl8fl"/>
+</mets:div>
+<mets:div ID="krs5c" LABEL="image 159" ORDER="432" TYPE="Static">
+<mets:fptr FILEID="wrf2o"/>
+</mets:div>
+<mets:div ID="k5npm" LABEL="image 160" ORDER="433" TYPE="Static">
+<mets:fptr FILEID="d64fn"/>
+</mets:div>
+<mets:div ID="l2b92" LABEL="image 161" ORDER="434" TYPE="Static">
+<mets:fptr FILEID="ov5v9"/>
+</mets:div>
+<mets:div ID="dnfrm" LABEL="image 162" ORDER="435" TYPE="Static">
+<mets:fptr FILEID="wgmk6"/>
+</mets:div>
+<mets:div ID="g97va" LABEL="image 163" ORDER="436" TYPE="Static">
+<mets:fptr FILEID="delsa"/>
+</mets:div>
+<mets:div ID="rk37b" LABEL="image 164" ORDER="437" TYPE="Static">
+<mets:fptr FILEID="gugru"/>
+</mets:div>
+<mets:div ID="mmbxu" LABEL="image 165" ORDER="438" TYPE="Static">
+<mets:fptr FILEID="ylshw"/>
+</mets:div>
+<mets:div ID="fx317" LABEL="image 166" ORDER="439" TYPE="Static">
+<mets:fptr FILEID="m6fnq"/>
+</mets:div>
+<mets:div ID="efhhv" LABEL="image 167" ORDER="440" TYPE="Static">
+<mets:fptr FILEID="b1ww7"/>
+</mets:div>
+<mets:div ID="lw8x9" LABEL="image 168" ORDER="441" TYPE="Static">
+<mets:fptr FILEID="ljz80"/>
+</mets:div>
+<mets:div ID="hbvg4" LABEL="image 169" ORDER="442" TYPE="Static">
+<mets:fptr FILEID="hrk7z"/>
+</mets:div>
+<mets:div ID="dhod6" LABEL="image 170" ORDER="443" TYPE="Static">
+<mets:fptr FILEID="j81nz"/>
+</mets:div>
+<mets:div ID="bmyb7" LABEL="image 171" ORDER="444" TYPE="Static">
+<mets:fptr FILEID="mro4g"/>
+</mets:div>
+<mets:div ID="r6ppr" LABEL="image 172" ORDER="445" TYPE="Static">
+<mets:fptr FILEID="kltin"/>
+</mets:div>
+<mets:div ID="kdxxm" LABEL="image 173" ORDER="446" TYPE="Static">
+<mets:fptr FILEID="y5a89"/>
+</mets:div>
+<mets:div ID="ed4y4" LABEL="image 174" ORDER="447" TYPE="Static">
+<mets:fptr FILEID="b86dc"/>
+</mets:div>
+<mets:div ID="eu8vp" LABEL="image 175" ORDER="448" TYPE="Static">
+<mets:fptr FILEID="q1szc"/>
+</mets:div>
+<mets:div ID="q1b44" LABEL="image 176" ORDER="449" TYPE="Static">
+<mets:fptr FILEID="d26fb"/>
+</mets:div>
+<mets:div ID="pvoht" LABEL="image 177" ORDER="450" TYPE="Static">
+<mets:fptr FILEID="bqf06"/>
+</mets:div>
+<mets:div ID="pw3mk" LABEL="image 178" ORDER="451" TYPE="Static">
+<mets:fptr FILEID="d0301"/>
+</mets:div>
+<mets:div ID="o7fxa" LABEL="image 179" ORDER="452" TYPE="Static">
+<mets:fptr FILEID="s2d2j"/>
+</mets:div>
+<mets:div ID="mzg0m" LABEL="image 180" ORDER="453" TYPE="Static">
+<mets:fptr FILEID="bt4wx"/>
+</mets:div>
+<mets:div ID="ff9fy" LABEL="image 181" ORDER="454" TYPE="Static">
+<mets:fptr FILEID="c9wkq"/>
+</mets:div>
+<mets:div ID="s678u" LABEL="image 182" ORDER="455" TYPE="Static">
+<mets:fptr FILEID="hepla"/>
+</mets:div>
+<mets:div ID="e7vz9" LABEL="image 183" ORDER="456" TYPE="Static">
+<mets:fptr FILEID="sgwme"/>
+</mets:div>
+<mets:div ID="dbdqz" LABEL="image 184" ORDER="457" TYPE="Static">
+<mets:fptr FILEID="bwjr6"/>
+</mets:div>
+<mets:div ID="lhwwt" LABEL="image 185" ORDER="458" TYPE="Static">
+<mets:fptr FILEID="e3bbr"/>
+</mets:div>
+<mets:div ID="vn32g" LABEL="image 186" ORDER="459" TYPE="Static">
+<mets:fptr FILEID="i7vxv"/>
+</mets:div>
+<mets:div ID="l1ub2" LABEL="image 187" ORDER="460" TYPE="Static">
+<mets:fptr FILEID="iun5g"/>
+</mets:div>
+<mets:div ID="xayky" LABEL="image 188" ORDER="461" TYPE="Static">
+<mets:fptr FILEID="tsq5t"/>
+</mets:div>
+<mets:div ID="obfyf" LABEL="image 189" ORDER="462" TYPE="Static">
+<mets:fptr FILEID="wcgvm"/>
+</mets:div>
+<mets:div ID="p590u" LABEL="image 190" ORDER="463" TYPE="Static">
+<mets:fptr FILEID="j9qcw"/>
+</mets:div>
+<mets:div ID="y6k05" LABEL="image 191" ORDER="464" TYPE="Static">
+<mets:fptr FILEID="e50nk"/>
+</mets:div>
+<mets:div ID="s5u3t" LABEL="image 192" ORDER="465" TYPE="Static">
+<mets:fptr FILEID="vplvg"/>
+</mets:div>
+<mets:div ID="qzohd" LABEL="image 193" ORDER="466" TYPE="Static">
+<mets:fptr FILEID="oeg72"/>
+</mets:div>
+<mets:div ID="q16z4" LABEL="image 194" ORDER="467" TYPE="Static">
+<mets:fptr FILEID="hvvhq"/>
+</mets:div>
+<mets:div ID="qzd0d" LABEL="image 195" ORDER="468" TYPE="Static">
+<mets:fptr FILEID="t8l8z"/>
+</mets:div>
+<mets:div ID="qstiu" LABEL="image 196" ORDER="469" TYPE="Static">
+<mets:fptr FILEID="f8dyi"/>
+</mets:div>
+<mets:div ID="ca01p" LABEL="image 197" ORDER="470" TYPE="Static">
+<mets:fptr FILEID="fflxv"/>
+</mets:div>
+<mets:div ID="c1d2k" LABEL="image 198" ORDER="471" TYPE="Static">
+<mets:fptr FILEID="kpoyk"/>
+</mets:div>
+<mets:div ID="y578j" LABEL="image 199" ORDER="472" TYPE="Static">
+<mets:fptr FILEID="yf81i"/>
+</mets:div>
+<mets:div ID="mh4l3" LABEL="image 200" ORDER="473" TYPE="Static">
+<mets:fptr FILEID="vv8gg"/>
+</mets:div>
+<mets:div ID="dncl1" LABEL="image 201" ORDER="474" TYPE="Static">
+<mets:fptr FILEID="x432s"/>
+</mets:div>
+<mets:div ID="qduvd" LABEL="image 202" ORDER="475" TYPE="Static">
+<mets:fptr FILEID="g7fbr"/>
+</mets:div>
+<mets:div ID="jofhb" LABEL="image 203" ORDER="476" TYPE="Static">
+<mets:fptr FILEID="t5091"/>
+</mets:div>
+<mets:div ID="xtpzf" LABEL="image 204" ORDER="477" TYPE="Static">
+<mets:fptr FILEID="fx3mf"/>
+</mets:div>
+<mets:div ID="nqonp" LABEL="image 205" ORDER="478" TYPE="Static">
+<mets:fptr FILEID="zqfsx"/>
+</mets:div>
+<mets:div ID="k5z2t" LABEL="image 206" ORDER="479" TYPE="Static">
+<mets:fptr FILEID="m4pwy"/>
+</mets:div>
+<mets:div ID="k4yc3" LABEL="image 207" ORDER="480" TYPE="Static">
+<mets:fptr FILEID="fjpe1"/>
+</mets:div>
+<mets:div ID="fddww" LABEL="image 208" ORDER="481" TYPE="Static">
+<mets:fptr FILEID="vty53"/>
+</mets:div>
+<mets:div ID="t5wlz" LABEL="image 209" ORDER="482" TYPE="Static">
+<mets:fptr FILEID="kukwl"/>
+</mets:div>
+<mets:div ID="iceh8" LABEL="image 210" ORDER="483" TYPE="Static">
+<mets:fptr FILEID="xo04e"/>
+</mets:div>
+<mets:div ID="equvs" LABEL="image 211" ORDER="484" TYPE="Static">
+<mets:fptr FILEID="m2v63"/>
+</mets:div>
+<mets:div ID="ty0vp" LABEL="image 212" ORDER="485" TYPE="Static">
+<mets:fptr FILEID="zl6fi"/>
+</mets:div>
+<mets:div ID="jpohd" LABEL="image 213" ORDER="486" TYPE="Static">
+<mets:fptr FILEID="x3sdg"/>
+</mets:div>
+<mets:div ID="o7760" LABEL="image 214" ORDER="487" TYPE="Static">
+<mets:fptr FILEID="ykwee"/>
+</mets:div>
+<mets:div ID="bjbei" LABEL="image 215" ORDER="488" TYPE="Static">
+<mets:fptr FILEID="jlwyi"/>
+</mets:div>
+<mets:div ID="emtkb" LABEL="image 216" ORDER="489" TYPE="Static">
+<mets:fptr FILEID="bgjq9"/>
+</mets:div>
+<mets:div ID="shlg0" LABEL="image 217" ORDER="490" TYPE="Static">
+<mets:fptr FILEID="icbda"/>
+</mets:div>
+<mets:div ID="eq88u" LABEL="image 218" ORDER="491" TYPE="Static">
+<mets:fptr FILEID="z2t4z"/>
+</mets:div>
+<mets:div ID="uv06l" LABEL="image 219" ORDER="492" TYPE="Static">
+<mets:fptr FILEID="c2dic"/>
+</mets:div>
+<mets:div ID="jwrym" LABEL="image 220" ORDER="493" TYPE="Static">
+<mets:fptr FILEID="kmtlu"/>
+</mets:div>
+<mets:div ID="clsbq" LABEL="image 221" ORDER="494" TYPE="Static">
+<mets:fptr FILEID="l04hq"/>
+</mets:div>
+<mets:div ID="apedz" LABEL="image 222" ORDER="495" TYPE="Static">
+<mets:fptr FILEID="ksbop"/>
+</mets:div>
+<mets:div ID="jwt54" LABEL="image 223" ORDER="496" TYPE="Static">
+<mets:fptr FILEID="njtkd"/>
+</mets:div>
+<mets:div ID="an496" LABEL="image 224" ORDER="497" TYPE="Static">
+<mets:fptr FILEID="zg7r3"/>
+</mets:div>
+<mets:div ID="xwwpt" LABEL="image 225" ORDER="498" TYPE="Static">
+<mets:fptr FILEID="mb6u3"/>
+</mets:div>
+<mets:div ID="d34gm" LABEL="image 226" ORDER="499" TYPE="Static">
+<mets:fptr FILEID="tkoln"/>
+</mets:div>
+<mets:div ID="e4krf" LABEL="image 227" ORDER="500" TYPE="Static">
+<mets:fptr FILEID="jepo2"/>
+</mets:div>
+<mets:div ID="wfux4" LABEL="image 228" ORDER="501" TYPE="Static">
+<mets:fptr FILEID="dbvpd"/>
+</mets:div>
+<mets:div ID="dbdho" LABEL="image 229" ORDER="502" TYPE="Static">
+<mets:fptr FILEID="pfs81"/>
+</mets:div>
+<mets:div ID="izodi" LABEL="image 230" ORDER="503" TYPE="Static">
+<mets:fptr FILEID="m35oz"/>
+</mets:div>
+<mets:div ID="vhzhm" LABEL="image 231" ORDER="504" TYPE="Static">
+<mets:fptr FILEID="mj8jr"/>
+</mets:div>
+<mets:div ID="xlidk" LABEL="image 232" ORDER="505" TYPE="Static">
+<mets:fptr FILEID="b7ztq"/>
+</mets:div>
+<mets:div ID="ejdi7" LABEL="image 233" ORDER="506" TYPE="Static">
+<mets:fptr FILEID="mewnx"/>
+</mets:div>
+<mets:div ID="xprni" LABEL="image 234" ORDER="507" TYPE="Static">
+<mets:fptr FILEID="cv5pz"/>
+</mets:div>
+<mets:div ID="prdq9" LABEL="image 235" ORDER="508" TYPE="Static">
+<mets:fptr FILEID="v7k65"/>
+</mets:div>
+<mets:div ID="v23tm" LABEL="image 236" ORDER="509" TYPE="Static">
+<mets:fptr FILEID="ombf5"/>
+</mets:div>
+<mets:div ID="yy7yz" LABEL="image 237" ORDER="510" TYPE="Static">
+<mets:fptr FILEID="ssfi4"/>
+</mets:div>
+<mets:div ID="vdp0q" LABEL="image 238" ORDER="511" TYPE="Static">
+<mets:fptr FILEID="syg1s"/>
+</mets:div>
+<mets:div ID="nc2pv" LABEL="image 239" ORDER="512" TYPE="Static">
+<mets:fptr FILEID="os6pg"/>
+</mets:div>
+<mets:div ID="flqk3" LABEL="image 240" ORDER="513" TYPE="Static">
+<mets:fptr FILEID="n0fxi"/>
+</mets:div>
+<mets:div ID="bqfdo" LABEL="image 241" ORDER="514" TYPE="Static">
+<mets:fptr FILEID="ezb2s"/>
+</mets:div>
+<mets:div ID="k8gpp" LABEL="image 242" ORDER="515" TYPE="Static">
+<mets:fptr FILEID="bq00n"/>
+</mets:div>
+<mets:div ID="srdk5" LABEL="image 243" ORDER="516" TYPE="Static">
+<mets:fptr FILEID="j1ayh"/>
+</mets:div>
+<mets:div ID="sg5pn" LABEL="image 1" ORDER="517" TYPE="Static">
+<mets:fptr FILEID="dl10y"/>
+</mets:div>
+<mets:div ID="uvn7x" LABEL="image 2" ORDER="518" TYPE="Static">
+<mets:fptr FILEID="uhjtm"/>
+</mets:div>
+<mets:div ID="yos9n" LABEL="image 3" ORDER="519" TYPE="Static">
+<mets:fptr FILEID="dl7a3"/>
+</mets:div>
+<mets:div ID="bi936" LABEL="image 4" ORDER="520" TYPE="Static">
+<mets:fptr FILEID="tt0tc"/>
+</mets:div>
+<mets:div ID="pfepa" LABEL="image 5" ORDER="521" TYPE="Static">
+<mets:fptr FILEID="g4whn"/>
+</mets:div>
+<mets:div ID="yxaa4" LABEL="image 6" ORDER="522" TYPE="Static">
+<mets:fptr FILEID="g66hd"/>
+</mets:div>
+<mets:div ID="c0qv5" LABEL="image 7" ORDER="523" TYPE="Static">
+<mets:fptr FILEID="t432o"/>
+</mets:div>
+<mets:div ID="skj0y" LABEL="image 8" ORDER="524" TYPE="Static">
+<mets:fptr FILEID="nt0fb"/>
+</mets:div>
+<mets:div ID="w1mfk" LABEL="image 9" ORDER="525" TYPE="Static">
+<mets:fptr FILEID="c8yjt"/>
+</mets:div>
+<mets:div ID="e34sc" LABEL="image 10" ORDER="526" TYPE="Static">
+<mets:fptr FILEID="pkwol"/>
+</mets:div>
+<mets:div ID="tta4e" LABEL="image 11" ORDER="527" TYPE="Static">
+<mets:fptr FILEID="vtw7x"/>
+</mets:div>
+<mets:div ID="jm04t" LABEL="image 12" ORDER="528" TYPE="Static">
+<mets:fptr FILEID="c0e5o"/>
+</mets:div>
+<mets:div ID="fccjb" LABEL="image 13" ORDER="529" TYPE="Static">
+<mets:fptr FILEID="kn3xy"/>
+</mets:div>
+<mets:div ID="mxy15" LABEL="image 14" ORDER="530" TYPE="Static">
+<mets:fptr FILEID="tw6bz"/>
+</mets:div>
+<mets:div ID="kivcq" LABEL="image 15" ORDER="531" TYPE="Static">
+<mets:fptr FILEID="cfw4l"/>
+</mets:div>
+<mets:div ID="wp4pj" LABEL="image 16" ORDER="532" TYPE="Static">
+<mets:fptr FILEID="k3icz"/>
+</mets:div>
+<mets:div ID="b4hft" LABEL="image 17" ORDER="533" TYPE="Static">
+<mets:fptr FILEID="wlrmm"/>
+</mets:div>
+<mets:div ID="hidub" LABEL="image 18" ORDER="534" TYPE="Static">
+<mets:fptr FILEID="zcqhr"/>
+</mets:div>
+<mets:div ID="ow3xq" LABEL="image 19" ORDER="535" TYPE="Static">
+<mets:fptr FILEID="b2aeu"/>
+</mets:div>
+<mets:div ID="oi3mu" LABEL="image 20" ORDER="536" TYPE="Static">
+<mets:fptr FILEID="mnhgp"/>
+</mets:div>
+<mets:div ID="u37tc" LABEL="image 21" ORDER="537" TYPE="Static">
+<mets:fptr FILEID="mzzbj"/>
+</mets:div>
+<mets:div ID="meos8" LABEL="image 22" ORDER="538" TYPE="Static">
+<mets:fptr FILEID="fosql"/>
+</mets:div>
+<mets:div ID="c291k" LABEL="image 23" ORDER="539" TYPE="Static">
+<mets:fptr FILEID="c9qfc"/>
+</mets:div>
+<mets:div ID="h0lpt" LABEL="image 24" ORDER="540" TYPE="Static">
+<mets:fptr FILEID="cjp3e"/>
+</mets:div>
+<mets:div ID="v6syw" LABEL="image 25" ORDER="541" TYPE="Static">
+<mets:fptr FILEID="mywpu"/>
+</mets:div>
+<mets:div ID="p5x5p" LABEL="image 26" ORDER="542" TYPE="Static">
+<mets:fptr FILEID="g7iej"/>
+</mets:div>
+<mets:div ID="v20wd" LABEL="image 27" ORDER="543" TYPE="Static">
+<mets:fptr FILEID="amui8"/>
+</mets:div>
+<mets:div ID="f2fk5" LABEL="image 28" ORDER="544" TYPE="Static">
+<mets:fptr FILEID="t188v"/>
+</mets:div>
+<mets:div ID="bfljh" LABEL="image 29" ORDER="545" TYPE="Static">
+<mets:fptr FILEID="iby1r"/>
+</mets:div>
+<mets:div ID="x66ea" LABEL="image 30" ORDER="546" TYPE="Static">
+<mets:fptr FILEID="phc22"/>
+</mets:div>
+<mets:div ID="h9zb3" LABEL="image 31" ORDER="547" TYPE="Static">
+<mets:fptr FILEID="xapi9"/>
+</mets:div>
+<mets:div ID="u2irs" LABEL="image 32" ORDER="548" TYPE="Static">
+<mets:fptr FILEID="s0deg"/>
+</mets:div>
+<mets:div ID="glh73" LABEL="image 33" ORDER="549" TYPE="Static">
+<mets:fptr FILEID="smqhh"/>
+</mets:div>
+<mets:div ID="sh1zo" LABEL="image 34" ORDER="550" TYPE="Static">
+<mets:fptr FILEID="n4cj8"/>
+</mets:div>
+<mets:div ID="xm1nn" LABEL="image 35" ORDER="551" TYPE="Static">
+<mets:fptr FILEID="pnic8"/>
+</mets:div>
+<mets:div ID="qe0yw" LABEL="image 36" ORDER="552" TYPE="Static">
+<mets:fptr FILEID="og5kn"/>
+</mets:div>
+<mets:div ID="mjdzw" LABEL="image 37" ORDER="553" TYPE="Static">
+<mets:fptr FILEID="nwk2z"/>
+</mets:div>
+<mets:div ID="yspkg" LABEL="image 38" ORDER="554" TYPE="Static">
+<mets:fptr FILEID="uxrzz"/>
+</mets:div>
+<mets:div ID="bsoz2" LABEL="image 39" ORDER="555" TYPE="Static">
+<mets:fptr FILEID="usw4x"/>
+</mets:div>
+<mets:div ID="sizl1" LABEL="image 40" ORDER="556" TYPE="Static">
+<mets:fptr FILEID="g7vcm"/>
+</mets:div>
+<mets:div ID="skcky" LABEL="image 41" ORDER="557" TYPE="Static">
+<mets:fptr FILEID="ur8p7"/>
+</mets:div>
+<mets:div ID="yp8d2" LABEL="image 42" ORDER="558" TYPE="Static">
+<mets:fptr FILEID="aipxr"/>
+</mets:div>
+<mets:div ID="nvb1d" LABEL="image 43" ORDER="559" TYPE="Static">
+<mets:fptr FILEID="vo06f"/>
+</mets:div>
+<mets:div ID="pj7j4" LABEL="image 44" ORDER="560" TYPE="Static">
+<mets:fptr FILEID="mzxyp"/>
+</mets:div>
+<mets:div ID="bv6k2" LABEL="image 45" ORDER="561" TYPE="Static">
+<mets:fptr FILEID="q71s3"/>
+</mets:div>
+<mets:div ID="v9sz0" LABEL="image 46" ORDER="562" TYPE="Static">
+<mets:fptr FILEID="mv1av"/>
+</mets:div>
+<mets:div ID="p65pq" LABEL="image 47" ORDER="563" TYPE="Static">
+<mets:fptr FILEID="d896r"/>
+</mets:div>
+<mets:div ID="yputc" LABEL="image 48" ORDER="564" TYPE="Static">
+<mets:fptr FILEID="zjs4p"/>
+</mets:div>
+<mets:div ID="xwudp" LABEL="image 49" ORDER="565" TYPE="Static">
+<mets:fptr FILEID="n0p8e"/>
+</mets:div>
+<mets:div ID="yilwv" LABEL="image 50" ORDER="566" TYPE="Static">
+<mets:fptr FILEID="gqmg9"/>
+</mets:div>
+<mets:div ID="mvmby" LABEL="image 51" ORDER="567" TYPE="Static">
+<mets:fptr FILEID="ak6qp"/>
+</mets:div>
+<mets:div ID="l1l95" LABEL="image 52" ORDER="568" TYPE="Static">
+<mets:fptr FILEID="b96hq"/>
+</mets:div>
+<mets:div ID="zotk4" LABEL="image 53" ORDER="569" TYPE="Static">
+<mets:fptr FILEID="ckp2v"/>
+</mets:div>
+<mets:div ID="pyf2q" LABEL="image 54" ORDER="570" TYPE="Static">
+<mets:fptr FILEID="k0ro9"/>
+</mets:div>
+<mets:div ID="lkn4r" LABEL="image 55" ORDER="571" TYPE="Static">
+<mets:fptr FILEID="gi3oe"/>
+</mets:div>
+<mets:div ID="njlvz" LABEL="image 56" ORDER="572" TYPE="Static">
+<mets:fptr FILEID="bzno0"/>
+</mets:div>
+<mets:div ID="xdu6x" LABEL="image 57" ORDER="573" TYPE="Static">
+<mets:fptr FILEID="qrfg2"/>
+</mets:div>
+<mets:div ID="j9mg0" LABEL="image 58" ORDER="574" TYPE="Static">
+<mets:fptr FILEID="y8792"/>
+</mets:div>
+<mets:div ID="ajrlh" LABEL="image 59" ORDER="575" TYPE="Static">
+<mets:fptr FILEID="tc1m3"/>
+</mets:div>
+<mets:div ID="fh151" LABEL="image 60" ORDER="576" TYPE="Static">
+<mets:fptr FILEID="tszb9"/>
+</mets:div>
+<mets:div ID="fwmee" LABEL="image 61" ORDER="577" TYPE="Static">
+<mets:fptr FILEID="ianjz"/>
+</mets:div>
+<mets:div ID="jerwg" LABEL="image 62" ORDER="578" TYPE="Static">
+<mets:fptr FILEID="sk8ck"/>
+</mets:div>
+<mets:div ID="cvi73" LABEL="image 63" ORDER="579" TYPE="Static">
+<mets:fptr FILEID="gsg0w"/>
+</mets:div>
+<mets:div ID="r6441" LABEL="image 64" ORDER="580" TYPE="Static">
+<mets:fptr FILEID="m9dep"/>
+</mets:div>
+<mets:div ID="skrt3" LABEL="image 65" ORDER="581" TYPE="Static">
+<mets:fptr FILEID="kqsjy"/>
+</mets:div>
+<mets:div ID="mat3o" LABEL="image 66" ORDER="582" TYPE="Static">
+<mets:fptr FILEID="rtsza"/>
+</mets:div>
+<mets:div ID="hlet8" LABEL="image 67" ORDER="583" TYPE="Static">
+<mets:fptr FILEID="ucgi6"/>
+</mets:div>
+<mets:div ID="v75pr" LABEL="image 68" ORDER="584" TYPE="Static">
+<mets:fptr FILEID="ua7bc"/>
+</mets:div>
+<mets:div ID="otjk5" LABEL="image 69" ORDER="585" TYPE="Static">
+<mets:fptr FILEID="xtlk6"/>
+</mets:div>
+<mets:div ID="nrnj0" LABEL="image 70" ORDER="586" TYPE="Static">
+<mets:fptr FILEID="bqbs0"/>
+</mets:div>
+<mets:div ID="zo99b" LABEL="image 71" ORDER="587" TYPE="Static">
+<mets:fptr FILEID="d1xg3"/>
+</mets:div>
+<mets:div ID="l5ckr" LABEL="image 72" ORDER="588" TYPE="Static">
+<mets:fptr FILEID="q8wdo"/>
+</mets:div>
+<mets:div ID="gicle" LABEL="image 73" ORDER="589" TYPE="Static">
+<mets:fptr FILEID="h909k"/>
+</mets:div>
+<mets:div ID="su6zp" LABEL="image 74" ORDER="590" TYPE="Static">
+<mets:fptr FILEID="phmlq"/>
+</mets:div>
+<mets:div ID="fc0b9" LABEL="image 75" ORDER="591" TYPE="Static">
+<mets:fptr FILEID="dlw45"/>
+</mets:div>
+<mets:div ID="plck5" LABEL="image 76" ORDER="592" TYPE="Static">
+<mets:fptr FILEID="gavkf"/>
+</mets:div>
+<mets:div ID="y1e11" LABEL="image 77" ORDER="593" TYPE="Static">
+<mets:fptr FILEID="oqg92"/>
+</mets:div>
+<mets:div ID="yte1o" LABEL="image 78" ORDER="594" TYPE="Static">
+<mets:fptr FILEID="pemfv"/>
+</mets:div>
+<mets:div ID="pis7o" LABEL="image 79" ORDER="595" TYPE="Static">
+<mets:fptr FILEID="l3wo6"/>
+</mets:div>
+<mets:div ID="aa8o4" LABEL="image 80" ORDER="596" TYPE="Static">
+<mets:fptr FILEID="vqmwl"/>
+</mets:div>
+<mets:div ID="b6pvx" LABEL="image 81" ORDER="597" TYPE="Static">
+<mets:fptr FILEID="zu4np"/>
+</mets:div>
+<mets:div ID="fh3qe" LABEL="image 82" ORDER="598" TYPE="Static">
+<mets:fptr FILEID="fhtd2"/>
+</mets:div>
+<mets:div ID="c69ug" LABEL="image 83" ORDER="599" TYPE="Static">
+<mets:fptr FILEID="bbehu"/>
+</mets:div>
+<mets:div ID="m9ge2" LABEL="image 84" ORDER="600" TYPE="Static">
+<mets:fptr FILEID="c78v3"/>
+</mets:div>
+<mets:div ID="fk26q" LABEL="image 85" ORDER="601" TYPE="Static">
+<mets:fptr FILEID="ck93t"/>
+</mets:div>
+<mets:div ID="m1x1o" LABEL="image 86" ORDER="602" TYPE="Static">
+<mets:fptr FILEID="axwvk"/>
+</mets:div>
+<mets:div ID="c3813" LABEL="image 87" ORDER="603" TYPE="Static">
+<mets:fptr FILEID="s54gg"/>
+</mets:div>
+<mets:div ID="zovc8" LABEL="image 88" ORDER="604" TYPE="Static">
+<mets:fptr FILEID="zmxdx"/>
+</mets:div>
+<mets:div ID="b6znh" LABEL="image 89" ORDER="605" TYPE="Static">
+<mets:fptr FILEID="if0kg"/>
+</mets:div>
+<mets:div ID="ckypq" LABEL="image 90" ORDER="606" TYPE="Static">
+<mets:fptr FILEID="hdipo"/>
+</mets:div>
+<mets:div ID="v2qcq" LABEL="image 91" ORDER="607" TYPE="Static">
+<mets:fptr FILEID="dg2ew"/>
+</mets:div>
+<mets:div ID="dm46g" LABEL="image 92" ORDER="608" TYPE="Static">
+<mets:fptr FILEID="njufs"/>
+</mets:div>
+<mets:div ID="pf99n" LABEL="image 93" ORDER="609" TYPE="Static">
+<mets:fptr FILEID="faxuy"/>
+</mets:div>
+<mets:div ID="y2cya" LABEL="image 94" ORDER="610" TYPE="Static">
+<mets:fptr FILEID="gtb81"/>
+</mets:div>
+<mets:div ID="pi1h3" LABEL="image 95" ORDER="611" TYPE="Static">
+<mets:fptr FILEID="rlw5z"/>
+</mets:div>
+<mets:div ID="tg7pc" LABEL="image 96" ORDER="612" TYPE="Static">
+<mets:fptr FILEID="geyq8"/>
+</mets:div>
+<mets:div ID="lm822" LABEL="image 97" ORDER="613" TYPE="Static">
+<mets:fptr FILEID="avg3i"/>
+</mets:div>
+<mets:div ID="o7dzb" LABEL="image 98" ORDER="614" TYPE="Static">
+<mets:fptr FILEID="fzmh3"/>
+</mets:div>
+<mets:div ID="qcbua" LABEL="image 99" ORDER="615" TYPE="Static">
+<mets:fptr FILEID="qj5jw"/>
+</mets:div>
+<mets:div ID="qjyi9" LABEL="image 100" ORDER="616" TYPE="Static">
+<mets:fptr FILEID="r8qvb"/>
+</mets:div>
+<mets:div ID="fivkp" LABEL="image 101" ORDER="617" TYPE="Static">
+<mets:fptr FILEID="wlnfj"/>
+</mets:div>
+<mets:div ID="hu9mz" LABEL="image 102" ORDER="618" TYPE="Static">
+<mets:fptr FILEID="aftmq"/>
+</mets:div>
+<mets:div ID="cwztm" LABEL="image 103" ORDER="619" TYPE="Static">
+<mets:fptr FILEID="ndx8x"/>
+</mets:div>
+<mets:div ID="xm6qy" LABEL="image 104" ORDER="620" TYPE="Static">
+<mets:fptr FILEID="a5czr"/>
+</mets:div>
+<mets:div ID="oqhx2" LABEL="image 105" ORDER="621" TYPE="Static">
+<mets:fptr FILEID="q0qis"/>
+</mets:div>
+<mets:div ID="b7028" LABEL="image 106" ORDER="622" TYPE="Static">
+<mets:fptr FILEID="nphyw"/>
+</mets:div>
+<mets:div ID="rj9yr" LABEL="image 107" ORDER="623" TYPE="Static">
+<mets:fptr FILEID="kx0g8"/>
+</mets:div>
+<mets:div ID="xkl3p" LABEL="image 108" ORDER="624" TYPE="Static">
+<mets:fptr FILEID="mpbts"/>
+</mets:div>
+<mets:div ID="s5sdj" LABEL="image 109" ORDER="625" TYPE="Static">
+<mets:fptr FILEID="nmtmc"/>
+</mets:div>
+<mets:div ID="ytev8" LABEL="image 110" ORDER="626" TYPE="Static">
+<mets:fptr FILEID="zjbmq"/>
+</mets:div>
+<mets:div ID="mfvvv" LABEL="image 111" ORDER="627" TYPE="Static">
+<mets:fptr FILEID="mtooq"/>
+</mets:div>
+<mets:div ID="bow62" LABEL="image 112" ORDER="628" TYPE="Static">
+<mets:fptr FILEID="nclt6"/>
+</mets:div>
+<mets:div ID="rn703" LABEL="image 113" ORDER="629" TYPE="Static">
+<mets:fptr FILEID="olxbi"/>
+</mets:div>
+<mets:div ID="kk812" LABEL="image 114" ORDER="630" TYPE="Static">
+<mets:fptr FILEID="clrsb"/>
+</mets:div>
+<mets:div ID="bxkfz" LABEL="image 115" ORDER="631" TYPE="Static">
+<mets:fptr FILEID="vt2ka"/>
+</mets:div>
+<mets:div ID="pfgjl" LABEL="image 116" ORDER="632" TYPE="Static">
+<mets:fptr FILEID="vkf8r"/>
+</mets:div>
+<mets:div ID="fyhtw" LABEL="image 117" ORDER="633" TYPE="Static">
+<mets:fptr FILEID="rxzsd"/>
+</mets:div>
+<mets:div ID="xn6du" LABEL="image 118" ORDER="634" TYPE="Static">
+<mets:fptr FILEID="hrnts"/>
+</mets:div>
+<mets:div ID="rl644" LABEL="image 119" ORDER="635" TYPE="Static">
+<mets:fptr FILEID="yuoze"/>
+</mets:div>
+<mets:div ID="i2yru" LABEL="image 120" ORDER="636" TYPE="Static">
+<mets:fptr FILEID="h0syv"/>
+</mets:div>
+<mets:div ID="a227l" LABEL="image 121" ORDER="637" TYPE="Static">
+<mets:fptr FILEID="pwmml"/>
+</mets:div>
+<mets:div ID="b7dul" LABEL="image 122" ORDER="638" TYPE="Static">
+<mets:fptr FILEID="k8h8u"/>
+</mets:div>
+<mets:div ID="ewip0" LABEL="image 123" ORDER="639" TYPE="Static">
+<mets:fptr FILEID="abo4t"/>
+</mets:div>
+<mets:div ID="x4got" LABEL="image 124" ORDER="640" TYPE="Static">
+<mets:fptr FILEID="d46z1"/>
+</mets:div>
+<mets:div ID="zxzrq" LABEL="image 125" ORDER="641" TYPE="Static">
+<mets:fptr FILEID="yx8ds"/>
+</mets:div>
+<mets:div ID="w5g9c" LABEL="image 126" ORDER="642" TYPE="Static">
+<mets:fptr FILEID="nelem"/>
+</mets:div>
+<mets:div ID="cxk4c" LABEL="image 127" ORDER="643" TYPE="Static">
+<mets:fptr FILEID="rz75f"/>
+</mets:div>
+<mets:div ID="lzr85" LABEL="image 128" ORDER="644" TYPE="Static">
+<mets:fptr FILEID="oub70"/>
+</mets:div>
+<mets:div ID="simfk" LABEL="image 129" ORDER="645" TYPE="Static">
+<mets:fptr FILEID="r8ugl"/>
+</mets:div>
+<mets:div ID="ecw4v" LABEL="image 130" ORDER="646" TYPE="Static">
+<mets:fptr FILEID="li7po"/>
+</mets:div>
+<mets:div ID="xcws6" LABEL="image 131" ORDER="647" TYPE="Static">
+<mets:fptr FILEID="qcjvs"/>
+</mets:div>
+<mets:div ID="hzp1a" LABEL="image 132" ORDER="648" TYPE="Static">
+<mets:fptr FILEID="z88bb"/>
+</mets:div>
+<mets:div ID="fpggk" LABEL="image 1" ORDER="649" TYPE="Static">
+<mets:fptr FILEID="l6bv7"/>
+</mets:div>
+<mets:div ID="h45ac" LABEL="image 2" ORDER="650" TYPE="Static">
+<mets:fptr FILEID="dq6jq"/>
+</mets:div>
+<mets:div ID="bax2e" LABEL="image 3" ORDER="651" TYPE="Static">
+<mets:fptr FILEID="cz5nc"/>
+</mets:div>
+<mets:div ID="a5hjw" LABEL="image 4" ORDER="652" TYPE="Static">
+<mets:fptr FILEID="asesw"/>
+</mets:div>
+<mets:div ID="dlth9" LABEL="image 5" ORDER="653" TYPE="Static">
+<mets:fptr FILEID="snpci"/>
+</mets:div>
+<mets:div ID="fz5xz" LABEL="image 6" ORDER="654" TYPE="Static">
+<mets:fptr FILEID="vum6x"/>
+</mets:div>
+<mets:div ID="iuf0y" LABEL="image 7" ORDER="655" TYPE="Static">
+<mets:fptr FILEID="w6r8n"/>
+</mets:div>
+<mets:div ID="bi8pn" LABEL="image 8" ORDER="656" TYPE="Static">
+<mets:fptr FILEID="iq7jx"/>
+</mets:div>
+<mets:div ID="dll1s" LABEL="image 9" ORDER="657" TYPE="Static">
+<mets:fptr FILEID="y5nkh"/>
+</mets:div>
+<mets:div ID="zo9yo" LABEL="image 10" ORDER="658" TYPE="Static">
+<mets:fptr FILEID="dp9np"/>
+</mets:div>
+<mets:div ID="j82hn" LABEL="image 11" ORDER="659" TYPE="Static">
+<mets:fptr FILEID="l43ke"/>
+</mets:div>
+<mets:div ID="z44qn" LABEL="image 12" ORDER="660" TYPE="Static">
+<mets:fptr FILEID="sq0th"/>
+</mets:div>
+<mets:div ID="t7ioh" LABEL="image 13" ORDER="661" TYPE="Static">
+<mets:fptr FILEID="nsrh6"/>
+</mets:div>
+<mets:div ID="jalle" LABEL="image 14" ORDER="662" TYPE="Static">
+<mets:fptr FILEID="xjrxs"/>
+</mets:div>
+<mets:div ID="k2b6b" LABEL="image 15" ORDER="663" TYPE="Static">
+<mets:fptr FILEID="ld924"/>
+</mets:div>
+<mets:div ID="gbtha" LABEL="image 16" ORDER="664" TYPE="Static">
+<mets:fptr FILEID="boamg"/>
+</mets:div>
+<mets:div ID="dryrl" LABEL="image 17" ORDER="665" TYPE="Static">
+<mets:fptr FILEID="f1pzl"/>
+</mets:div>
+<mets:div ID="oxuxc" LABEL="image 18" ORDER="666" TYPE="Static">
+<mets:fptr FILEID="n3y9e"/>
+</mets:div>
+<mets:div ID="rhs4z" LABEL="image 19" ORDER="667" TYPE="Static">
+<mets:fptr FILEID="s58ay"/>
+</mets:div>
+<mets:div ID="wpy93" LABEL="image 20" ORDER="668" TYPE="Static">
+<mets:fptr FILEID="c9s4a"/>
+</mets:div>
+<mets:div ID="wg7rb" LABEL="image 21" ORDER="669" TYPE="Static">
+<mets:fptr FILEID="c5mgk"/>
+</mets:div>
+<mets:div ID="lxj40" LABEL="image 22" ORDER="670" TYPE="Static">
+<mets:fptr FILEID="jridz"/>
+</mets:div>
+<mets:div ID="rs9jz" LABEL="image 23" ORDER="671" TYPE="Static">
+<mets:fptr FILEID="d7lp7"/>
+</mets:div>
+<mets:div ID="qst2v" LABEL="image 24" ORDER="672" TYPE="Static">
+<mets:fptr FILEID="e9emc"/>
+</mets:div>
+<mets:div ID="dhalt" LABEL="image 25" ORDER="673" TYPE="Static">
+<mets:fptr FILEID="lpiug"/>
+</mets:div>
+<mets:div ID="bkz0i" LABEL="image 26" ORDER="674" TYPE="Static">
+<mets:fptr FILEID="kl9ar"/>
+</mets:div>
+<mets:div ID="ex7k3" LABEL="image 27" ORDER="675" TYPE="Static">
+<mets:fptr FILEID="fcigj"/>
+</mets:div>
+<mets:div ID="gwodc" LABEL="image 28" ORDER="676" TYPE="Static">
+<mets:fptr FILEID="m1tbi"/>
+</mets:div>
+<mets:div ID="ayqky" LABEL="image 29" ORDER="677" TYPE="Static">
+<mets:fptr FILEID="dthum"/>
+</mets:div>
+<mets:div ID="w8uyj" LABEL="image 30" ORDER="678" TYPE="Static">
+<mets:fptr FILEID="axnw8"/>
+</mets:div>
+<mets:div ID="epize" LABEL="image 31" ORDER="679" TYPE="Static">
+<mets:fptr FILEID="avkzj"/>
+</mets:div>
+<mets:div ID="d2gnc" LABEL="image 32" ORDER="680" TYPE="Static">
+<mets:fptr FILEID="xwk2l"/>
+</mets:div>
+<mets:div ID="q40cj" LABEL="image 33" ORDER="681" TYPE="Static">
+<mets:fptr FILEID="p79g6"/>
+</mets:div>
+<mets:div ID="fu5n0" LABEL="image 34" ORDER="682" TYPE="Static">
+<mets:fptr FILEID="fiaa7"/>
+</mets:div>
+<mets:div ID="skseb" LABEL="image 35" ORDER="683" TYPE="Static">
+<mets:fptr FILEID="zjpdw"/>
+</mets:div>
+<mets:div ID="syqis" LABEL="image 36" ORDER="684" TYPE="Static">
+<mets:fptr FILEID="f3vui"/>
+</mets:div>
+<mets:div ID="a3fov" LABEL="image 37" ORDER="685" TYPE="Static">
+<mets:fptr FILEID="nutfr"/>
+</mets:div>
+<mets:div ID="cvol2" LABEL="image 38" ORDER="686" TYPE="Static">
+<mets:fptr FILEID="b4jgf"/>
+</mets:div>
+<mets:div ID="d28rh" LABEL="image 39" ORDER="687" TYPE="Static">
+<mets:fptr FILEID="wiafv"/>
+</mets:div>
+<mets:div ID="g0o2i" LABEL="image 40" ORDER="688" TYPE="Static">
+<mets:fptr FILEID="x28xs"/>
+</mets:div>
+<mets:div ID="wmnlc" LABEL="image 41" ORDER="689" TYPE="Static">
+<mets:fptr FILEID="apsww"/>
+</mets:div>
+<mets:div ID="hnoe8" LABEL="image 42" ORDER="690" TYPE="Static">
+<mets:fptr FILEID="xwrv3"/>
+</mets:div>
+<mets:div ID="eqxdc" LABEL="image 43" ORDER="691" TYPE="Static">
+<mets:fptr FILEID="tetm3"/>
+</mets:div>
+<mets:div ID="yyi9h" LABEL="image 44" ORDER="692" TYPE="Static">
+<mets:fptr FILEID="aag2e"/>
+</mets:div>
+<mets:div ID="yanx2" LABEL="image 45" ORDER="693" TYPE="Static">
+<mets:fptr FILEID="pznb4"/>
+</mets:div>
+<mets:div ID="ec89a" LABEL="image 46" ORDER="694" TYPE="Static">
+<mets:fptr FILEID="hxmh0"/>
+</mets:div>
+<mets:div ID="ler34" LABEL="image 47" ORDER="695" TYPE="Static">
+<mets:fptr FILEID="pzgqm"/>
+</mets:div>
+<mets:div ID="b8nni" LABEL="image 48" ORDER="696" TYPE="Static">
+<mets:fptr FILEID="bz2kn"/>
+</mets:div>
+<mets:div ID="nbt0x" LABEL="image 49" ORDER="697" TYPE="Static">
+<mets:fptr FILEID="namvv"/>
+</mets:div>
+<mets:div ID="jny2e" LABEL="image 50" ORDER="698" TYPE="Static">
+<mets:fptr FILEID="o7zf5"/>
+</mets:div>
+<mets:div ID="ilvye" LABEL="image 51" ORDER="699" TYPE="Static">
+<mets:fptr FILEID="aeo3u"/>
+</mets:div>
+<mets:div ID="v67aq" LABEL="image 52" ORDER="700" TYPE="Static">
+<mets:fptr FILEID="p1ku7"/>
+</mets:div>
+<mets:div ID="tqqa1" LABEL="image 53" ORDER="701" TYPE="Static">
+<mets:fptr FILEID="r2n0e"/>
+</mets:div>
+<mets:div ID="nvl2v" LABEL="image 54" ORDER="702" TYPE="Static">
+<mets:fptr FILEID="mo9g4"/>
+</mets:div>
+<mets:div ID="m4cb0" LABEL="image 55" ORDER="703" TYPE="Static">
+<mets:fptr FILEID="eaa6t"/>
+</mets:div>
+<mets:div ID="syc60" LABEL="image 56" ORDER="704" TYPE="Static">
+<mets:fptr FILEID="zpbmo"/>
+</mets:div>
+<mets:div ID="k4cuz" LABEL="image 57" ORDER="705" TYPE="Static">
+<mets:fptr FILEID="ktlcq"/>
+</mets:div>
+<mets:div ID="zndsc" LABEL="image 58" ORDER="706" TYPE="Static">
+<mets:fptr FILEID="wk7hn"/>
+</mets:div>
+<mets:div ID="vliv3" LABEL="image 59" ORDER="707" TYPE="Static">
+<mets:fptr FILEID="hqoix"/>
+</mets:div>
+<mets:div ID="rja5h" LABEL="image 60" ORDER="708" TYPE="Static">
+<mets:fptr FILEID="jrzk6"/>
+</mets:div>
+<mets:div ID="ljlsi" LABEL="image 61" ORDER="709" TYPE="Static">
+<mets:fptr FILEID="haql9"/>
+</mets:div>
+<mets:div ID="k4397" LABEL="image 62" ORDER="710" TYPE="Static">
+<mets:fptr FILEID="r75cw"/>
+</mets:div>
+<mets:div ID="v23sg" LABEL="image 63" ORDER="711" TYPE="Static">
+<mets:fptr FILEID="fggxk"/>
+</mets:div>
+<mets:div ID="ee948" LABEL="image 64" ORDER="712" TYPE="Static">
+<mets:fptr FILEID="naka0"/>
+</mets:div>
+<mets:div ID="qo3jo" LABEL="image 65" ORDER="713" TYPE="Static">
+<mets:fptr FILEID="icc37"/>
+</mets:div>
+<mets:div ID="wvssc" LABEL="image 66" ORDER="714" TYPE="Static">
+<mets:fptr FILEID="hjwzr"/>
+</mets:div>
+<mets:div ID="t6mqp" LABEL="image 67" ORDER="715" TYPE="Static">
+<mets:fptr FILEID="jlkm4"/>
+</mets:div>
+<mets:div ID="pkoo6" LABEL="image 68" ORDER="716" TYPE="Static">
+<mets:fptr FILEID="yxebu"/>
+</mets:div>
+<mets:div ID="ys3bk" LABEL="image 69" ORDER="717" TYPE="Static">
+<mets:fptr FILEID="a1wby"/>
+</mets:div>
+<mets:div ID="h3rut" LABEL="image 70" ORDER="718" TYPE="Static">
+<mets:fptr FILEID="ozyc8"/>
+</mets:div>
+<mets:div ID="iear6" LABEL="image 71" ORDER="719" TYPE="Static">
+<mets:fptr FILEID="dcsyg"/>
+</mets:div>
+<mets:div ID="yhxew" LABEL="image 72" ORDER="720" TYPE="Static">
+<mets:fptr FILEID="tidfl"/>
+</mets:div>
+<mets:div ID="n7cco" LABEL="image 73" ORDER="721" TYPE="Static">
+<mets:fptr FILEID="xxxw2"/>
+</mets:div>
+<mets:div ID="j1dft" LABEL="image 74" ORDER="722" TYPE="Static">
+<mets:fptr FILEID="md3o9"/>
+</mets:div>
+<mets:div ID="cxxij" LABEL="image 75" ORDER="723" TYPE="Static">
+<mets:fptr FILEID="sh7sc"/>
+</mets:div>
+<mets:div ID="sml75" LABEL="image 76" ORDER="724" TYPE="Static">
+<mets:fptr FILEID="vm529"/>
+</mets:div>
+<mets:div ID="urfhu" LABEL="image 77" ORDER="725" TYPE="Static">
+<mets:fptr FILEID="rupn1"/>
+</mets:div>
+<mets:div ID="oaf2a" LABEL="image 78" ORDER="726" TYPE="Static">
+<mets:fptr FILEID="ql0i0"/>
+</mets:div>
+<mets:div ID="zg7le" LABEL="image 79" ORDER="727" TYPE="Static">
+<mets:fptr FILEID="f4yeh"/>
+</mets:div>
+<mets:div ID="fvejj" LABEL="image 80" ORDER="728" TYPE="Static">
+<mets:fptr FILEID="dlnqz"/>
+</mets:div>
+<mets:div ID="clmdc" LABEL="image 81" ORDER="729" TYPE="Static">
+<mets:fptr FILEID="ofo0v"/>
+</mets:div>
+<mets:div ID="z8s8l" LABEL="image 82" ORDER="730" TYPE="Static">
+<mets:fptr FILEID="y5fnf"/>
+</mets:div>
+<mets:div ID="nelez" LABEL="image 83" ORDER="731" TYPE="Static">
+<mets:fptr FILEID="z5n8y"/>
+</mets:div>
+<mets:div ID="axxxn" LABEL="image 84" ORDER="732" TYPE="Static">
+<mets:fptr FILEID="odt3y"/>
+</mets:div>
+<mets:div ID="t9vlx" LABEL="image 85" ORDER="733" TYPE="Static">
+<mets:fptr FILEID="knrhz"/>
+</mets:div>
+<mets:div ID="jkdt6" LABEL="image 86" ORDER="734" TYPE="Static">
+<mets:fptr FILEID="aeo5d"/>
+</mets:div>
+<mets:div ID="fk00d" LABEL="image 87" ORDER="735" TYPE="Static">
+<mets:fptr FILEID="ejy60"/>
+</mets:div>
+<mets:div ID="f979f" LABEL="image 88" ORDER="736" TYPE="Static">
+<mets:fptr FILEID="zklad"/>
+</mets:div>
+<mets:div ID="jyjzs" LABEL="image 89" ORDER="737" TYPE="Static">
+<mets:fptr FILEID="lplo0"/>
+</mets:div>
+<mets:div ID="m5yln" LABEL="image 90" ORDER="738" TYPE="Static">
+<mets:fptr FILEID="o115b"/>
+</mets:div>
+<mets:div ID="xilms" LABEL="image 91" ORDER="739" TYPE="Static">
+<mets:fptr FILEID="ojeo2"/>
+</mets:div>
+<mets:div ID="f7ukp" LABEL="image 92" ORDER="740" TYPE="Static">
+<mets:fptr FILEID="tgax3"/>
+</mets:div>
+<mets:div ID="m8qg5" LABEL="image 93" ORDER="741" TYPE="Static">
+<mets:fptr FILEID="oj1t4"/>
+</mets:div>
+<mets:div ID="pj8g3" LABEL="image 94" ORDER="742" TYPE="Static">
+<mets:fptr FILEID="ndyzb"/>
+</mets:div>
+<mets:div ID="motbb" LABEL="image 95" ORDER="743" TYPE="Static">
+<mets:fptr FILEID="l7dmh"/>
+</mets:div>
+<mets:div ID="s87cr" LABEL="image 96" ORDER="744" TYPE="Static">
+<mets:fptr FILEID="yw9m6"/>
+</mets:div>
+<mets:div ID="m0jqp" LABEL="image 97" ORDER="745" TYPE="Static">
+<mets:fptr FILEID="vx12f"/>
+</mets:div>
+<mets:div ID="m52e9" LABEL="image 98" ORDER="746" TYPE="Static">
+<mets:fptr FILEID="qp5ir"/>
+</mets:div>
+<mets:div ID="n1wd4" LABEL="image 99" ORDER="747" TYPE="Static">
+<mets:fptr FILEID="b2r2t"/>
+</mets:div>
+<mets:div ID="ozmpq" LABEL="image 100" ORDER="748" TYPE="Static">
+<mets:fptr FILEID="jqd9z"/>
+</mets:div>
+<mets:div ID="abpuc" LABEL="image 101" ORDER="749" TYPE="Static">
+<mets:fptr FILEID="gho5w"/>
+</mets:div>
+<mets:div ID="yy2fc" LABEL="image 102" ORDER="750" TYPE="Static">
+<mets:fptr FILEID="xwveo"/>
+</mets:div>
+<mets:div ID="qrnew" LABEL="image 103" ORDER="751" TYPE="Static">
+<mets:fptr FILEID="xrmfl"/>
+</mets:div>
+<mets:div ID="z7r8g" LABEL="image 104" ORDER="752" TYPE="Static">
+<mets:fptr FILEID="igbls"/>
+</mets:div>
+<mets:div ID="gyqzu" LABEL="image 1" ORDER="753" TYPE="Static">
+<mets:fptr FILEID="qhdeb"/>
+</mets:div>
+<mets:div ID="zz6sl" LABEL="image 2" ORDER="754" TYPE="Static">
+<mets:fptr FILEID="nutcv"/>
+</mets:div>
+<mets:div ID="e000u" LABEL="image 3" ORDER="755" TYPE="Static">
+<mets:fptr FILEID="pnhhq"/>
+</mets:div>
+<mets:div ID="h313g" LABEL="image 4" ORDER="756" TYPE="Static">
+<mets:fptr FILEID="hhivk"/>
+</mets:div>
+<mets:div ID="de9gt" LABEL="image 5" ORDER="757" TYPE="Static">
+<mets:fptr FILEID="byg39"/>
+</mets:div>
+<mets:div ID="jvpnf" LABEL="image 6" ORDER="758" TYPE="Static">
+<mets:fptr FILEID="ju0a7"/>
+</mets:div>
+<mets:div ID="li2kp" LABEL="image 7" ORDER="759" TYPE="Static">
+<mets:fptr FILEID="muc9s"/>
+</mets:div>
+<mets:div ID="dsn2r" LABEL="image 8" ORDER="760" TYPE="Static">
+<mets:fptr FILEID="ezk09"/>
+</mets:div>
+<mets:div ID="ydxiq" LABEL="image 9" ORDER="761" TYPE="Static">
+<mets:fptr FILEID="h0o6b"/>
+</mets:div>
+<mets:div ID="gx5en" LABEL="image 10" ORDER="762" TYPE="Static">
+<mets:fptr FILEID="mrhlc"/>
+</mets:div>
+<mets:div ID="ksbrt" LABEL="image 11" ORDER="763" TYPE="Static">
+<mets:fptr FILEID="tfpo8"/>
+</mets:div>
+<mets:div ID="xa8jm" LABEL="image 12" ORDER="764" TYPE="Static">
+<mets:fptr FILEID="abr5m"/>
+</mets:div>
+<mets:div ID="pkmbt" LABEL="image 13" ORDER="765" TYPE="Static">
+<mets:fptr FILEID="bl7vm"/>
+</mets:div>
+<mets:div ID="tutgu" LABEL="image 14" ORDER="766" TYPE="Static">
+<mets:fptr FILEID="xhwg9"/>
+</mets:div>
+<mets:div ID="de83k" LABEL="image 15" ORDER="767" TYPE="Static">
+<mets:fptr FILEID="nuu5z"/>
+</mets:div>
+<mets:div ID="lio2s" LABEL="image 16" ORDER="768" TYPE="Static">
+<mets:fptr FILEID="me7q5"/>
+</mets:div>
+<mets:div ID="cvxsc" LABEL="image 17" ORDER="769" TYPE="Static">
+<mets:fptr FILEID="shgs4"/>
+</mets:div>
+<mets:div ID="lfaih" LABEL="image 18" ORDER="770" TYPE="Static">
+<mets:fptr FILEID="yblsu"/>
+</mets:div>
+<mets:div ID="qs10e" LABEL="image 19" ORDER="771" TYPE="Static">
+<mets:fptr FILEID="fu8kd"/>
+</mets:div>
+<mets:div ID="spau2" LABEL="image 20" ORDER="772" TYPE="Static">
+<mets:fptr FILEID="asy6a"/>
+</mets:div>
+<mets:div ID="yrkj0" LABEL="image 21" ORDER="773" TYPE="Static">
+<mets:fptr FILEID="pphid"/>
+</mets:div>
+<mets:div ID="jqv3s" LABEL="image 22" ORDER="774" TYPE="Static">
+<mets:fptr FILEID="lo1fn"/>
+</mets:div>
+<mets:div ID="xufk2" LABEL="image 23" ORDER="775" TYPE="Static">
+<mets:fptr FILEID="y40nj"/>
+</mets:div>
+<mets:div ID="kniuz" LABEL="image 24" ORDER="776" TYPE="Static">
+<mets:fptr FILEID="t1ffw"/>
+</mets:div>
+<mets:div ID="aip14" LABEL="image 25" ORDER="777" TYPE="Static">
+<mets:fptr FILEID="eq8ru"/>
+</mets:div>
+<mets:div ID="d1v99" LABEL="image 26" ORDER="778" TYPE="Static">
+<mets:fptr FILEID="pcd72"/>
+</mets:div>
+<mets:div ID="s5fw8" LABEL="image 27" ORDER="779" TYPE="Static">
+<mets:fptr FILEID="ukely"/>
+</mets:div>
+<mets:div ID="dpiso" LABEL="image 28" ORDER="780" TYPE="Static">
+<mets:fptr FILEID="z617f"/>
+</mets:div>
+<mets:div ID="g8m4w" LABEL="image 29" ORDER="781" TYPE="Static">
+<mets:fptr FILEID="r4dbx"/>
+</mets:div>
+<mets:div ID="z1z5v" LABEL="image 30" ORDER="782" TYPE="Static">
+<mets:fptr FILEID="pt7yk"/>
+</mets:div>
+<mets:div ID="mx1ac" LABEL="image 31" ORDER="783" TYPE="Static">
+<mets:fptr FILEID="lxwff"/>
+</mets:div>
+<mets:div ID="qrygz" LABEL="image 32" ORDER="784" TYPE="Static">
+<mets:fptr FILEID="f2mjo"/>
+</mets:div>
+<mets:div ID="ksryo" LABEL="image 33" ORDER="785" TYPE="Static">
+<mets:fptr FILEID="khuxu"/>
+</mets:div>
+<mets:div ID="tpqxy" LABEL="image 34" ORDER="786" TYPE="Static">
+<mets:fptr FILEID="bp2ah"/>
+</mets:div>
+<mets:div ID="t0kpj" LABEL="image 35" ORDER="787" TYPE="Static">
+<mets:fptr FILEID="hfjhl"/>
+</mets:div>
+<mets:div ID="stahh" LABEL="image 36" ORDER="788" TYPE="Static">
+<mets:fptr FILEID="dzw4u"/>
+</mets:div>
+<mets:div ID="f9h4f" LABEL="image 37" ORDER="789" TYPE="Static">
+<mets:fptr FILEID="w199v"/>
+</mets:div>
+<mets:div ID="x8u5z" LABEL="image 38" ORDER="790" TYPE="Static">
+<mets:fptr FILEID="ogr8y"/>
+</mets:div>
+<mets:div ID="tdu62" LABEL="image 39" ORDER="791" TYPE="Static">
+<mets:fptr FILEID="qzmgo"/>
+</mets:div>
+<mets:div ID="qigjk" LABEL="image 40" ORDER="792" TYPE="Static">
+<mets:fptr FILEID="z7yig"/>
+</mets:div>
+<mets:div ID="b9jrk" LABEL="image 41" ORDER="793" TYPE="Static">
+<mets:fptr FILEID="rh2ll"/>
+</mets:div>
+<mets:div ID="wy6d6" LABEL="image 42" ORDER="794" TYPE="Static">
+<mets:fptr FILEID="oreht"/>
+</mets:div>
+<mets:div ID="ri6i7" LABEL="image 43" ORDER="795" TYPE="Static">
+<mets:fptr FILEID="amget"/>
+</mets:div>
+<mets:div ID="qkljv" LABEL="image 44" ORDER="796" TYPE="Static">
+<mets:fptr FILEID="ax17o"/>
+</mets:div>
+<mets:div ID="t44h8" LABEL="image 45" ORDER="797" TYPE="Static">
+<mets:fptr FILEID="mmy64"/>
+</mets:div>
+<mets:div ID="nusoh" LABEL="image 46" ORDER="798" TYPE="Static">
+<mets:fptr FILEID="d141t"/>
+</mets:div>
+<mets:div ID="qkw0s" LABEL="image 1" ORDER="799" TYPE="Static">
+<mets:fptr FILEID="xjpzg"/>
+</mets:div>
+<mets:div ID="uxye7" LABEL="image 2" ORDER="800" TYPE="Static">
+<mets:fptr FILEID="vbm3m"/>
+</mets:div>
+<mets:div ID="iq5ov" LABEL="image 3" ORDER="801" TYPE="Static">
+<mets:fptr FILEID="hlsda"/>
+</mets:div>
+<mets:div ID="n0q8o" LABEL="image 4" ORDER="802" TYPE="Static">
+<mets:fptr FILEID="t2r9q"/>
+</mets:div>
+<mets:div ID="mi5n9" LABEL="image 5" ORDER="803" TYPE="Static">
+<mets:fptr FILEID="yvhwk"/>
+</mets:div>
+<mets:div ID="pkgai" LABEL="image 6" ORDER="804" TYPE="Static">
+<mets:fptr FILEID="m4uf6"/>
+</mets:div>
+<mets:div ID="wcpe2" LABEL="image 7" ORDER="805" TYPE="Static">
+<mets:fptr FILEID="jqjgw"/>
+</mets:div>
+<mets:div ID="qle0s" LABEL="image 8" ORDER="806" TYPE="Static">
+<mets:fptr FILEID="t98md"/>
+</mets:div>
+<mets:div ID="pm9ej" LABEL="image 9" ORDER="807" TYPE="Static">
+<mets:fptr FILEID="z0szl"/>
+</mets:div>
+<mets:div ID="d4mmy" LABEL="image 10" ORDER="808" TYPE="Static">
+<mets:fptr FILEID="q5dnx"/>
+</mets:div>
+<mets:div ID="iqebj" LABEL="image 11" ORDER="809" TYPE="Static">
+<mets:fptr FILEID="vjg9z"/>
+</mets:div>
+<mets:div ID="d2f4m" LABEL="image 12" ORDER="810" TYPE="Static">
+<mets:fptr FILEID="w0fnp"/>
+</mets:div>
+<mets:div ID="wh1q2" LABEL="image 13" ORDER="811" TYPE="Static">
+<mets:fptr FILEID="epsr9"/>
+</mets:div>
+<mets:div ID="sory0" LABEL="image 14" ORDER="812" TYPE="Static">
+<mets:fptr FILEID="x9dpw"/>
+</mets:div>
+<mets:div ID="xs0ay" LABEL="image 15" ORDER="813" TYPE="Static">
+<mets:fptr FILEID="ejpro"/>
+</mets:div>
+<mets:div ID="ew3rz" LABEL="image 16" ORDER="814" TYPE="Static">
+<mets:fptr FILEID="rcm5k"/>
+</mets:div>
+<mets:div ID="tvvj4" LABEL="image 17" ORDER="815" TYPE="Static">
+<mets:fptr FILEID="x1qfl"/>
+</mets:div>
+<mets:div ID="dcrcz" LABEL="image 18" ORDER="816" TYPE="Static">
+<mets:fptr FILEID="tjd5u"/>
+</mets:div>
+<mets:div ID="fkqgg" LABEL="image 19" ORDER="817" TYPE="Static">
+<mets:fptr FILEID="mh998"/>
+</mets:div>
+<mets:div ID="ze9oz" LABEL="image 20" ORDER="818" TYPE="Static">
+<mets:fptr FILEID="xomqh"/>
+</mets:div>
+<mets:div ID="sdjnw" LABEL="image 21" ORDER="819" TYPE="Static">
+<mets:fptr FILEID="dlc0x"/>
+</mets:div>
+<mets:div ID="ii8fz" LABEL="image 22" ORDER="820" TYPE="Static">
+<mets:fptr FILEID="x4z1d"/>
+</mets:div>
+<mets:div ID="j2fa4" LABEL="image 23" ORDER="821" TYPE="Static">
+<mets:fptr FILEID="jkko8"/>
+</mets:div>
+<mets:div ID="gx64z" LABEL="image 24" ORDER="822" TYPE="Static">
+<mets:fptr FILEID="lng8l"/>
+</mets:div>
+<mets:div ID="loiwj" LABEL="image 25" ORDER="823" TYPE="Static">
+<mets:fptr FILEID="plzdt"/>
+</mets:div>
+<mets:div ID="kqbn8" LABEL="image 26" ORDER="824" TYPE="Static">
+<mets:fptr FILEID="zfcpi"/>
+</mets:div>
+<mets:div ID="lj6no" LABEL="image 27" ORDER="825" TYPE="Static">
+<mets:fptr FILEID="e7llx"/>
+</mets:div>
+<mets:div ID="qmq4x" LABEL="image 28" ORDER="826" TYPE="Static">
+<mets:fptr FILEID="e4dsi"/>
+</mets:div>
+<mets:div ID="mkdqj" LABEL="image 29" ORDER="827" TYPE="Static">
+<mets:fptr FILEID="rk6os"/>
+</mets:div>
+<mets:div ID="p46az" LABEL="image 30" ORDER="828" TYPE="Static">
+<mets:fptr FILEID="kmb94"/>
+</mets:div>
+<mets:div ID="nkrj2" LABEL="image 31" ORDER="829" TYPE="Static">
+<mets:fptr FILEID="n4eat"/>
+</mets:div>
+<mets:div ID="n3q19" LABEL="image 32" ORDER="830" TYPE="Static">
+<mets:fptr FILEID="siapl"/>
+</mets:div>
+<mets:div ID="ziomc" LABEL="image 33" ORDER="831" TYPE="Static">
+<mets:fptr FILEID="zyd0k"/>
+</mets:div>
+<mets:div ID="zd955" LABEL="image 34" ORDER="832" TYPE="Static">
+<mets:fptr FILEID="l46r4"/>
+</mets:div>
+<mets:div ID="cv38h" LABEL="image 35" ORDER="833" TYPE="Static">
+<mets:fptr FILEID="jyt4v"/>
+</mets:div>
+<mets:div ID="imkj3" LABEL="image 36" ORDER="834" TYPE="Static">
+<mets:fptr FILEID="ky080"/>
+</mets:div>
+<mets:div ID="qd08x" LABEL="image 37" ORDER="835" TYPE="Static">
+<mets:fptr FILEID="kqyef"/>
+</mets:div>
+<mets:div ID="dyzh8" LABEL="image 38" ORDER="836" TYPE="Static">
+<mets:fptr FILEID="lmrck"/>
+</mets:div>
+<mets:div ID="sowlf" LABEL="image 39" ORDER="837" TYPE="Static">
+<mets:fptr FILEID="aoqob"/>
+</mets:div>
+<mets:div ID="nj75l" LABEL="image 40" ORDER="838" TYPE="Static">
+<mets:fptr FILEID="aykzw"/>
+</mets:div>
+<mets:div ID="wdbi6" LABEL="image 41" ORDER="839" TYPE="Static">
+<mets:fptr FILEID="hiviw"/>
+</mets:div>
+<mets:div ID="pnjq3" LABEL="image 42" ORDER="840" TYPE="Static">
+<mets:fptr FILEID="swcbj"/>
+</mets:div>
+<mets:div ID="hecpl" LABEL="image 43" ORDER="841" TYPE="Static">
+<mets:fptr FILEID="qc203"/>
+</mets:div>
+<mets:div ID="emj7r" LABEL="image 44" ORDER="842" TYPE="Static">
+<mets:fptr FILEID="w28gk"/>
+</mets:div>
+<mets:div ID="j2kto" LABEL="image 45" ORDER="843" TYPE="Static">
+<mets:fptr FILEID="vn2l3"/>
+</mets:div>
+<mets:div ID="zgx6m" LABEL="image 46" ORDER="844" TYPE="Static">
+<mets:fptr FILEID="crmfq"/>
+</mets:div>
+<mets:div ID="izdko" LABEL="image 47" ORDER="845" TYPE="Static">
+<mets:fptr FILEID="kj946"/>
+</mets:div>
+<mets:div ID="r6v26" LABEL="image 48" ORDER="846" TYPE="Static">
+<mets:fptr FILEID="psnh7"/>
+</mets:div>
+<mets:div ID="juxud" LABEL="image 49" ORDER="847" TYPE="Static">
+<mets:fptr FILEID="po3pl"/>
+</mets:div>
+<mets:div ID="qjcut" LABEL="image 50" ORDER="848" TYPE="Static">
+<mets:fptr FILEID="ynh4h"/>
+</mets:div>
+<mets:div ID="l3rqk" LABEL="image 51" ORDER="849" TYPE="Static">
+<mets:fptr FILEID="a616s"/>
+</mets:div>
+<mets:div ID="t7jmk" LABEL="image 52" ORDER="850" TYPE="Static">
+<mets:fptr FILEID="xdl46"/>
+</mets:div>
+<mets:div ID="ru7ub" LABEL="image 53" ORDER="851" TYPE="Static">
+<mets:fptr FILEID="qmkaw"/>
+</mets:div>
+<mets:div ID="b48jc" LABEL="image 54" ORDER="852" TYPE="Static">
+<mets:fptr FILEID="ckmq2"/>
+</mets:div>
+<mets:div ID="x1vdx" LABEL="image 55" ORDER="853" TYPE="Static">
+<mets:fptr FILEID="ucgcs"/>
+</mets:div>
+<mets:div ID="ila7g" LABEL="image 56" ORDER="854" TYPE="Static">
+<mets:fptr FILEID="v7omr"/>
+</mets:div>
+<mets:div ID="j4q9q" LABEL="image 57" ORDER="855" TYPE="Static">
+<mets:fptr FILEID="gug1q"/>
+</mets:div>
+<mets:div ID="g33mu" LABEL="image 58" ORDER="856" TYPE="Static">
+<mets:fptr FILEID="bufjw"/>
+</mets:div>
+<mets:div ID="jn4qg" LABEL="image 59" ORDER="857" TYPE="Static">
+<mets:fptr FILEID="dwpv8"/>
+</mets:div>
+<mets:div ID="x6d98" LABEL="image 60" ORDER="858" TYPE="Static">
+<mets:fptr FILEID="tav4j"/>
+</mets:div>
+<mets:div ID="tk8wg" LABEL="image 61" ORDER="859" TYPE="Static">
+<mets:fptr FILEID="m3v1n"/>
+</mets:div>
+<mets:div ID="c1p84" LABEL="image 62" ORDER="860" TYPE="Static">
+<mets:fptr FILEID="rujkd"/>
+</mets:div>
+<mets:div ID="kq9to" LABEL="image 63" ORDER="861" TYPE="Static">
+<mets:fptr FILEID="z9frs"/>
+</mets:div>
+<mets:div ID="vrfr0" LABEL="image 64" ORDER="862" TYPE="Static">
+<mets:fptr FILEID="oprak"/>
+</mets:div>
+<mets:div ID="g5gey" LABEL="image 65" ORDER="863" TYPE="Static">
+<mets:fptr FILEID="w77k6"/>
+</mets:div>
+<mets:div ID="a3lyg" LABEL="image 66" ORDER="864" TYPE="Static">
+<mets:fptr FILEID="ojy89"/>
+</mets:div>
+<mets:div ID="k3b8m" LABEL="image 67" ORDER="865" TYPE="Static">
+<mets:fptr FILEID="dugwz"/>
+</mets:div>
+<mets:div ID="tqqqh" LABEL="image 68" ORDER="866" TYPE="Static">
+<mets:fptr FILEID="osk5f"/>
+</mets:div>
+<mets:div ID="soomj" LABEL="image 69" ORDER="867" TYPE="Static">
+<mets:fptr FILEID="yvzsk"/>
+</mets:div>
+<mets:div ID="s8ja0" LABEL="image 70" ORDER="868" TYPE="Static">
+<mets:fptr FILEID="eg1hw"/>
+</mets:div>
+<mets:div ID="d3yfz" LABEL="image 71" ORDER="869" TYPE="Static">
+<mets:fptr FILEID="ryno3"/>
+</mets:div>
+<mets:div ID="ppwul" LABEL="image 72" ORDER="870" TYPE="Static">
+<mets:fptr FILEID="ndsim"/>
+</mets:div>
+<mets:div ID="c2xf9" LABEL="image 73" ORDER="871" TYPE="Static">
+<mets:fptr FILEID="vei4g"/>
+</mets:div>
+<mets:div ID="b7dbm" LABEL="image 74" ORDER="872" TYPE="Static">
+<mets:fptr FILEID="kff0a"/>
+</mets:div>
+<mets:div ID="fol7v" LABEL="image 75" ORDER="873" TYPE="Static">
+<mets:fptr FILEID="duekt"/>
+</mets:div>
+<mets:div ID="fp1sk" LABEL="image 76" ORDER="874" TYPE="Static">
+<mets:fptr FILEID="qc7cu"/>
+</mets:div>
+<mets:div ID="psbqo" LABEL="image 77" ORDER="875" TYPE="Static">
+<mets:fptr FILEID="uk3av"/>
+</mets:div>
+<mets:div ID="ae1xb" LABEL="image 78" ORDER="876" TYPE="Static">
+<mets:fptr FILEID="b1s6e"/>
+</mets:div>
+<mets:div ID="vdg19" LABEL="image 79" ORDER="877" TYPE="Static">
+<mets:fptr FILEID="q74m3"/>
+</mets:div>
+<mets:div ID="bctiy" LABEL="image 80" ORDER="878" TYPE="Static">
+<mets:fptr FILEID="px8ki"/>
+</mets:div>
+<mets:div ID="slnjc" LABEL="image 81" ORDER="879" TYPE="Static">
+<mets:fptr FILEID="n8znw"/>
+</mets:div>
+<mets:div ID="t872a" LABEL="image 82" ORDER="880" TYPE="Static">
+<mets:fptr FILEID="ni2i6"/>
+</mets:div>
+<mets:div ID="ed3zj" LABEL="image 83" ORDER="881" TYPE="Static">
+<mets:fptr FILEID="ra7lj"/>
+</mets:div>
+<mets:div ID="swwmx" LABEL="image 84" ORDER="882" TYPE="Static">
+<mets:fptr FILEID="wr2gu"/>
+</mets:div>
+<mets:div ID="mwncr" LABEL="image 85" ORDER="883" TYPE="Static">
+<mets:fptr FILEID="u4xo5"/>
+</mets:div>
+<mets:div ID="aj8yn" LABEL="image 86" ORDER="884" TYPE="Static">
+<mets:fptr FILEID="hfq4h"/>
+</mets:div>
+<mets:div ID="tz530" LABEL="image 87" ORDER="885" TYPE="Static">
+<mets:fptr FILEID="toi1y"/>
+</mets:div>
+<mets:div ID="wk4vd" LABEL="image 88" ORDER="886" TYPE="Static">
+<mets:fptr FILEID="fgv25"/>
+</mets:div>
+<mets:div ID="j1yz6" LABEL="image 89" ORDER="887" TYPE="Static">
+<mets:fptr FILEID="j5gdk"/>
+</mets:div>
+<mets:div ID="danzq" LABEL="image 90" ORDER="888" TYPE="Static">
+<mets:fptr FILEID="zo7ix"/>
+</mets:div>
+<mets:div ID="fvbee" LABEL="image 91" ORDER="889" TYPE="Static">
+<mets:fptr FILEID="b2opi"/>
+</mets:div>
+<mets:div ID="txfdv" LABEL="image 92" ORDER="890" TYPE="Static">
+<mets:fptr FILEID="wtcvb"/>
+</mets:div>
+<mets:div ID="xsfvf" LABEL="image 93" ORDER="891" TYPE="Static">
+<mets:fptr FILEID="ppx2j"/>
+</mets:div>
+<mets:div ID="k4hkc" LABEL="image 94" ORDER="892" TYPE="Static">
+<mets:fptr FILEID="ehnek"/>
+</mets:div>
+<mets:div ID="ljhec" LABEL="image 95" ORDER="893" TYPE="Static">
+<mets:fptr FILEID="gvbey"/>
+</mets:div>
+<mets:div ID="au75c" LABEL="image 96" ORDER="894" TYPE="Static">
+<mets:fptr FILEID="i02uz"/>
+</mets:div>
+<mets:div ID="tl8c2" LABEL="image 97" ORDER="895" TYPE="Static">
+<mets:fptr FILEID="zqers"/>
+</mets:div>
+<mets:div ID="jm222" LABEL="image 98" ORDER="896" TYPE="Static">
+<mets:fptr FILEID="s6rga"/>
+</mets:div>
+<mets:div ID="kuaj7" LABEL="image 99" ORDER="897" TYPE="Static">
+<mets:fptr FILEID="rzh99"/>
+</mets:div>
+<mets:div ID="nvbel" LABEL="image 100" ORDER="898" TYPE="Static">
+<mets:fptr FILEID="defod"/>
+</mets:div>
+<mets:div ID="ew8u1" LABEL="image 101" ORDER="899" TYPE="Static">
+<mets:fptr FILEID="xrnh5"/>
+</mets:div>
+<mets:div ID="vpkia" LABEL="image 102" ORDER="900" TYPE="Static">
+<mets:fptr FILEID="dtbzd"/>
+</mets:div>
+<mets:div ID="rhlha" LABEL="image 103" ORDER="901" TYPE="Static">
+<mets:fptr FILEID="zne2z"/>
+</mets:div>
+<mets:div ID="cnc86" LABEL="image 104" ORDER="902" TYPE="Static">
+<mets:fptr FILEID="mh2w0"/>
+</mets:div>
+<mets:div ID="hqnyl" LABEL="image 105" ORDER="903" TYPE="Static">
+<mets:fptr FILEID="cjc1w"/>
+</mets:div>
+<mets:div ID="cp9cb" LABEL="image 106" ORDER="904" TYPE="Static">
+<mets:fptr FILEID="vcz1c"/>
+</mets:div>
+<mets:div ID="qockn" LABEL="image 107" ORDER="905" TYPE="Static">
+<mets:fptr FILEID="i0f5u"/>
+</mets:div>
+<mets:div ID="axj5d" LABEL="image 108" ORDER="906" TYPE="Static">
+<mets:fptr FILEID="k4quw"/>
+</mets:div>
+<mets:div ID="rumgx" LABEL="image 109" ORDER="907" TYPE="Static">
+<mets:fptr FILEID="p70xr"/>
+</mets:div>
+<mets:div ID="cadni" LABEL="image 110" ORDER="908" TYPE="Static">
+<mets:fptr FILEID="qd684"/>
+</mets:div>
+<mets:div ID="h5cmt" LABEL="image 111" ORDER="909" TYPE="Static">
+<mets:fptr FILEID="ubc16"/>
+</mets:div>
+<mets:div ID="uazmi" LABEL="image 112" ORDER="910" TYPE="Static">
+<mets:fptr FILEID="cn2tp"/>
+</mets:div>
+<mets:div ID="oxmh4" LABEL="image 113" ORDER="911" TYPE="Static">
+<mets:fptr FILEID="sufwl"/>
+</mets:div>
+<mets:div ID="ea21p" LABEL="image 114" ORDER="912" TYPE="Static">
+<mets:fptr FILEID="lkr9d"/>
+</mets:div>
+<mets:div ID="cxgk1" LABEL="image 115" ORDER="913" TYPE="Static">
+<mets:fptr FILEID="yb2ct"/>
+</mets:div>
+<mets:div ID="iohi6" LABEL="image 116" ORDER="914" TYPE="Static">
+<mets:fptr FILEID="pq6me"/>
+</mets:div>
+<mets:div ID="v6f2w" LABEL="image 117" ORDER="915" TYPE="Static">
+<mets:fptr FILEID="w8l42"/>
+</mets:div>
+<mets:div ID="u9erd" LABEL="image 118" ORDER="916" TYPE="Static">
+<mets:fptr FILEID="oxzlx"/>
+</mets:div>
+<mets:div ID="vwp5z" LABEL="image 119" ORDER="917" TYPE="Static">
+<mets:fptr FILEID="foe73"/>
+</mets:div>
+<mets:div ID="uctva" LABEL="image 120" ORDER="918" TYPE="Static">
+<mets:fptr FILEID="iesca"/>
+</mets:div>
+<mets:div ID="yyjnj" LABEL="image 121" ORDER="919" TYPE="Static">
+<mets:fptr FILEID="cyhg3"/>
+</mets:div>
+<mets:div ID="pvpb5" LABEL="image 122" ORDER="920" TYPE="Static">
+<mets:fptr FILEID="khjsf"/>
+</mets:div>
+<mets:div ID="r9h9s" LABEL="image 123" ORDER="921" TYPE="Static">
+<mets:fptr FILEID="evg9a"/>
+</mets:div>
+<mets:div ID="dc8ru" LABEL="image 124" ORDER="922" TYPE="Static">
+<mets:fptr FILEID="k14sf"/>
+</mets:div>
+<mets:div ID="csyxq" LABEL="image 125" ORDER="923" TYPE="Static">
+<mets:fptr FILEID="htxd3"/>
+</mets:div>
+<mets:div ID="r1lvl" LABEL="image 126" ORDER="924" TYPE="Static">
+<mets:fptr FILEID="rv3kd"/>
+</mets:div>
+<mets:div ID="u63ez" LABEL="image 127" ORDER="925" TYPE="Static">
+<mets:fptr FILEID="f5shi"/>
+</mets:div>
+<mets:div ID="xe2ro" LABEL="image 128" ORDER="926" TYPE="Static">
+<mets:fptr FILEID="qt0k5"/>
+</mets:div>
+<mets:div ID="am0zm" LABEL="image 129" ORDER="927" TYPE="Static">
+<mets:fptr FILEID="n8423"/>
+</mets:div>
+<mets:div ID="j7wom" LABEL="image 130" ORDER="928" TYPE="Static">
+<mets:fptr FILEID="ygg5u"/>
+</mets:div>
+<mets:div ID="r42ye" LABEL="image 131" ORDER="929" TYPE="Static">
+<mets:fptr FILEID="yfbf2"/>
+</mets:div>
+<mets:div ID="qb3qc" LABEL="image 132" ORDER="930" TYPE="Static">
+<mets:fptr FILEID="k2spy"/>
+</mets:div>
+<mets:div ID="jtcwx" LABEL="image 133" ORDER="931" TYPE="Static">
+<mets:fptr FILEID="qgvda"/>
+</mets:div>
+<mets:div ID="dzi4q" LABEL="image 134" ORDER="932" TYPE="Static">
+<mets:fptr FILEID="rd5w4"/>
+</mets:div>
+<mets:div ID="n16rg" LABEL="image 135" ORDER="933" TYPE="Static">
+<mets:fptr FILEID="cpm1t"/>
+</mets:div>
+<mets:div ID="ocb33" LABEL="image 136" ORDER="934" TYPE="Static">
+<mets:fptr FILEID="omujt"/>
+</mets:div>
+<mets:div ID="u0xij" LABEL="image 137" ORDER="935" TYPE="Static">
+<mets:fptr FILEID="qse11"/>
+</mets:div>
+<mets:div ID="sg5fm" LABEL="image 138" ORDER="936" TYPE="Static">
+<mets:fptr FILEID="lxzhy"/>
+</mets:div>
+<mets:div ID="kn1lu" LABEL="image 139" ORDER="937" TYPE="Static">
+<mets:fptr FILEID="npaje"/>
+</mets:div>
+<mets:div ID="pcnuu" LABEL="image 140" ORDER="938" TYPE="Static">
+<mets:fptr FILEID="jlqd2"/>
+</mets:div>
+<mets:div ID="jl5kz" LABEL="image 141" ORDER="939" TYPE="Static">
+<mets:fptr FILEID="v49s0"/>
+</mets:div>
+<mets:div ID="ck27q" LABEL="image 142" ORDER="940" TYPE="Static">
+<mets:fptr FILEID="e5h3z"/>
+</mets:div>
+<mets:div ID="l0ni0" LABEL="image 143" ORDER="941" TYPE="Static">
+<mets:fptr FILEID="d7u5r"/>
+</mets:div>
+<mets:div ID="g78fi" LABEL="image 144" ORDER="942" TYPE="Static">
+<mets:fptr FILEID="qynoj"/>
+</mets:div>
+<mets:div ID="du8lg" LABEL="image 145" ORDER="943" TYPE="Static">
+<mets:fptr FILEID="p3f0i"/>
+</mets:div>
+<mets:div ID="z673l" LABEL="image 146" ORDER="944" TYPE="Static">
+<mets:fptr FILEID="lt0oh"/>
+</mets:div>
+<mets:div ID="cw4p6" LABEL="image 147" ORDER="945" TYPE="Static">
+<mets:fptr FILEID="v485l"/>
+</mets:div>
+<mets:div ID="dc87r" LABEL="image 148" ORDER="946" TYPE="Static">
+<mets:fptr FILEID="gakux"/>
+</mets:div>
+<mets:div ID="lx7zq" LABEL="image 149" ORDER="947" TYPE="Static">
+<mets:fptr FILEID="jfgwc"/>
+</mets:div>
+<mets:div ID="r7xn4" LABEL="image 150" ORDER="948" TYPE="Static">
+<mets:fptr FILEID="er8bv"/>
+</mets:div>
+<mets:div ID="bn46x" LABEL="image 151" ORDER="949" TYPE="Static">
+<mets:fptr FILEID="gor76"/>
+</mets:div>
+<mets:div ID="ujuwn" LABEL="image 152" ORDER="950" TYPE="Static">
+<mets:fptr FILEID="bmo8c"/>
+</mets:div>
+<mets:div ID="asf89" LABEL="image 153" ORDER="951" TYPE="Static">
+<mets:fptr FILEID="thg9a"/>
+</mets:div>
+<mets:div ID="dth5l" LABEL="image 154" ORDER="952" TYPE="Static">
+<mets:fptr FILEID="hdojr"/>
+</mets:div>
+<mets:div ID="pl9rt" LABEL="image 155" ORDER="953" TYPE="Static">
+<mets:fptr FILEID="f1pih"/>
+</mets:div>
+<mets:div ID="gz0tp" LABEL="image 156" ORDER="954" TYPE="Static">
+<mets:fptr FILEID="sbunq"/>
+</mets:div>
+<mets:div ID="oa58m" LABEL="image 157" ORDER="955" TYPE="Static">
+<mets:fptr FILEID="jfuz0"/>
+</mets:div>
+<mets:div ID="rz89h" LABEL="image 158" ORDER="956" TYPE="Static">
+<mets:fptr FILEID="zo1zv"/>
+</mets:div>
+<mets:div ID="f1bqa" LABEL="image 159" ORDER="957" TYPE="Static">
+<mets:fptr FILEID="nviid"/>
+</mets:div>
+<mets:div ID="hlp7c" LABEL="image 160" ORDER="958" TYPE="Static">
+<mets:fptr FILEID="ajtwz"/>
+</mets:div>
+<mets:div ID="bjx4b" LABEL="image 161" ORDER="959" TYPE="Static">
+<mets:fptr FILEID="m8qf2"/>
+</mets:div>
+<mets:div ID="k6kif" LABEL="image 162" ORDER="960" TYPE="Static">
+<mets:fptr FILEID="et3er"/>
+</mets:div>
+<mets:div ID="pgd4t" LABEL="image 163" ORDER="961" TYPE="Static">
+<mets:fptr FILEID="hgzay"/>
+</mets:div>
+<mets:div ID="cei0b" LABEL="image 164" ORDER="962" TYPE="Static">
+<mets:fptr FILEID="c6nh0"/>
+</mets:div>
+<mets:div ID="inlvd" LABEL="image 165" ORDER="963" TYPE="Static">
+<mets:fptr FILEID="z4yps"/>
+</mets:div>
+<mets:div ID="nepe5" LABEL="image 166" ORDER="964" TYPE="Static">
+<mets:fptr FILEID="p8hmx"/>
+</mets:div>
+<mets:div ID="jwa8y" LABEL="image 167" ORDER="965" TYPE="Static">
+<mets:fptr FILEID="t38xa"/>
+</mets:div>
+<mets:div ID="rx6vo" LABEL="image 168" ORDER="966" TYPE="Static">
+<mets:fptr FILEID="ewmca"/>
+</mets:div>
+<mets:div ID="pashd" LABEL="image 169" ORDER="967" TYPE="Static">
+<mets:fptr FILEID="e20ki"/>
+</mets:div>
+<mets:div ID="fd7xo" LABEL="image 170" ORDER="968" TYPE="Static">
+<mets:fptr FILEID="pgdmj"/>
+</mets:div>
+<mets:div ID="bloll" LABEL="image 171" ORDER="969" TYPE="Static">
+<mets:fptr FILEID="krams"/>
+</mets:div>
+<mets:div ID="fi7pj" LABEL="image 172" ORDER="970" TYPE="Static">
+<mets:fptr FILEID="ljyjn"/>
+</mets:div>
+<mets:div ID="dx1mq" LABEL="image 173" ORDER="971" TYPE="Static">
+<mets:fptr FILEID="yfpat"/>
+</mets:div>
+<mets:div ID="brp61" LABEL="image 174" ORDER="972" TYPE="Static">
+<mets:fptr FILEID="ushd8"/>
+</mets:div>
+<mets:div ID="kl9qm" LABEL="image 175" ORDER="973" TYPE="Static">
+<mets:fptr FILEID="evhyk"/>
+</mets:div>
+<mets:div ID="qvwtq" LABEL="image 176" ORDER="974" TYPE="Static">
+<mets:fptr FILEID="m3vx1"/>
+</mets:div>
+<mets:div ID="rbzve" LABEL="image 177" ORDER="975" TYPE="Static">
+<mets:fptr FILEID="dqj33"/>
+</mets:div>
+<mets:div ID="jspc0" LABEL="image 178" ORDER="976" TYPE="Static">
+<mets:fptr FILEID="zevnb"/>
+</mets:div>
+<mets:div ID="ih5p3" LABEL="image 179" ORDER="977" TYPE="Static">
+<mets:fptr FILEID="ipuys"/>
+</mets:div>
+<mets:div ID="snf0c" LABEL="image 180" ORDER="978" TYPE="Static">
+<mets:fptr FILEID="mj5xl"/>
+</mets:div>
+<mets:div ID="llody" LABEL="image 181" ORDER="979" TYPE="Static">
+<mets:fptr FILEID="w8szf"/>
+</mets:div>
+<mets:div ID="d01xd" LABEL="image 182" ORDER="980" TYPE="Static">
+<mets:fptr FILEID="gfddm"/>
+</mets:div>
+<mets:div ID="e5xb2" LABEL="image 183" ORDER="981" TYPE="Static">
+<mets:fptr FILEID="u46vg"/>
+</mets:div>
+<mets:div ID="jt624" LABEL="image 184" ORDER="982" TYPE="Static">
+<mets:fptr FILEID="ivjjk"/>
+</mets:div>
+<mets:div ID="jfk3o" LABEL="image 185" ORDER="983" TYPE="Static">
+<mets:fptr FILEID="omw6y"/>
+</mets:div>
+<mets:div ID="ul1qr" LABEL="image 186" ORDER="984" TYPE="Static">
+<mets:fptr FILEID="yoq6k"/>
+</mets:div>
+<mets:div ID="zks1p" LABEL="image 187" ORDER="985" TYPE="Static">
+<mets:fptr FILEID="r7kk7"/>
+</mets:div>
+<mets:div ID="s9sjo" LABEL="image 188" ORDER="986" TYPE="Static">
+<mets:fptr FILEID="ptioh"/>
+</mets:div>
+<mets:div ID="rf8s0" LABEL="image 189" ORDER="987" TYPE="Static">
+<mets:fptr FILEID="joi92"/>
+</mets:div>
+<mets:div ID="jvv9v" LABEL="image 190" ORDER="988" TYPE="Static">
+<mets:fptr FILEID="zpaiv"/>
+</mets:div>
+<mets:div ID="o11yw" LABEL="image 191" ORDER="989" TYPE="Static">
+<mets:fptr FILEID="yqq07"/>
+</mets:div>
+<mets:div ID="o3y64" LABEL="image 192" ORDER="990" TYPE="Static">
+<mets:fptr FILEID="xmgq5"/>
+</mets:div>
+<mets:div ID="ds9e6" LABEL="image 193" ORDER="991" TYPE="Static">
+<mets:fptr FILEID="jh7w2"/>
+</mets:div>
+<mets:div ID="oaw1v" LABEL="image 194" ORDER="992" TYPE="Static">
+<mets:fptr FILEID="g1tve"/>
+</mets:div>
+<mets:div ID="mnxf7" LABEL="image 195" ORDER="993" TYPE="Static">
+<mets:fptr FILEID="jdtaw"/>
+</mets:div>
+<mets:div ID="ouo9a" LABEL="image 196" ORDER="994" TYPE="Static">
+<mets:fptr FILEID="t8qu0"/>
+</mets:div>
+<mets:div ID="zxp07" LABEL="image 197" ORDER="995" TYPE="Static">
+<mets:fptr FILEID="he1jr"/>
+</mets:div>
+<mets:div ID="n8idl" LABEL="image 198" ORDER="996" TYPE="Static">
+<mets:fptr FILEID="luhbr"/>
+</mets:div>
+<mets:div ID="nxgpe" LABEL="image 199" ORDER="997" TYPE="Static">
+<mets:fptr FILEID="zi46d"/>
+</mets:div>
+<mets:div ID="qlzj5" LABEL="image 200" ORDER="998" TYPE="Static">
+<mets:fptr FILEID="nn7cn"/>
+</mets:div>
+<mets:div ID="exqd1" LABEL="image 201" ORDER="999" TYPE="Static">
+<mets:fptr FILEID="zqhb0"/>
+</mets:div>
+<mets:div ID="dkyhn" LABEL="image 202" ORDER="1000" TYPE="Static">
+<mets:fptr FILEID="uz3nx"/>
+</mets:div>
+<mets:div ID="oappe" LABEL="image 203" ORDER="1001" TYPE="Static">
+<mets:fptr FILEID="mdk3l"/>
+</mets:div>
+<mets:div ID="o820t" LABEL="image 204" ORDER="1002" TYPE="Static">
+<mets:fptr FILEID="wyo40"/>
+</mets:div>
+<mets:div ID="gt4da" LABEL="image 205" ORDER="1003" TYPE="Static">
+<mets:fptr FILEID="cd9nr"/>
+</mets:div>
+<mets:div ID="f3132" LABEL="image 206" ORDER="1004" TYPE="Static">
+<mets:fptr FILEID="ay98v"/>
+</mets:div>
+<mets:div ID="f9wav" LABEL="image 207" ORDER="1005" TYPE="Static">
+<mets:fptr FILEID="j3isb"/>
+</mets:div>
+<mets:div ID="uwrra" LABEL="image 208" ORDER="1006" TYPE="Static">
+<mets:fptr FILEID="ksq0a"/>
+</mets:div>
+<mets:div ID="r5h6p" LABEL="image 209" ORDER="1007" TYPE="Static">
+<mets:fptr FILEID="xjqaq"/>
+</mets:div>
+<mets:div ID="pb5n5" LABEL="image 210" ORDER="1008" TYPE="Static">
+<mets:fptr FILEID="eiiqf"/>
+</mets:div>
+<mets:div ID="c95pe" LABEL="image 211" ORDER="1009" TYPE="Static">
+<mets:fptr FILEID="hu71u"/>
+</mets:div>
+<mets:div ID="hqlyq" LABEL="image 212" ORDER="1010" TYPE="Static">
+<mets:fptr FILEID="uhxe7"/>
+</mets:div>
+<mets:div ID="hpg9u" LABEL="image 213" ORDER="1011" TYPE="Static">
+<mets:fptr FILEID="ujeh6"/>
+</mets:div>
+<mets:div ID="rmui9" LABEL="image 214" ORDER="1012" TYPE="Static">
+<mets:fptr FILEID="j70y7"/>
+</mets:div>
+<mets:div ID="g6nge" LABEL="image 215" ORDER="1013" TYPE="Static">
+<mets:fptr FILEID="scadl"/>
+</mets:div>
+<mets:div ID="jgxk1" LABEL="image 216" ORDER="1014" TYPE="Static">
+<mets:fptr FILEID="mko05"/>
+</mets:div>
+<mets:div ID="pacw9" LABEL="image 217" ORDER="1015" TYPE="Static">
+<mets:fptr FILEID="whria"/>
+</mets:div>
+<mets:div ID="ir2is" LABEL="image 218" ORDER="1016" TYPE="Static">
+<mets:fptr FILEID="yasdz"/>
+</mets:div>
+<mets:div ID="ca4fw" LABEL="image 219" ORDER="1017" TYPE="Static">
+<mets:fptr FILEID="fd9jf"/>
+</mets:div>
+<mets:div ID="tbiec" LABEL="image 220" ORDER="1018" TYPE="Static">
+<mets:fptr FILEID="pt9fn"/>
+</mets:div>
+<mets:div ID="ui8ej" LABEL="image 221" ORDER="1019" TYPE="Static">
+<mets:fptr FILEID="c22e4"/>
+</mets:div>
+<mets:div ID="tob4r" LABEL="image 222" ORDER="1020" TYPE="Static">
+<mets:fptr FILEID="w819o"/>
+</mets:div>
+<mets:div ID="wt9it" LABEL="image 223" ORDER="1021" TYPE="Static">
+<mets:fptr FILEID="tckbr"/>
+</mets:div>
+<mets:div ID="l1rz0" LABEL="image 224" ORDER="1022" TYPE="Static">
+<mets:fptr FILEID="lmy6e"/>
+</mets:div>
+<mets:div ID="sjam9" LABEL="image 225" ORDER="1023" TYPE="Static">
+<mets:fptr FILEID="ptswy"/>
+</mets:div>
+<mets:div ID="p42cu" LABEL="image 226" ORDER="1024" TYPE="Static">
+<mets:fptr FILEID="dgtk6"/>
+</mets:div>
+<mets:div ID="e8ccc" LABEL="image 227" ORDER="1025" TYPE="Static">
+<mets:fptr FILEID="o2wnl"/>
+</mets:div>
+<mets:div ID="kw9ka" LABEL="image 228" ORDER="1026" TYPE="Static">
+<mets:fptr FILEID="pfiex"/>
+</mets:div>
+<mets:div ID="q7pfi" LABEL="image 229" ORDER="1027" TYPE="Static">
+<mets:fptr FILEID="hy4wa"/>
+</mets:div>
+<mets:div ID="n7cw8" LABEL="image 230" ORDER="1028" TYPE="Static">
+<mets:fptr FILEID="k3ud6"/>
+</mets:div>
+<mets:div ID="nts9y" LABEL="image 231" ORDER="1029" TYPE="Static">
+<mets:fptr FILEID="p8xsz"/>
+</mets:div>
+<mets:div ID="ctnzr" LABEL="image 232" ORDER="1030" TYPE="Static">
+<mets:fptr FILEID="wjsur"/>
+</mets:div>
+<mets:div ID="ih16y" LABEL="image 233" ORDER="1031" TYPE="Static">
+<mets:fptr FILEID="xg2pz"/>
+</mets:div>
+<mets:div ID="u1mkl" LABEL="image 234" ORDER="1032" TYPE="Static">
+<mets:fptr FILEID="clpgh"/>
+</mets:div>
+<mets:div ID="vdol3" LABEL="image 235" ORDER="1033" TYPE="Static">
+<mets:fptr FILEID="fj8s9"/>
+</mets:div>
+</mets:div>
+</mets:div>
+</mets:structMap>
+<mets:structMap TYPE="Physical">
+<mets:div ID="y2wzi" TYPE="MultiVolumeSet">
+<mets:div ID="v1phys" LABEL="scrapbook_01" TYPE="BoundVolume">
+<mets:div ID="gyg2c" ORDER="1" TYPE="Static">
+<mets:fptr FILEID="l5baq"/>
+</mets:div>
+<mets:div ID="c60qf" ORDER="2" TYPE="Static">
+<mets:fptr FILEID="b7zl3"/>
+</mets:div>
+<mets:div ID="i41kx" ORDER="3" TYPE="Static">
+<mets:fptr FILEID="x6tb4"/>
+</mets:div>
+<mets:div ID="ve2fe" ORDER="4" TYPE="Static">
+<mets:fptr FILEID="d7rez"/>
+</mets:div>
+<mets:div ID="nfanv" ORDER="5" TYPE="Static">
+<mets:fptr FILEID="avxb5"/>
+</mets:div>
+<mets:div ID="qw5e4" ORDER="6" TYPE="Static">
+<mets:fptr FILEID="kji8y"/>
+</mets:div>
+<mets:div ID="ogtkp" ORDER="7" TYPE="Static">
+<mets:fptr FILEID="qx8bu"/>
+</mets:div>
+<mets:div ID="u8hmb" ORDER="8" TYPE="Static">
+<mets:fptr FILEID="utkd3"/>
+</mets:div>
+<mets:div ID="sfj1c" ORDER="9" TYPE="Static">
+<mets:fptr FILEID="px9u1"/>
+</mets:div>
+<mets:div ID="v0kja" ORDER="10" TYPE="Static">
+<mets:fptr FILEID="fujgx"/>
+</mets:div>
+<mets:div ID="zatj4" ORDER="11" TYPE="Static">
+<mets:fptr FILEID="no9dy"/>
+</mets:div>
+<mets:div ID="k4hoo" ORDER="12" TYPE="Static">
+<mets:fptr FILEID="fy2zm"/>
+</mets:div>
+<mets:div ID="pg1x8" ORDER="13" TYPE="Static">
+<mets:fptr FILEID="shc5u"/>
+</mets:div>
+<mets:div ID="x07ph" ORDER="14" TYPE="Static">
+<mets:fptr FILEID="kysvi"/>
+</mets:div>
+<mets:div ID="c31tm" ORDER="15" TYPE="Static">
+<mets:fptr FILEID="t9a8m"/>
+</mets:div>
+<mets:div ID="gdyl3" ORDER="16" TYPE="Static">
+<mets:fptr FILEID="oz7pl"/>
+</mets:div>
+<mets:div ID="z5n82" ORDER="17" TYPE="Static">
+<mets:fptr FILEID="z4dm9"/>
+</mets:div>
+<mets:div ID="jatec" ORDER="18" TYPE="Static">
+<mets:fptr FILEID="p3txt"/>
+</mets:div>
+<mets:div ID="x89qp" ORDER="19" TYPE="Static">
+<mets:fptr FILEID="b6g6h"/>
+</mets:div>
+<mets:div ID="bmwyv" ORDER="20" TYPE="Static">
+<mets:fptr FILEID="lkang"/>
+</mets:div>
+<mets:div ID="qefs1" ORDER="21" TYPE="Static">
+<mets:fptr FILEID="t9m8s"/>
+</mets:div>
+<mets:div ID="idw85" ORDER="22" TYPE="Static">
+<mets:fptr FILEID="fdozy"/>
+</mets:div>
+<mets:div ID="fx8o8" ORDER="23" TYPE="Static">
+<mets:fptr FILEID="d1yqw"/>
+</mets:div>
+<mets:div ID="yufby" ORDER="24" TYPE="Static">
+<mets:fptr FILEID="y9jjj"/>
+</mets:div>
+<mets:div ID="y3gap" ORDER="25" TYPE="Static">
+<mets:fptr FILEID="gnrbg"/>
+</mets:div>
+<mets:div ID="gxdm6" ORDER="26" TYPE="Static">
+<mets:fptr FILEID="f3tg4"/>
+</mets:div>
+<mets:div ID="pfymr" ORDER="27" TYPE="Static">
+<mets:fptr FILEID="scrtl"/>
+</mets:div>
+<mets:div ID="haxsv" ORDER="28" TYPE="Static">
+<mets:fptr FILEID="zkae8"/>
+</mets:div>
+<mets:div ID="ioi1f" ORDER="29" TYPE="Static">
+<mets:fptr FILEID="hi82a"/>
+</mets:div>
+<mets:div ID="c2e57" ORDER="30" TYPE="Static">
+<mets:fptr FILEID="e4hwb"/>
+</mets:div>
+<mets:div ID="czkre" ORDER="31" TYPE="Static">
+<mets:fptr FILEID="ick68"/>
+</mets:div>
+<mets:div ID="t9wy0" ORDER="32" TYPE="Static">
+<mets:fptr FILEID="xno7n"/>
+</mets:div>
+<mets:div ID="oyr4u" ORDER="33" TYPE="Static">
+<mets:fptr FILEID="uir9m"/>
+</mets:div>
+<mets:div ID="dt7ub" ORDER="34" TYPE="Static">
+<mets:fptr FILEID="gvmjb"/>
+</mets:div>
+<mets:div ID="rrtd3" ORDER="35" TYPE="Static">
+<mets:fptr FILEID="f5boc"/>
+</mets:div>
+<mets:div ID="hnkx1" ORDER="36" TYPE="Static">
+<mets:fptr FILEID="owo44"/>
+</mets:div>
+<mets:div ID="tj8wb" ORDER="37" TYPE="Static">
+<mets:fptr FILEID="npc2a"/>
+</mets:div>
+<mets:div ID="ymoxp" ORDER="38" TYPE="Static">
+<mets:fptr FILEID="y05o2"/>
+</mets:div>
+<mets:div ID="zabja" ORDER="39" TYPE="Static">
+<mets:fptr FILEID="ilpzx"/>
+</mets:div>
+<mets:div ID="gnfsl" ORDER="40" TYPE="Static">
+<mets:fptr FILEID="ayryk"/>
+</mets:div>
+<mets:div ID="u7ik3" ORDER="41" TYPE="Static">
+<mets:fptr FILEID="mnmdv"/>
+</mets:div>
+<mets:div ID="iib4u" ORDER="42" TYPE="Static">
+<mets:fptr FILEID="tbvw9"/>
+</mets:div>
+<mets:div ID="pn0jc" ORDER="43" TYPE="Static">
+<mets:fptr FILEID="n90tt"/>
+</mets:div>
+<mets:div ID="p4d96" ORDER="44" TYPE="Static">
+<mets:fptr FILEID="wmky0"/>
+</mets:div>
+<mets:div ID="tqp9g" ORDER="45" TYPE="Static">
+<mets:fptr FILEID="aioqq"/>
+</mets:div>
+<mets:div ID="u896k" ORDER="46" TYPE="Static">
+<mets:fptr FILEID="t1gez"/>
+</mets:div>
+<mets:div ID="pvdet" ORDER="47" TYPE="Static">
+<mets:fptr FILEID="hu1ty"/>
+</mets:div>
+<mets:div ID="afqzi" ORDER="48" TYPE="Static">
+<mets:fptr FILEID="r530k"/>
+</mets:div>
+<mets:div ID="ynuwp" ORDER="49" TYPE="Static">
+<mets:fptr FILEID="shlfg"/>
+</mets:div>
+<mets:div ID="puqz6" ORDER="50" TYPE="Static">
+<mets:fptr FILEID="q4eqv"/>
+</mets:div>
+<mets:div ID="dwy9i" ORDER="51" TYPE="Static">
+<mets:fptr FILEID="a1int"/>
+</mets:div>
+<mets:div ID="jri1p" ORDER="52" TYPE="Static">
+<mets:fptr FILEID="cixxw"/>
+</mets:div>
+<mets:div ID="jsjb4" ORDER="53" TYPE="Static">
+<mets:fptr FILEID="zeagq"/>
+</mets:div>
+<mets:div ID="xge99" ORDER="54" TYPE="Static">
+<mets:fptr FILEID="xp6se"/>
+</mets:div>
+<mets:div ID="czk44" ORDER="55" TYPE="Static">
+<mets:fptr FILEID="q5pwa"/>
+</mets:div>
+<mets:div ID="hx79c" ORDER="56" TYPE="Static">
+<mets:fptr FILEID="lez6y"/>
+</mets:div>
+<mets:div ID="hx7i3" ORDER="57" TYPE="Static">
+<mets:fptr FILEID="cazkp"/>
+</mets:div>
+<mets:div ID="x9s58" ORDER="58" TYPE="Static">
+<mets:fptr FILEID="l19ce"/>
+</mets:div>
+<mets:div ID="n16py" ORDER="59" TYPE="Static">
+<mets:fptr FILEID="sbec1"/>
+</mets:div>
+<mets:div ID="fbvux" ORDER="60" TYPE="Static">
+<mets:fptr FILEID="liulp"/>
+</mets:div>
+<mets:div ID="j6oy6" ORDER="61" TYPE="Static">
+<mets:fptr FILEID="l85k7"/>
+</mets:div>
+<mets:div ID="mm6o7" ORDER="62" TYPE="Static">
+<mets:fptr FILEID="u68l8"/>
+</mets:div>
+<mets:div ID="s65vr" ORDER="63" TYPE="Static">
+<mets:fptr FILEID="j180l"/>
+</mets:div>
+<mets:div ID="xzqn4" ORDER="64" TYPE="Static">
+<mets:fptr FILEID="zohoz"/>
+</mets:div>
+<mets:div ID="ikfmk" ORDER="65" TYPE="Static">
+<mets:fptr FILEID="kgusw"/>
+</mets:div>
+<mets:div ID="d7r5a" ORDER="66" TYPE="Static">
+<mets:fptr FILEID="t1hbj"/>
+</mets:div>
+<mets:div ID="na4z0" ORDER="67" TYPE="Static">
+<mets:fptr FILEID="u9pjh"/>
+</mets:div>
+<mets:div ID="ja4un" ORDER="68" TYPE="Static">
+<mets:fptr FILEID="hruzn"/>
+</mets:div>
+<mets:div ID="obry5" ORDER="69" TYPE="Static">
+<mets:fptr FILEID="qs479"/>
+</mets:div>
+<mets:div ID="cppc7" ORDER="70" TYPE="Static">
+<mets:fptr FILEID="pnv2x"/>
+</mets:div>
+<mets:div ID="ocd91" ORDER="71" TYPE="Static">
+<mets:fptr FILEID="zk9zd"/>
+</mets:div>
+<mets:div ID="ozj5f" ORDER="72" TYPE="Static">
+<mets:fptr FILEID="b6asb"/>
+</mets:div>
+<mets:div ID="zibwk" ORDER="73" TYPE="Static">
+<mets:fptr FILEID="qyd9w"/>
+</mets:div>
+<mets:div ID="j3riv" ORDER="74" TYPE="Static">
+<mets:fptr FILEID="c5g3p"/>
+</mets:div>
+<mets:div ID="mn7r4" ORDER="75" TYPE="Static">
+<mets:fptr FILEID="dd3jp"/>
+</mets:div>
+<mets:div ID="eie1q" ORDER="76" TYPE="Static">
+<mets:fptr FILEID="geyd4"/>
+</mets:div>
+<mets:div ID="ku2gn" ORDER="77" TYPE="Static">
+<mets:fptr FILEID="nuysl"/>
+</mets:div>
+<mets:div ID="x9fku" ORDER="78" TYPE="Static">
+<mets:fptr FILEID="wyi47"/>
+</mets:div>
+<mets:div ID="pg02p" ORDER="79" TYPE="Static">
+<mets:fptr FILEID="v1jwi"/>
+</mets:div>
+<mets:div ID="dbi81" ORDER="80" TYPE="Static">
+<mets:fptr FILEID="le4jg"/>
+</mets:div>
+<mets:div ID="ye85w" ORDER="81" TYPE="Static">
+<mets:fptr FILEID="u6e51"/>
+</mets:div>
+<mets:div ID="goldy" ORDER="82" TYPE="Static">
+<mets:fptr FILEID="h2yh5"/>
+</mets:div>
+<mets:div ID="a3jqi" ORDER="83" TYPE="Static">
+<mets:fptr FILEID="sfkqu"/>
+</mets:div>
+<mets:div ID="hnn5m" ORDER="84" TYPE="Static">
+<mets:fptr FILEID="eb68m"/>
+</mets:div>
+<mets:div ID="j8u2m" ORDER="85" TYPE="Static">
+<mets:fptr FILEID="ba7pj"/>
+</mets:div>
+<mets:div ID="wfrss" ORDER="86" TYPE="Static">
+<mets:fptr FILEID="gmrzp"/>
+</mets:div>
+<mets:div ID="i5kk6" ORDER="87" TYPE="Static">
+<mets:fptr FILEID="yvmh8"/>
+</mets:div>
+<mets:div ID="v7ovs" ORDER="88" TYPE="Static">
+<mets:fptr FILEID="y6nyp"/>
+</mets:div>
+<mets:div ID="xbq3c" ORDER="89" TYPE="Static">
+<mets:fptr FILEID="ow1zi"/>
+</mets:div>
+<mets:div ID="jyii1" ORDER="90" TYPE="Static">
+<mets:fptr FILEID="bkg58"/>
+</mets:div>
+<mets:div ID="hz041" ORDER="91" TYPE="Static">
+<mets:fptr FILEID="d856l"/>
+</mets:div>
+<mets:div ID="gft9v" ORDER="92" TYPE="Static">
+<mets:fptr FILEID="aragj"/>
+</mets:div>
+<mets:div ID="dwqsi" ORDER="93" TYPE="Static">
+<mets:fptr FILEID="c7ca7"/>
+</mets:div>
+<mets:div ID="qd7i8" ORDER="94" TYPE="Static">
+<mets:fptr FILEID="charw"/>
+</mets:div>
+<mets:div ID="aio1g" ORDER="95" TYPE="Static">
+<mets:fptr FILEID="crsxc"/>
+</mets:div>
+<mets:div ID="se1bv" ORDER="96" TYPE="Static">
+<mets:fptr FILEID="r9y6g"/>
+</mets:div>
+<mets:div ID="mcs0g" ORDER="97" TYPE="Static">
+<mets:fptr FILEID="itq91"/>
+</mets:div>
+<mets:div ID="atvvw" ORDER="98" TYPE="Static">
+<mets:fptr FILEID="xnxhm"/>
+</mets:div>
+<mets:div ID="pls8m" ORDER="99" TYPE="Static">
+<mets:fptr FILEID="vzziq"/>
+</mets:div>
+<mets:div ID="fovtu" ORDER="100" TYPE="Static">
+<mets:fptr FILEID="jmgdg"/>
+</mets:div>
+<mets:div ID="y9wns" ORDER="101" TYPE="Static">
+<mets:fptr FILEID="p2qk7"/>
+</mets:div>
+<mets:div ID="ef4cg" ORDER="102" TYPE="Static">
+<mets:fptr FILEID="hvz24"/>
+</mets:div>
+<mets:div ID="mtkgs" ORDER="103" TYPE="Static">
+<mets:fptr FILEID="ull2i"/>
+</mets:div>
+<mets:div ID="hhmal" ORDER="104" TYPE="Static">
+<mets:fptr FILEID="cpn5w"/>
+</mets:div>
+<mets:div ID="ptt10" ORDER="105" TYPE="Static">
+<mets:fptr FILEID="xsa6f"/>
+</mets:div>
+<mets:div ID="b9on8" ORDER="106" TYPE="Static">
+<mets:fptr FILEID="zhprw"/>
+</mets:div>
+<mets:div ID="qvl9l" ORDER="107" TYPE="Static">
+<mets:fptr FILEID="rf115"/>
+</mets:div>
+<mets:div ID="l5lw4" ORDER="108" TYPE="Static">
+<mets:fptr FILEID="cc019"/>
+</mets:div>
+<mets:div ID="g8570" ORDER="109" TYPE="Static">
+<mets:fptr FILEID="knl23"/>
+</mets:div>
+<mets:div ID="cfozr" ORDER="110" TYPE="Static">
+<mets:fptr FILEID="yk3nf"/>
+</mets:div>
+<mets:div ID="tlr1v" ORDER="111" TYPE="Static">
+<mets:fptr FILEID="k6h3b"/>
+</mets:div>
+<mets:div ID="kxdyl" ORDER="112" TYPE="Static">
+<mets:fptr FILEID="pu2re"/>
+</mets:div>
+<mets:div ID="fccsd" ORDER="113" TYPE="Static">
+<mets:fptr FILEID="zodsq"/>
+</mets:div>
+<mets:div ID="devg8" ORDER="114" TYPE="Static">
+<mets:fptr FILEID="f8gf6"/>
+</mets:div>
+<mets:div ID="kcw5v" ORDER="115" TYPE="Static">
+<mets:fptr FILEID="bu548"/>
+</mets:div>
+<mets:div ID="txat4" ORDER="116" TYPE="Static">
+<mets:fptr FILEID="e8mee"/>
+</mets:div>
+<mets:div ID="i3de7" ORDER="117" TYPE="Static">
+<mets:fptr FILEID="hjan6"/>
+</mets:div>
+<mets:div ID="wdm5i" ORDER="118" TYPE="Static">
+<mets:fptr FILEID="tobgg"/>
+</mets:div>
+<mets:div ID="c9wsj" ORDER="119" TYPE="Static">
+<mets:fptr FILEID="zuoqn"/>
+</mets:div>
+<mets:div ID="ngyne" ORDER="120" TYPE="Static">
+<mets:fptr FILEID="rlb1z"/>
+</mets:div>
+<mets:div ID="vbxou" ORDER="121" TYPE="Static">
+<mets:fptr FILEID="brwmw"/>
+</mets:div>
+<mets:div ID="v1vef" ORDER="122" TYPE="Static">
+<mets:fptr FILEID="zwylh"/>
+</mets:div>
+<mets:div ID="xc6tu" ORDER="123" TYPE="Static">
+<mets:fptr FILEID="ivnzm"/>
+</mets:div>
+<mets:div ID="kitiv" ORDER="124" TYPE="Static">
+<mets:fptr FILEID="yn3bj"/>
+</mets:div>
+<mets:div ID="r6s7l" ORDER="125" TYPE="Static">
+<mets:fptr FILEID="cistq"/>
+</mets:div>
+<mets:div ID="gnhje" ORDER="126" TYPE="Static">
+<mets:fptr FILEID="faekk"/>
+</mets:div>
+<mets:div ID="e4gb0" ORDER="127" TYPE="Static">
+<mets:fptr FILEID="x3kaz"/>
+</mets:div>
+<mets:div ID="llyoe" ORDER="128" TYPE="Static">
+<mets:fptr FILEID="f5crn"/>
+</mets:div>
+<mets:div ID="d6pd8" ORDER="129" TYPE="Static">
+<mets:fptr FILEID="hv0zw"/>
+</mets:div>
+<mets:div ID="llr1l" ORDER="130" TYPE="Static">
+<mets:fptr FILEID="gmhd5"/>
+</mets:div>
+<mets:div ID="mxb68" ORDER="131" TYPE="Static">
+<mets:fptr FILEID="jzwgk"/>
+</mets:div>
+<mets:div ID="nj3fu" ORDER="132" TYPE="Static">
+<mets:fptr FILEID="nss32"/>
+</mets:div>
+<mets:div ID="unl1s" ORDER="133" TYPE="Static">
+<mets:fptr FILEID="e1ev8"/>
+</mets:div>
+<mets:div ID="c12be" ORDER="134" TYPE="Static">
+<mets:fptr FILEID="uze97"/>
+</mets:div>
+<mets:div ID="thvyo" ORDER="135" TYPE="Static">
+<mets:fptr FILEID="gkc4z"/>
+</mets:div>
+<mets:div ID="qfvyw" ORDER="136" TYPE="Static">
+<mets:fptr FILEID="ycc7i"/>
+</mets:div>
+</mets:div>
+<mets:div ID="v2phys" LABEL="scrapbook_02" TYPE="BoundVolume">
+<mets:div ID="ordi9" ORDER="1" TYPE="Static">
+<mets:fptr FILEID="gbw01"/>
+</mets:div>
+<mets:div ID="evqil" ORDER="2" TYPE="Static">
+<mets:fptr FILEID="nmsij"/>
+</mets:div>
+<mets:div ID="ri5n0" ORDER="3" TYPE="Static">
+<mets:fptr FILEID="vzbuy"/>
+</mets:div>
+<mets:div ID="yyhw1" ORDER="4" TYPE="Static">
+<mets:fptr FILEID="uessr"/>
+</mets:div>
+<mets:div ID="mnrcv" ORDER="5" TYPE="Static">
+<mets:fptr FILEID="sc6n7"/>
+</mets:div>
+<mets:div ID="w59a3" ORDER="6" TYPE="Static">
+<mets:fptr FILEID="y77dv"/>
+</mets:div>
+<mets:div ID="xmqgz" ORDER="7" TYPE="Static">
+<mets:fptr FILEID="ey6xg"/>
+</mets:div>
+<mets:div ID="y9dkj" ORDER="8" TYPE="Static">
+<mets:fptr FILEID="ytgv2"/>
+</mets:div>
+<mets:div ID="pb301" ORDER="9" TYPE="Static">
+<mets:fptr FILEID="p6m1g"/>
+</mets:div>
+<mets:div ID="giyxe" ORDER="10" TYPE="Static">
+<mets:fptr FILEID="pksi3"/>
+</mets:div>
+<mets:div ID="kwhpf" ORDER="11" TYPE="Static">
+<mets:fptr FILEID="y766a"/>
+</mets:div>
+<mets:div ID="d6j28" ORDER="12" TYPE="Static">
+<mets:fptr FILEID="yv4sv"/>
+</mets:div>
+<mets:div ID="gt654" ORDER="13" TYPE="Static">
+<mets:fptr FILEID="a0yrw"/>
+</mets:div>
+<mets:div ID="l4ozh" ORDER="14" TYPE="Static">
+<mets:fptr FILEID="xc1c6"/>
+</mets:div>
+<mets:div ID="uqlx7" ORDER="15" TYPE="Static">
+<mets:fptr FILEID="kk92r"/>
+</mets:div>
+<mets:div ID="b0kne" ORDER="16" TYPE="Static">
+<mets:fptr FILEID="jr55e"/>
+</mets:div>
+<mets:div ID="j8n60" ORDER="17" TYPE="Static">
+<mets:fptr FILEID="ll9fu"/>
+</mets:div>
+<mets:div ID="wvbs4" ORDER="18" TYPE="Static">
+<mets:fptr FILEID="st3j2"/>
+</mets:div>
+<mets:div ID="zoi1v" ORDER="19" TYPE="Static">
+<mets:fptr FILEID="mglo7"/>
+</mets:div>
+<mets:div ID="dlxhe" ORDER="20" TYPE="Static">
+<mets:fptr FILEID="x613p"/>
+</mets:div>
+<mets:div ID="mci7l" ORDER="21" TYPE="Static">
+<mets:fptr FILEID="l5mqk"/>
+</mets:div>
+<mets:div ID="wzx6h" ORDER="22" TYPE="Static">
+<mets:fptr FILEID="hstfn"/>
+</mets:div>
+<mets:div ID="kc578" ORDER="23" TYPE="Static">
+<mets:fptr FILEID="omvdz"/>
+</mets:div>
+<mets:div ID="v3lkj" ORDER="24" TYPE="Static">
+<mets:fptr FILEID="gj6lz"/>
+</mets:div>
+<mets:div ID="sbbxh" ORDER="25" TYPE="Static">
+<mets:fptr FILEID="zdvyi"/>
+</mets:div>
+<mets:div ID="rp7y2" ORDER="26" TYPE="Static">
+<mets:fptr FILEID="jj7kw"/>
+</mets:div>
+<mets:div ID="e6bye" ORDER="27" TYPE="Static">
+<mets:fptr FILEID="vadp6"/>
+</mets:div>
+<mets:div ID="d77os" ORDER="28" TYPE="Static">
+<mets:fptr FILEID="g1ja2"/>
+</mets:div>
+<mets:div ID="mdoaq" ORDER="29" TYPE="Static">
+<mets:fptr FILEID="dsfnb"/>
+</mets:div>
+<mets:div ID="qm36i" ORDER="30" TYPE="Static">
+<mets:fptr FILEID="i1o1x"/>
+</mets:div>
+<mets:div ID="vobz8" ORDER="31" TYPE="Static">
+<mets:fptr FILEID="zdj6t"/>
+</mets:div>
+<mets:div ID="li0c6" ORDER="32" TYPE="Static">
+<mets:fptr FILEID="sldpu"/>
+</mets:div>
+<mets:div ID="btjjc" ORDER="33" TYPE="Static">
+<mets:fptr FILEID="o6kby"/>
+</mets:div>
+<mets:div ID="ux50j" ORDER="34" TYPE="Static">
+<mets:fptr FILEID="pzq3d"/>
+</mets:div>
+<mets:div ID="e29eg" ORDER="35" TYPE="Static">
+<mets:fptr FILEID="p5d50"/>
+</mets:div>
+<mets:div ID="ncyvd" ORDER="36" TYPE="Static">
+<mets:fptr FILEID="fa3o8"/>
+</mets:div>
+<mets:div ID="mguwl" ORDER="37" TYPE="Static">
+<mets:fptr FILEID="h5lsi"/>
+</mets:div>
+<mets:div ID="ec5j6" ORDER="38" TYPE="Static">
+<mets:fptr FILEID="w35tq"/>
+</mets:div>
+<mets:div ID="p67aw" ORDER="39" TYPE="Static">
+<mets:fptr FILEID="wff2e"/>
+</mets:div>
+<mets:div ID="frs25" ORDER="40" TYPE="Static">
+<mets:fptr FILEID="zvrun"/>
+</mets:div>
+<mets:div ID="xb5ag" ORDER="41" TYPE="Static">
+<mets:fptr FILEID="tbg6m"/>
+</mets:div>
+<mets:div ID="zr8sa" ORDER="42" TYPE="Static">
+<mets:fptr FILEID="lqszf"/>
+</mets:div>
+<mets:div ID="pmtcc" ORDER="43" TYPE="Static">
+<mets:fptr FILEID="erre9"/>
+</mets:div>
+<mets:div ID="thbn5" ORDER="44" TYPE="Static">
+<mets:fptr FILEID="vt6zp"/>
+</mets:div>
+<mets:div ID="k2b8g" ORDER="45" TYPE="Static">
+<mets:fptr FILEID="mlgzw"/>
+</mets:div>
+<mets:div ID="stwkn" ORDER="46" TYPE="Static">
+<mets:fptr FILEID="z0uxp"/>
+</mets:div>
+<mets:div ID="qcyih" ORDER="47" TYPE="Static">
+<mets:fptr FILEID="e8yob"/>
+</mets:div>
+<mets:div ID="l3g1j" ORDER="48" TYPE="Static">
+<mets:fptr FILEID="zoq1z"/>
+</mets:div>
+<mets:div ID="fz5c5" ORDER="49" TYPE="Static">
+<mets:fptr FILEID="jkgp6"/>
+</mets:div>
+<mets:div ID="gzqcg" ORDER="50" TYPE="Static">
+<mets:fptr FILEID="f8a7y"/>
+</mets:div>
+<mets:div ID="v1u87" ORDER="51" TYPE="Static">
+<mets:fptr FILEID="vzjv5"/>
+</mets:div>
+<mets:div ID="fb9tr" ORDER="52" TYPE="Static">
+<mets:fptr FILEID="cwj2o"/>
+</mets:div>
+<mets:div ID="lm4xm" ORDER="53" TYPE="Static">
+<mets:fptr FILEID="i0mso"/>
+</mets:div>
+<mets:div ID="pyjhg" ORDER="54" TYPE="Static">
+<mets:fptr FILEID="ca7oe"/>
+</mets:div>
+<mets:div ID="r6kwf" ORDER="55" TYPE="Static">
+<mets:fptr FILEID="r2d8z"/>
+</mets:div>
+<mets:div ID="n19ps" ORDER="56" TYPE="Static">
+<mets:fptr FILEID="z1tr9"/>
+</mets:div>
+<mets:div ID="e6ahn" ORDER="57" TYPE="Static">
+<mets:fptr FILEID="j6gen"/>
+</mets:div>
+<mets:div ID="m0zf6" ORDER="58" TYPE="Static">
+<mets:fptr FILEID="xln4i"/>
+</mets:div>
+<mets:div ID="ofdb5" ORDER="59" TYPE="Static">
+<mets:fptr FILEID="vn9l5"/>
+</mets:div>
+<mets:div ID="qm7js" ORDER="60" TYPE="Static">
+<mets:fptr FILEID="t1gc0"/>
+</mets:div>
+<mets:div ID="m1kx1" ORDER="61" TYPE="Static">
+<mets:fptr FILEID="xnyc5"/>
+</mets:div>
+<mets:div ID="gb210" ORDER="62" TYPE="Static">
+<mets:fptr FILEID="g4cnz"/>
+</mets:div>
+<mets:div ID="fa2pl" ORDER="63" TYPE="Static">
+<mets:fptr FILEID="i8m2c"/>
+</mets:div>
+<mets:div ID="bhnus" ORDER="64" TYPE="Static">
+<mets:fptr FILEID="aisvb"/>
+</mets:div>
+<mets:div ID="e1yat" ORDER="65" TYPE="Static">
+<mets:fptr FILEID="pdd45"/>
+</mets:div>
+<mets:div ID="igl79" ORDER="66" TYPE="Static">
+<mets:fptr FILEID="byq68"/>
+</mets:div>
+<mets:div ID="ann6t" ORDER="67" TYPE="Static">
+<mets:fptr FILEID="sdqg6"/>
+</mets:div>
+<mets:div ID="i8kd7" ORDER="68" TYPE="Static">
+<mets:fptr FILEID="e2kbq"/>
+</mets:div>
+<mets:div ID="ors0x" ORDER="69" TYPE="Static">
+<mets:fptr FILEID="ym1mf"/>
+</mets:div>
+<mets:div ID="m015b" ORDER="70" TYPE="Static">
+<mets:fptr FILEID="xpanh"/>
+</mets:div>
+<mets:div ID="abpfv" ORDER="71" TYPE="Static">
+<mets:fptr FILEID="d7ne5"/>
+</mets:div>
+<mets:div ID="kn3h9" ORDER="72" TYPE="Static">
+<mets:fptr FILEID="s5yaa"/>
+</mets:div>
+<mets:div ID="dah1i" ORDER="73" TYPE="Static">
+<mets:fptr FILEID="zdkxu"/>
+</mets:div>
+<mets:div ID="b5jsf" ORDER="74" TYPE="Static">
+<mets:fptr FILEID="scqf7"/>
+</mets:div>
+<mets:div ID="fjy84" ORDER="75" TYPE="Static">
+<mets:fptr FILEID="vdzak"/>
+</mets:div>
+<mets:div ID="oj554" ORDER="76" TYPE="Static">
+<mets:fptr FILEID="gjlie"/>
+</mets:div>
+<mets:div ID="b1ff7" ORDER="77" TYPE="Static">
+<mets:fptr FILEID="hqsxz"/>
+</mets:div>
+<mets:div ID="ofsve" ORDER="78" TYPE="Static">
+<mets:fptr FILEID="hqqcu"/>
+</mets:div>
+<mets:div ID="dvgj2" ORDER="79" TYPE="Static">
+<mets:fptr FILEID="xfa6r"/>
+</mets:div>
+<mets:div ID="k100f" ORDER="80" TYPE="Static">
+<mets:fptr FILEID="rstpt"/>
+</mets:div>
+<mets:div ID="hv3kb" ORDER="81" TYPE="Static">
+<mets:fptr FILEID="ubcs8"/>
+</mets:div>
+<mets:div ID="x94jd" ORDER="82" TYPE="Static">
+<mets:fptr FILEID="svn96"/>
+</mets:div>
+<mets:div ID="qgzay" ORDER="83" TYPE="Static">
+<mets:fptr FILEID="o4cys"/>
+</mets:div>
+<mets:div ID="mlfvj" ORDER="84" TYPE="Static">
+<mets:fptr FILEID="l5yu1"/>
+</mets:div>
+<mets:div ID="zr7f7" ORDER="85" TYPE="Static">
+<mets:fptr FILEID="xv323"/>
+</mets:div>
+<mets:div ID="yr23x" ORDER="86" TYPE="Static">
+<mets:fptr FILEID="imzjt"/>
+</mets:div>
+<mets:div ID="trdn7" ORDER="87" TYPE="Static">
+<mets:fptr FILEID="kholk"/>
+</mets:div>
+<mets:div ID="cjg97" ORDER="88" TYPE="Static">
+<mets:fptr FILEID="rqh5x"/>
+</mets:div>
+<mets:div ID="gz19y" ORDER="89" TYPE="Static">
+<mets:fptr FILEID="owvra"/>
+</mets:div>
+<mets:div ID="a2fv5" ORDER="90" TYPE="Static">
+<mets:fptr FILEID="t73z8"/>
+</mets:div>
+<mets:div ID="txd8b" ORDER="91" TYPE="Static">
+<mets:fptr FILEID="u1hx1"/>
+</mets:div>
+<mets:div ID="i3v15" ORDER="92" TYPE="Static">
+<mets:fptr FILEID="a4dnn"/>
+</mets:div>
+<mets:div ID="yq1dy" ORDER="93" TYPE="Static">
+<mets:fptr FILEID="irbal"/>
+</mets:div>
+<mets:div ID="bggcf" ORDER="94" TYPE="Static">
+<mets:fptr FILEID="t5roh"/>
+</mets:div>
+<mets:div ID="x27eb" ORDER="95" TYPE="Static">
+<mets:fptr FILEID="a9glf"/>
+</mets:div>
+<mets:div ID="c6pb3" ORDER="96" TYPE="Static">
+<mets:fptr FILEID="zyahj"/>
+</mets:div>
+<mets:div ID="kdfss" ORDER="97" TYPE="Static">
+<mets:fptr FILEID="yw0hr"/>
+</mets:div>
+<mets:div ID="zyaff" ORDER="98" TYPE="Static">
+<mets:fptr FILEID="v6tzx"/>
+</mets:div>
+<mets:div ID="kicy7" ORDER="99" TYPE="Static">
+<mets:fptr FILEID="vvj31"/>
+</mets:div>
+<mets:div ID="bd4cj" ORDER="100" TYPE="Static">
+<mets:fptr FILEID="zt1z1"/>
+</mets:div>
+<mets:div ID="tgk2g" ORDER="101" TYPE="Static">
+<mets:fptr FILEID="anj9n"/>
+</mets:div>
+<mets:div ID="pw5r7" ORDER="102" TYPE="Static">
+<mets:fptr FILEID="yra7f"/>
+</mets:div>
+<mets:div ID="uch4f" ORDER="103" TYPE="Static">
+<mets:fptr FILEID="v5rlk"/>
+</mets:div>
+<mets:div ID="dsm31" ORDER="104" TYPE="Static">
+<mets:fptr FILEID="w16r2"/>
+</mets:div>
+<mets:div ID="ki82r" ORDER="105" TYPE="Static">
+<mets:fptr FILEID="hjddo"/>
+</mets:div>
+<mets:div ID="lg1lm" ORDER="106" TYPE="Static">
+<mets:fptr FILEID="vnysn"/>
+</mets:div>
+<mets:div ID="vvbm6" ORDER="107" TYPE="Static">
+<mets:fptr FILEID="u1z1k"/>
+</mets:div>
+<mets:div ID="mb10g" ORDER="108" TYPE="Static">
+<mets:fptr FILEID="ygg14"/>
+</mets:div>
+<mets:div ID="kwea2" ORDER="109" TYPE="Static">
+<mets:fptr FILEID="yotr5"/>
+</mets:div>
+<mets:div ID="hj4zc" ORDER="110" TYPE="Static">
+<mets:fptr FILEID="clkeo"/>
+</mets:div>
+<mets:div ID="xj2d1" ORDER="111" TYPE="Static">
+<mets:fptr FILEID="cvyv5"/>
+</mets:div>
+<mets:div ID="ri545" ORDER="112" TYPE="Static">
+<mets:fptr FILEID="c3ohx"/>
+</mets:div>
+<mets:div ID="x4wm8" ORDER="113" TYPE="Static">
+<mets:fptr FILEID="buqgu"/>
+</mets:div>
+<mets:div ID="m1u4l" ORDER="114" TYPE="Static">
+<mets:fptr FILEID="ggrpe"/>
+</mets:div>
+<mets:div ID="hj5yg" ORDER="115" TYPE="Static">
+<mets:fptr FILEID="gvk7z"/>
+</mets:div>
+<mets:div ID="gi1vp" ORDER="116" TYPE="Static">
+<mets:fptr FILEID="x26y3"/>
+</mets:div>
+<mets:div ID="wspy0" ORDER="117" TYPE="Static">
+<mets:fptr FILEID="reuys"/>
+</mets:div>
+<mets:div ID="vn3jy" ORDER="118" TYPE="Static">
+<mets:fptr FILEID="mr2cf"/>
+</mets:div>
+<mets:div ID="w53ex" ORDER="119" TYPE="Static">
+<mets:fptr FILEID="yy2up"/>
+</mets:div>
+<mets:div ID="bhw3u" ORDER="120" TYPE="Static">
+<mets:fptr FILEID="l2132"/>
+</mets:div>
+<mets:div ID="u258q" ORDER="121" TYPE="Static">
+<mets:fptr FILEID="qerhs"/>
+</mets:div>
+<mets:div ID="xzjqn" ORDER="122" TYPE="Static">
+<mets:fptr FILEID="dfd89"/>
+</mets:div>
+<mets:div ID="kb3oe" ORDER="123" TYPE="Static">
+<mets:fptr FILEID="nad7m"/>
+</mets:div>
+<mets:div ID="a30uv" ORDER="124" TYPE="Static">
+<mets:fptr FILEID="yim2w"/>
+</mets:div>
+<mets:div ID="uz3gg" ORDER="125" TYPE="Static">
+<mets:fptr FILEID="iylx4"/>
+</mets:div>
+<mets:div ID="v0kv9" ORDER="126" TYPE="Static">
+<mets:fptr FILEID="nag3e"/>
+</mets:div>
+<mets:div ID="xun1l" ORDER="127" TYPE="Static">
+<mets:fptr FILEID="jhio2"/>
+</mets:div>
+<mets:div ID="j0i45" ORDER="128" TYPE="Static">
+<mets:fptr FILEID="sdun3"/>
+</mets:div>
+<mets:div ID="wsifo" ORDER="129" TYPE="Static">
+<mets:fptr FILEID="ajto8"/>
+</mets:div>
+<mets:div ID="b11r9" ORDER="130" TYPE="Static">
+<mets:fptr FILEID="ggrib"/>
+</mets:div>
+<mets:div ID="eboge" ORDER="131" TYPE="Static">
+<mets:fptr FILEID="q40sl"/>
+</mets:div>
+<mets:div ID="nnxlq" ORDER="132" TYPE="Static">
+<mets:fptr FILEID="nz7ra"/>
+</mets:div>
+<mets:div ID="raezl" ORDER="133" TYPE="Static">
+<mets:fptr FILEID="flfya"/>
+</mets:div>
+<mets:div ID="kx8zi" ORDER="134" TYPE="Static">
+<mets:fptr FILEID="pn8ht"/>
+</mets:div>
+<mets:div ID="x9h41" ORDER="135" TYPE="Static">
+<mets:fptr FILEID="flzoo"/>
+</mets:div>
+<mets:div ID="ro8mv" ORDER="136" TYPE="Static">
+<mets:fptr FILEID="ilv71"/>
+</mets:div>
+<mets:div ID="z629j" ORDER="137" TYPE="Static">
+<mets:fptr FILEID="k60at"/>
+</mets:div>
+</mets:div>
+<mets:div ID="v3phys" LABEL="scrapbook_03" TYPE="BoundVolume">
+<mets:div ID="bo0n5" ORDER="1" TYPE="Static">
+<mets:fptr FILEID="v8a82"/>
+</mets:div>
+<mets:div ID="mhvte" ORDER="2" TYPE="Static">
+<mets:fptr FILEID="rf6zl"/>
+</mets:div>
+<mets:div ID="a18ze" ORDER="3" TYPE="Static">
+<mets:fptr FILEID="msgw3"/>
+</mets:div>
+<mets:div ID="rx9qc" ORDER="4" TYPE="Static">
+<mets:fptr FILEID="q90z9"/>
+</mets:div>
+<mets:div ID="otp5p" ORDER="5" TYPE="Static">
+<mets:fptr FILEID="rphap"/>
+</mets:div>
+<mets:div ID="wswyo" ORDER="6" TYPE="Static">
+<mets:fptr FILEID="sae8v"/>
+</mets:div>
+<mets:div ID="np2md" ORDER="7" TYPE="Static">
+<mets:fptr FILEID="na812"/>
+</mets:div>
+<mets:div ID="qitjl" ORDER="8" TYPE="Static">
+<mets:fptr FILEID="tt15e"/>
+</mets:div>
+<mets:div ID="lb2wr" ORDER="9" TYPE="Static">
+<mets:fptr FILEID="i6ijp"/>
+</mets:div>
+<mets:div ID="x2gm9" ORDER="10" TYPE="Static">
+<mets:fptr FILEID="addcz"/>
+</mets:div>
+<mets:div ID="ajeov" ORDER="11" TYPE="Static">
+<mets:fptr FILEID="pq6u7"/>
+</mets:div>
+<mets:div ID="rpg3y" ORDER="12" TYPE="Static">
+<mets:fptr FILEID="kmm4w"/>
+</mets:div>
+<mets:div ID="catv3" ORDER="13" TYPE="Static">
+<mets:fptr FILEID="jeznt"/>
+</mets:div>
+<mets:div ID="bp270" ORDER="14" TYPE="Static">
+<mets:fptr FILEID="it3aw"/>
+</mets:div>
+<mets:div ID="fbygv" ORDER="15" TYPE="Static">
+<mets:fptr FILEID="jqadt"/>
+</mets:div>
+<mets:div ID="ds9f7" ORDER="16" TYPE="Static">
+<mets:fptr FILEID="q1ltt"/>
+</mets:div>
+<mets:div ID="m8vhx" ORDER="17" TYPE="Static">
+<mets:fptr FILEID="mgp2i"/>
+</mets:div>
+<mets:div ID="jmj4s" ORDER="18" TYPE="Static">
+<mets:fptr FILEID="k9wp3"/>
+</mets:div>
+<mets:div ID="kkp13" ORDER="19" TYPE="Static">
+<mets:fptr FILEID="eg9ti"/>
+</mets:div>
+<mets:div ID="b93lf" ORDER="20" TYPE="Static">
+<mets:fptr FILEID="sdpla"/>
+</mets:div>
+<mets:div ID="h1e6c" ORDER="21" TYPE="Static">
+<mets:fptr FILEID="hcsg3"/>
+</mets:div>
+<mets:div ID="r5hzc" ORDER="22" TYPE="Static">
+<mets:fptr FILEID="e6vm7"/>
+</mets:div>
+<mets:div ID="iz9vg" ORDER="23" TYPE="Static">
+<mets:fptr FILEID="hrylu"/>
+</mets:div>
+<mets:div ID="zfirf" ORDER="24" TYPE="Static">
+<mets:fptr FILEID="e2ngf"/>
+</mets:div>
+<mets:div ID="kbcb4" ORDER="25" TYPE="Static">
+<mets:fptr FILEID="yafgs"/>
+</mets:div>
+<mets:div ID="jlzyr" ORDER="26" TYPE="Static">
+<mets:fptr FILEID="oiccp"/>
+</mets:div>
+<mets:div ID="ijbvo" ORDER="27" TYPE="Static">
+<mets:fptr FILEID="x553l"/>
+</mets:div>
+<mets:div ID="b7fc8" ORDER="28" TYPE="Static">
+<mets:fptr FILEID="sakj7"/>
+</mets:div>
+<mets:div ID="tv670" ORDER="29" TYPE="Static">
+<mets:fptr FILEID="fk967"/>
+</mets:div>
+<mets:div ID="myxv1" ORDER="30" TYPE="Static">
+<mets:fptr FILEID="ezaho"/>
+</mets:div>
+<mets:div ID="ypnti" ORDER="31" TYPE="Static">
+<mets:fptr FILEID="k4kj8"/>
+</mets:div>
+<mets:div ID="vnqlu" ORDER="32" TYPE="Static">
+<mets:fptr FILEID="d0xo9"/>
+</mets:div>
+<mets:div ID="bmy4i" ORDER="33" TYPE="Static">
+<mets:fptr FILEID="n1g65"/>
+</mets:div>
+<mets:div ID="vhfz5" ORDER="34" TYPE="Static">
+<mets:fptr FILEID="sbxsa"/>
+</mets:div>
+<mets:div ID="gik8x" ORDER="35" TYPE="Static">
+<mets:fptr FILEID="yrxbt"/>
+</mets:div>
+<mets:div ID="f9udy" ORDER="36" TYPE="Static">
+<mets:fptr FILEID="m3dwo"/>
+</mets:div>
+<mets:div ID="o4r27" ORDER="37" TYPE="Static">
+<mets:fptr FILEID="oiw85"/>
+</mets:div>
+<mets:div ID="byvcg" ORDER="38" TYPE="Static">
+<mets:fptr FILEID="c2xvy"/>
+</mets:div>
+<mets:div ID="x0h4z" ORDER="39" TYPE="Static">
+<mets:fptr FILEID="xkgya"/>
+</mets:div>
+<mets:div ID="ayuai" ORDER="40" TYPE="Static">
+<mets:fptr FILEID="k56b0"/>
+</mets:div>
+<mets:div ID="cblu3" ORDER="41" TYPE="Static">
+<mets:fptr FILEID="np848"/>
+</mets:div>
+<mets:div ID="isg8u" ORDER="42" TYPE="Static">
+<mets:fptr FILEID="btxon"/>
+</mets:div>
+<mets:div ID="zvzjp" ORDER="43" TYPE="Static">
+<mets:fptr FILEID="zgua9"/>
+</mets:div>
+<mets:div ID="mubgg" ORDER="44" TYPE="Static">
+<mets:fptr FILEID="i9w2q"/>
+</mets:div>
+<mets:div ID="ofp52" ORDER="45" TYPE="Static">
+<mets:fptr FILEID="cdn97"/>
+</mets:div>
+<mets:div ID="mw6pq" ORDER="46" TYPE="Static">
+<mets:fptr FILEID="cyk5m"/>
+</mets:div>
+<mets:div ID="dtqm4" ORDER="47" TYPE="Static">
+<mets:fptr FILEID="msgcu"/>
+</mets:div>
+<mets:div ID="ssitp" ORDER="48" TYPE="Static">
+<mets:fptr FILEID="h7g54"/>
+</mets:div>
+<mets:div ID="szn7y" ORDER="49" TYPE="Static">
+<mets:fptr FILEID="h7wff"/>
+</mets:div>
+<mets:div ID="axtcb" ORDER="50" TYPE="Static">
+<mets:fptr FILEID="a2j6w"/>
+</mets:div>
+<mets:div ID="dun79" ORDER="51" TYPE="Static">
+<mets:fptr FILEID="lc0gq"/>
+</mets:div>
+<mets:div ID="fzn0c" ORDER="52" TYPE="Static">
+<mets:fptr FILEID="mpuzm"/>
+</mets:div>
+<mets:div ID="csgxt" ORDER="53" TYPE="Static">
+<mets:fptr FILEID="c43f8"/>
+</mets:div>
+<mets:div ID="f72mg" ORDER="54" TYPE="Static">
+<mets:fptr FILEID="hqors"/>
+</mets:div>
+<mets:div ID="se3qi" ORDER="55" TYPE="Static">
+<mets:fptr FILEID="pwz0y"/>
+</mets:div>
+<mets:div ID="k1gv8" ORDER="56" TYPE="Static">
+<mets:fptr FILEID="jpfw9"/>
+</mets:div>
+<mets:div ID="buocr" ORDER="57" TYPE="Static">
+<mets:fptr FILEID="xxu34"/>
+</mets:div>
+<mets:div ID="ig5h4" ORDER="58" TYPE="Static">
+<mets:fptr FILEID="cj88e"/>
+</mets:div>
+<mets:div ID="bsbwk" ORDER="59" TYPE="Static">
+<mets:fptr FILEID="edhjy"/>
+</mets:div>
+<mets:div ID="mt176" ORDER="60" TYPE="Static">
+<mets:fptr FILEID="wovmb"/>
+</mets:div>
+<mets:div ID="qxsx0" ORDER="61" TYPE="Static">
+<mets:fptr FILEID="wdw0w"/>
+</mets:div>
+<mets:div ID="wybhr" ORDER="62" TYPE="Static">
+<mets:fptr FILEID="xftm6"/>
+</mets:div>
+<mets:div ID="j1hc1" ORDER="63" TYPE="Static">
+<mets:fptr FILEID="jem8q"/>
+</mets:div>
+<mets:div ID="xnp24" ORDER="64" TYPE="Static">
+<mets:fptr FILEID="euvrk"/>
+</mets:div>
+<mets:div ID="a4txg" ORDER="65" TYPE="Static">
+<mets:fptr FILEID="jo42w"/>
+</mets:div>
+<mets:div ID="eogmd" ORDER="66" TYPE="Static">
+<mets:fptr FILEID="ddcxk"/>
+</mets:div>
+<mets:div ID="zlvsz" ORDER="67" TYPE="Static">
+<mets:fptr FILEID="ol623"/>
+</mets:div>
+<mets:div ID="ej3wb" ORDER="68" TYPE="Static">
+<mets:fptr FILEID="pgzme"/>
+</mets:div>
+<mets:div ID="xtdww" ORDER="69" TYPE="Static">
+<mets:fptr FILEID="c42ke"/>
+</mets:div>
+<mets:div ID="e12ng" ORDER="70" TYPE="Static">
+<mets:fptr FILEID="b5gpt"/>
+</mets:div>
+<mets:div ID="l1skf" ORDER="71" TYPE="Static">
+<mets:fptr FILEID="p8p2e"/>
+</mets:div>
+<mets:div ID="qyusz" ORDER="72" TYPE="Static">
+<mets:fptr FILEID="p05ft"/>
+</mets:div>
+<mets:div ID="ceby6" ORDER="73" TYPE="Static">
+<mets:fptr FILEID="s9gmi"/>
+</mets:div>
+<mets:div ID="pyp4u" ORDER="74" TYPE="Static">
+<mets:fptr FILEID="rqsvs"/>
+</mets:div>
+<mets:div ID="fm28s" ORDER="75" TYPE="Static">
+<mets:fptr FILEID="qysu4"/>
+</mets:div>
+<mets:div ID="huizr" ORDER="76" TYPE="Static">
+<mets:fptr FILEID="k58hg"/>
+</mets:div>
+<mets:div ID="qnimt" ORDER="77" TYPE="Static">
+<mets:fptr FILEID="q52s0"/>
+</mets:div>
+<mets:div ID="rwolg" ORDER="78" TYPE="Static">
+<mets:fptr FILEID="r2l7i"/>
+</mets:div>
+<mets:div ID="cjj7g" ORDER="79" TYPE="Static">
+<mets:fptr FILEID="liqys"/>
+</mets:div>
+<mets:div ID="my8vv" ORDER="80" TYPE="Static">
+<mets:fptr FILEID="mp1np"/>
+</mets:div>
+<mets:div ID="n2j1n" ORDER="81" TYPE="Static">
+<mets:fptr FILEID="hmam0"/>
+</mets:div>
+<mets:div ID="ctcvq" ORDER="82" TYPE="Static">
+<mets:fptr FILEID="mu9ue"/>
+</mets:div>
+<mets:div ID="hfgsw" ORDER="83" TYPE="Static">
+<mets:fptr FILEID="fsr8g"/>
+</mets:div>
+<mets:div ID="obtpa" ORDER="84" TYPE="Static">
+<mets:fptr FILEID="mh9il"/>
+</mets:div>
+<mets:div ID="wccvj" ORDER="85" TYPE="Static">
+<mets:fptr FILEID="ph9o0"/>
+</mets:div>
+<mets:div ID="k09g5" ORDER="86" TYPE="Static">
+<mets:fptr FILEID="s0tzp"/>
+</mets:div>
+<mets:div ID="i2wnd" ORDER="87" TYPE="Static">
+<mets:fptr FILEID="fgwqb"/>
+</mets:div>
+<mets:div ID="xqw8m" ORDER="88" TYPE="Static">
+<mets:fptr FILEID="r91qd"/>
+</mets:div>
+<mets:div ID="w5tlj" ORDER="89" TYPE="Static">
+<mets:fptr FILEID="hqbdd"/>
+</mets:div>
+<mets:div ID="jtu1z" ORDER="90" TYPE="Static">
+<mets:fptr FILEID="j2vyn"/>
+</mets:div>
+<mets:div ID="gi0lv" ORDER="91" TYPE="Static">
+<mets:fptr FILEID="x0sww"/>
+</mets:div>
+<mets:div ID="rdaem" ORDER="92" TYPE="Static">
+<mets:fptr FILEID="muvut"/>
+</mets:div>
+<mets:div ID="i4yrg" ORDER="93" TYPE="Static">
+<mets:fptr FILEID="qkept"/>
+</mets:div>
+<mets:div ID="kv6ra" ORDER="94" TYPE="Static">
+<mets:fptr FILEID="l6su7"/>
+</mets:div>
+<mets:div ID="ravvm" ORDER="95" TYPE="Static">
+<mets:fptr FILEID="v3o0d"/>
+</mets:div>
+<mets:div ID="zsbts" ORDER="96" TYPE="Static">
+<mets:fptr FILEID="ypnf1"/>
+</mets:div>
+<mets:div ID="aojso" ORDER="97" TYPE="Static">
+<mets:fptr FILEID="icr4e"/>
+</mets:div>
+<mets:div ID="dq4b4" ORDER="98" TYPE="Static">
+<mets:fptr FILEID="u9a0j"/>
+</mets:div>
+<mets:div ID="vi568" ORDER="99" TYPE="Static">
+<mets:fptr FILEID="bagdc"/>
+</mets:div>
+<mets:div ID="mp3r3" ORDER="100" TYPE="Static">
+<mets:fptr FILEID="y2r1y"/>
+</mets:div>
+<mets:div ID="p8zk5" ORDER="101" TYPE="Static">
+<mets:fptr FILEID="j7f6y"/>
+</mets:div>
+<mets:div ID="ttupq" ORDER="102" TYPE="Static">
+<mets:fptr FILEID="z6rzx"/>
+</mets:div>
+<mets:div ID="a2kxx" ORDER="103" TYPE="Static">
+<mets:fptr FILEID="rofj9"/>
+</mets:div>
+<mets:div ID="xtqdk" ORDER="104" TYPE="Static">
+<mets:fptr FILEID="hohj1"/>
+</mets:div>
+<mets:div ID="ui4ln" ORDER="105" TYPE="Static">
+<mets:fptr FILEID="livvw"/>
+</mets:div>
+<mets:div ID="pkrgw" ORDER="106" TYPE="Static">
+<mets:fptr FILEID="jy4la"/>
+</mets:div>
+<mets:div ID="d1dar" ORDER="107" TYPE="Static">
+<mets:fptr FILEID="f3u75"/>
+</mets:div>
+<mets:div ID="qrp2a" ORDER="108" TYPE="Static">
+<mets:fptr FILEID="ftxer"/>
+</mets:div>
+<mets:div ID="aylmi" ORDER="109" TYPE="Static">
+<mets:fptr FILEID="d3z6p"/>
+</mets:div>
+<mets:div ID="tr0qp" ORDER="110" TYPE="Static">
+<mets:fptr FILEID="u3m5u"/>
+</mets:div>
+<mets:div ID="z9rde" ORDER="111" TYPE="Static">
+<mets:fptr FILEID="k215o"/>
+</mets:div>
+<mets:div ID="kzfo7" ORDER="112" TYPE="Static">
+<mets:fptr FILEID="f0sim"/>
+</mets:div>
+<mets:div ID="xob6a" ORDER="113" TYPE="Static">
+<mets:fptr FILEID="wqfwg"/>
+</mets:div>
+<mets:div ID="rp6zu" ORDER="114" TYPE="Static">
+<mets:fptr FILEID="zzj9h"/>
+</mets:div>
+<mets:div ID="g2qz9" ORDER="115" TYPE="Static">
+<mets:fptr FILEID="f77v3"/>
+</mets:div>
+<mets:div ID="ujkbu" ORDER="116" TYPE="Static">
+<mets:fptr FILEID="qlqti"/>
+</mets:div>
+<mets:div ID="a3iy0" ORDER="117" TYPE="Static">
+<mets:fptr FILEID="valzj"/>
+</mets:div>
+<mets:div ID="v5ape" ORDER="118" TYPE="Static">
+<mets:fptr FILEID="r4d2z"/>
+</mets:div>
+<mets:div ID="locc7" ORDER="119" TYPE="Static">
+<mets:fptr FILEID="tcmhj"/>
+</mets:div>
+<mets:div ID="pmdp2" ORDER="120" TYPE="Static">
+<mets:fptr FILEID="j4k24"/>
+</mets:div>
+<mets:div ID="i1wmy" ORDER="121" TYPE="Static">
+<mets:fptr FILEID="ecn91"/>
+</mets:div>
+<mets:div ID="l0dhb" ORDER="122" TYPE="Static">
+<mets:fptr FILEID="x3qo9"/>
+</mets:div>
+<mets:div ID="jmqq0" ORDER="123" TYPE="Static">
+<mets:fptr FILEID="uzt4f"/>
+</mets:div>
+<mets:div ID="rqcrt" ORDER="124" TYPE="Static">
+<mets:fptr FILEID="frxra"/>
+</mets:div>
+<mets:div ID="ebv22" ORDER="125" TYPE="Static">
+<mets:fptr FILEID="vc74u"/>
+</mets:div>
+<mets:div ID="wczgr" ORDER="126" TYPE="Static">
+<mets:fptr FILEID="waq1u"/>
+</mets:div>
+<mets:div ID="n1xeg" ORDER="127" TYPE="Static">
+<mets:fptr FILEID="wbrp1"/>
+</mets:div>
+<mets:div ID="i2bmo" ORDER="128" TYPE="Static">
+<mets:fptr FILEID="ablkt"/>
+</mets:div>
+<mets:div ID="pxr0d" ORDER="129" TYPE="Static">
+<mets:fptr FILEID="d959w"/>
+</mets:div>
+<mets:div ID="jqga1" ORDER="130" TYPE="Static">
+<mets:fptr FILEID="vow3a"/>
+</mets:div>
+<mets:div ID="w20s1" ORDER="131" TYPE="Static">
+<mets:fptr FILEID="d6qle"/>
+</mets:div>
+<mets:div ID="zhe3n" ORDER="132" TYPE="Static">
+<mets:fptr FILEID="vklm5"/>
+</mets:div>
+<mets:div ID="f4yuy" ORDER="133" TYPE="Static">
+<mets:fptr FILEID="bfqit"/>
+</mets:div>
+<mets:div ID="wqmob" ORDER="134" TYPE="Static">
+<mets:fptr FILEID="vx5ox"/>
+</mets:div>
+<mets:div ID="k1x31" ORDER="135" TYPE="Static">
+<mets:fptr FILEID="cntk1"/>
+</mets:div>
+<mets:div ID="d0m85" ORDER="136" TYPE="Static">
+<mets:fptr FILEID="ofvd3"/>
+</mets:div>
+<mets:div ID="q51qm" ORDER="137" TYPE="Static">
+<mets:fptr FILEID="lg46u"/>
+</mets:div>
+<mets:div ID="fl26a" ORDER="138" TYPE="Static">
+<mets:fptr FILEID="g0br0"/>
+</mets:div>
+<mets:div ID="pnw6r" ORDER="139" TYPE="Static">
+<mets:fptr FILEID="mfobf"/>
+</mets:div>
+<mets:div ID="ojgrh" ORDER="140" TYPE="Static">
+<mets:fptr FILEID="khw76"/>
+</mets:div>
+<mets:div ID="tk5ei" ORDER="141" TYPE="Static">
+<mets:fptr FILEID="k17e9"/>
+</mets:div>
+<mets:div ID="qbd8z" ORDER="142" TYPE="Static">
+<mets:fptr FILEID="uny9n"/>
+</mets:div>
+<mets:div ID="haky4" ORDER="143" TYPE="Static">
+<mets:fptr FILEID="uyww5"/>
+</mets:div>
+<mets:div ID="l6y5b" ORDER="144" TYPE="Static">
+<mets:fptr FILEID="tf461"/>
+</mets:div>
+<mets:div ID="i1oyx" ORDER="145" TYPE="Static">
+<mets:fptr FILEID="nwufz"/>
+</mets:div>
+<mets:div ID="xuum9" ORDER="146" TYPE="Static">
+<mets:fptr FILEID="y7xj9"/>
+</mets:div>
+<mets:div ID="m8t1v" ORDER="147" TYPE="Static">
+<mets:fptr FILEID="st4yo"/>
+</mets:div>
+<mets:div ID="z4gw7" ORDER="148" TYPE="Static">
+<mets:fptr FILEID="g5sem"/>
+</mets:div>
+<mets:div ID="w5v4u" ORDER="149" TYPE="Static">
+<mets:fptr FILEID="mxzg7"/>
+</mets:div>
+<mets:div ID="a46jj" ORDER="150" TYPE="Static">
+<mets:fptr FILEID="xut8u"/>
+</mets:div>
+<mets:div ID="uuvkq" ORDER="151" TYPE="Static">
+<mets:fptr FILEID="syhcf"/>
+</mets:div>
+<mets:div ID="li87d" ORDER="152" TYPE="Static">
+<mets:fptr FILEID="g0cyu"/>
+</mets:div>
+<mets:div ID="hwro2" ORDER="153" TYPE="Static">
+<mets:fptr FILEID="lfevo"/>
+</mets:div>
+<mets:div ID="h4gy0" ORDER="154" TYPE="Static">
+<mets:fptr FILEID="je1hs"/>
+</mets:div>
+<mets:div ID="fwla8" ORDER="155" TYPE="Static">
+<mets:fptr FILEID="y1dxx"/>
+</mets:div>
+<mets:div ID="umxs2" ORDER="156" TYPE="Static">
+<mets:fptr FILEID="lll96"/>
+</mets:div>
+<mets:div ID="c7fey" ORDER="157" TYPE="Static">
+<mets:fptr FILEID="zmqge"/>
+</mets:div>
+<mets:div ID="zh4wl" ORDER="158" TYPE="Static">
+<mets:fptr FILEID="jl8fl"/>
+</mets:div>
+<mets:div ID="m6eau" ORDER="159" TYPE="Static">
+<mets:fptr FILEID="wrf2o"/>
+</mets:div>
+<mets:div ID="nzm0y" ORDER="160" TYPE="Static">
+<mets:fptr FILEID="d64fn"/>
+</mets:div>
+<mets:div ID="cjcaf" ORDER="161" TYPE="Static">
+<mets:fptr FILEID="ov5v9"/>
+</mets:div>
+<mets:div ID="c5kis" ORDER="162" TYPE="Static">
+<mets:fptr FILEID="wgmk6"/>
+</mets:div>
+<mets:div ID="o96bi" ORDER="163" TYPE="Static">
+<mets:fptr FILEID="delsa"/>
+</mets:div>
+<mets:div ID="vcc2z" ORDER="164" TYPE="Static">
+<mets:fptr FILEID="gugru"/>
+</mets:div>
+<mets:div ID="a22tf" ORDER="165" TYPE="Static">
+<mets:fptr FILEID="ylshw"/>
+</mets:div>
+<mets:div ID="ewbo3" ORDER="166" TYPE="Static">
+<mets:fptr FILEID="m6fnq"/>
+</mets:div>
+<mets:div ID="q3y2v" ORDER="167" TYPE="Static">
+<mets:fptr FILEID="b1ww7"/>
+</mets:div>
+<mets:div ID="d1hpi" ORDER="168" TYPE="Static">
+<mets:fptr FILEID="ljz80"/>
+</mets:div>
+<mets:div ID="uqoqg" ORDER="169" TYPE="Static">
+<mets:fptr FILEID="hrk7z"/>
+</mets:div>
+<mets:div ID="d51fn" ORDER="170" TYPE="Static">
+<mets:fptr FILEID="j81nz"/>
+</mets:div>
+<mets:div ID="ihtvo" ORDER="171" TYPE="Static">
+<mets:fptr FILEID="mro4g"/>
+</mets:div>
+<mets:div ID="hywk5" ORDER="172" TYPE="Static">
+<mets:fptr FILEID="kltin"/>
+</mets:div>
+<mets:div ID="q43nc" ORDER="173" TYPE="Static">
+<mets:fptr FILEID="y5a89"/>
+</mets:div>
+<mets:div ID="c6znz" ORDER="174" TYPE="Static">
+<mets:fptr FILEID="b86dc"/>
+</mets:div>
+<mets:div ID="ecf9d" ORDER="175" TYPE="Static">
+<mets:fptr FILEID="q1szc"/>
+</mets:div>
+<mets:div ID="afyp9" ORDER="176" TYPE="Static">
+<mets:fptr FILEID="d26fb"/>
+</mets:div>
+<mets:div ID="xtgi4" ORDER="177" TYPE="Static">
+<mets:fptr FILEID="bqf06"/>
+</mets:div>
+<mets:div ID="w4jld" ORDER="178" TYPE="Static">
+<mets:fptr FILEID="d0301"/>
+</mets:div>
+<mets:div ID="dbjef" ORDER="179" TYPE="Static">
+<mets:fptr FILEID="s2d2j"/>
+</mets:div>
+<mets:div ID="xa9j6" ORDER="180" TYPE="Static">
+<mets:fptr FILEID="bt4wx"/>
+</mets:div>
+<mets:div ID="goiim" ORDER="181" TYPE="Static">
+<mets:fptr FILEID="c9wkq"/>
+</mets:div>
+<mets:div ID="jy0g6" ORDER="182" TYPE="Static">
+<mets:fptr FILEID="hepla"/>
+</mets:div>
+<mets:div ID="ah9b4" ORDER="183" TYPE="Static">
+<mets:fptr FILEID="sgwme"/>
+</mets:div>
+<mets:div ID="k0191" ORDER="184" TYPE="Static">
+<mets:fptr FILEID="bwjr6"/>
+</mets:div>
+<mets:div ID="f8frq" ORDER="185" TYPE="Static">
+<mets:fptr FILEID="e3bbr"/>
+</mets:div>
+<mets:div ID="muis6" ORDER="186" TYPE="Static">
+<mets:fptr FILEID="i7vxv"/>
+</mets:div>
+<mets:div ID="ya2u2" ORDER="187" TYPE="Static">
+<mets:fptr FILEID="iun5g"/>
+</mets:div>
+<mets:div ID="jvsr9" ORDER="188" TYPE="Static">
+<mets:fptr FILEID="tsq5t"/>
+</mets:div>
+<mets:div ID="eojba" ORDER="189" TYPE="Static">
+<mets:fptr FILEID="wcgvm"/>
+</mets:div>
+<mets:div ID="tyhw1" ORDER="190" TYPE="Static">
+<mets:fptr FILEID="j9qcw"/>
+</mets:div>
+<mets:div ID="llnhm" ORDER="191" TYPE="Static">
+<mets:fptr FILEID="e50nk"/>
+</mets:div>
+<mets:div ID="x10n7" ORDER="192" TYPE="Static">
+<mets:fptr FILEID="vplvg"/>
+</mets:div>
+<mets:div ID="gywxu" ORDER="193" TYPE="Static">
+<mets:fptr FILEID="oeg72"/>
+</mets:div>
+<mets:div ID="smcxh" ORDER="194" TYPE="Static">
+<mets:fptr FILEID="hvvhq"/>
+</mets:div>
+<mets:div ID="j9y6q" ORDER="195" TYPE="Static">
+<mets:fptr FILEID="t8l8z"/>
+</mets:div>
+<mets:div ID="gm5ut" ORDER="196" TYPE="Static">
+<mets:fptr FILEID="f8dyi"/>
+</mets:div>
+<mets:div ID="qyi77" ORDER="197" TYPE="Static">
+<mets:fptr FILEID="fflxv"/>
+</mets:div>
+<mets:div ID="dvzn1" ORDER="198" TYPE="Static">
+<mets:fptr FILEID="kpoyk"/>
+</mets:div>
+<mets:div ID="kcxmc" ORDER="199" TYPE="Static">
+<mets:fptr FILEID="yf81i"/>
+</mets:div>
+<mets:div ID="xvkh6" ORDER="200" TYPE="Static">
+<mets:fptr FILEID="vv8gg"/>
+</mets:div>
+<mets:div ID="bdu0g" ORDER="201" TYPE="Static">
+<mets:fptr FILEID="x432s"/>
+</mets:div>
+<mets:div ID="v5mvs" ORDER="202" TYPE="Static">
+<mets:fptr FILEID="g7fbr"/>
+</mets:div>
+<mets:div ID="aema9" ORDER="203" TYPE="Static">
+<mets:fptr FILEID="t5091"/>
+</mets:div>
+<mets:div ID="c2cnt" ORDER="204" TYPE="Static">
+<mets:fptr FILEID="fx3mf"/>
+</mets:div>
+<mets:div ID="b6bkb" ORDER="205" TYPE="Static">
+<mets:fptr FILEID="zqfsx"/>
+</mets:div>
+<mets:div ID="xmqww" ORDER="206" TYPE="Static">
+<mets:fptr FILEID="m4pwy"/>
+</mets:div>
+<mets:div ID="l9nmp" ORDER="207" TYPE="Static">
+<mets:fptr FILEID="fjpe1"/>
+</mets:div>
+<mets:div ID="tf6t3" ORDER="208" TYPE="Static">
+<mets:fptr FILEID="vty53"/>
+</mets:div>
+<mets:div ID="b4gqt" ORDER="209" TYPE="Static">
+<mets:fptr FILEID="kukwl"/>
+</mets:div>
+<mets:div ID="xiqo8" ORDER="210" TYPE="Static">
+<mets:fptr FILEID="xo04e"/>
+</mets:div>
+<mets:div ID="jbihs" ORDER="211" TYPE="Static">
+<mets:fptr FILEID="m2v63"/>
+</mets:div>
+<mets:div ID="wxv06" ORDER="212" TYPE="Static">
+<mets:fptr FILEID="zl6fi"/>
+</mets:div>
+<mets:div ID="kmcxw" ORDER="213" TYPE="Static">
+<mets:fptr FILEID="x3sdg"/>
+</mets:div>
+<mets:div ID="uvlft" ORDER="214" TYPE="Static">
+<mets:fptr FILEID="ykwee"/>
+</mets:div>
+<mets:div ID="il5ab" ORDER="215" TYPE="Static">
+<mets:fptr FILEID="jlwyi"/>
+</mets:div>
+<mets:div ID="x3boz" ORDER="216" TYPE="Static">
+<mets:fptr FILEID="bgjq9"/>
+</mets:div>
+<mets:div ID="nz9tz" ORDER="217" TYPE="Static">
+<mets:fptr FILEID="icbda"/>
+</mets:div>
+<mets:div ID="clyjd" ORDER="218" TYPE="Static">
+<mets:fptr FILEID="z2t4z"/>
+</mets:div>
+<mets:div ID="nnc13" ORDER="219" TYPE="Static">
+<mets:fptr FILEID="c2dic"/>
+</mets:div>
+<mets:div ID="yaair" ORDER="220" TYPE="Static">
+<mets:fptr FILEID="kmtlu"/>
+</mets:div>
+<mets:div ID="d2b5s" ORDER="221" TYPE="Static">
+<mets:fptr FILEID="l04hq"/>
+</mets:div>
+<mets:div ID="ts83z" ORDER="222" TYPE="Static">
+<mets:fptr FILEID="ksbop"/>
+</mets:div>
+<mets:div ID="pa8p3" ORDER="223" TYPE="Static">
+<mets:fptr FILEID="njtkd"/>
+</mets:div>
+<mets:div ID="ffks8" ORDER="224" TYPE="Static">
+<mets:fptr FILEID="zg7r3"/>
+</mets:div>
+<mets:div ID="pf2pr" ORDER="225" TYPE="Static">
+<mets:fptr FILEID="mb6u3"/>
+</mets:div>
+<mets:div ID="l6j1k" ORDER="226" TYPE="Static">
+<mets:fptr FILEID="tkoln"/>
+</mets:div>
+<mets:div ID="v8tul" ORDER="227" TYPE="Static">
+<mets:fptr FILEID="jepo2"/>
+</mets:div>
+<mets:div ID="x25pj" ORDER="228" TYPE="Static">
+<mets:fptr FILEID="dbvpd"/>
+</mets:div>
+<mets:div ID="xn7jj" ORDER="229" TYPE="Static">
+<mets:fptr FILEID="pfs81"/>
+</mets:div>
+<mets:div ID="bjdrq" ORDER="230" TYPE="Static">
+<mets:fptr FILEID="m35oz"/>
+</mets:div>
+<mets:div ID="r40fu" ORDER="231" TYPE="Static">
+<mets:fptr FILEID="mj8jr"/>
+</mets:div>
+<mets:div ID="pme8v" ORDER="232" TYPE="Static">
+<mets:fptr FILEID="b7ztq"/>
+</mets:div>
+<mets:div ID="hfscy" ORDER="233" TYPE="Static">
+<mets:fptr FILEID="mewnx"/>
+</mets:div>
+<mets:div ID="h8zyz" ORDER="234" TYPE="Static">
+<mets:fptr FILEID="cv5pz"/>
+</mets:div>
+<mets:div ID="cqubb" ORDER="235" TYPE="Static">
+<mets:fptr FILEID="v7k65"/>
+</mets:div>
+<mets:div ID="m13it" ORDER="236" TYPE="Static">
+<mets:fptr FILEID="ombf5"/>
+</mets:div>
+<mets:div ID="u4bki" ORDER="237" TYPE="Static">
+<mets:fptr FILEID="ssfi4"/>
+</mets:div>
+<mets:div ID="zp7u8" ORDER="238" TYPE="Static">
+<mets:fptr FILEID="syg1s"/>
+</mets:div>
+<mets:div ID="wz2ev" ORDER="239" TYPE="Static">
+<mets:fptr FILEID="os6pg"/>
+</mets:div>
+<mets:div ID="t4nka" ORDER="240" TYPE="Static">
+<mets:fptr FILEID="n0fxi"/>
+</mets:div>
+<mets:div ID="sz046" ORDER="241" TYPE="Static">
+<mets:fptr FILEID="ezb2s"/>
+</mets:div>
+<mets:div ID="tsbyc" ORDER="242" TYPE="Static">
+<mets:fptr FILEID="bq00n"/>
+</mets:div>
+<mets:div ID="g7pfb" ORDER="243" TYPE="Static">
+<mets:fptr FILEID="j1ayh"/>
+</mets:div>
+</mets:div>
+<mets:div ID="v4phys" LABEL="scrapbook_04" TYPE="BoundVolume">
+<mets:div ID="t4rf3" ORDER="1" TYPE="Static">
+<mets:fptr FILEID="dl10y"/>
+</mets:div>
+<mets:div ID="uvobg" ORDER="2" TYPE="Static">
+<mets:fptr FILEID="uhjtm"/>
+</mets:div>
+<mets:div ID="hvklc" ORDER="3" TYPE="Static">
+<mets:fptr FILEID="dl7a3"/>
+</mets:div>
+<mets:div ID="tqw7a" ORDER="4" TYPE="Static">
+<mets:fptr FILEID="tt0tc"/>
+</mets:div>
+<mets:div ID="ccfk7" ORDER="5" TYPE="Static">
+<mets:fptr FILEID="g4whn"/>
+</mets:div>
+<mets:div ID="an35j" ORDER="6" TYPE="Static">
+<mets:fptr FILEID="g66hd"/>
+</mets:div>
+<mets:div ID="z2dni" ORDER="7" TYPE="Static">
+<mets:fptr FILEID="t432o"/>
+</mets:div>
+<mets:div ID="hcr8u" ORDER="8" TYPE="Static">
+<mets:fptr FILEID="nt0fb"/>
+</mets:div>
+<mets:div ID="jrx7o" ORDER="9" TYPE="Static">
+<mets:fptr FILEID="c8yjt"/>
+</mets:div>
+<mets:div ID="s4qna" ORDER="10" TYPE="Static">
+<mets:fptr FILEID="pkwol"/>
+</mets:div>
+<mets:div ID="vxsd7" ORDER="11" TYPE="Static">
+<mets:fptr FILEID="vtw7x"/>
+</mets:div>
+<mets:div ID="v5td1" ORDER="12" TYPE="Static">
+<mets:fptr FILEID="c0e5o"/>
+</mets:div>
+<mets:div ID="l1jj3" ORDER="13" TYPE="Static">
+<mets:fptr FILEID="kn3xy"/>
+</mets:div>
+<mets:div ID="dou3p" ORDER="14" TYPE="Static">
+<mets:fptr FILEID="tw6bz"/>
+</mets:div>
+<mets:div ID="s4zf1" ORDER="15" TYPE="Static">
+<mets:fptr FILEID="cfw4l"/>
+</mets:div>
+<mets:div ID="ki5j8" ORDER="16" TYPE="Static">
+<mets:fptr FILEID="k3icz"/>
+</mets:div>
+<mets:div ID="u2dl9" ORDER="17" TYPE="Static">
+<mets:fptr FILEID="wlrmm"/>
+</mets:div>
+<mets:div ID="w68hb" ORDER="18" TYPE="Static">
+<mets:fptr FILEID="zcqhr"/>
+</mets:div>
+<mets:div ID="jdyr1" ORDER="19" TYPE="Static">
+<mets:fptr FILEID="b2aeu"/>
+</mets:div>
+<mets:div ID="trg2q" ORDER="20" TYPE="Static">
+<mets:fptr FILEID="mnhgp"/>
+</mets:div>
+<mets:div ID="yf9pr" ORDER="21" TYPE="Static">
+<mets:fptr FILEID="mzzbj"/>
+</mets:div>
+<mets:div ID="i6sna" ORDER="22" TYPE="Static">
+<mets:fptr FILEID="fosql"/>
+</mets:div>
+<mets:div ID="crd8y" ORDER="23" TYPE="Static">
+<mets:fptr FILEID="c9qfc"/>
+</mets:div>
+<mets:div ID="ci6mx" ORDER="24" TYPE="Static">
+<mets:fptr FILEID="cjp3e"/>
+</mets:div>
+<mets:div ID="g0b7e" ORDER="25" TYPE="Static">
+<mets:fptr FILEID="mywpu"/>
+</mets:div>
+<mets:div ID="swm3y" ORDER="26" TYPE="Static">
+<mets:fptr FILEID="g7iej"/>
+</mets:div>
+<mets:div ID="xtqho" ORDER="27" TYPE="Static">
+<mets:fptr FILEID="amui8"/>
+</mets:div>
+<mets:div ID="ocyz9" ORDER="28" TYPE="Static">
+<mets:fptr FILEID="t188v"/>
+</mets:div>
+<mets:div ID="z4tfq" ORDER="29" TYPE="Static">
+<mets:fptr FILEID="iby1r"/>
+</mets:div>
+<mets:div ID="usdma" ORDER="30" TYPE="Static">
+<mets:fptr FILEID="phc22"/>
+</mets:div>
+<mets:div ID="rjzxo" ORDER="31" TYPE="Static">
+<mets:fptr FILEID="xapi9"/>
+</mets:div>
+<mets:div ID="czg3w" ORDER="32" TYPE="Static">
+<mets:fptr FILEID="s0deg"/>
+</mets:div>
+<mets:div ID="mhgoe" ORDER="33" TYPE="Static">
+<mets:fptr FILEID="smqhh"/>
+</mets:div>
+<mets:div ID="k5ft1" ORDER="34" TYPE="Static">
+<mets:fptr FILEID="n4cj8"/>
+</mets:div>
+<mets:div ID="dytk1" ORDER="35" TYPE="Static">
+<mets:fptr FILEID="pnic8"/>
+</mets:div>
+<mets:div ID="ek685" ORDER="36" TYPE="Static">
+<mets:fptr FILEID="og5kn"/>
+</mets:div>
+<mets:div ID="uhw8l" ORDER="37" TYPE="Static">
+<mets:fptr FILEID="nwk2z"/>
+</mets:div>
+<mets:div ID="ijms8" ORDER="38" TYPE="Static">
+<mets:fptr FILEID="uxrzz"/>
+</mets:div>
+<mets:div ID="ggsfk" ORDER="39" TYPE="Static">
+<mets:fptr FILEID="usw4x"/>
+</mets:div>
+<mets:div ID="e78z4" ORDER="40" TYPE="Static">
+<mets:fptr FILEID="g7vcm"/>
+</mets:div>
+<mets:div ID="e1z4u" ORDER="41" TYPE="Static">
+<mets:fptr FILEID="ur8p7"/>
+</mets:div>
+<mets:div ID="wrdrq" ORDER="42" TYPE="Static">
+<mets:fptr FILEID="aipxr"/>
+</mets:div>
+<mets:div ID="veeio" ORDER="43" TYPE="Static">
+<mets:fptr FILEID="vo06f"/>
+</mets:div>
+<mets:div ID="y9it8" ORDER="44" TYPE="Static">
+<mets:fptr FILEID="mzxyp"/>
+</mets:div>
+<mets:div ID="mshz9" ORDER="45" TYPE="Static">
+<mets:fptr FILEID="q71s3"/>
+</mets:div>
+<mets:div ID="gj8mo" ORDER="46" TYPE="Static">
+<mets:fptr FILEID="mv1av"/>
+</mets:div>
+<mets:div ID="e9zit" ORDER="47" TYPE="Static">
+<mets:fptr FILEID="d896r"/>
+</mets:div>
+<mets:div ID="ky4cf" ORDER="48" TYPE="Static">
+<mets:fptr FILEID="zjs4p"/>
+</mets:div>
+<mets:div ID="h4coa" ORDER="49" TYPE="Static">
+<mets:fptr FILEID="n0p8e"/>
+</mets:div>
+<mets:div ID="i3q87" ORDER="50" TYPE="Static">
+<mets:fptr FILEID="gqmg9"/>
+</mets:div>
+<mets:div ID="pj9zb" ORDER="51" TYPE="Static">
+<mets:fptr FILEID="ak6qp"/>
+</mets:div>
+<mets:div ID="r1ses" ORDER="52" TYPE="Static">
+<mets:fptr FILEID="b96hq"/>
+</mets:div>
+<mets:div ID="rhbhs" ORDER="53" TYPE="Static">
+<mets:fptr FILEID="ckp2v"/>
+</mets:div>
+<mets:div ID="hc4wl" ORDER="54" TYPE="Static">
+<mets:fptr FILEID="k0ro9"/>
+</mets:div>
+<mets:div ID="aulss" ORDER="55" TYPE="Static">
+<mets:fptr FILEID="gi3oe"/>
+</mets:div>
+<mets:div ID="alkqn" ORDER="56" TYPE="Static">
+<mets:fptr FILEID="bzno0"/>
+</mets:div>
+<mets:div ID="nbjtk" ORDER="57" TYPE="Static">
+<mets:fptr FILEID="qrfg2"/>
+</mets:div>
+<mets:div ID="g2msv" ORDER="58" TYPE="Static">
+<mets:fptr FILEID="y8792"/>
+</mets:div>
+<mets:div ID="qoi6f" ORDER="59" TYPE="Static">
+<mets:fptr FILEID="tc1m3"/>
+</mets:div>
+<mets:div ID="pt8na" ORDER="60" TYPE="Static">
+<mets:fptr FILEID="tszb9"/>
+</mets:div>
+<mets:div ID="v7zun" ORDER="61" TYPE="Static">
+<mets:fptr FILEID="ianjz"/>
+</mets:div>
+<mets:div ID="w1lcl" ORDER="62" TYPE="Static">
+<mets:fptr FILEID="sk8ck"/>
+</mets:div>
+<mets:div ID="dz4f0" ORDER="63" TYPE="Static">
+<mets:fptr FILEID="gsg0w"/>
+</mets:div>
+<mets:div ID="b00ax" ORDER="64" TYPE="Static">
+<mets:fptr FILEID="m9dep"/>
+</mets:div>
+<mets:div ID="xulzy" ORDER="65" TYPE="Static">
+<mets:fptr FILEID="kqsjy"/>
+</mets:div>
+<mets:div ID="zd9jw" ORDER="66" TYPE="Static">
+<mets:fptr FILEID="rtsza"/>
+</mets:div>
+<mets:div ID="utdep" ORDER="67" TYPE="Static">
+<mets:fptr FILEID="ucgi6"/>
+</mets:div>
+<mets:div ID="ojqc7" ORDER="68" TYPE="Static">
+<mets:fptr FILEID="ua7bc"/>
+</mets:div>
+<mets:div ID="stowx" ORDER="69" TYPE="Static">
+<mets:fptr FILEID="xtlk6"/>
+</mets:div>
+<mets:div ID="dgn86" ORDER="70" TYPE="Static">
+<mets:fptr FILEID="bqbs0"/>
+</mets:div>
+<mets:div ID="tslgu" ORDER="71" TYPE="Static">
+<mets:fptr FILEID="d1xg3"/>
+</mets:div>
+<mets:div ID="qouq9" ORDER="72" TYPE="Static">
+<mets:fptr FILEID="q8wdo"/>
+</mets:div>
+<mets:div ID="wyq87" ORDER="73" TYPE="Static">
+<mets:fptr FILEID="h909k"/>
+</mets:div>
+<mets:div ID="v6bn8" ORDER="74" TYPE="Static">
+<mets:fptr FILEID="phmlq"/>
+</mets:div>
+<mets:div ID="kz03m" ORDER="75" TYPE="Static">
+<mets:fptr FILEID="dlw45"/>
+</mets:div>
+<mets:div ID="hge9v" ORDER="76" TYPE="Static">
+<mets:fptr FILEID="gavkf"/>
+</mets:div>
+<mets:div ID="hfxhi" ORDER="77" TYPE="Static">
+<mets:fptr FILEID="oqg92"/>
+</mets:div>
+<mets:div ID="p7ff8" ORDER="78" TYPE="Static">
+<mets:fptr FILEID="pemfv"/>
+</mets:div>
+<mets:div ID="goqor" ORDER="79" TYPE="Static">
+<mets:fptr FILEID="l3wo6"/>
+</mets:div>
+<mets:div ID="h4qmt" ORDER="80" TYPE="Static">
+<mets:fptr FILEID="vqmwl"/>
+</mets:div>
+<mets:div ID="z91w2" ORDER="81" TYPE="Static">
+<mets:fptr FILEID="zu4np"/>
+</mets:div>
+<mets:div ID="b9017" ORDER="82" TYPE="Static">
+<mets:fptr FILEID="fhtd2"/>
+</mets:div>
+<mets:div ID="vqbgs" ORDER="83" TYPE="Static">
+<mets:fptr FILEID="bbehu"/>
+</mets:div>
+<mets:div ID="jam30" ORDER="84" TYPE="Static">
+<mets:fptr FILEID="c78v3"/>
+</mets:div>
+<mets:div ID="mw8jg" ORDER="85" TYPE="Static">
+<mets:fptr FILEID="ck93t"/>
+</mets:div>
+<mets:div ID="hzu0y" ORDER="86" TYPE="Static">
+<mets:fptr FILEID="axwvk"/>
+</mets:div>
+<mets:div ID="vwtf0" ORDER="87" TYPE="Static">
+<mets:fptr FILEID="s54gg"/>
+</mets:div>
+<mets:div ID="uoqgi" ORDER="88" TYPE="Static">
+<mets:fptr FILEID="zmxdx"/>
+</mets:div>
+<mets:div ID="hq036" ORDER="89" TYPE="Static">
+<mets:fptr FILEID="if0kg"/>
+</mets:div>
+<mets:div ID="ksjxh" ORDER="90" TYPE="Static">
+<mets:fptr FILEID="hdipo"/>
+</mets:div>
+<mets:div ID="olbge" ORDER="91" TYPE="Static">
+<mets:fptr FILEID="dg2ew"/>
+</mets:div>
+<mets:div ID="iy0pa" ORDER="92" TYPE="Static">
+<mets:fptr FILEID="njufs"/>
+</mets:div>
+<mets:div ID="qjbsh" ORDER="93" TYPE="Static">
+<mets:fptr FILEID="faxuy"/>
+</mets:div>
+<mets:div ID="vtddo" ORDER="94" TYPE="Static">
+<mets:fptr FILEID="gtb81"/>
+</mets:div>
+<mets:div ID="yzvdl" ORDER="95" TYPE="Static">
+<mets:fptr FILEID="rlw5z"/>
+</mets:div>
+<mets:div ID="h1s8t" ORDER="96" TYPE="Static">
+<mets:fptr FILEID="geyq8"/>
+</mets:div>
+<mets:div ID="f3wcj" ORDER="97" TYPE="Static">
+<mets:fptr FILEID="avg3i"/>
+</mets:div>
+<mets:div ID="a2xp5" ORDER="98" TYPE="Static">
+<mets:fptr FILEID="fzmh3"/>
+</mets:div>
+<mets:div ID="sane7" ORDER="99" TYPE="Static">
+<mets:fptr FILEID="qj5jw"/>
+</mets:div>
+<mets:div ID="qqh3u" ORDER="100" TYPE="Static">
+<mets:fptr FILEID="r8qvb"/>
+</mets:div>
+<mets:div ID="h4tpm" ORDER="101" TYPE="Static">
+<mets:fptr FILEID="wlnfj"/>
+</mets:div>
+<mets:div ID="ss04j" ORDER="102" TYPE="Static">
+<mets:fptr FILEID="aftmq"/>
+</mets:div>
+<mets:div ID="y51m6" ORDER="103" TYPE="Static">
+<mets:fptr FILEID="ndx8x"/>
+</mets:div>
+<mets:div ID="b59oz" ORDER="104" TYPE="Static">
+<mets:fptr FILEID="a5czr"/>
+</mets:div>
+<mets:div ID="nsc63" ORDER="105" TYPE="Static">
+<mets:fptr FILEID="q0qis"/>
+</mets:div>
+<mets:div ID="pvh1q" ORDER="106" TYPE="Static">
+<mets:fptr FILEID="nphyw"/>
+</mets:div>
+<mets:div ID="kgqrj" ORDER="107" TYPE="Static">
+<mets:fptr FILEID="kx0g8"/>
+</mets:div>
+<mets:div ID="jsaik" ORDER="108" TYPE="Static">
+<mets:fptr FILEID="mpbts"/>
+</mets:div>
+<mets:div ID="vawg9" ORDER="109" TYPE="Static">
+<mets:fptr FILEID="nmtmc"/>
+</mets:div>
+<mets:div ID="dg5du" ORDER="110" TYPE="Static">
+<mets:fptr FILEID="zjbmq"/>
+</mets:div>
+<mets:div ID="s6enn" ORDER="111" TYPE="Static">
+<mets:fptr FILEID="mtooq"/>
+</mets:div>
+<mets:div ID="dhl93" ORDER="112" TYPE="Static">
+<mets:fptr FILEID="nclt6"/>
+</mets:div>
+<mets:div ID="x0yje" ORDER="113" TYPE="Static">
+<mets:fptr FILEID="olxbi"/>
+</mets:div>
+<mets:div ID="m97pe" ORDER="114" TYPE="Static">
+<mets:fptr FILEID="clrsb"/>
+</mets:div>
+<mets:div ID="mve1v" ORDER="115" TYPE="Static">
+<mets:fptr FILEID="vt2ka"/>
+</mets:div>
+<mets:div ID="opgdf" ORDER="116" TYPE="Static">
+<mets:fptr FILEID="vkf8r"/>
+</mets:div>
+<mets:div ID="wg504" ORDER="117" TYPE="Static">
+<mets:fptr FILEID="rxzsd"/>
+</mets:div>
+<mets:div ID="o1wi5" ORDER="118" TYPE="Static">
+<mets:fptr FILEID="hrnts"/>
+</mets:div>
+<mets:div ID="e6ax9" ORDER="119" TYPE="Static">
+<mets:fptr FILEID="yuoze"/>
+</mets:div>
+<mets:div ID="c2o3m" ORDER="120" TYPE="Static">
+<mets:fptr FILEID="h0syv"/>
+</mets:div>
+<mets:div ID="ntcj8" ORDER="121" TYPE="Static">
+<mets:fptr FILEID="pwmml"/>
+</mets:div>
+<mets:div ID="dwfsj" ORDER="122" TYPE="Static">
+<mets:fptr FILEID="k8h8u"/>
+</mets:div>
+<mets:div ID="t7qr5" ORDER="123" TYPE="Static">
+<mets:fptr FILEID="abo4t"/>
+</mets:div>
+<mets:div ID="yf19h" ORDER="124" TYPE="Static">
+<mets:fptr FILEID="d46z1"/>
+</mets:div>
+<mets:div ID="imqlw" ORDER="125" TYPE="Static">
+<mets:fptr FILEID="yx8ds"/>
+</mets:div>
+<mets:div ID="fket6" ORDER="126" TYPE="Static">
+<mets:fptr FILEID="nelem"/>
+</mets:div>
+<mets:div ID="dv3a9" ORDER="127" TYPE="Static">
+<mets:fptr FILEID="rz75f"/>
+</mets:div>
+<mets:div ID="qmgdi" ORDER="128" TYPE="Static">
+<mets:fptr FILEID="oub70"/>
+</mets:div>
+<mets:div ID="eu83m" ORDER="129" TYPE="Static">
+<mets:fptr FILEID="r8ugl"/>
+</mets:div>
+<mets:div ID="oe4u4" ORDER="130" TYPE="Static">
+<mets:fptr FILEID="li7po"/>
+</mets:div>
+<mets:div ID="uyk95" ORDER="131" TYPE="Static">
+<mets:fptr FILEID="qcjvs"/>
+</mets:div>
+<mets:div ID="vfstl" ORDER="132" TYPE="Static">
+<mets:fptr FILEID="z88bb"/>
+</mets:div>
+</mets:div>
+<mets:div ID="v5phys" LABEL="scrapbook_05" TYPE="BoundVolume">
+<mets:div ID="gfjji" ORDER="1" TYPE="Static">
+<mets:fptr FILEID="l6bv7"/>
+</mets:div>
+<mets:div ID="ncv9p" ORDER="2" TYPE="Static">
+<mets:fptr FILEID="dq6jq"/>
+</mets:div>
+<mets:div ID="zgw9j" ORDER="3" TYPE="Static">
+<mets:fptr FILEID="cz5nc"/>
+</mets:div>
+<mets:div ID="n5d2x" ORDER="4" TYPE="Static">
+<mets:fptr FILEID="asesw"/>
+</mets:div>
+<mets:div ID="hj4s9" ORDER="5" TYPE="Static">
+<mets:fptr FILEID="snpci"/>
+</mets:div>
+<mets:div ID="jjezq" ORDER="6" TYPE="Static">
+<mets:fptr FILEID="vum6x"/>
+</mets:div>
+<mets:div ID="h9nyx" ORDER="7" TYPE="Static">
+<mets:fptr FILEID="w6r8n"/>
+</mets:div>
+<mets:div ID="x7uue" ORDER="8" TYPE="Static">
+<mets:fptr FILEID="iq7jx"/>
+</mets:div>
+<mets:div ID="t6u9o" ORDER="9" TYPE="Static">
+<mets:fptr FILEID="y5nkh"/>
+</mets:div>
+<mets:div ID="wmx1l" ORDER="10" TYPE="Static">
+<mets:fptr FILEID="dp9np"/>
+</mets:div>
+<mets:div ID="fmxwd" ORDER="11" TYPE="Static">
+<mets:fptr FILEID="l43ke"/>
+</mets:div>
+<mets:div ID="gw7k0" ORDER="12" TYPE="Static">
+<mets:fptr FILEID="sq0th"/>
+</mets:div>
+<mets:div ID="bbvj1" ORDER="13" TYPE="Static">
+<mets:fptr FILEID="nsrh6"/>
+</mets:div>
+<mets:div ID="wjam1" ORDER="14" TYPE="Static">
+<mets:fptr FILEID="xjrxs"/>
+</mets:div>
+<mets:div ID="ugt6x" ORDER="15" TYPE="Static">
+<mets:fptr FILEID="ld924"/>
+</mets:div>
+<mets:div ID="fcfsr" ORDER="16" TYPE="Static">
+<mets:fptr FILEID="boamg"/>
+</mets:div>
+<mets:div ID="ciifs" ORDER="17" TYPE="Static">
+<mets:fptr FILEID="f1pzl"/>
+</mets:div>
+<mets:div ID="y94rm" ORDER="18" TYPE="Static">
+<mets:fptr FILEID="n3y9e"/>
+</mets:div>
+<mets:div ID="e30x0" ORDER="19" TYPE="Static">
+<mets:fptr FILEID="s58ay"/>
+</mets:div>
+<mets:div ID="avski" ORDER="20" TYPE="Static">
+<mets:fptr FILEID="c9s4a"/>
+</mets:div>
+<mets:div ID="t79g6" ORDER="21" TYPE="Static">
+<mets:fptr FILEID="c5mgk"/>
+</mets:div>
+<mets:div ID="fa7ze" ORDER="22" TYPE="Static">
+<mets:fptr FILEID="jridz"/>
+</mets:div>
+<mets:div ID="bkqv7" ORDER="23" TYPE="Static">
+<mets:fptr FILEID="d7lp7"/>
+</mets:div>
+<mets:div ID="gohjz" ORDER="24" TYPE="Static">
+<mets:fptr FILEID="e9emc"/>
+</mets:div>
+<mets:div ID="f3jq7" ORDER="25" TYPE="Static">
+<mets:fptr FILEID="lpiug"/>
+</mets:div>
+<mets:div ID="giyln" ORDER="26" TYPE="Static">
+<mets:fptr FILEID="kl9ar"/>
+</mets:div>
+<mets:div ID="k9aca" ORDER="27" TYPE="Static">
+<mets:fptr FILEID="fcigj"/>
+</mets:div>
+<mets:div ID="qst4s" ORDER="28" TYPE="Static">
+<mets:fptr FILEID="m1tbi"/>
+</mets:div>
+<mets:div ID="sh6l7" ORDER="29" TYPE="Static">
+<mets:fptr FILEID="dthum"/>
+</mets:div>
+<mets:div ID="na5ks" ORDER="30" TYPE="Static">
+<mets:fptr FILEID="axnw8"/>
+</mets:div>
+<mets:div ID="gqr2g" ORDER="31" TYPE="Static">
+<mets:fptr FILEID="avkzj"/>
+</mets:div>
+<mets:div ID="wklqo" ORDER="32" TYPE="Static">
+<mets:fptr FILEID="xwk2l"/>
+</mets:div>
+<mets:div ID="o8nxs" ORDER="33" TYPE="Static">
+<mets:fptr FILEID="p79g6"/>
+</mets:div>
+<mets:div ID="zd7u7" ORDER="34" TYPE="Static">
+<mets:fptr FILEID="fiaa7"/>
+</mets:div>
+<mets:div ID="yge4a" ORDER="35" TYPE="Static">
+<mets:fptr FILEID="zjpdw"/>
+</mets:div>
+<mets:div ID="apbrl" ORDER="36" TYPE="Static">
+<mets:fptr FILEID="f3vui"/>
+</mets:div>
+<mets:div ID="udmld" ORDER="37" TYPE="Static">
+<mets:fptr FILEID="nutfr"/>
+</mets:div>
+<mets:div ID="wp375" ORDER="38" TYPE="Static">
+<mets:fptr FILEID="b4jgf"/>
+</mets:div>
+<mets:div ID="drnw1" ORDER="39" TYPE="Static">
+<mets:fptr FILEID="wiafv"/>
+</mets:div>
+<mets:div ID="o7ajt" ORDER="40" TYPE="Static">
+<mets:fptr FILEID="x28xs"/>
+</mets:div>
+<mets:div ID="jea7e" ORDER="41" TYPE="Static">
+<mets:fptr FILEID="apsww"/>
+</mets:div>
+<mets:div ID="e539m" ORDER="42" TYPE="Static">
+<mets:fptr FILEID="xwrv3"/>
+</mets:div>
+<mets:div ID="otg7x" ORDER="43" TYPE="Static">
+<mets:fptr FILEID="tetm3"/>
+</mets:div>
+<mets:div ID="e6vot" ORDER="44" TYPE="Static">
+<mets:fptr FILEID="aag2e"/>
+</mets:div>
+<mets:div ID="icm37" ORDER="45" TYPE="Static">
+<mets:fptr FILEID="pznb4"/>
+</mets:div>
+<mets:div ID="fuqx4" ORDER="46" TYPE="Static">
+<mets:fptr FILEID="hxmh0"/>
+</mets:div>
+<mets:div ID="lihve" ORDER="47" TYPE="Static">
+<mets:fptr FILEID="pzgqm"/>
+</mets:div>
+<mets:div ID="f9r8d" ORDER="48" TYPE="Static">
+<mets:fptr FILEID="bz2kn"/>
+</mets:div>
+<mets:div ID="b5jlk" ORDER="49" TYPE="Static">
+<mets:fptr FILEID="namvv"/>
+</mets:div>
+<mets:div ID="cs0pq" ORDER="50" TYPE="Static">
+<mets:fptr FILEID="o7zf5"/>
+</mets:div>
+<mets:div ID="jbqhe" ORDER="51" TYPE="Static">
+<mets:fptr FILEID="aeo3u"/>
+</mets:div>
+<mets:div ID="icc7b" ORDER="52" TYPE="Static">
+<mets:fptr FILEID="p1ku7"/>
+</mets:div>
+<mets:div ID="p5qyt" ORDER="53" TYPE="Static">
+<mets:fptr FILEID="r2n0e"/>
+</mets:div>
+<mets:div ID="tg9oq" ORDER="54" TYPE="Static">
+<mets:fptr FILEID="mo9g4"/>
+</mets:div>
+<mets:div ID="c7vlh" ORDER="55" TYPE="Static">
+<mets:fptr FILEID="eaa6t"/>
+</mets:div>
+<mets:div ID="r9qjw" ORDER="56" TYPE="Static">
+<mets:fptr FILEID="zpbmo"/>
+</mets:div>
+<mets:div ID="kfs34" ORDER="57" TYPE="Static">
+<mets:fptr FILEID="ktlcq"/>
+</mets:div>
+<mets:div ID="h8v08" ORDER="58" TYPE="Static">
+<mets:fptr FILEID="wk7hn"/>
+</mets:div>
+<mets:div ID="yunhz" ORDER="59" TYPE="Static">
+<mets:fptr FILEID="hqoix"/>
+</mets:div>
+<mets:div ID="futmc" ORDER="60" TYPE="Static">
+<mets:fptr FILEID="jrzk6"/>
+</mets:div>
+<mets:div ID="tlk4g" ORDER="61" TYPE="Static">
+<mets:fptr FILEID="haql9"/>
+</mets:div>
+<mets:div ID="n20lf" ORDER="62" TYPE="Static">
+<mets:fptr FILEID="r75cw"/>
+</mets:div>
+<mets:div ID="fosps" ORDER="63" TYPE="Static">
+<mets:fptr FILEID="fggxk"/>
+</mets:div>
+<mets:div ID="xzci3" ORDER="64" TYPE="Static">
+<mets:fptr FILEID="naka0"/>
+</mets:div>
+<mets:div ID="nytfr" ORDER="65" TYPE="Static">
+<mets:fptr FILEID="icc37"/>
+</mets:div>
+<mets:div ID="aub42" ORDER="66" TYPE="Static">
+<mets:fptr FILEID="hjwzr"/>
+</mets:div>
+<mets:div ID="l6itx" ORDER="67" TYPE="Static">
+<mets:fptr FILEID="jlkm4"/>
+</mets:div>
+<mets:div ID="wna0s" ORDER="68" TYPE="Static">
+<mets:fptr FILEID="yxebu"/>
+</mets:div>
+<mets:div ID="mhz5g" ORDER="69" TYPE="Static">
+<mets:fptr FILEID="a1wby"/>
+</mets:div>
+<mets:div ID="snszb" ORDER="70" TYPE="Static">
+<mets:fptr FILEID="ozyc8"/>
+</mets:div>
+<mets:div ID="ngfyq" ORDER="71" TYPE="Static">
+<mets:fptr FILEID="dcsyg"/>
+</mets:div>
+<mets:div ID="gdeo9" ORDER="72" TYPE="Static">
+<mets:fptr FILEID="tidfl"/>
+</mets:div>
+<mets:div ID="wytne" ORDER="73" TYPE="Static">
+<mets:fptr FILEID="xxxw2"/>
+</mets:div>
+<mets:div ID="imz0b" ORDER="74" TYPE="Static">
+<mets:fptr FILEID="md3o9"/>
+</mets:div>
+<mets:div ID="zj3kb" ORDER="75" TYPE="Static">
+<mets:fptr FILEID="sh7sc"/>
+</mets:div>
+<mets:div ID="n66t9" ORDER="76" TYPE="Static">
+<mets:fptr FILEID="vm529"/>
+</mets:div>
+<mets:div ID="kc529" ORDER="77" TYPE="Static">
+<mets:fptr FILEID="rupn1"/>
+</mets:div>
+<mets:div ID="fbuab" ORDER="78" TYPE="Static">
+<mets:fptr FILEID="ql0i0"/>
+</mets:div>
+<mets:div ID="gqtpm" ORDER="79" TYPE="Static">
+<mets:fptr FILEID="f4yeh"/>
+</mets:div>
+<mets:div ID="luz22" ORDER="80" TYPE="Static">
+<mets:fptr FILEID="dlnqz"/>
+</mets:div>
+<mets:div ID="w5j9g" ORDER="81" TYPE="Static">
+<mets:fptr FILEID="ofo0v"/>
+</mets:div>
+<mets:div ID="scvv4" ORDER="82" TYPE="Static">
+<mets:fptr FILEID="y5fnf"/>
+</mets:div>
+<mets:div ID="ywqrk" ORDER="83" TYPE="Static">
+<mets:fptr FILEID="z5n8y"/>
+</mets:div>
+<mets:div ID="kw3bg" ORDER="84" TYPE="Static">
+<mets:fptr FILEID="odt3y"/>
+</mets:div>
+<mets:div ID="lbao9" ORDER="85" TYPE="Static">
+<mets:fptr FILEID="knrhz"/>
+</mets:div>
+<mets:div ID="wnp0v" ORDER="86" TYPE="Static">
+<mets:fptr FILEID="aeo5d"/>
+</mets:div>
+<mets:div ID="pg68n" ORDER="87" TYPE="Static">
+<mets:fptr FILEID="ejy60"/>
+</mets:div>
+<mets:div ID="wi598" ORDER="88" TYPE="Static">
+<mets:fptr FILEID="zklad"/>
+</mets:div>
+<mets:div ID="iot7x" ORDER="89" TYPE="Static">
+<mets:fptr FILEID="lplo0"/>
+</mets:div>
+<mets:div ID="ysnmn" ORDER="90" TYPE="Static">
+<mets:fptr FILEID="o115b"/>
+</mets:div>
+<mets:div ID="q05mb" ORDER="91" TYPE="Static">
+<mets:fptr FILEID="ojeo2"/>
+</mets:div>
+<mets:div ID="phuqi" ORDER="92" TYPE="Static">
+<mets:fptr FILEID="tgax3"/>
+</mets:div>
+<mets:div ID="fek9n" ORDER="93" TYPE="Static">
+<mets:fptr FILEID="oj1t4"/>
+</mets:div>
+<mets:div ID="nxuj3" ORDER="94" TYPE="Static">
+<mets:fptr FILEID="ndyzb"/>
+</mets:div>
+<mets:div ID="ji4ek" ORDER="95" TYPE="Static">
+<mets:fptr FILEID="l7dmh"/>
+</mets:div>
+<mets:div ID="baj6u" ORDER="96" TYPE="Static">
+<mets:fptr FILEID="yw9m6"/>
+</mets:div>
+<mets:div ID="ci5e8" ORDER="97" TYPE="Static">
+<mets:fptr FILEID="vx12f"/>
+</mets:div>
+<mets:div ID="iz9m4" ORDER="98" TYPE="Static">
+<mets:fptr FILEID="qp5ir"/>
+</mets:div>
+<mets:div ID="gyuae" ORDER="99" TYPE="Static">
+<mets:fptr FILEID="b2r2t"/>
+</mets:div>
+<mets:div ID="bf2tl" ORDER="100" TYPE="Static">
+<mets:fptr FILEID="jqd9z"/>
+</mets:div>
+<mets:div ID="neh09" ORDER="101" TYPE="Static">
+<mets:fptr FILEID="gho5w"/>
+</mets:div>
+<mets:div ID="nms4c" ORDER="102" TYPE="Static">
+<mets:fptr FILEID="xwveo"/>
+</mets:div>
+<mets:div ID="hxa39" ORDER="103" TYPE="Static">
+<mets:fptr FILEID="xrmfl"/>
+</mets:div>
+<mets:div ID="gm91y" ORDER="104" TYPE="Static">
+<mets:fptr FILEID="igbls"/>
+</mets:div>
+</mets:div>
+<mets:div ID="v6phys" LABEL="scrapbook_06" TYPE="BoundVolume">
+<mets:div ID="kaike" ORDER="1" TYPE="Static">
+<mets:fptr FILEID="qhdeb"/>
+</mets:div>
+<mets:div ID="tjpr6" ORDER="2" TYPE="Static">
+<mets:fptr FILEID="nutcv"/>
+</mets:div>
+<mets:div ID="nv2ic" ORDER="3" TYPE="Static">
+<mets:fptr FILEID="pnhhq"/>
+</mets:div>
+<mets:div ID="wgimh" ORDER="4" TYPE="Static">
+<mets:fptr FILEID="hhivk"/>
+</mets:div>
+<mets:div ID="tbamr" ORDER="5" TYPE="Static">
+<mets:fptr FILEID="byg39"/>
+</mets:div>
+<mets:div ID="rtfdt" ORDER="6" TYPE="Static">
+<mets:fptr FILEID="ju0a7"/>
+</mets:div>
+<mets:div ID="ziaj4" ORDER="7" TYPE="Static">
+<mets:fptr FILEID="muc9s"/>
+</mets:div>
+<mets:div ID="oh100" ORDER="8" TYPE="Static">
+<mets:fptr FILEID="ezk09"/>
+</mets:div>
+<mets:div ID="wnn0o" ORDER="9" TYPE="Static">
+<mets:fptr FILEID="h0o6b"/>
+</mets:div>
+<mets:div ID="j7kmt" ORDER="10" TYPE="Static">
+<mets:fptr FILEID="mrhlc"/>
+</mets:div>
+<mets:div ID="wvzcw" ORDER="11" TYPE="Static">
+<mets:fptr FILEID="tfpo8"/>
+</mets:div>
+<mets:div ID="yk5m2" ORDER="12" TYPE="Static">
+<mets:fptr FILEID="abr5m"/>
+</mets:div>
+<mets:div ID="wco8l" ORDER="13" TYPE="Static">
+<mets:fptr FILEID="bl7vm"/>
+</mets:div>
+<mets:div ID="kqe7k" ORDER="14" TYPE="Static">
+<mets:fptr FILEID="xhwg9"/>
+</mets:div>
+<mets:div ID="tnu4k" ORDER="15" TYPE="Static">
+<mets:fptr FILEID="nuu5z"/>
+</mets:div>
+<mets:div ID="guhq7" ORDER="16" TYPE="Static">
+<mets:fptr FILEID="me7q5"/>
+</mets:div>
+<mets:div ID="rc0u0" ORDER="17" TYPE="Static">
+<mets:fptr FILEID="shgs4"/>
+</mets:div>
+<mets:div ID="l00si" ORDER="18" TYPE="Static">
+<mets:fptr FILEID="yblsu"/>
+</mets:div>
+<mets:div ID="knub9" ORDER="19" TYPE="Static">
+<mets:fptr FILEID="fu8kd"/>
+</mets:div>
+<mets:div ID="t08lt" ORDER="20" TYPE="Static">
+<mets:fptr FILEID="asy6a"/>
+</mets:div>
+<mets:div ID="kscc8" ORDER="21" TYPE="Static">
+<mets:fptr FILEID="pphid"/>
+</mets:div>
+<mets:div ID="rgr8x" ORDER="22" TYPE="Static">
+<mets:fptr FILEID="lo1fn"/>
+</mets:div>
+<mets:div ID="qyeud" ORDER="23" TYPE="Static">
+<mets:fptr FILEID="y40nj"/>
+</mets:div>
+<mets:div ID="o6wdw" ORDER="24" TYPE="Static">
+<mets:fptr FILEID="t1ffw"/>
+</mets:div>
+<mets:div ID="i6qq0" ORDER="25" TYPE="Static">
+<mets:fptr FILEID="eq8ru"/>
+</mets:div>
+<mets:div ID="o4bsj" ORDER="26" TYPE="Static">
+<mets:fptr FILEID="pcd72"/>
+</mets:div>
+<mets:div ID="bftcs" ORDER="27" TYPE="Static">
+<mets:fptr FILEID="ukely"/>
+</mets:div>
+<mets:div ID="dbspc" ORDER="28" TYPE="Static">
+<mets:fptr FILEID="z617f"/>
+</mets:div>
+<mets:div ID="vh2l4" ORDER="29" TYPE="Static">
+<mets:fptr FILEID="r4dbx"/>
+</mets:div>
+<mets:div ID="j5by7" ORDER="30" TYPE="Static">
+<mets:fptr FILEID="pt7yk"/>
+</mets:div>
+<mets:div ID="pmwc6" ORDER="31" TYPE="Static">
+<mets:fptr FILEID="lxwff"/>
+</mets:div>
+<mets:div ID="sk42s" ORDER="32" TYPE="Static">
+<mets:fptr FILEID="f2mjo"/>
+</mets:div>
+<mets:div ID="rr7r0" ORDER="33" TYPE="Static">
+<mets:fptr FILEID="khuxu"/>
+</mets:div>
+<mets:div ID="l65pm" ORDER="34" TYPE="Static">
+<mets:fptr FILEID="bp2ah"/>
+</mets:div>
+<mets:div ID="z5tmm" ORDER="35" TYPE="Static">
+<mets:fptr FILEID="hfjhl"/>
+</mets:div>
+<mets:div ID="fxhow" ORDER="36" TYPE="Static">
+<mets:fptr FILEID="dzw4u"/>
+</mets:div>
+<mets:div ID="soruw" ORDER="37" TYPE="Static">
+<mets:fptr FILEID="w199v"/>
+</mets:div>
+<mets:div ID="aa9in" ORDER="38" TYPE="Static">
+<mets:fptr FILEID="ogr8y"/>
+</mets:div>
+<mets:div ID="i0z14" ORDER="39" TYPE="Static">
+<mets:fptr FILEID="qzmgo"/>
+</mets:div>
+<mets:div ID="zjbk9" ORDER="40" TYPE="Static">
+<mets:fptr FILEID="z7yig"/>
+</mets:div>
+<mets:div ID="xiiiw" ORDER="41" TYPE="Static">
+<mets:fptr FILEID="rh2ll"/>
+</mets:div>
+<mets:div ID="ab1c7" ORDER="42" TYPE="Static">
+<mets:fptr FILEID="oreht"/>
+</mets:div>
+<mets:div ID="ev4ww" ORDER="43" TYPE="Static">
+<mets:fptr FILEID="amget"/>
+</mets:div>
+<mets:div ID="avzh9" ORDER="44" TYPE="Static">
+<mets:fptr FILEID="ax17o"/>
+</mets:div>
+<mets:div ID="yaxhl" ORDER="45" TYPE="Static">
+<mets:fptr FILEID="mmy64"/>
+</mets:div>
+<mets:div ID="i7dlv" ORDER="46" TYPE="Static">
+<mets:fptr FILEID="d141t"/>
+</mets:div>
+</mets:div>
+<mets:div ID="v7phys" LABEL="scrapbook_07" TYPE="BoundVolume">
+<mets:div ID="uj09d" ORDER="1" TYPE="Static">
+<mets:fptr FILEID="xjpzg"/>
+</mets:div>
+<mets:div ID="g7sph" ORDER="2" TYPE="Static">
+<mets:fptr FILEID="vbm3m"/>
+</mets:div>
+<mets:div ID="mzru3" ORDER="3" TYPE="Static">
+<mets:fptr FILEID="hlsda"/>
+</mets:div>
+<mets:div ID="dj0dt" ORDER="4" TYPE="Static">
+<mets:fptr FILEID="t2r9q"/>
+</mets:div>
+<mets:div ID="xq4f6" ORDER="5" TYPE="Static">
+<mets:fptr FILEID="yvhwk"/>
+</mets:div>
+<mets:div ID="fsh3y" ORDER="6" TYPE="Static">
+<mets:fptr FILEID="m4uf6"/>
+</mets:div>
+<mets:div ID="y6idy" ORDER="7" TYPE="Static">
+<mets:fptr FILEID="jqjgw"/>
+</mets:div>
+<mets:div ID="mbamo" ORDER="8" TYPE="Static">
+<mets:fptr FILEID="t98md"/>
+</mets:div>
+<mets:div ID="ja3kz" ORDER="9" TYPE="Static">
+<mets:fptr FILEID="z0szl"/>
+</mets:div>
+<mets:div ID="pz07f" ORDER="10" TYPE="Static">
+<mets:fptr FILEID="q5dnx"/>
+</mets:div>
+<mets:div ID="ex1y5" ORDER="11" TYPE="Static">
+<mets:fptr FILEID="vjg9z"/>
+</mets:div>
+<mets:div ID="olrfj" ORDER="12" TYPE="Static">
+<mets:fptr FILEID="w0fnp"/>
+</mets:div>
+<mets:div ID="i9min" ORDER="13" TYPE="Static">
+<mets:fptr FILEID="epsr9"/>
+</mets:div>
+<mets:div ID="ryueq" ORDER="14" TYPE="Static">
+<mets:fptr FILEID="x9dpw"/>
+</mets:div>
+<mets:div ID="n6hyi" ORDER="15" TYPE="Static">
+<mets:fptr FILEID="ejpro"/>
+</mets:div>
+<mets:div ID="a9qhp" ORDER="16" TYPE="Static">
+<mets:fptr FILEID="rcm5k"/>
+</mets:div>
+<mets:div ID="wwyjw" ORDER="17" TYPE="Static">
+<mets:fptr FILEID="x1qfl"/>
+</mets:div>
+<mets:div ID="f4338" ORDER="18" TYPE="Static">
+<mets:fptr FILEID="tjd5u"/>
+</mets:div>
+<mets:div ID="jkp4p" ORDER="19" TYPE="Static">
+<mets:fptr FILEID="mh998"/>
+</mets:div>
+<mets:div ID="oubjw" ORDER="20" TYPE="Static">
+<mets:fptr FILEID="xomqh"/>
+</mets:div>
+<mets:div ID="jakob" ORDER="21" TYPE="Static">
+<mets:fptr FILEID="dlc0x"/>
+</mets:div>
+<mets:div ID="vsjrb" ORDER="22" TYPE="Static">
+<mets:fptr FILEID="x4z1d"/>
+</mets:div>
+<mets:div ID="zhbaw" ORDER="23" TYPE="Static">
+<mets:fptr FILEID="jkko8"/>
+</mets:div>
+<mets:div ID="s3zg5" ORDER="24" TYPE="Static">
+<mets:fptr FILEID="lng8l"/>
+</mets:div>
+<mets:div ID="fe4so" ORDER="25" TYPE="Static">
+<mets:fptr FILEID="plzdt"/>
+</mets:div>
+<mets:div ID="bwuxr" ORDER="26" TYPE="Static">
+<mets:fptr FILEID="zfcpi"/>
+</mets:div>
+<mets:div ID="ku1mz" ORDER="27" TYPE="Static">
+<mets:fptr FILEID="e7llx"/>
+</mets:div>
+<mets:div ID="m2td0" ORDER="28" TYPE="Static">
+<mets:fptr FILEID="e4dsi"/>
+</mets:div>
+<mets:div ID="vhvaj" ORDER="29" TYPE="Static">
+<mets:fptr FILEID="rk6os"/>
+</mets:div>
+<mets:div ID="hp0nc" ORDER="30" TYPE="Static">
+<mets:fptr FILEID="kmb94"/>
+</mets:div>
+<mets:div ID="r7qf2" ORDER="31" TYPE="Static">
+<mets:fptr FILEID="n4eat"/>
+</mets:div>
+<mets:div ID="oflum" ORDER="32" TYPE="Static">
+<mets:fptr FILEID="siapl"/>
+</mets:div>
+<mets:div ID="su746" ORDER="33" TYPE="Static">
+<mets:fptr FILEID="zyd0k"/>
+</mets:div>
+<mets:div ID="jzcym" ORDER="34" TYPE="Static">
+<mets:fptr FILEID="l46r4"/>
+</mets:div>
+<mets:div ID="af3gb" ORDER="35" TYPE="Static">
+<mets:fptr FILEID="jyt4v"/>
+</mets:div>
+<mets:div ID="vtdim" ORDER="36" TYPE="Static">
+<mets:fptr FILEID="ky080"/>
+</mets:div>
+<mets:div ID="g6t3v" ORDER="37" TYPE="Static">
+<mets:fptr FILEID="kqyef"/>
+</mets:div>
+<mets:div ID="swrkk" ORDER="38" TYPE="Static">
+<mets:fptr FILEID="lmrck"/>
+</mets:div>
+<mets:div ID="gy19d" ORDER="39" TYPE="Static">
+<mets:fptr FILEID="aoqob"/>
+</mets:div>
+<mets:div ID="v18v6" ORDER="40" TYPE="Static">
+<mets:fptr FILEID="aykzw"/>
+</mets:div>
+<mets:div ID="noasl" ORDER="41" TYPE="Static">
+<mets:fptr FILEID="hiviw"/>
+</mets:div>
+<mets:div ID="kdzsa" ORDER="42" TYPE="Static">
+<mets:fptr FILEID="swcbj"/>
+</mets:div>
+<mets:div ID="hjl78" ORDER="43" TYPE="Static">
+<mets:fptr FILEID="qc203"/>
+</mets:div>
+<mets:div ID="zbcmu" ORDER="44" TYPE="Static">
+<mets:fptr FILEID="w28gk"/>
+</mets:div>
+<mets:div ID="ttyqb" ORDER="45" TYPE="Static">
+<mets:fptr FILEID="vn2l3"/>
+</mets:div>
+<mets:div ID="yhqdr" ORDER="46" TYPE="Static">
+<mets:fptr FILEID="crmfq"/>
+</mets:div>
+<mets:div ID="h42e7" ORDER="47" TYPE="Static">
+<mets:fptr FILEID="kj946"/>
+</mets:div>
+<mets:div ID="sut8q" ORDER="48" TYPE="Static">
+<mets:fptr FILEID="psnh7"/>
+</mets:div>
+<mets:div ID="q1ru8" ORDER="49" TYPE="Static">
+<mets:fptr FILEID="po3pl"/>
+</mets:div>
+<mets:div ID="npup0" ORDER="50" TYPE="Static">
+<mets:fptr FILEID="ynh4h"/>
+</mets:div>
+<mets:div ID="yxb6q" ORDER="51" TYPE="Static">
+<mets:fptr FILEID="a616s"/>
+</mets:div>
+<mets:div ID="snz3a" ORDER="52" TYPE="Static">
+<mets:fptr FILEID="xdl46"/>
+</mets:div>
+<mets:div ID="iezoe" ORDER="53" TYPE="Static">
+<mets:fptr FILEID="qmkaw"/>
+</mets:div>
+<mets:div ID="hqiy2" ORDER="54" TYPE="Static">
+<mets:fptr FILEID="ckmq2"/>
+</mets:div>
+<mets:div ID="nkuxv" ORDER="55" TYPE="Static">
+<mets:fptr FILEID="ucgcs"/>
+</mets:div>
+<mets:div ID="u7tdf" ORDER="56" TYPE="Static">
+<mets:fptr FILEID="v7omr"/>
+</mets:div>
+<mets:div ID="damf2" ORDER="57" TYPE="Static">
+<mets:fptr FILEID="gug1q"/>
+</mets:div>
+<mets:div ID="rcun8" ORDER="58" TYPE="Static">
+<mets:fptr FILEID="bufjw"/>
+</mets:div>
+<mets:div ID="kr8cr" ORDER="59" TYPE="Static">
+<mets:fptr FILEID="dwpv8"/>
+</mets:div>
+<mets:div ID="on7s3" ORDER="60" TYPE="Static">
+<mets:fptr FILEID="tav4j"/>
+</mets:div>
+<mets:div ID="b0qr1" ORDER="61" TYPE="Static">
+<mets:fptr FILEID="m3v1n"/>
+</mets:div>
+<mets:div ID="j7g6r" ORDER="62" TYPE="Static">
+<mets:fptr FILEID="rujkd"/>
+</mets:div>
+<mets:div ID="dw0uv" ORDER="63" TYPE="Static">
+<mets:fptr FILEID="z9frs"/>
+</mets:div>
+<mets:div ID="kifdy" ORDER="64" TYPE="Static">
+<mets:fptr FILEID="oprak"/>
+</mets:div>
+<mets:div ID="p33g2" ORDER="65" TYPE="Static">
+<mets:fptr FILEID="w77k6"/>
+</mets:div>
+<mets:div ID="qbqhq" ORDER="66" TYPE="Static">
+<mets:fptr FILEID="ojy89"/>
+</mets:div>
+<mets:div ID="w67vd" ORDER="67" TYPE="Static">
+<mets:fptr FILEID="dugwz"/>
+</mets:div>
+<mets:div ID="ji5qj" ORDER="68" TYPE="Static">
+<mets:fptr FILEID="osk5f"/>
+</mets:div>
+<mets:div ID="prrkx" ORDER="69" TYPE="Static">
+<mets:fptr FILEID="yvzsk"/>
+</mets:div>
+<mets:div ID="t4xbg" ORDER="70" TYPE="Static">
+<mets:fptr FILEID="eg1hw"/>
+</mets:div>
+<mets:div ID="ouq6a" ORDER="71" TYPE="Static">
+<mets:fptr FILEID="ryno3"/>
+</mets:div>
+<mets:div ID="ers8h" ORDER="72" TYPE="Static">
+<mets:fptr FILEID="ndsim"/>
+</mets:div>
+<mets:div ID="li0v8" ORDER="73" TYPE="Static">
+<mets:fptr FILEID="vei4g"/>
+</mets:div>
+<mets:div ID="ug0sd" ORDER="74" TYPE="Static">
+<mets:fptr FILEID="kff0a"/>
+</mets:div>
+<mets:div ID="xsvo5" ORDER="75" TYPE="Static">
+<mets:fptr FILEID="duekt"/>
+</mets:div>
+<mets:div ID="ksyya" ORDER="76" TYPE="Static">
+<mets:fptr FILEID="qc7cu"/>
+</mets:div>
+<mets:div ID="qries" ORDER="77" TYPE="Static">
+<mets:fptr FILEID="uk3av"/>
+</mets:div>
+<mets:div ID="ae4pa" ORDER="78" TYPE="Static">
+<mets:fptr FILEID="b1s6e"/>
+</mets:div>
+<mets:div ID="pp1ll" ORDER="79" TYPE="Static">
+<mets:fptr FILEID="q74m3"/>
+</mets:div>
+<mets:div ID="gj3ha" ORDER="80" TYPE="Static">
+<mets:fptr FILEID="px8ki"/>
+</mets:div>
+<mets:div ID="x78cu" ORDER="81" TYPE="Static">
+<mets:fptr FILEID="n8znw"/>
+</mets:div>
+<mets:div ID="dd0mp" ORDER="82" TYPE="Static">
+<mets:fptr FILEID="ni2i6"/>
+</mets:div>
+<mets:div ID="lizp9" ORDER="83" TYPE="Static">
+<mets:fptr FILEID="ra7lj"/>
+</mets:div>
+<mets:div ID="udq4y" ORDER="84" TYPE="Static">
+<mets:fptr FILEID="wr2gu"/>
+</mets:div>
+<mets:div ID="z45lv" ORDER="85" TYPE="Static">
+<mets:fptr FILEID="u4xo5"/>
+</mets:div>
+<mets:div ID="bqce0" ORDER="86" TYPE="Static">
+<mets:fptr FILEID="hfq4h"/>
+</mets:div>
+<mets:div ID="viwxi" ORDER="87" TYPE="Static">
+<mets:fptr FILEID="toi1y"/>
+</mets:div>
+<mets:div ID="dgs45" ORDER="88" TYPE="Static">
+<mets:fptr FILEID="fgv25"/>
+</mets:div>
+<mets:div ID="lioe3" ORDER="89" TYPE="Static">
+<mets:fptr FILEID="j5gdk"/>
+</mets:div>
+<mets:div ID="avyfi" ORDER="90" TYPE="Static">
+<mets:fptr FILEID="zo7ix"/>
+</mets:div>
+<mets:div ID="ianx2" ORDER="91" TYPE="Static">
+<mets:fptr FILEID="b2opi"/>
+</mets:div>
+<mets:div ID="ry1l1" ORDER="92" TYPE="Static">
+<mets:fptr FILEID="wtcvb"/>
+</mets:div>
+<mets:div ID="xuebz" ORDER="93" TYPE="Static">
+<mets:fptr FILEID="ppx2j"/>
+</mets:div>
+<mets:div ID="doc7r" ORDER="94" TYPE="Static">
+<mets:fptr FILEID="ehnek"/>
+</mets:div>
+<mets:div ID="o9lic" ORDER="95" TYPE="Static">
+<mets:fptr FILEID="gvbey"/>
+</mets:div>
+<mets:div ID="drykq" ORDER="96" TYPE="Static">
+<mets:fptr FILEID="i02uz"/>
+</mets:div>
+<mets:div ID="fep96" ORDER="97" TYPE="Static">
+<mets:fptr FILEID="zqers"/>
+</mets:div>
+<mets:div ID="yc6e2" ORDER="98" TYPE="Static">
+<mets:fptr FILEID="s6rga"/>
+</mets:div>
+<mets:div ID="lb0cf" ORDER="99" TYPE="Static">
+<mets:fptr FILEID="rzh99"/>
+</mets:div>
+<mets:div ID="daymf" ORDER="100" TYPE="Static">
+<mets:fptr FILEID="defod"/>
+</mets:div>
+<mets:div ID="znjjz" ORDER="101" TYPE="Static">
+<mets:fptr FILEID="xrnh5"/>
+</mets:div>
+<mets:div ID="cxcox" ORDER="102" TYPE="Static">
+<mets:fptr FILEID="dtbzd"/>
+</mets:div>
+<mets:div ID="ovrps" ORDER="103" TYPE="Static">
+<mets:fptr FILEID="zne2z"/>
+</mets:div>
+<mets:div ID="uonxy" ORDER="104" TYPE="Static">
+<mets:fptr FILEID="mh2w0"/>
+</mets:div>
+<mets:div ID="kannb" ORDER="105" TYPE="Static">
+<mets:fptr FILEID="cjc1w"/>
+</mets:div>
+<mets:div ID="s4x3d" ORDER="106" TYPE="Static">
+<mets:fptr FILEID="vcz1c"/>
+</mets:div>
+<mets:div ID="rx7io" ORDER="107" TYPE="Static">
+<mets:fptr FILEID="i0f5u"/>
+</mets:div>
+<mets:div ID="lu8ya" ORDER="108" TYPE="Static">
+<mets:fptr FILEID="k4quw"/>
+</mets:div>
+<mets:div ID="h6kna" ORDER="109" TYPE="Static">
+<mets:fptr FILEID="p70xr"/>
+</mets:div>
+<mets:div ID="m1yw0" ORDER="110" TYPE="Static">
+<mets:fptr FILEID="qd684"/>
+</mets:div>
+<mets:div ID="wbyvb" ORDER="111" TYPE="Static">
+<mets:fptr FILEID="ubc16"/>
+</mets:div>
+<mets:div ID="ntg35" ORDER="112" TYPE="Static">
+<mets:fptr FILEID="cn2tp"/>
+</mets:div>
+<mets:div ID="w0cqd" ORDER="113" TYPE="Static">
+<mets:fptr FILEID="sufwl"/>
+</mets:div>
+<mets:div ID="w3aw7" ORDER="114" TYPE="Static">
+<mets:fptr FILEID="lkr9d"/>
+</mets:div>
+<mets:div ID="msiib" ORDER="115" TYPE="Static">
+<mets:fptr FILEID="yb2ct"/>
+</mets:div>
+<mets:div ID="rtabk" ORDER="116" TYPE="Static">
+<mets:fptr FILEID="pq6me"/>
+</mets:div>
+<mets:div ID="nokpj" ORDER="117" TYPE="Static">
+<mets:fptr FILEID="w8l42"/>
+</mets:div>
+<mets:div ID="sckfd" ORDER="118" TYPE="Static">
+<mets:fptr FILEID="oxzlx"/>
+</mets:div>
+<mets:div ID="um6ll" ORDER="119" TYPE="Static">
+<mets:fptr FILEID="foe73"/>
+</mets:div>
+<mets:div ID="nzkke" ORDER="120" TYPE="Static">
+<mets:fptr FILEID="iesca"/>
+</mets:div>
+<mets:div ID="cs3tq" ORDER="121" TYPE="Static">
+<mets:fptr FILEID="cyhg3"/>
+</mets:div>
+<mets:div ID="ndv3r" ORDER="122" TYPE="Static">
+<mets:fptr FILEID="khjsf"/>
+</mets:div>
+<mets:div ID="hmxpi" ORDER="123" TYPE="Static">
+<mets:fptr FILEID="evg9a"/>
+</mets:div>
+<mets:div ID="yset9" ORDER="124" TYPE="Static">
+<mets:fptr FILEID="k14sf"/>
+</mets:div>
+<mets:div ID="b776r" ORDER="125" TYPE="Static">
+<mets:fptr FILEID="htxd3"/>
+</mets:div>
+<mets:div ID="xxb5z" ORDER="126" TYPE="Static">
+<mets:fptr FILEID="rv3kd"/>
+</mets:div>
+<mets:div ID="pljri" ORDER="127" TYPE="Static">
+<mets:fptr FILEID="f5shi"/>
+</mets:div>
+<mets:div ID="qjjuk" ORDER="128" TYPE="Static">
+<mets:fptr FILEID="qt0k5"/>
+</mets:div>
+<mets:div ID="h390y" ORDER="129" TYPE="Static">
+<mets:fptr FILEID="n8423"/>
+</mets:div>
+<mets:div ID="to854" ORDER="130" TYPE="Static">
+<mets:fptr FILEID="ygg5u"/>
+</mets:div>
+<mets:div ID="ozyey" ORDER="131" TYPE="Static">
+<mets:fptr FILEID="yfbf2"/>
+</mets:div>
+<mets:div ID="o6fpj" ORDER="132" TYPE="Static">
+<mets:fptr FILEID="k2spy"/>
+</mets:div>
+<mets:div ID="t55b0" ORDER="133" TYPE="Static">
+<mets:fptr FILEID="qgvda"/>
+</mets:div>
+<mets:div ID="hebpf" ORDER="134" TYPE="Static">
+<mets:fptr FILEID="rd5w4"/>
+</mets:div>
+<mets:div ID="o8pj0" ORDER="135" TYPE="Static">
+<mets:fptr FILEID="cpm1t"/>
+</mets:div>
+<mets:div ID="n1dap" ORDER="136" TYPE="Static">
+<mets:fptr FILEID="omujt"/>
+</mets:div>
+<mets:div ID="bi2qz" ORDER="137" TYPE="Static">
+<mets:fptr FILEID="qse11"/>
+</mets:div>
+<mets:div ID="nhw2s" ORDER="138" TYPE="Static">
+<mets:fptr FILEID="lxzhy"/>
+</mets:div>
+<mets:div ID="k1wg1" ORDER="139" TYPE="Static">
+<mets:fptr FILEID="npaje"/>
+</mets:div>
+<mets:div ID="okgqb" ORDER="140" TYPE="Static">
+<mets:fptr FILEID="jlqd2"/>
+</mets:div>
+<mets:div ID="if1di" ORDER="141" TYPE="Static">
+<mets:fptr FILEID="v49s0"/>
+</mets:div>
+<mets:div ID="mxiu0" ORDER="142" TYPE="Static">
+<mets:fptr FILEID="e5h3z"/>
+</mets:div>
+<mets:div ID="o3hki" ORDER="143" TYPE="Static">
+<mets:fptr FILEID="d7u5r"/>
+</mets:div>
+<mets:div ID="u09li" ORDER="144" TYPE="Static">
+<mets:fptr FILEID="qynoj"/>
+</mets:div>
+<mets:div ID="fqwfm" ORDER="145" TYPE="Static">
+<mets:fptr FILEID="p3f0i"/>
+</mets:div>
+<mets:div ID="f242m" ORDER="146" TYPE="Static">
+<mets:fptr FILEID="lt0oh"/>
+</mets:div>
+<mets:div ID="o6nhg" ORDER="147" TYPE="Static">
+<mets:fptr FILEID="v485l"/>
+</mets:div>
+<mets:div ID="jl4vq" ORDER="148" TYPE="Static">
+<mets:fptr FILEID="gakux"/>
+</mets:div>
+<mets:div ID="aci2o" ORDER="149" TYPE="Static">
+<mets:fptr FILEID="jfgwc"/>
+</mets:div>
+<mets:div ID="p1u4u" ORDER="150" TYPE="Static">
+<mets:fptr FILEID="er8bv"/>
+</mets:div>
+<mets:div ID="h2il6" ORDER="151" TYPE="Static">
+<mets:fptr FILEID="gor76"/>
+</mets:div>
+<mets:div ID="m8w2n" ORDER="152" TYPE="Static">
+<mets:fptr FILEID="bmo8c"/>
+</mets:div>
+<mets:div ID="wzitw" ORDER="153" TYPE="Static">
+<mets:fptr FILEID="thg9a"/>
+</mets:div>
+<mets:div ID="kdld5" ORDER="154" TYPE="Static">
+<mets:fptr FILEID="hdojr"/>
+</mets:div>
+<mets:div ID="p3ybh" ORDER="155" TYPE="Static">
+<mets:fptr FILEID="f1pih"/>
+</mets:div>
+<mets:div ID="gj6jf" ORDER="156" TYPE="Static">
+<mets:fptr FILEID="sbunq"/>
+</mets:div>
+<mets:div ID="sstkv" ORDER="157" TYPE="Static">
+<mets:fptr FILEID="jfuz0"/>
+</mets:div>
+<mets:div ID="uphto" ORDER="158" TYPE="Static">
+<mets:fptr FILEID="zo1zv"/>
+</mets:div>
+<mets:div ID="fhtd8" ORDER="159" TYPE="Static">
+<mets:fptr FILEID="nviid"/>
+</mets:div>
+<mets:div ID="clduy" ORDER="160" TYPE="Static">
+<mets:fptr FILEID="ajtwz"/>
+</mets:div>
+<mets:div ID="xy5oh" ORDER="161" TYPE="Static">
+<mets:fptr FILEID="m8qf2"/>
+</mets:div>
+<mets:div ID="agjzp" ORDER="162" TYPE="Static">
+<mets:fptr FILEID="et3er"/>
+</mets:div>
+<mets:div ID="lskml" ORDER="163" TYPE="Static">
+<mets:fptr FILEID="hgzay"/>
+</mets:div>
+<mets:div ID="ak0bp" ORDER="164" TYPE="Static">
+<mets:fptr FILEID="c6nh0"/>
+</mets:div>
+<mets:div ID="wzlbq" ORDER="165" TYPE="Static">
+<mets:fptr FILEID="z4yps"/>
+</mets:div>
+<mets:div ID="yzi8s" ORDER="166" TYPE="Static">
+<mets:fptr FILEID="p8hmx"/>
+</mets:div>
+<mets:div ID="uy1m5" ORDER="167" TYPE="Static">
+<mets:fptr FILEID="t38xa"/>
+</mets:div>
+<mets:div ID="e6o3t" ORDER="168" TYPE="Static">
+<mets:fptr FILEID="ewmca"/>
+</mets:div>
+<mets:div ID="f0uw8" ORDER="169" TYPE="Static">
+<mets:fptr FILEID="e20ki"/>
+</mets:div>
+<mets:div ID="sq24b" ORDER="170" TYPE="Static">
+<mets:fptr FILEID="pgdmj"/>
+</mets:div>
+<mets:div ID="bdnfr" ORDER="171" TYPE="Static">
+<mets:fptr FILEID="krams"/>
+</mets:div>
+<mets:div ID="dqlzr" ORDER="172" TYPE="Static">
+<mets:fptr FILEID="ljyjn"/>
+</mets:div>
+<mets:div ID="txxzq" ORDER="173" TYPE="Static">
+<mets:fptr FILEID="yfpat"/>
+</mets:div>
+<mets:div ID="wisdr" ORDER="174" TYPE="Static">
+<mets:fptr FILEID="ushd8"/>
+</mets:div>
+<mets:div ID="mcro8" ORDER="175" TYPE="Static">
+<mets:fptr FILEID="evhyk"/>
+</mets:div>
+<mets:div ID="b02pu" ORDER="176" TYPE="Static">
+<mets:fptr FILEID="m3vx1"/>
+</mets:div>
+<mets:div ID="kjuf1" ORDER="177" TYPE="Static">
+<mets:fptr FILEID="dqj33"/>
+</mets:div>
+<mets:div ID="lo6w2" ORDER="178" TYPE="Static">
+<mets:fptr FILEID="zevnb"/>
+</mets:div>
+<mets:div ID="agrlr" ORDER="179" TYPE="Static">
+<mets:fptr FILEID="ipuys"/>
+</mets:div>
+<mets:div ID="ujw5a" ORDER="180" TYPE="Static">
+<mets:fptr FILEID="mj5xl"/>
+</mets:div>
+<mets:div ID="ltt9g" ORDER="181" TYPE="Static">
+<mets:fptr FILEID="w8szf"/>
+</mets:div>
+<mets:div ID="apja3" ORDER="182" TYPE="Static">
+<mets:fptr FILEID="gfddm"/>
+</mets:div>
+<mets:div ID="iwit8" ORDER="183" TYPE="Static">
+<mets:fptr FILEID="u46vg"/>
+</mets:div>
+<mets:div ID="rqdv4" ORDER="184" TYPE="Static">
+<mets:fptr FILEID="ivjjk"/>
+</mets:div>
+<mets:div ID="rq191" ORDER="185" TYPE="Static">
+<mets:fptr FILEID="omw6y"/>
+</mets:div>
+<mets:div ID="s50ba" ORDER="186" TYPE="Static">
+<mets:fptr FILEID="yoq6k"/>
+</mets:div>
+<mets:div ID="vtsrc" ORDER="187" TYPE="Static">
+<mets:fptr FILEID="r7kk7"/>
+</mets:div>
+<mets:div ID="o5tor" ORDER="188" TYPE="Static">
+<mets:fptr FILEID="ptioh"/>
+</mets:div>
+<mets:div ID="vgo8t" ORDER="189" TYPE="Static">
+<mets:fptr FILEID="joi92"/>
+</mets:div>
+<mets:div ID="wo2na" ORDER="190" TYPE="Static">
+<mets:fptr FILEID="zpaiv"/>
+</mets:div>
+<mets:div ID="gubor" ORDER="191" TYPE="Static">
+<mets:fptr FILEID="yqq07"/>
+</mets:div>
+<mets:div ID="z355x" ORDER="192" TYPE="Static">
+<mets:fptr FILEID="xmgq5"/>
+</mets:div>
+<mets:div ID="xbvt8" ORDER="193" TYPE="Static">
+<mets:fptr FILEID="jh7w2"/>
+</mets:div>
+<mets:div ID="ns8ud" ORDER="194" TYPE="Static">
+<mets:fptr FILEID="g1tve"/>
+</mets:div>
+<mets:div ID="n87fm" ORDER="195" TYPE="Static">
+<mets:fptr FILEID="jdtaw"/>
+</mets:div>
+<mets:div ID="dekpv" ORDER="196" TYPE="Static">
+<mets:fptr FILEID="t8qu0"/>
+</mets:div>
+<mets:div ID="th3ix" ORDER="197" TYPE="Static">
+<mets:fptr FILEID="he1jr"/>
+</mets:div>
+<mets:div ID="ql5qq" ORDER="198" TYPE="Static">
+<mets:fptr FILEID="luhbr"/>
+</mets:div>
+<mets:div ID="hemsj" ORDER="199" TYPE="Static">
+<mets:fptr FILEID="zi46d"/>
+</mets:div>
+<mets:div ID="zjznv" ORDER="200" TYPE="Static">
+<mets:fptr FILEID="nn7cn"/>
+</mets:div>
+<mets:div ID="u2q3y" ORDER="201" TYPE="Static">
+<mets:fptr FILEID="zqhb0"/>
+</mets:div>
+<mets:div ID="mdr42" ORDER="202" TYPE="Static">
+<mets:fptr FILEID="uz3nx"/>
+</mets:div>
+<mets:div ID="tj8mk" ORDER="203" TYPE="Static">
+<mets:fptr FILEID="mdk3l"/>
+</mets:div>
+<mets:div ID="j8v8g" ORDER="204" TYPE="Static">
+<mets:fptr FILEID="wyo40"/>
+</mets:div>
+<mets:div ID="s54ys" ORDER="205" TYPE="Static">
+<mets:fptr FILEID="cd9nr"/>
+</mets:div>
+<mets:div ID="d923w" ORDER="206" TYPE="Static">
+<mets:fptr FILEID="ay98v"/>
+</mets:div>
+<mets:div ID="r07bl" ORDER="207" TYPE="Static">
+<mets:fptr FILEID="j3isb"/>
+</mets:div>
+<mets:div ID="qsilx" ORDER="208" TYPE="Static">
+<mets:fptr FILEID="ksq0a"/>
+</mets:div>
+<mets:div ID="mhtmh" ORDER="209" TYPE="Static">
+<mets:fptr FILEID="xjqaq"/>
+</mets:div>
+<mets:div ID="hvk20" ORDER="210" TYPE="Static">
+<mets:fptr FILEID="eiiqf"/>
+</mets:div>
+<mets:div ID="ebqbe" ORDER="211" TYPE="Static">
+<mets:fptr FILEID="hu71u"/>
+</mets:div>
+<mets:div ID="x6mkv" ORDER="212" TYPE="Static">
+<mets:fptr FILEID="uhxe7"/>
+</mets:div>
+<mets:div ID="llrly" ORDER="213" TYPE="Static">
+<mets:fptr FILEID="ujeh6"/>
+</mets:div>
+<mets:div ID="bi6sf" ORDER="214" TYPE="Static">
+<mets:fptr FILEID="j70y7"/>
+</mets:div>
+<mets:div ID="whlt0" ORDER="215" TYPE="Static">
+<mets:fptr FILEID="scadl"/>
+</mets:div>
+<mets:div ID="xhah9" ORDER="216" TYPE="Static">
+<mets:fptr FILEID="mko05"/>
+</mets:div>
+<mets:div ID="bnh1c" ORDER="217" TYPE="Static">
+<mets:fptr FILEID="whria"/>
+</mets:div>
+<mets:div ID="znw79" ORDER="218" TYPE="Static">
+<mets:fptr FILEID="yasdz"/>
+</mets:div>
+<mets:div ID="jttez" ORDER="219" TYPE="Static">
+<mets:fptr FILEID="fd9jf"/>
+</mets:div>
+<mets:div ID="o9rmd" ORDER="220" TYPE="Static">
+<mets:fptr FILEID="pt9fn"/>
+</mets:div>
+<mets:div ID="w04kj" ORDER="221" TYPE="Static">
+<mets:fptr FILEID="c22e4"/>
+</mets:div>
+<mets:div ID="m7760" ORDER="222" TYPE="Static">
+<mets:fptr FILEID="w819o"/>
+</mets:div>
+<mets:div ID="x5m0i" ORDER="223" TYPE="Static">
+<mets:fptr FILEID="tckbr"/>
+</mets:div>
+<mets:div ID="jzz0t" ORDER="224" TYPE="Static">
+<mets:fptr FILEID="lmy6e"/>
+</mets:div>
+<mets:div ID="yef4v" ORDER="225" TYPE="Static">
+<mets:fptr FILEID="ptswy"/>
+</mets:div>
+<mets:div ID="znnc1" ORDER="226" TYPE="Static">
+<mets:fptr FILEID="dgtk6"/>
+</mets:div>
+<mets:div ID="hn6rs" ORDER="227" TYPE="Static">
+<mets:fptr FILEID="o2wnl"/>
+</mets:div>
+<mets:div ID="ab9ud" ORDER="228" TYPE="Static">
+<mets:fptr FILEID="pfiex"/>
+</mets:div>
+<mets:div ID="c4elz" ORDER="229" TYPE="Static">
+<mets:fptr FILEID="hy4wa"/>
+</mets:div>
+<mets:div ID="os4q5" ORDER="230" TYPE="Static">
+<mets:fptr FILEID="k3ud6"/>
+</mets:div>
+<mets:div ID="z60f7" ORDER="231" TYPE="Static">
+<mets:fptr FILEID="p8xsz"/>
+</mets:div>
+<mets:div ID="uf48f" ORDER="232" TYPE="Static">
+<mets:fptr FILEID="wjsur"/>
+</mets:div>
+<mets:div ID="k3zx4" ORDER="233" TYPE="Static">
+<mets:fptr FILEID="xg2pz"/>
+</mets:div>
+<mets:div ID="awy0l" ORDER="234" TYPE="Static">
+<mets:fptr FILEID="clpgh"/>
+</mets:div>
+<mets:div ID="idvyu" ORDER="235" TYPE="Static">
+<mets:fptr FILEID="fj8s9"/>
+</mets:div>
+</mets:div>
+</mets:div>
+</mets:structMap>
+<mets:structMap LABEL="Contents" TYPE="Logical">
+<mets:div DMDID="nagzi nagzi" ID="vjuy5" LABEL="" TYPE="Work">
+<mets:div ID="v1log" LABEL="scrapbook 1" TYPE="BoundArt">
+<mets:div ID="yuy2v" ORDER="1" TYPE="LogicalMember">
+<mets:fptr FILEID="l5baq"/>
+</mets:div>
+<mets:div ID="blm1o" ORDER="2" TYPE="LogicalMember">
+<mets:fptr FILEID="b7zl3"/>
+</mets:div>
+<mets:div ID="zplxj" ORDER="3" TYPE="LogicalMember">
+<mets:fptr FILEID="x6tb4"/>
+</mets:div>
+<mets:div ID="vsuu3" ORDER="4" TYPE="LogicalMember">
+<mets:fptr FILEID="d7rez"/>
+</mets:div>
+<mets:div ID="nu357" ORDER="5" TYPE="LogicalMember">
+<mets:fptr FILEID="avxb5"/>
+</mets:div>
+<mets:div ID="e5p9m" ORDER="6" TYPE="LogicalMember">
+<mets:fptr FILEID="kji8y"/>
+</mets:div>
+<mets:div ID="bu4y4" ORDER="7" TYPE="LogicalMember">
+<mets:fptr FILEID="qx8bu"/>
+</mets:div>
+<mets:div ID="vejkm" ORDER="8" TYPE="LogicalMember">
+<mets:fptr FILEID="utkd3"/>
+</mets:div>
+<mets:div ID="y4dwl" ORDER="9" TYPE="LogicalMember">
+<mets:fptr FILEID="px9u1"/>
+</mets:div>
+<mets:div ID="y27rm" ORDER="10" TYPE="LogicalMember">
+<mets:fptr FILEID="fujgx"/>
+</mets:div>
+<mets:div ID="fxzdg" ORDER="11" TYPE="LogicalMember">
+<mets:fptr FILEID="no9dy"/>
+</mets:div>
+<mets:div ID="yjv1d" ORDER="12" TYPE="LogicalMember">
+<mets:fptr FILEID="fy2zm"/>
+</mets:div>
+<mets:div ID="tlhqm" ORDER="13" TYPE="LogicalMember">
+<mets:fptr FILEID="shc5u"/>
+</mets:div>
+<mets:div ID="op8ct" ORDER="14" TYPE="LogicalMember">
+<mets:fptr FILEID="kysvi"/>
+</mets:div>
+<mets:div ID="fqegm" ORDER="15" TYPE="LogicalMember">
+<mets:fptr FILEID="t9a8m"/>
+</mets:div>
+<mets:div ID="xvrw6" ORDER="16" TYPE="LogicalMember">
+<mets:fptr FILEID="oz7pl"/>
+</mets:div>
+<mets:div ID="q8xmh" ORDER="17" TYPE="LogicalMember">
+<mets:fptr FILEID="z4dm9"/>
+</mets:div>
+<mets:div ID="rmmjr" ORDER="18" TYPE="LogicalMember">
+<mets:fptr FILEID="p3txt"/>
+</mets:div>
+<mets:div ID="bl8dt" ORDER="19" TYPE="LogicalMember">
+<mets:fptr FILEID="b6g6h"/>
+</mets:div>
+<mets:div ID="tlelh" ORDER="20" TYPE="LogicalMember">
+<mets:fptr FILEID="lkang"/>
+</mets:div>
+<mets:div ID="y38fh" ORDER="21" TYPE="LogicalMember">
+<mets:fptr FILEID="t9m8s"/>
+</mets:div>
+<mets:div ID="cz84f" ORDER="22" TYPE="LogicalMember">
+<mets:fptr FILEID="fdozy"/>
+</mets:div>
+<mets:div ID="mrnum" ORDER="23" TYPE="LogicalMember">
+<mets:fptr FILEID="d1yqw"/>
+</mets:div>
+<mets:div ID="qn2bt" ORDER="24" TYPE="LogicalMember">
+<mets:fptr FILEID="y9jjj"/>
+</mets:div>
+<mets:div ID="lgsom" ORDER="25" TYPE="LogicalMember">
+<mets:fptr FILEID="gnrbg"/>
+</mets:div>
+<mets:div ID="ou8xa" ORDER="26" TYPE="LogicalMember">
+<mets:fptr FILEID="f3tg4"/>
+</mets:div>
+<mets:div ID="kentc" ORDER="27" TYPE="LogicalMember">
+<mets:fptr FILEID="scrtl"/>
+</mets:div>
+<mets:div ID="tj3o1" ORDER="28" TYPE="LogicalMember">
+<mets:fptr FILEID="zkae8"/>
+</mets:div>
+<mets:div ID="orbpf" ORDER="29" TYPE="LogicalMember">
+<mets:fptr FILEID="hi82a"/>
+</mets:div>
+<mets:div ID="h1xow" ORDER="30" TYPE="LogicalMember">
+<mets:fptr FILEID="e4hwb"/>
+</mets:div>
+<mets:div ID="b33nv" ORDER="31" TYPE="LogicalMember">
+<mets:fptr FILEID="ick68"/>
+</mets:div>
+<mets:div ID="rpq47" ORDER="32" TYPE="LogicalMember">
+<mets:fptr FILEID="xno7n"/>
+</mets:div>
+<mets:div ID="apf37" ORDER="33" TYPE="LogicalMember">
+<mets:fptr FILEID="uir9m"/>
+</mets:div>
+<mets:div ID="ryz6u" ORDER="34" TYPE="LogicalMember">
+<mets:fptr FILEID="gvmjb"/>
+</mets:div>
+<mets:div ID="y0pzl" ORDER="35" TYPE="LogicalMember">
+<mets:fptr FILEID="f5boc"/>
+</mets:div>
+<mets:div ID="pihsz" ORDER="36" TYPE="LogicalMember">
+<mets:fptr FILEID="owo44"/>
+</mets:div>
+<mets:div ID="zo0ye" ORDER="37" TYPE="LogicalMember">
+<mets:fptr FILEID="npc2a"/>
+</mets:div>
+<mets:div ID="d4ej9" ORDER="38" TYPE="LogicalMember">
+<mets:fptr FILEID="y05o2"/>
+</mets:div>
+<mets:div ID="tls2k" ORDER="39" TYPE="LogicalMember">
+<mets:fptr FILEID="ilpzx"/>
+</mets:div>
+<mets:div ID="ar522" ORDER="40" TYPE="LogicalMember">
+<mets:fptr FILEID="ayryk"/>
+</mets:div>
+<mets:div ID="lx7ss" ORDER="41" TYPE="LogicalMember">
+<mets:fptr FILEID="mnmdv"/>
+</mets:div>
+<mets:div ID="xl7j2" ORDER="42" TYPE="LogicalMember">
+<mets:fptr FILEID="tbvw9"/>
+</mets:div>
+<mets:div ID="zcgtg" ORDER="43" TYPE="LogicalMember">
+<mets:fptr FILEID="n90tt"/>
+</mets:div>
+<mets:div ID="pu2f6" ORDER="44" TYPE="LogicalMember">
+<mets:fptr FILEID="wmky0"/>
+</mets:div>
+<mets:div ID="mnuzv" ORDER="45" TYPE="LogicalMember">
+<mets:fptr FILEID="aioqq"/>
+</mets:div>
+<mets:div ID="vx17g" ORDER="46" TYPE="LogicalMember">
+<mets:fptr FILEID="t1gez"/>
+</mets:div>
+<mets:div ID="lhiol" ORDER="47" TYPE="LogicalMember">
+<mets:fptr FILEID="hu1ty"/>
+</mets:div>
+<mets:div ID="cvj8x" ORDER="48" TYPE="LogicalMember">
+<mets:fptr FILEID="r530k"/>
+</mets:div>
+<mets:div ID="izbil" ORDER="49" TYPE="LogicalMember">
+<mets:fptr FILEID="shlfg"/>
+</mets:div>
+<mets:div ID="bjemy" ORDER="50" TYPE="LogicalMember">
+<mets:fptr FILEID="q4eqv"/>
+</mets:div>
+<mets:div ID="wkjst" ORDER="51" TYPE="LogicalMember">
+<mets:fptr FILEID="a1int"/>
+</mets:div>
+<mets:div ID="y2yd7" ORDER="52" TYPE="LogicalMember">
+<mets:fptr FILEID="cixxw"/>
+</mets:div>
+<mets:div ID="fbi0v" ORDER="53" TYPE="LogicalMember">
+<mets:fptr FILEID="zeagq"/>
+</mets:div>
+<mets:div ID="zr22o" ORDER="54" TYPE="LogicalMember">
+<mets:fptr FILEID="xp6se"/>
+</mets:div>
+<mets:div ID="xaspy" ORDER="55" TYPE="LogicalMember">
+<mets:fptr FILEID="q5pwa"/>
+</mets:div>
+<mets:div ID="b7bjh" ORDER="56" TYPE="LogicalMember">
+<mets:fptr FILEID="lez6y"/>
+</mets:div>
+<mets:div ID="jgwy0" ORDER="57" TYPE="LogicalMember">
+<mets:fptr FILEID="cazkp"/>
+</mets:div>
+<mets:div ID="ua0fw" ORDER="58" TYPE="LogicalMember">
+<mets:fptr FILEID="l19ce"/>
+</mets:div>
+<mets:div ID="kcvob" ORDER="59" TYPE="LogicalMember">
+<mets:fptr FILEID="sbec1"/>
+</mets:div>
+<mets:div ID="jup9l" ORDER="60" TYPE="LogicalMember">
+<mets:fptr FILEID="liulp"/>
+</mets:div>
+<mets:div ID="ol14e" ORDER="61" TYPE="LogicalMember">
+<mets:fptr FILEID="l85k7"/>
+</mets:div>
+<mets:div ID="quiiw" ORDER="62" TYPE="LogicalMember">
+<mets:fptr FILEID="u68l8"/>
+</mets:div>
+<mets:div ID="uv4gd" ORDER="63" TYPE="LogicalMember">
+<mets:fptr FILEID="j180l"/>
+</mets:div>
+<mets:div ID="jgr3x" ORDER="64" TYPE="LogicalMember">
+<mets:fptr FILEID="zohoz"/>
+</mets:div>
+<mets:div ID="g96l5" ORDER="65" TYPE="LogicalMember">
+<mets:fptr FILEID="kgusw"/>
+</mets:div>
+<mets:div ID="rt1b3" ORDER="66" TYPE="LogicalMember">
+<mets:fptr FILEID="t1hbj"/>
+</mets:div>
+<mets:div ID="jhrvw" ORDER="67" TYPE="LogicalMember">
+<mets:fptr FILEID="u9pjh"/>
+</mets:div>
+<mets:div ID="vsovi" ORDER="68" TYPE="LogicalMember">
+<mets:fptr FILEID="hruzn"/>
+</mets:div>
+<mets:div ID="vaw4k" ORDER="69" TYPE="LogicalMember">
+<mets:fptr FILEID="qs479"/>
+</mets:div>
+<mets:div ID="txryq" ORDER="70" TYPE="LogicalMember">
+<mets:fptr FILEID="pnv2x"/>
+</mets:div>
+<mets:div ID="igzhg" ORDER="71" TYPE="LogicalMember">
+<mets:fptr FILEID="zk9zd"/>
+</mets:div>
+<mets:div ID="e21tv" ORDER="72" TYPE="LogicalMember">
+<mets:fptr FILEID="b6asb"/>
+</mets:div>
+<mets:div ID="u9xyg" ORDER="73" TYPE="LogicalMember">
+<mets:fptr FILEID="qyd9w"/>
+</mets:div>
+<mets:div ID="magwk" ORDER="74" TYPE="LogicalMember">
+<mets:fptr FILEID="c5g3p"/>
+</mets:div>
+<mets:div ID="glhxq" ORDER="75" TYPE="LogicalMember">
+<mets:fptr FILEID="dd3jp"/>
+</mets:div>
+<mets:div ID="xnwf2" ORDER="76" TYPE="LogicalMember">
+<mets:fptr FILEID="geyd4"/>
+</mets:div>
+<mets:div ID="h7346" ORDER="77" TYPE="LogicalMember">
+<mets:fptr FILEID="nuysl"/>
+</mets:div>
+<mets:div ID="t4zit" ORDER="78" TYPE="LogicalMember">
+<mets:fptr FILEID="wyi47"/>
+</mets:div>
+<mets:div ID="bcyb8" ORDER="79" TYPE="LogicalMember">
+<mets:fptr FILEID="v1jwi"/>
+</mets:div>
+<mets:div ID="wxe27" ORDER="80" TYPE="LogicalMember">
+<mets:fptr FILEID="le4jg"/>
+</mets:div>
+<mets:div ID="hy1ug" ORDER="81" TYPE="LogicalMember">
+<mets:fptr FILEID="u6e51"/>
+</mets:div>
+<mets:div ID="ks4a6" ORDER="82" TYPE="LogicalMember">
+<mets:fptr FILEID="h2yh5"/>
+</mets:div>
+<mets:div ID="rwyjm" ORDER="83" TYPE="LogicalMember">
+<mets:fptr FILEID="sfkqu"/>
+</mets:div>
+<mets:div ID="p64cl" ORDER="84" TYPE="LogicalMember">
+<mets:fptr FILEID="eb68m"/>
+</mets:div>
+<mets:div ID="ecmjh" ORDER="85" TYPE="LogicalMember">
+<mets:fptr FILEID="ba7pj"/>
+</mets:div>
+<mets:div ID="hm3rl" ORDER="86" TYPE="LogicalMember">
+<mets:fptr FILEID="gmrzp"/>
+</mets:div>
+<mets:div ID="tz9wq" ORDER="87" TYPE="LogicalMember">
+<mets:fptr FILEID="yvmh8"/>
+</mets:div>
+<mets:div ID="xl4uc" ORDER="88" TYPE="LogicalMember">
+<mets:fptr FILEID="y6nyp"/>
+</mets:div>
+<mets:div ID="n8h9b" ORDER="89" TYPE="LogicalMember">
+<mets:fptr FILEID="ow1zi"/>
+</mets:div>
+<mets:div ID="lhdv0" ORDER="90" TYPE="LogicalMember">
+<mets:fptr FILEID="bkg58"/>
+</mets:div>
+<mets:div ID="r69ev" ORDER="91" TYPE="LogicalMember">
+<mets:fptr FILEID="d856l"/>
+</mets:div>
+<mets:div ID="jhqle" ORDER="92" TYPE="LogicalMember">
+<mets:fptr FILEID="aragj"/>
+</mets:div>
+<mets:div ID="tjmd2" ORDER="93" TYPE="LogicalMember">
+<mets:fptr FILEID="c7ca7"/>
+</mets:div>
+<mets:div ID="g8l3b" ORDER="94" TYPE="LogicalMember">
+<mets:fptr FILEID="charw"/>
+</mets:div>
+<mets:div ID="hvwp9" ORDER="95" TYPE="LogicalMember">
+<mets:fptr FILEID="crsxc"/>
+</mets:div>
+<mets:div ID="prx5r" ORDER="96" TYPE="LogicalMember">
+<mets:fptr FILEID="r9y6g"/>
+</mets:div>
+<mets:div ID="h7pbb" ORDER="97" TYPE="LogicalMember">
+<mets:fptr FILEID="itq91"/>
+</mets:div>
+<mets:div ID="hxh37" ORDER="98" TYPE="LogicalMember">
+<mets:fptr FILEID="xnxhm"/>
+</mets:div>
+<mets:div ID="srfu6" ORDER="99" TYPE="LogicalMember">
+<mets:fptr FILEID="vzziq"/>
+</mets:div>
+<mets:div ID="aien8" ORDER="100" TYPE="LogicalMember">
+<mets:fptr FILEID="jmgdg"/>
+</mets:div>
+<mets:div ID="pzos3" ORDER="101" TYPE="LogicalMember">
+<mets:fptr FILEID="p2qk7"/>
+</mets:div>
+<mets:div ID="ccw1n" ORDER="102" TYPE="LogicalMember">
+<mets:fptr FILEID="hvz24"/>
+</mets:div>
+<mets:div ID="m40oe" ORDER="103" TYPE="LogicalMember">
+<mets:fptr FILEID="ull2i"/>
+</mets:div>
+<mets:div ID="dx0ql" ORDER="104" TYPE="LogicalMember">
+<mets:fptr FILEID="cpn5w"/>
+</mets:div>
+<mets:div ID="sgb5a" ORDER="105" TYPE="LogicalMember">
+<mets:fptr FILEID="xsa6f"/>
+</mets:div>
+<mets:div ID="p145u" ORDER="106" TYPE="LogicalMember">
+<mets:fptr FILEID="zhprw"/>
+</mets:div>
+<mets:div ID="c54hd" ORDER="107" TYPE="LogicalMember">
+<mets:fptr FILEID="rf115"/>
+</mets:div>
+<mets:div ID="ah0ty" ORDER="108" TYPE="LogicalMember">
+<mets:fptr FILEID="cc019"/>
+</mets:div>
+<mets:div ID="u84lc" ORDER="109" TYPE="LogicalMember">
+<mets:fptr FILEID="knl23"/>
+</mets:div>
+<mets:div ID="bm2n4" ORDER="110" TYPE="LogicalMember">
+<mets:fptr FILEID="yk3nf"/>
+</mets:div>
+<mets:div ID="g1ygi" ORDER="111" TYPE="LogicalMember">
+<mets:fptr FILEID="k6h3b"/>
+</mets:div>
+<mets:div ID="j2sqr" ORDER="112" TYPE="LogicalMember">
+<mets:fptr FILEID="pu2re"/>
+</mets:div>
+<mets:div ID="v8h0v" ORDER="113" TYPE="LogicalMember">
+<mets:fptr FILEID="zodsq"/>
+</mets:div>
+<mets:div ID="wlise" ORDER="114" TYPE="LogicalMember">
+<mets:fptr FILEID="f8gf6"/>
+</mets:div>
+<mets:div ID="jnhja" ORDER="115" TYPE="LogicalMember">
+<mets:fptr FILEID="bu548"/>
+</mets:div>
+<mets:div ID="ipkek" ORDER="116" TYPE="LogicalMember">
+<mets:fptr FILEID="e8mee"/>
+</mets:div>
+<mets:div ID="bf3ai" ORDER="117" TYPE="LogicalMember">
+<mets:fptr FILEID="hjan6"/>
+</mets:div>
+<mets:div ID="tqdl4" ORDER="118" TYPE="LogicalMember">
+<mets:fptr FILEID="tobgg"/>
+</mets:div>
+<mets:div ID="qinmv" ORDER="119" TYPE="LogicalMember">
+<mets:fptr FILEID="zuoqn"/>
+</mets:div>
+<mets:div ID="rr5d3" ORDER="120" TYPE="LogicalMember">
+<mets:fptr FILEID="rlb1z"/>
+</mets:div>
+<mets:div ID="quo3a" ORDER="121" TYPE="LogicalMember">
+<mets:fptr FILEID="brwmw"/>
+</mets:div>
+<mets:div ID="q5uum" ORDER="122" TYPE="LogicalMember">
+<mets:fptr FILEID="zwylh"/>
+</mets:div>
+<mets:div ID="ilrx4" ORDER="123" TYPE="LogicalMember">
+<mets:fptr FILEID="ivnzm"/>
+</mets:div>
+<mets:div ID="sg916" ORDER="124" TYPE="LogicalMember">
+<mets:fptr FILEID="yn3bj"/>
+</mets:div>
+<mets:div ID="dgdkr" ORDER="125" TYPE="LogicalMember">
+<mets:fptr FILEID="cistq"/>
+</mets:div>
+<mets:div ID="uj0g6" ORDER="126" TYPE="LogicalMember">
+<mets:fptr FILEID="faekk"/>
+</mets:div>
+<mets:div ID="s25ng" ORDER="127" TYPE="LogicalMember">
+<mets:fptr FILEID="x3kaz"/>
+</mets:div>
+<mets:div ID="uikdh" ORDER="128" TYPE="LogicalMember">
+<mets:fptr FILEID="f5crn"/>
+</mets:div>
+<mets:div ID="p6qfn" ORDER="129" TYPE="LogicalMember">
+<mets:fptr FILEID="hv0zw"/>
+</mets:div>
+<mets:div ID="jr6op" ORDER="130" TYPE="LogicalMember">
+<mets:fptr FILEID="gmhd5"/>
+</mets:div>
+<mets:div ID="l4ewz" ORDER="131" TYPE="LogicalMember">
+<mets:fptr FILEID="jzwgk"/>
+</mets:div>
+<mets:div ID="c1485" ORDER="132" TYPE="LogicalMember">
+<mets:fptr FILEID="nss32"/>
+</mets:div>
+<mets:div ID="n5bk7" ORDER="133" TYPE="LogicalMember">
+<mets:fptr FILEID="e1ev8"/>
+</mets:div>
+<mets:div ID="mp0oy" ORDER="134" TYPE="LogicalMember">
+<mets:fptr FILEID="uze97"/>
+</mets:div>
+<mets:div ID="dk8mb" ORDER="135" TYPE="LogicalMember">
+<mets:fptr FILEID="gkc4z"/>
+</mets:div>
+<mets:div ID="aucow" ORDER="136" TYPE="LogicalMember">
+<mets:fptr FILEID="ycc7i"/>
+</mets:div>
+</mets:div>
+<mets:div ID="v2log" LABEL="scrapbook 2" TYPE="BoundArt">
+<mets:div ID="k5lfr" ORDER="1" TYPE="LogicalMember">
+<mets:fptr FILEID="gbw01"/>
+</mets:div>
+<mets:div ID="zf7zw" ORDER="2" TYPE="LogicalMember">
+<mets:fptr FILEID="nmsij"/>
+</mets:div>
+<mets:div ID="e0r1m" ORDER="3" TYPE="LogicalMember">
+<mets:fptr FILEID="vzbuy"/>
+</mets:div>
+<mets:div ID="gds0t" ORDER="4" TYPE="LogicalMember">
+<mets:fptr FILEID="uessr"/>
+</mets:div>
+<mets:div ID="lay74" ORDER="5" TYPE="LogicalMember">
+<mets:fptr FILEID="sc6n7"/>
+</mets:div>
+<mets:div ID="m3u8p" ORDER="6" TYPE="LogicalMember">
+<mets:fptr FILEID="y77dv"/>
+</mets:div>
+<mets:div ID="urx0d" ORDER="7" TYPE="LogicalMember">
+<mets:fptr FILEID="ey6xg"/>
+</mets:div>
+<mets:div ID="jkeh9" ORDER="8" TYPE="LogicalMember">
+<mets:fptr FILEID="ytgv2"/>
+</mets:div>
+<mets:div ID="xpd1w" ORDER="9" TYPE="LogicalMember">
+<mets:fptr FILEID="p6m1g"/>
+</mets:div>
+<mets:div ID="hhfsi" ORDER="10" TYPE="LogicalMember">
+<mets:fptr FILEID="pksi3"/>
+</mets:div>
+<mets:div ID="q14g7" ORDER="11" TYPE="LogicalMember">
+<mets:fptr FILEID="y766a"/>
+</mets:div>
+<mets:div ID="n2db7" ORDER="12" TYPE="LogicalMember">
+<mets:fptr FILEID="yv4sv"/>
+</mets:div>
+<mets:div ID="okujf" ORDER="13" TYPE="LogicalMember">
+<mets:fptr FILEID="a0yrw"/>
+</mets:div>
+<mets:div ID="p58er" ORDER="14" TYPE="LogicalMember">
+<mets:fptr FILEID="xc1c6"/>
+</mets:div>
+<mets:div ID="dguru" ORDER="15" TYPE="LogicalMember">
+<mets:fptr FILEID="kk92r"/>
+</mets:div>
+<mets:div ID="mzxfg" ORDER="16" TYPE="LogicalMember">
+<mets:fptr FILEID="jr55e"/>
+</mets:div>
+<mets:div ID="u3ip5" ORDER="17" TYPE="LogicalMember">
+<mets:fptr FILEID="ll9fu"/>
+</mets:div>
+<mets:div ID="p2v89" ORDER="18" TYPE="LogicalMember">
+<mets:fptr FILEID="st3j2"/>
+</mets:div>
+<mets:div ID="xhnrz" ORDER="19" TYPE="LogicalMember">
+<mets:fptr FILEID="mglo7"/>
+</mets:div>
+<mets:div ID="zmy6f" ORDER="20" TYPE="LogicalMember">
+<mets:fptr FILEID="x613p"/>
+</mets:div>
+<mets:div ID="okftc" ORDER="21" TYPE="LogicalMember">
+<mets:fptr FILEID="l5mqk"/>
+</mets:div>
+<mets:div ID="gfy49" ORDER="22" TYPE="LogicalMember">
+<mets:fptr FILEID="hstfn"/>
+</mets:div>
+<mets:div ID="zck2g" ORDER="23" TYPE="LogicalMember">
+<mets:fptr FILEID="omvdz"/>
+</mets:div>
+<mets:div ID="bl8s0" ORDER="24" TYPE="LogicalMember">
+<mets:fptr FILEID="gj6lz"/>
+</mets:div>
+<mets:div ID="jz73o" ORDER="25" TYPE="LogicalMember">
+<mets:fptr FILEID="zdvyi"/>
+</mets:div>
+<mets:div ID="hugkl" ORDER="26" TYPE="LogicalMember">
+<mets:fptr FILEID="jj7kw"/>
+</mets:div>
+<mets:div ID="gejat" ORDER="27" TYPE="LogicalMember">
+<mets:fptr FILEID="vadp6"/>
+</mets:div>
+<mets:div ID="jd961" ORDER="28" TYPE="LogicalMember">
+<mets:fptr FILEID="g1ja2"/>
+</mets:div>
+<mets:div ID="anij5" ORDER="29" TYPE="LogicalMember">
+<mets:fptr FILEID="dsfnb"/>
+</mets:div>
+<mets:div ID="qkkvl" ORDER="30" TYPE="LogicalMember">
+<mets:fptr FILEID="i1o1x"/>
+</mets:div>
+<mets:div ID="skb0f" ORDER="31" TYPE="LogicalMember">
+<mets:fptr FILEID="zdj6t"/>
+</mets:div>
+<mets:div ID="e4z7h" ORDER="32" TYPE="LogicalMember">
+<mets:fptr FILEID="sldpu"/>
+</mets:div>
+<mets:div ID="tgb2x" ORDER="33" TYPE="LogicalMember">
+<mets:fptr FILEID="o6kby"/>
+</mets:div>
+<mets:div ID="z3vx9" ORDER="34" TYPE="LogicalMember">
+<mets:fptr FILEID="pzq3d"/>
+</mets:div>
+<mets:div ID="cyp9n" ORDER="35" TYPE="LogicalMember">
+<mets:fptr FILEID="p5d50"/>
+</mets:div>
+<mets:div ID="s34q5" ORDER="36" TYPE="LogicalMember">
+<mets:fptr FILEID="fa3o8"/>
+</mets:div>
+<mets:div ID="i9ktk" ORDER="37" TYPE="LogicalMember">
+<mets:fptr FILEID="h5lsi"/>
+</mets:div>
+<mets:div ID="vzyfr" ORDER="38" TYPE="LogicalMember">
+<mets:fptr FILEID="w35tq"/>
+</mets:div>
+<mets:div ID="un02w" ORDER="39" TYPE="LogicalMember">
+<mets:fptr FILEID="wff2e"/>
+</mets:div>
+<mets:div ID="gpqj5" ORDER="40" TYPE="LogicalMember">
+<mets:fptr FILEID="zvrun"/>
+</mets:div>
+<mets:div ID="iinxt" ORDER="41" TYPE="LogicalMember">
+<mets:fptr FILEID="tbg6m"/>
+</mets:div>
+<mets:div ID="xwbto" ORDER="42" TYPE="LogicalMember">
+<mets:fptr FILEID="lqszf"/>
+</mets:div>
+<mets:div ID="qs3v9" ORDER="43" TYPE="LogicalMember">
+<mets:fptr FILEID="erre9"/>
+</mets:div>
+<mets:div ID="ux3yc" ORDER="44" TYPE="LogicalMember">
+<mets:fptr FILEID="vt6zp"/>
+</mets:div>
+<mets:div ID="qjq5z" ORDER="45" TYPE="LogicalMember">
+<mets:fptr FILEID="mlgzw"/>
+</mets:div>
+<mets:div ID="j5i54" ORDER="46" TYPE="LogicalMember">
+<mets:fptr FILEID="z0uxp"/>
+</mets:div>
+<mets:div ID="pomg5" ORDER="47" TYPE="LogicalMember">
+<mets:fptr FILEID="e8yob"/>
+</mets:div>
+<mets:div ID="onelh" ORDER="48" TYPE="LogicalMember">
+<mets:fptr FILEID="zoq1z"/>
+</mets:div>
+<mets:div ID="yd12g" ORDER="49" TYPE="LogicalMember">
+<mets:fptr FILEID="jkgp6"/>
+</mets:div>
+<mets:div ID="zios9" ORDER="50" TYPE="LogicalMember">
+<mets:fptr FILEID="f8a7y"/>
+</mets:div>
+<mets:div ID="b68r7" ORDER="51" TYPE="LogicalMember">
+<mets:fptr FILEID="vzjv5"/>
+</mets:div>
+<mets:div ID="mk7qu" ORDER="52" TYPE="LogicalMember">
+<mets:fptr FILEID="cwj2o"/>
+</mets:div>
+<mets:div ID="jvjhj" ORDER="53" TYPE="LogicalMember">
+<mets:fptr FILEID="i0mso"/>
+</mets:div>
+<mets:div ID="hoij5" ORDER="54" TYPE="LogicalMember">
+<mets:fptr FILEID="ca7oe"/>
+</mets:div>
+<mets:div ID="ha81m" ORDER="55" TYPE="LogicalMember">
+<mets:fptr FILEID="r2d8z"/>
+</mets:div>
+<mets:div ID="wcp4j" ORDER="56" TYPE="LogicalMember">
+<mets:fptr FILEID="z1tr9"/>
+</mets:div>
+<mets:div ID="s6iv6" ORDER="57" TYPE="LogicalMember">
+<mets:fptr FILEID="j6gen"/>
+</mets:div>
+<mets:div ID="xrjvo" ORDER="58" TYPE="LogicalMember">
+<mets:fptr FILEID="xln4i"/>
+</mets:div>
+<mets:div ID="ryhqb" ORDER="59" TYPE="LogicalMember">
+<mets:fptr FILEID="vn9l5"/>
+</mets:div>
+<mets:div ID="vqeh3" ORDER="60" TYPE="LogicalMember">
+<mets:fptr FILEID="t1gc0"/>
+</mets:div>
+<mets:div ID="st011" ORDER="61" TYPE="LogicalMember">
+<mets:fptr FILEID="xnyc5"/>
+</mets:div>
+<mets:div ID="c0gj2" ORDER="62" TYPE="LogicalMember">
+<mets:fptr FILEID="g4cnz"/>
+</mets:div>
+<mets:div ID="lhoxa" ORDER="63" TYPE="LogicalMember">
+<mets:fptr FILEID="i8m2c"/>
+</mets:div>
+<mets:div ID="rbvcn" ORDER="64" TYPE="LogicalMember">
+<mets:fptr FILEID="aisvb"/>
+</mets:div>
+<mets:div ID="w2s36" ORDER="65" TYPE="LogicalMember">
+<mets:fptr FILEID="pdd45"/>
+</mets:div>
+<mets:div ID="p9ita" ORDER="66" TYPE="LogicalMember">
+<mets:fptr FILEID="byq68"/>
+</mets:div>
+<mets:div ID="qeyqw" ORDER="67" TYPE="LogicalMember">
+<mets:fptr FILEID="sdqg6"/>
+</mets:div>
+<mets:div ID="zb918" ORDER="68" TYPE="LogicalMember">
+<mets:fptr FILEID="e2kbq"/>
+</mets:div>
+<mets:div ID="v9br2" ORDER="69" TYPE="LogicalMember">
+<mets:fptr FILEID="ym1mf"/>
+</mets:div>
+<mets:div ID="debr0" ORDER="70" TYPE="LogicalMember">
+<mets:fptr FILEID="xpanh"/>
+</mets:div>
+<mets:div ID="tsbf2" ORDER="71" TYPE="LogicalMember">
+<mets:fptr FILEID="d7ne5"/>
+</mets:div>
+<mets:div ID="eohaz" ORDER="72" TYPE="LogicalMember">
+<mets:fptr FILEID="s5yaa"/>
+</mets:div>
+<mets:div ID="wflc1" ORDER="73" TYPE="LogicalMember">
+<mets:fptr FILEID="zdkxu"/>
+</mets:div>
+<mets:div ID="qfv8a" ORDER="74" TYPE="LogicalMember">
+<mets:fptr FILEID="scqf7"/>
+</mets:div>
+<mets:div ID="b6e2v" ORDER="75" TYPE="LogicalMember">
+<mets:fptr FILEID="vdzak"/>
+</mets:div>
+<mets:div ID="c4k91" ORDER="76" TYPE="LogicalMember">
+<mets:fptr FILEID="gjlie"/>
+</mets:div>
+<mets:div ID="vdn9w" ORDER="77" TYPE="LogicalMember">
+<mets:fptr FILEID="hqsxz"/>
+</mets:div>
+<mets:div ID="q4aq1" ORDER="78" TYPE="LogicalMember">
+<mets:fptr FILEID="hqqcu"/>
+</mets:div>
+<mets:div ID="ia29t" ORDER="79" TYPE="LogicalMember">
+<mets:fptr FILEID="xfa6r"/>
+</mets:div>
+<mets:div ID="p6fmy" ORDER="80" TYPE="LogicalMember">
+<mets:fptr FILEID="rstpt"/>
+</mets:div>
+<mets:div ID="bkq48" ORDER="81" TYPE="LogicalMember">
+<mets:fptr FILEID="ubcs8"/>
+</mets:div>
+<mets:div ID="n8977" ORDER="82" TYPE="LogicalMember">
+<mets:fptr FILEID="svn96"/>
+</mets:div>
+<mets:div ID="bruc9" ORDER="83" TYPE="LogicalMember">
+<mets:fptr FILEID="o4cys"/>
+</mets:div>
+<mets:div ID="sed2m" ORDER="84" TYPE="LogicalMember">
+<mets:fptr FILEID="l5yu1"/>
+</mets:div>
+<mets:div ID="s5hat" ORDER="85" TYPE="LogicalMember">
+<mets:fptr FILEID="xv323"/>
+</mets:div>
+<mets:div ID="jy1hk" ORDER="86" TYPE="LogicalMember">
+<mets:fptr FILEID="imzjt"/>
+</mets:div>
+<mets:div ID="a3eo5" ORDER="87" TYPE="LogicalMember">
+<mets:fptr FILEID="kholk"/>
+</mets:div>
+<mets:div ID="t4j9u" ORDER="88" TYPE="LogicalMember">
+<mets:fptr FILEID="rqh5x"/>
+</mets:div>
+<mets:div ID="pqgd5" ORDER="89" TYPE="LogicalMember">
+<mets:fptr FILEID="owvra"/>
+</mets:div>
+<mets:div ID="t98ze" ORDER="90" TYPE="LogicalMember">
+<mets:fptr FILEID="t73z8"/>
+</mets:div>
+<mets:div ID="isapi" ORDER="91" TYPE="LogicalMember">
+<mets:fptr FILEID="u1hx1"/>
+</mets:div>
+<mets:div ID="kvrsc" ORDER="92" TYPE="LogicalMember">
+<mets:fptr FILEID="a4dnn"/>
+</mets:div>
+<mets:div ID="tuinn" ORDER="93" TYPE="LogicalMember">
+<mets:fptr FILEID="irbal"/>
+</mets:div>
+<mets:div ID="srwin" ORDER="94" TYPE="LogicalMember">
+<mets:fptr FILEID="t5roh"/>
+</mets:div>
+<mets:div ID="fic7g" ORDER="95" TYPE="LogicalMember">
+<mets:fptr FILEID="a9glf"/>
+</mets:div>
+<mets:div ID="v7eqz" ORDER="96" TYPE="LogicalMember">
+<mets:fptr FILEID="zyahj"/>
+</mets:div>
+<mets:div ID="vyy21" ORDER="97" TYPE="LogicalMember">
+<mets:fptr FILEID="yw0hr"/>
+</mets:div>
+<mets:div ID="eajcj" ORDER="98" TYPE="LogicalMember">
+<mets:fptr FILEID="v6tzx"/>
+</mets:div>
+<mets:div ID="he228" ORDER="99" TYPE="LogicalMember">
+<mets:fptr FILEID="vvj31"/>
+</mets:div>
+<mets:div ID="dsq73" ORDER="100" TYPE="LogicalMember">
+<mets:fptr FILEID="zt1z1"/>
+</mets:div>
+<mets:div ID="rq2lm" ORDER="101" TYPE="LogicalMember">
+<mets:fptr FILEID="anj9n"/>
+</mets:div>
+<mets:div ID="n4d0j" ORDER="102" TYPE="LogicalMember">
+<mets:fptr FILEID="yra7f"/>
+</mets:div>
+<mets:div ID="p69z4" ORDER="103" TYPE="LogicalMember">
+<mets:fptr FILEID="v5rlk"/>
+</mets:div>
+<mets:div ID="qdfho" ORDER="104" TYPE="LogicalMember">
+<mets:fptr FILEID="w16r2"/>
+</mets:div>
+<mets:div ID="kj85d" ORDER="105" TYPE="LogicalMember">
+<mets:fptr FILEID="hjddo"/>
+</mets:div>
+<mets:div ID="jp6go" ORDER="106" TYPE="LogicalMember">
+<mets:fptr FILEID="vnysn"/>
+</mets:div>
+<mets:div ID="d8mq9" ORDER="107" TYPE="LogicalMember">
+<mets:fptr FILEID="u1z1k"/>
+</mets:div>
+<mets:div ID="tp5er" ORDER="108" TYPE="LogicalMember">
+<mets:fptr FILEID="ygg14"/>
+</mets:div>
+<mets:div ID="bwmlv" ORDER="109" TYPE="LogicalMember">
+<mets:fptr FILEID="yotr5"/>
+</mets:div>
+<mets:div ID="r7fh0" ORDER="110" TYPE="LogicalMember">
+<mets:fptr FILEID="clkeo"/>
+</mets:div>
+<mets:div ID="efvle" ORDER="111" TYPE="LogicalMember">
+<mets:fptr FILEID="cvyv5"/>
+</mets:div>
+<mets:div ID="tp8qd" ORDER="112" TYPE="LogicalMember">
+<mets:fptr FILEID="c3ohx"/>
+</mets:div>
+<mets:div ID="zj5hj" ORDER="113" TYPE="LogicalMember">
+<mets:fptr FILEID="buqgu"/>
+</mets:div>
+<mets:div ID="rljhr" ORDER="114" TYPE="LogicalMember">
+<mets:fptr FILEID="ggrpe"/>
+</mets:div>
+<mets:div ID="kh1gk" ORDER="115" TYPE="LogicalMember">
+<mets:fptr FILEID="gvk7z"/>
+</mets:div>
+<mets:div ID="z42iw" ORDER="116" TYPE="LogicalMember">
+<mets:fptr FILEID="x26y3"/>
+</mets:div>
+<mets:div ID="pu6jh" ORDER="117" TYPE="LogicalMember">
+<mets:fptr FILEID="reuys"/>
+</mets:div>
+<mets:div ID="xteew" ORDER="118" TYPE="LogicalMember">
+<mets:fptr FILEID="mr2cf"/>
+</mets:div>
+<mets:div ID="fnu8v" ORDER="119" TYPE="LogicalMember">
+<mets:fptr FILEID="yy2up"/>
+</mets:div>
+<mets:div ID="bnuup" ORDER="120" TYPE="LogicalMember">
+<mets:fptr FILEID="l2132"/>
+</mets:div>
+<mets:div ID="tz53t" ORDER="121" TYPE="LogicalMember">
+<mets:fptr FILEID="qerhs"/>
+</mets:div>
+<mets:div ID="o8ima" ORDER="122" TYPE="LogicalMember">
+<mets:fptr FILEID="dfd89"/>
+</mets:div>
+<mets:div ID="cnp4k" ORDER="123" TYPE="LogicalMember">
+<mets:fptr FILEID="nad7m"/>
+</mets:div>
+<mets:div ID="gxm5s" ORDER="124" TYPE="LogicalMember">
+<mets:fptr FILEID="yim2w"/>
+</mets:div>
+<mets:div ID="dcvn6" ORDER="125" TYPE="LogicalMember">
+<mets:fptr FILEID="iylx4"/>
+</mets:div>
+<mets:div ID="rgg2m" ORDER="126" TYPE="LogicalMember">
+<mets:fptr FILEID="nag3e"/>
+</mets:div>
+<mets:div ID="lnvit" ORDER="127" TYPE="LogicalMember">
+<mets:fptr FILEID="jhio2"/>
+</mets:div>
+<mets:div ID="j8e2j" ORDER="128" TYPE="LogicalMember">
+<mets:fptr FILEID="sdun3"/>
+</mets:div>
+<mets:div ID="jdfnv" ORDER="129" TYPE="LogicalMember">
+<mets:fptr FILEID="ajto8"/>
+</mets:div>
+<mets:div ID="i5bl6" ORDER="130" TYPE="LogicalMember">
+<mets:fptr FILEID="ggrib"/>
+</mets:div>
+<mets:div ID="m05qn" ORDER="131" TYPE="LogicalMember">
+<mets:fptr FILEID="q40sl"/>
+</mets:div>
+<mets:div ID="ae8me" ORDER="132" TYPE="LogicalMember">
+<mets:fptr FILEID="nz7ra"/>
+</mets:div>
+<mets:div ID="swdg1" ORDER="133" TYPE="LogicalMember">
+<mets:fptr FILEID="flfya"/>
+</mets:div>
+<mets:div ID="issns" ORDER="134" TYPE="LogicalMember">
+<mets:fptr FILEID="pn8ht"/>
+</mets:div>
+<mets:div ID="r13xj" ORDER="135" TYPE="LogicalMember">
+<mets:fptr FILEID="flzoo"/>
+</mets:div>
+<mets:div ID="o0o9r" ORDER="136" TYPE="LogicalMember">
+<mets:fptr FILEID="ilv71"/>
+</mets:div>
+<mets:div ID="p3c6r" ORDER="137" TYPE="LogicalMember">
+<mets:fptr FILEID="k60at"/>
+</mets:div>
+</mets:div>
+<mets:div ID="v3log" LABEL="scrapbook 3" TYPE="BoundArt">
+<mets:div ID="pvgzf" ORDER="1" TYPE="LogicalMember">
+<mets:fptr FILEID="v8a82"/>
+</mets:div>
+<mets:div ID="lumk4" ORDER="2" TYPE="LogicalMember">
+<mets:fptr FILEID="rf6zl"/>
+</mets:div>
+<mets:div ID="bh172" ORDER="3" TYPE="LogicalMember">
+<mets:fptr FILEID="msgw3"/>
+</mets:div>
+<mets:div ID="y527f" ORDER="4" TYPE="LogicalMember">
+<mets:fptr FILEID="q90z9"/>
+</mets:div>
+<mets:div ID="jqqqn" ORDER="5" TYPE="LogicalMember">
+<mets:fptr FILEID="rphap"/>
+</mets:div>
+<mets:div ID="sxt1g" ORDER="6" TYPE="LogicalMember">
+<mets:fptr FILEID="sae8v"/>
+</mets:div>
+<mets:div ID="dimyo" ORDER="7" TYPE="LogicalMember">
+<mets:fptr FILEID="na812"/>
+</mets:div>
+<mets:div ID="pfayf" ORDER="8" TYPE="LogicalMember">
+<mets:fptr FILEID="tt15e"/>
+</mets:div>
+<mets:div ID="wvd9o" ORDER="9" TYPE="LogicalMember">
+<mets:fptr FILEID="i6ijp"/>
+</mets:div>
+<mets:div ID="yom61" ORDER="10" TYPE="LogicalMember">
+<mets:fptr FILEID="addcz"/>
+</mets:div>
+<mets:div ID="cxi15" ORDER="11" TYPE="LogicalMember">
+<mets:fptr FILEID="pq6u7"/>
+</mets:div>
+<mets:div ID="cilxd" ORDER="12" TYPE="LogicalMember">
+<mets:fptr FILEID="kmm4w"/>
+</mets:div>
+<mets:div ID="norqn" ORDER="13" TYPE="LogicalMember">
+<mets:fptr FILEID="jeznt"/>
+</mets:div>
+<mets:div ID="dyvp3" ORDER="14" TYPE="LogicalMember">
+<mets:fptr FILEID="it3aw"/>
+</mets:div>
+<mets:div ID="t7zrx" ORDER="15" TYPE="LogicalMember">
+<mets:fptr FILEID="jqadt"/>
+</mets:div>
+<mets:div ID="gexum" ORDER="16" TYPE="LogicalMember">
+<mets:fptr FILEID="q1ltt"/>
+</mets:div>
+<mets:div ID="yh5o5" ORDER="17" TYPE="LogicalMember">
+<mets:fptr FILEID="mgp2i"/>
+</mets:div>
+<mets:div ID="d0vth" ORDER="18" TYPE="LogicalMember">
+<mets:fptr FILEID="k9wp3"/>
+</mets:div>
+<mets:div ID="gg2ab" ORDER="19" TYPE="LogicalMember">
+<mets:fptr FILEID="eg9ti"/>
+</mets:div>
+<mets:div ID="m2vcv" ORDER="20" TYPE="LogicalMember">
+<mets:fptr FILEID="sdpla"/>
+</mets:div>
+<mets:div ID="be3y5" ORDER="21" TYPE="LogicalMember">
+<mets:fptr FILEID="hcsg3"/>
+</mets:div>
+<mets:div ID="sgof9" ORDER="22" TYPE="LogicalMember">
+<mets:fptr FILEID="e6vm7"/>
+</mets:div>
+<mets:div ID="vftj1" ORDER="23" TYPE="LogicalMember">
+<mets:fptr FILEID="hrylu"/>
+</mets:div>
+<mets:div ID="kjpte" ORDER="24" TYPE="LogicalMember">
+<mets:fptr FILEID="e2ngf"/>
+</mets:div>
+<mets:div ID="sf5aq" ORDER="25" TYPE="LogicalMember">
+<mets:fptr FILEID="yafgs"/>
+</mets:div>
+<mets:div ID="p58aq" ORDER="26" TYPE="LogicalMember">
+<mets:fptr FILEID="oiccp"/>
+</mets:div>
+<mets:div ID="frfbw" ORDER="27" TYPE="LogicalMember">
+<mets:fptr FILEID="x553l"/>
+</mets:div>
+<mets:div ID="unpff" ORDER="28" TYPE="LogicalMember">
+<mets:fptr FILEID="sakj7"/>
+</mets:div>
+<mets:div ID="x0n2b" ORDER="29" TYPE="LogicalMember">
+<mets:fptr FILEID="fk967"/>
+</mets:div>
+<mets:div ID="yqxhx" ORDER="30" TYPE="LogicalMember">
+<mets:fptr FILEID="ezaho"/>
+</mets:div>
+<mets:div ID="xtgwt" ORDER="31" TYPE="LogicalMember">
+<mets:fptr FILEID="k4kj8"/>
+</mets:div>
+<mets:div ID="hutlk" ORDER="32" TYPE="LogicalMember">
+<mets:fptr FILEID="d0xo9"/>
+</mets:div>
+<mets:div ID="yjxv2" ORDER="33" TYPE="LogicalMember">
+<mets:fptr FILEID="n1g65"/>
+</mets:div>
+<mets:div ID="dgpuv" ORDER="34" TYPE="LogicalMember">
+<mets:fptr FILEID="sbxsa"/>
+</mets:div>
+<mets:div ID="mnlet" ORDER="35" TYPE="LogicalMember">
+<mets:fptr FILEID="yrxbt"/>
+</mets:div>
+<mets:div ID="p9kn6" ORDER="36" TYPE="LogicalMember">
+<mets:fptr FILEID="m3dwo"/>
+</mets:div>
+<mets:div ID="j9mx0" ORDER="37" TYPE="LogicalMember">
+<mets:fptr FILEID="oiw85"/>
+</mets:div>
+<mets:div ID="kfjku" ORDER="38" TYPE="LogicalMember">
+<mets:fptr FILEID="c2xvy"/>
+</mets:div>
+<mets:div ID="sub1e" ORDER="39" TYPE="LogicalMember">
+<mets:fptr FILEID="xkgya"/>
+</mets:div>
+<mets:div ID="gfxvv" ORDER="40" TYPE="LogicalMember">
+<mets:fptr FILEID="k56b0"/>
+</mets:div>
+<mets:div ID="cecwn" ORDER="41" TYPE="LogicalMember">
+<mets:fptr FILEID="np848"/>
+</mets:div>
+<mets:div ID="k8f66" ORDER="42" TYPE="LogicalMember">
+<mets:fptr FILEID="btxon"/>
+</mets:div>
+<mets:div ID="q1o9q" ORDER="43" TYPE="LogicalMember">
+<mets:fptr FILEID="zgua9"/>
+</mets:div>
+<mets:div ID="wpem1" ORDER="44" TYPE="LogicalMember">
+<mets:fptr FILEID="i9w2q"/>
+</mets:div>
+<mets:div ID="kpmer" ORDER="45" TYPE="LogicalMember">
+<mets:fptr FILEID="cdn97"/>
+</mets:div>
+<mets:div ID="g96q4" ORDER="46" TYPE="LogicalMember">
+<mets:fptr FILEID="cyk5m"/>
+</mets:div>
+<mets:div ID="n3sld" ORDER="47" TYPE="LogicalMember">
+<mets:fptr FILEID="msgcu"/>
+</mets:div>
+<mets:div ID="ez8a5" ORDER="48" TYPE="LogicalMember">
+<mets:fptr FILEID="h7g54"/>
+</mets:div>
+<mets:div ID="mnqey" ORDER="49" TYPE="LogicalMember">
+<mets:fptr FILEID="h7wff"/>
+</mets:div>
+<mets:div ID="lo65v" ORDER="50" TYPE="LogicalMember">
+<mets:fptr FILEID="a2j6w"/>
+</mets:div>
+<mets:div ID="mv58g" ORDER="51" TYPE="LogicalMember">
+<mets:fptr FILEID="lc0gq"/>
+</mets:div>
+<mets:div ID="l83z5" ORDER="52" TYPE="LogicalMember">
+<mets:fptr FILEID="mpuzm"/>
+</mets:div>
+<mets:div ID="vqy9m" ORDER="53" TYPE="LogicalMember">
+<mets:fptr FILEID="c43f8"/>
+</mets:div>
+<mets:div ID="fykl8" ORDER="54" TYPE="LogicalMember">
+<mets:fptr FILEID="hqors"/>
+</mets:div>
+<mets:div ID="rux19" ORDER="55" TYPE="LogicalMember">
+<mets:fptr FILEID="pwz0y"/>
+</mets:div>
+<mets:div ID="rbyev" ORDER="56" TYPE="LogicalMember">
+<mets:fptr FILEID="jpfw9"/>
+</mets:div>
+<mets:div ID="kv14p" ORDER="57" TYPE="LogicalMember">
+<mets:fptr FILEID="xxu34"/>
+</mets:div>
+<mets:div ID="to930" ORDER="58" TYPE="LogicalMember">
+<mets:fptr FILEID="cj88e"/>
+</mets:div>
+<mets:div ID="dl27i" ORDER="59" TYPE="LogicalMember">
+<mets:fptr FILEID="edhjy"/>
+</mets:div>
+<mets:div ID="e3d7o" ORDER="60" TYPE="LogicalMember">
+<mets:fptr FILEID="wovmb"/>
+</mets:div>
+<mets:div ID="jubro" ORDER="61" TYPE="LogicalMember">
+<mets:fptr FILEID="wdw0w"/>
+</mets:div>
+<mets:div ID="v8e0v" ORDER="62" TYPE="LogicalMember">
+<mets:fptr FILEID="xftm6"/>
+</mets:div>
+<mets:div ID="td0ux" ORDER="63" TYPE="LogicalMember">
+<mets:fptr FILEID="jem8q"/>
+</mets:div>
+<mets:div ID="hlbah" ORDER="64" TYPE="LogicalMember">
+<mets:fptr FILEID="euvrk"/>
+</mets:div>
+<mets:div ID="zc6we" ORDER="65" TYPE="LogicalMember">
+<mets:fptr FILEID="jo42w"/>
+</mets:div>
+<mets:div ID="heupn" ORDER="66" TYPE="LogicalMember">
+<mets:fptr FILEID="ddcxk"/>
+</mets:div>
+<mets:div ID="p40w6" ORDER="67" TYPE="LogicalMember">
+<mets:fptr FILEID="ol623"/>
+</mets:div>
+<mets:div ID="fmbvl" ORDER="68" TYPE="LogicalMember">
+<mets:fptr FILEID="pgzme"/>
+</mets:div>
+<mets:div ID="xk531" ORDER="69" TYPE="LogicalMember">
+<mets:fptr FILEID="c42ke"/>
+</mets:div>
+<mets:div ID="vqezi" ORDER="70" TYPE="LogicalMember">
+<mets:fptr FILEID="b5gpt"/>
+</mets:div>
+<mets:div ID="y20cf" ORDER="71" TYPE="LogicalMember">
+<mets:fptr FILEID="p8p2e"/>
+</mets:div>
+<mets:div ID="tgton" ORDER="72" TYPE="LogicalMember">
+<mets:fptr FILEID="p05ft"/>
+</mets:div>
+<mets:div ID="f8umv" ORDER="73" TYPE="LogicalMember">
+<mets:fptr FILEID="s9gmi"/>
+</mets:div>
+<mets:div ID="you0u" ORDER="74" TYPE="LogicalMember">
+<mets:fptr FILEID="rqsvs"/>
+</mets:div>
+<mets:div ID="r2tli" ORDER="75" TYPE="LogicalMember">
+<mets:fptr FILEID="qysu4"/>
+</mets:div>
+<mets:div ID="fny1z" ORDER="76" TYPE="LogicalMember">
+<mets:fptr FILEID="k58hg"/>
+</mets:div>
+<mets:div ID="hqsta" ORDER="77" TYPE="LogicalMember">
+<mets:fptr FILEID="q52s0"/>
+</mets:div>
+<mets:div ID="r7uos" ORDER="78" TYPE="LogicalMember">
+<mets:fptr FILEID="r2l7i"/>
+</mets:div>
+<mets:div ID="zvq7h" ORDER="79" TYPE="LogicalMember">
+<mets:fptr FILEID="liqys"/>
+</mets:div>
+<mets:div ID="kpazl" ORDER="80" TYPE="LogicalMember">
+<mets:fptr FILEID="mp1np"/>
+</mets:div>
+<mets:div ID="w78sp" ORDER="81" TYPE="LogicalMember">
+<mets:fptr FILEID="hmam0"/>
+</mets:div>
+<mets:div ID="ycgll" ORDER="82" TYPE="LogicalMember">
+<mets:fptr FILEID="mu9ue"/>
+</mets:div>
+<mets:div ID="j3k7d" ORDER="83" TYPE="LogicalMember">
+<mets:fptr FILEID="fsr8g"/>
+</mets:div>
+<mets:div ID="l6qel" ORDER="84" TYPE="LogicalMember">
+<mets:fptr FILEID="mh9il"/>
+</mets:div>
+<mets:div ID="i1diw" ORDER="85" TYPE="LogicalMember">
+<mets:fptr FILEID="ph9o0"/>
+</mets:div>
+<mets:div ID="ywz5x" ORDER="86" TYPE="LogicalMember">
+<mets:fptr FILEID="s0tzp"/>
+</mets:div>
+<mets:div ID="qv8ht" ORDER="87" TYPE="LogicalMember">
+<mets:fptr FILEID="fgwqb"/>
+</mets:div>
+<mets:div ID="v2vwz" ORDER="88" TYPE="LogicalMember">
+<mets:fptr FILEID="r91qd"/>
+</mets:div>
+<mets:div ID="lmnq7" ORDER="89" TYPE="LogicalMember">
+<mets:fptr FILEID="hqbdd"/>
+</mets:div>
+<mets:div ID="evm3p" ORDER="90" TYPE="LogicalMember">
+<mets:fptr FILEID="j2vyn"/>
+</mets:div>
+<mets:div ID="dcdo8" ORDER="91" TYPE="LogicalMember">
+<mets:fptr FILEID="x0sww"/>
+</mets:div>
+<mets:div ID="c4y6r" ORDER="92" TYPE="LogicalMember">
+<mets:fptr FILEID="muvut"/>
+</mets:div>
+<mets:div ID="n40x3" ORDER="93" TYPE="LogicalMember">
+<mets:fptr FILEID="qkept"/>
+</mets:div>
+<mets:div ID="v3zhx" ORDER="94" TYPE="LogicalMember">
+<mets:fptr FILEID="l6su7"/>
+</mets:div>
+<mets:div ID="grel2" ORDER="95" TYPE="LogicalMember">
+<mets:fptr FILEID="v3o0d"/>
+</mets:div>
+<mets:div ID="c4ij1" ORDER="96" TYPE="LogicalMember">
+<mets:fptr FILEID="ypnf1"/>
+</mets:div>
+<mets:div ID="j0mr3" ORDER="97" TYPE="LogicalMember">
+<mets:fptr FILEID="icr4e"/>
+</mets:div>
+<mets:div ID="vbyaj" ORDER="98" TYPE="LogicalMember">
+<mets:fptr FILEID="u9a0j"/>
+</mets:div>
+<mets:div ID="qgbuj" ORDER="99" TYPE="LogicalMember">
+<mets:fptr FILEID="bagdc"/>
+</mets:div>
+<mets:div ID="mqfx3" ORDER="100" TYPE="LogicalMember">
+<mets:fptr FILEID="y2r1y"/>
+</mets:div>
+<mets:div ID="l65vh" ORDER="101" TYPE="LogicalMember">
+<mets:fptr FILEID="j7f6y"/>
+</mets:div>
+<mets:div ID="mvh1y" ORDER="102" TYPE="LogicalMember">
+<mets:fptr FILEID="z6rzx"/>
+</mets:div>
+<mets:div ID="xhxmc" ORDER="103" TYPE="LogicalMember">
+<mets:fptr FILEID="rofj9"/>
+</mets:div>
+<mets:div ID="cy44n" ORDER="104" TYPE="LogicalMember">
+<mets:fptr FILEID="hohj1"/>
+</mets:div>
+<mets:div ID="i45a8" ORDER="105" TYPE="LogicalMember">
+<mets:fptr FILEID="livvw"/>
+</mets:div>
+<mets:div ID="sqmzi" ORDER="106" TYPE="LogicalMember">
+<mets:fptr FILEID="jy4la"/>
+</mets:div>
+<mets:div ID="cqxcc" ORDER="107" TYPE="LogicalMember">
+<mets:fptr FILEID="f3u75"/>
+</mets:div>
+<mets:div ID="psli9" ORDER="108" TYPE="LogicalMember">
+<mets:fptr FILEID="ftxer"/>
+</mets:div>
+<mets:div ID="fc9fy" ORDER="109" TYPE="LogicalMember">
+<mets:fptr FILEID="d3z6p"/>
+</mets:div>
+<mets:div ID="whp2d" ORDER="110" TYPE="LogicalMember">
+<mets:fptr FILEID="u3m5u"/>
+</mets:div>
+<mets:div ID="sr1xq" ORDER="111" TYPE="LogicalMember">
+<mets:fptr FILEID="k215o"/>
+</mets:div>
+<mets:div ID="j4jca" ORDER="112" TYPE="LogicalMember">
+<mets:fptr FILEID="f0sim"/>
+</mets:div>
+<mets:div ID="iwj28" ORDER="113" TYPE="LogicalMember">
+<mets:fptr FILEID="wqfwg"/>
+</mets:div>
+<mets:div ID="kn0bo" ORDER="114" TYPE="LogicalMember">
+<mets:fptr FILEID="zzj9h"/>
+</mets:div>
+<mets:div ID="wkask" ORDER="115" TYPE="LogicalMember">
+<mets:fptr FILEID="f77v3"/>
+</mets:div>
+<mets:div ID="y0x0r" ORDER="116" TYPE="LogicalMember">
+<mets:fptr FILEID="qlqti"/>
+</mets:div>
+<mets:div ID="hlgii" ORDER="117" TYPE="LogicalMember">
+<mets:fptr FILEID="valzj"/>
+</mets:div>
+<mets:div ID="y2gj6" ORDER="118" TYPE="LogicalMember">
+<mets:fptr FILEID="r4d2z"/>
+</mets:div>
+<mets:div ID="x9lef" ORDER="119" TYPE="LogicalMember">
+<mets:fptr FILEID="tcmhj"/>
+</mets:div>
+<mets:div ID="qz4j1" ORDER="120" TYPE="LogicalMember">
+<mets:fptr FILEID="j4k24"/>
+</mets:div>
+<mets:div ID="fjshh" ORDER="121" TYPE="LogicalMember">
+<mets:fptr FILEID="ecn91"/>
+</mets:div>
+<mets:div ID="g8qrm" ORDER="122" TYPE="LogicalMember">
+<mets:fptr FILEID="x3qo9"/>
+</mets:div>
+<mets:div ID="zupbe" ORDER="123" TYPE="LogicalMember">
+<mets:fptr FILEID="uzt4f"/>
+</mets:div>
+<mets:div ID="xar2t" ORDER="124" TYPE="LogicalMember">
+<mets:fptr FILEID="frxra"/>
+</mets:div>
+<mets:div ID="m0az0" ORDER="125" TYPE="LogicalMember">
+<mets:fptr FILEID="vc74u"/>
+</mets:div>
+<mets:div ID="tn41a" ORDER="126" TYPE="LogicalMember">
+<mets:fptr FILEID="waq1u"/>
+</mets:div>
+<mets:div ID="ti7cb" ORDER="127" TYPE="LogicalMember">
+<mets:fptr FILEID="wbrp1"/>
+</mets:div>
+<mets:div ID="ell28" ORDER="128" TYPE="LogicalMember">
+<mets:fptr FILEID="ablkt"/>
+</mets:div>
+<mets:div ID="yjhok" ORDER="129" TYPE="LogicalMember">
+<mets:fptr FILEID="d959w"/>
+</mets:div>
+<mets:div ID="ckqnz" ORDER="130" TYPE="LogicalMember">
+<mets:fptr FILEID="vow3a"/>
+</mets:div>
+<mets:div ID="ye56l" ORDER="131" TYPE="LogicalMember">
+<mets:fptr FILEID="d6qle"/>
+</mets:div>
+<mets:div ID="zj1wy" ORDER="132" TYPE="LogicalMember">
+<mets:fptr FILEID="vklm5"/>
+</mets:div>
+<mets:div ID="uxjwz" ORDER="133" TYPE="LogicalMember">
+<mets:fptr FILEID="bfqit"/>
+</mets:div>
+<mets:div ID="rjp3s" ORDER="134" TYPE="LogicalMember">
+<mets:fptr FILEID="vx5ox"/>
+</mets:div>
+<mets:div ID="rv2jg" ORDER="135" TYPE="LogicalMember">
+<mets:fptr FILEID="cntk1"/>
+</mets:div>
+<mets:div ID="uzs84" ORDER="136" TYPE="LogicalMember">
+<mets:fptr FILEID="ofvd3"/>
+</mets:div>
+<mets:div ID="fz51c" ORDER="137" TYPE="LogicalMember">
+<mets:fptr FILEID="lg46u"/>
+</mets:div>
+<mets:div ID="o4vt0" ORDER="138" TYPE="LogicalMember">
+<mets:fptr FILEID="g0br0"/>
+</mets:div>
+<mets:div ID="sxujj" ORDER="139" TYPE="LogicalMember">
+<mets:fptr FILEID="mfobf"/>
+</mets:div>
+<mets:div ID="nw6ec" ORDER="140" TYPE="LogicalMember">
+<mets:fptr FILEID="khw76"/>
+</mets:div>
+<mets:div ID="fo1ch" ORDER="141" TYPE="LogicalMember">
+<mets:fptr FILEID="k17e9"/>
+</mets:div>
+<mets:div ID="tl5hd" ORDER="142" TYPE="LogicalMember">
+<mets:fptr FILEID="uny9n"/>
+</mets:div>
+<mets:div ID="ocesj" ORDER="143" TYPE="LogicalMember">
+<mets:fptr FILEID="uyww5"/>
+</mets:div>
+<mets:div ID="e52nw" ORDER="144" TYPE="LogicalMember">
+<mets:fptr FILEID="tf461"/>
+</mets:div>
+<mets:div ID="nynzc" ORDER="145" TYPE="LogicalMember">
+<mets:fptr FILEID="nwufz"/>
+</mets:div>
+<mets:div ID="g3et2" ORDER="146" TYPE="LogicalMember">
+<mets:fptr FILEID="y7xj9"/>
+</mets:div>
+<mets:div ID="x5vxt" ORDER="147" TYPE="LogicalMember">
+<mets:fptr FILEID="st4yo"/>
+</mets:div>
+<mets:div ID="qqb5v" ORDER="148" TYPE="LogicalMember">
+<mets:fptr FILEID="g5sem"/>
+</mets:div>
+<mets:div ID="jj6ey" ORDER="149" TYPE="LogicalMember">
+<mets:fptr FILEID="mxzg7"/>
+</mets:div>
+<mets:div ID="yp4y5" ORDER="150" TYPE="LogicalMember">
+<mets:fptr FILEID="xut8u"/>
+</mets:div>
+<mets:div ID="i4r9y" ORDER="151" TYPE="LogicalMember">
+<mets:fptr FILEID="syhcf"/>
+</mets:div>
+<mets:div ID="r2lld" ORDER="152" TYPE="LogicalMember">
+<mets:fptr FILEID="g0cyu"/>
+</mets:div>
+<mets:div ID="kamlf" ORDER="153" TYPE="LogicalMember">
+<mets:fptr FILEID="lfevo"/>
+</mets:div>
+<mets:div ID="z8xgm" ORDER="154" TYPE="LogicalMember">
+<mets:fptr FILEID="je1hs"/>
+</mets:div>
+<mets:div ID="xl2n4" ORDER="155" TYPE="LogicalMember">
+<mets:fptr FILEID="y1dxx"/>
+</mets:div>
+<mets:div ID="bphi5" ORDER="156" TYPE="LogicalMember">
+<mets:fptr FILEID="lll96"/>
+</mets:div>
+<mets:div ID="zrdc7" ORDER="157" TYPE="LogicalMember">
+<mets:fptr FILEID="zmqge"/>
+</mets:div>
+<mets:div ID="kpow4" ORDER="158" TYPE="LogicalMember">
+<mets:fptr FILEID="jl8fl"/>
+</mets:div>
+<mets:div ID="ygbg1" ORDER="159" TYPE="LogicalMember">
+<mets:fptr FILEID="wrf2o"/>
+</mets:div>
+<mets:div ID="w76s6" ORDER="160" TYPE="LogicalMember">
+<mets:fptr FILEID="d64fn"/>
+</mets:div>
+<mets:div ID="xh0vt" ORDER="161" TYPE="LogicalMember">
+<mets:fptr FILEID="ov5v9"/>
+</mets:div>
+<mets:div ID="strqo" ORDER="162" TYPE="LogicalMember">
+<mets:fptr FILEID="wgmk6"/>
+</mets:div>
+<mets:div ID="x301c" ORDER="163" TYPE="LogicalMember">
+<mets:fptr FILEID="delsa"/>
+</mets:div>
+<mets:div ID="zzw0j" ORDER="164" TYPE="LogicalMember">
+<mets:fptr FILEID="gugru"/>
+</mets:div>
+<mets:div ID="z774x" ORDER="165" TYPE="LogicalMember">
+<mets:fptr FILEID="ylshw"/>
+</mets:div>
+<mets:div ID="la6oe" ORDER="166" TYPE="LogicalMember">
+<mets:fptr FILEID="m6fnq"/>
+</mets:div>
+<mets:div ID="bw7g3" ORDER="167" TYPE="LogicalMember">
+<mets:fptr FILEID="b1ww7"/>
+</mets:div>
+<mets:div ID="pun0s" ORDER="168" TYPE="LogicalMember">
+<mets:fptr FILEID="ljz80"/>
+</mets:div>
+<mets:div ID="hv4ak" ORDER="169" TYPE="LogicalMember">
+<mets:fptr FILEID="hrk7z"/>
+</mets:div>
+<mets:div ID="ln55s" ORDER="170" TYPE="LogicalMember">
+<mets:fptr FILEID="j81nz"/>
+</mets:div>
+<mets:div ID="x1vbw" ORDER="171" TYPE="LogicalMember">
+<mets:fptr FILEID="mro4g"/>
+</mets:div>
+<mets:div ID="r31n7" ORDER="172" TYPE="LogicalMember">
+<mets:fptr FILEID="kltin"/>
+</mets:div>
+<mets:div ID="es74d" ORDER="173" TYPE="LogicalMember">
+<mets:fptr FILEID="y5a89"/>
+</mets:div>
+<mets:div ID="eh69i" ORDER="174" TYPE="LogicalMember">
+<mets:fptr FILEID="b86dc"/>
+</mets:div>
+<mets:div ID="pwf4g" ORDER="175" TYPE="LogicalMember">
+<mets:fptr FILEID="q1szc"/>
+</mets:div>
+<mets:div ID="gs1in" ORDER="176" TYPE="LogicalMember">
+<mets:fptr FILEID="d26fb"/>
+</mets:div>
+<mets:div ID="jut0c" ORDER="177" TYPE="LogicalMember">
+<mets:fptr FILEID="bqf06"/>
+</mets:div>
+<mets:div ID="keepz" ORDER="178" TYPE="LogicalMember">
+<mets:fptr FILEID="d0301"/>
+</mets:div>
+<mets:div ID="zjom6" ORDER="179" TYPE="LogicalMember">
+<mets:fptr FILEID="s2d2j"/>
+</mets:div>
+<mets:div ID="z0c5g" ORDER="180" TYPE="LogicalMember">
+<mets:fptr FILEID="bt4wx"/>
+</mets:div>
+<mets:div ID="xrtfv" ORDER="181" TYPE="LogicalMember">
+<mets:fptr FILEID="c9wkq"/>
+</mets:div>
+<mets:div ID="dgj3j" ORDER="182" TYPE="LogicalMember">
+<mets:fptr FILEID="hepla"/>
+</mets:div>
+<mets:div ID="nkwhq" ORDER="183" TYPE="LogicalMember">
+<mets:fptr FILEID="sgwme"/>
+</mets:div>
+<mets:div ID="vdawj" ORDER="184" TYPE="LogicalMember">
+<mets:fptr FILEID="bwjr6"/>
+</mets:div>
+<mets:div ID="eswlg" ORDER="185" TYPE="LogicalMember">
+<mets:fptr FILEID="e3bbr"/>
+</mets:div>
+<mets:div ID="a7zcq" ORDER="186" TYPE="LogicalMember">
+<mets:fptr FILEID="i7vxv"/>
+</mets:div>
+<mets:div ID="itj6l" ORDER="187" TYPE="LogicalMember">
+<mets:fptr FILEID="iun5g"/>
+</mets:div>
+<mets:div ID="gpe7h" ORDER="188" TYPE="LogicalMember">
+<mets:fptr FILEID="tsq5t"/>
+</mets:div>
+<mets:div ID="q58dp" ORDER="189" TYPE="LogicalMember">
+<mets:fptr FILEID="wcgvm"/>
+</mets:div>
+<mets:div ID="ok8py" ORDER="190" TYPE="LogicalMember">
+<mets:fptr FILEID="j9qcw"/>
+</mets:div>
+<mets:div ID="i1zbi" ORDER="191" TYPE="LogicalMember">
+<mets:fptr FILEID="e50nk"/>
+</mets:div>
+<mets:div ID="pcr93" ORDER="192" TYPE="LogicalMember">
+<mets:fptr FILEID="vplvg"/>
+</mets:div>
+<mets:div ID="sz6nj" ORDER="193" TYPE="LogicalMember">
+<mets:fptr FILEID="oeg72"/>
+</mets:div>
+<mets:div ID="ktjyx" ORDER="194" TYPE="LogicalMember">
+<mets:fptr FILEID="hvvhq"/>
+</mets:div>
+<mets:div ID="c3k6j" ORDER="195" TYPE="LogicalMember">
+<mets:fptr FILEID="t8l8z"/>
+</mets:div>
+<mets:div ID="jchix" ORDER="196" TYPE="LogicalMember">
+<mets:fptr FILEID="f8dyi"/>
+</mets:div>
+<mets:div ID="s213q" ORDER="197" TYPE="LogicalMember">
+<mets:fptr FILEID="fflxv"/>
+</mets:div>
+<mets:div ID="b2vpl" ORDER="198" TYPE="LogicalMember">
+<mets:fptr FILEID="kpoyk"/>
+</mets:div>
+<mets:div ID="y014a" ORDER="199" TYPE="LogicalMember">
+<mets:fptr FILEID="yf81i"/>
+</mets:div>
+<mets:div ID="y1rsp" ORDER="200" TYPE="LogicalMember">
+<mets:fptr FILEID="vv8gg"/>
+</mets:div>
+<mets:div ID="gs0zv" ORDER="201" TYPE="LogicalMember">
+<mets:fptr FILEID="x432s"/>
+</mets:div>
+<mets:div ID="jmk7x" ORDER="202" TYPE="LogicalMember">
+<mets:fptr FILEID="g7fbr"/>
+</mets:div>
+<mets:div ID="tsauz" ORDER="203" TYPE="LogicalMember">
+<mets:fptr FILEID="t5091"/>
+</mets:div>
+<mets:div ID="txef3" ORDER="204" TYPE="LogicalMember">
+<mets:fptr FILEID="fx3mf"/>
+</mets:div>
+<mets:div ID="wtxv5" ORDER="205" TYPE="LogicalMember">
+<mets:fptr FILEID="zqfsx"/>
+</mets:div>
+<mets:div ID="t86cl" ORDER="206" TYPE="LogicalMember">
+<mets:fptr FILEID="m4pwy"/>
+</mets:div>
+<mets:div ID="oxhfe" ORDER="207" TYPE="LogicalMember">
+<mets:fptr FILEID="fjpe1"/>
+</mets:div>
+<mets:div ID="hgyir" ORDER="208" TYPE="LogicalMember">
+<mets:fptr FILEID="vty53"/>
+</mets:div>
+<mets:div ID="h7so2" ORDER="209" TYPE="LogicalMember">
+<mets:fptr FILEID="kukwl"/>
+</mets:div>
+<mets:div ID="mmgxq" ORDER="210" TYPE="LogicalMember">
+<mets:fptr FILEID="xo04e"/>
+</mets:div>
+<mets:div ID="d1h5d" ORDER="211" TYPE="LogicalMember">
+<mets:fptr FILEID="m2v63"/>
+</mets:div>
+<mets:div ID="pmx13" ORDER="212" TYPE="LogicalMember">
+<mets:fptr FILEID="zl6fi"/>
+</mets:div>
+<mets:div ID="etbwx" ORDER="213" TYPE="LogicalMember">
+<mets:fptr FILEID="x3sdg"/>
+</mets:div>
+<mets:div ID="wn4h1" ORDER="214" TYPE="LogicalMember">
+<mets:fptr FILEID="ykwee"/>
+</mets:div>
+<mets:div ID="t6z2c" ORDER="215" TYPE="LogicalMember">
+<mets:fptr FILEID="jlwyi"/>
+</mets:div>
+<mets:div ID="bl7mn" ORDER="216" TYPE="LogicalMember">
+<mets:fptr FILEID="bgjq9"/>
+</mets:div>
+<mets:div ID="hc3yc" ORDER="217" TYPE="LogicalMember">
+<mets:fptr FILEID="icbda"/>
+</mets:div>
+<mets:div ID="jst9t" ORDER="218" TYPE="LogicalMember">
+<mets:fptr FILEID="z2t4z"/>
+</mets:div>
+<mets:div ID="jgpvb" ORDER="219" TYPE="LogicalMember">
+<mets:fptr FILEID="c2dic"/>
+</mets:div>
+<mets:div ID="pepwy" ORDER="220" TYPE="LogicalMember">
+<mets:fptr FILEID="kmtlu"/>
+</mets:div>
+<mets:div ID="qi070" ORDER="221" TYPE="LogicalMember">
+<mets:fptr FILEID="l04hq"/>
+</mets:div>
+<mets:div ID="a4slj" ORDER="222" TYPE="LogicalMember">
+<mets:fptr FILEID="ksbop"/>
+</mets:div>
+<mets:div ID="mfll9" ORDER="223" TYPE="LogicalMember">
+<mets:fptr FILEID="njtkd"/>
+</mets:div>
+<mets:div ID="n4m1o" ORDER="224" TYPE="LogicalMember">
+<mets:fptr FILEID="zg7r3"/>
+</mets:div>
+<mets:div ID="fd39u" ORDER="225" TYPE="LogicalMember">
+<mets:fptr FILEID="mb6u3"/>
+</mets:div>
+<mets:div ID="xy0ym" ORDER="226" TYPE="LogicalMember">
+<mets:fptr FILEID="tkoln"/>
+</mets:div>
+<mets:div ID="upqnz" ORDER="227" TYPE="LogicalMember">
+<mets:fptr FILEID="jepo2"/>
+</mets:div>
+<mets:div ID="y4392" ORDER="228" TYPE="LogicalMember">
+<mets:fptr FILEID="dbvpd"/>
+</mets:div>
+<mets:div ID="scwbu" ORDER="229" TYPE="LogicalMember">
+<mets:fptr FILEID="pfs81"/>
+</mets:div>
+<mets:div ID="w5ihy" ORDER="230" TYPE="LogicalMember">
+<mets:fptr FILEID="m35oz"/>
+</mets:div>
+<mets:div ID="swq0b" ORDER="231" TYPE="LogicalMember">
+<mets:fptr FILEID="mj8jr"/>
+</mets:div>
+<mets:div ID="msp3i" ORDER="232" TYPE="LogicalMember">
+<mets:fptr FILEID="b7ztq"/>
+</mets:div>
+<mets:div ID="qhodr" ORDER="233" TYPE="LogicalMember">
+<mets:fptr FILEID="mewnx"/>
+</mets:div>
+<mets:div ID="r7dzf" ORDER="234" TYPE="LogicalMember">
+<mets:fptr FILEID="cv5pz"/>
+</mets:div>
+<mets:div ID="amntv" ORDER="235" TYPE="LogicalMember">
+<mets:fptr FILEID="v7k65"/>
+</mets:div>
+<mets:div ID="nrmuw" ORDER="236" TYPE="LogicalMember">
+<mets:fptr FILEID="ombf5"/>
+</mets:div>
+<mets:div ID="pjdys" ORDER="237" TYPE="LogicalMember">
+<mets:fptr FILEID="ssfi4"/>
+</mets:div>
+<mets:div ID="zf2p6" ORDER="238" TYPE="LogicalMember">
+<mets:fptr FILEID="syg1s"/>
+</mets:div>
+<mets:div ID="q2lwn" ORDER="239" TYPE="LogicalMember">
+<mets:fptr FILEID="os6pg"/>
+</mets:div>
+<mets:div ID="u2imp" ORDER="240" TYPE="LogicalMember">
+<mets:fptr FILEID="n0fxi"/>
+</mets:div>
+<mets:div ID="stk5i" ORDER="241" TYPE="LogicalMember">
+<mets:fptr FILEID="ezb2s"/>
+</mets:div>
+<mets:div ID="kjs03" ORDER="242" TYPE="LogicalMember">
+<mets:fptr FILEID="bq00n"/>
+</mets:div>
+<mets:div ID="x8tpk" ORDER="243" TYPE="LogicalMember">
+<mets:fptr FILEID="j1ayh"/>
+</mets:div>
+</mets:div>
+<mets:div ID="v4log" LABEL="scrapbook 4" TYPE="BoundArt">
+<mets:div ID="nst0r" ORDER="1" TYPE="LogicalMember">
+<mets:fptr FILEID="dl10y"/>
+</mets:div>
+<mets:div ID="zldds" ORDER="2" TYPE="LogicalMember">
+<mets:fptr FILEID="uhjtm"/>
+</mets:div>
+<mets:div ID="xmok5" ORDER="3" TYPE="LogicalMember">
+<mets:fptr FILEID="dl7a3"/>
+</mets:div>
+<mets:div ID="ks09z" ORDER="4" TYPE="LogicalMember">
+<mets:fptr FILEID="tt0tc"/>
+</mets:div>
+<mets:div ID="pxz8e" ORDER="5" TYPE="LogicalMember">
+<mets:fptr FILEID="g4whn"/>
+</mets:div>
+<mets:div ID="n358c" ORDER="6" TYPE="LogicalMember">
+<mets:fptr FILEID="g66hd"/>
+</mets:div>
+<mets:div ID="odxdo" ORDER="7" TYPE="LogicalMember">
+<mets:fptr FILEID="t432o"/>
+</mets:div>
+<mets:div ID="vonp4" ORDER="8" TYPE="LogicalMember">
+<mets:fptr FILEID="nt0fb"/>
+</mets:div>
+<mets:div ID="yxrdf" ORDER="9" TYPE="LogicalMember">
+<mets:fptr FILEID="c8yjt"/>
+</mets:div>
+<mets:div ID="umpvt" ORDER="10" TYPE="LogicalMember">
+<mets:fptr FILEID="pkwol"/>
+</mets:div>
+<mets:div ID="v2vn5" ORDER="11" TYPE="LogicalMember">
+<mets:fptr FILEID="vtw7x"/>
+</mets:div>
+<mets:div ID="o3z1b" ORDER="12" TYPE="LogicalMember">
+<mets:fptr FILEID="c0e5o"/>
+</mets:div>
+<mets:div ID="xsps3" ORDER="13" TYPE="LogicalMember">
+<mets:fptr FILEID="kn3xy"/>
+</mets:div>
+<mets:div ID="ylr4d" ORDER="14" TYPE="LogicalMember">
+<mets:fptr FILEID="tw6bz"/>
+</mets:div>
+<mets:div ID="gyp8o" ORDER="15" TYPE="LogicalMember">
+<mets:fptr FILEID="cfw4l"/>
+</mets:div>
+<mets:div ID="t2lvh" ORDER="16" TYPE="LogicalMember">
+<mets:fptr FILEID="k3icz"/>
+</mets:div>
+<mets:div ID="n92lb" ORDER="17" TYPE="LogicalMember">
+<mets:fptr FILEID="wlrmm"/>
+</mets:div>
+<mets:div ID="rqu9l" ORDER="18" TYPE="LogicalMember">
+<mets:fptr FILEID="zcqhr"/>
+</mets:div>
+<mets:div ID="fmshj" ORDER="19" TYPE="LogicalMember">
+<mets:fptr FILEID="b2aeu"/>
+</mets:div>
+<mets:div ID="f7br5" ORDER="20" TYPE="LogicalMember">
+<mets:fptr FILEID="mnhgp"/>
+</mets:div>
+<mets:div ID="zkebz" ORDER="21" TYPE="LogicalMember">
+<mets:fptr FILEID="mzzbj"/>
+</mets:div>
+<mets:div ID="xuorg" ORDER="22" TYPE="LogicalMember">
+<mets:fptr FILEID="fosql"/>
+</mets:div>
+<mets:div ID="r4bt7" ORDER="23" TYPE="LogicalMember">
+<mets:fptr FILEID="c9qfc"/>
+</mets:div>
+<mets:div ID="plzsm" ORDER="24" TYPE="LogicalMember">
+<mets:fptr FILEID="cjp3e"/>
+</mets:div>
+<mets:div ID="i7tfd" ORDER="25" TYPE="LogicalMember">
+<mets:fptr FILEID="mywpu"/>
+</mets:div>
+<mets:div ID="bm4n0" ORDER="26" TYPE="LogicalMember">
+<mets:fptr FILEID="g7iej"/>
+</mets:div>
+<mets:div ID="s81qt" ORDER="27" TYPE="LogicalMember">
+<mets:fptr FILEID="amui8"/>
+</mets:div>
+<mets:div ID="b3xg9" ORDER="28" TYPE="LogicalMember">
+<mets:fptr FILEID="t188v"/>
+</mets:div>
+<mets:div ID="k5ukz" ORDER="29" TYPE="LogicalMember">
+<mets:fptr FILEID="iby1r"/>
+</mets:div>
+<mets:div ID="ylm89" ORDER="30" TYPE="LogicalMember">
+<mets:fptr FILEID="phc22"/>
+</mets:div>
+<mets:div ID="mnblz" ORDER="31" TYPE="LogicalMember">
+<mets:fptr FILEID="xapi9"/>
+</mets:div>
+<mets:div ID="fwtql" ORDER="32" TYPE="LogicalMember">
+<mets:fptr FILEID="s0deg"/>
+</mets:div>
+<mets:div ID="te575" ORDER="33" TYPE="LogicalMember">
+<mets:fptr FILEID="smqhh"/>
+</mets:div>
+<mets:div ID="beyuj" ORDER="34" TYPE="LogicalMember">
+<mets:fptr FILEID="n4cj8"/>
+</mets:div>
+<mets:div ID="jirek" ORDER="35" TYPE="LogicalMember">
+<mets:fptr FILEID="pnic8"/>
+</mets:div>
+<mets:div ID="r8rev" ORDER="36" TYPE="LogicalMember">
+<mets:fptr FILEID="og5kn"/>
+</mets:div>
+<mets:div ID="a60x2" ORDER="37" TYPE="LogicalMember">
+<mets:fptr FILEID="nwk2z"/>
+</mets:div>
+<mets:div ID="qn12c" ORDER="38" TYPE="LogicalMember">
+<mets:fptr FILEID="uxrzz"/>
+</mets:div>
+<mets:div ID="f4pue" ORDER="39" TYPE="LogicalMember">
+<mets:fptr FILEID="usw4x"/>
+</mets:div>
+<mets:div ID="kluuo" ORDER="40" TYPE="LogicalMember">
+<mets:fptr FILEID="g7vcm"/>
+</mets:div>
+<mets:div ID="lkj2i" ORDER="41" TYPE="LogicalMember">
+<mets:fptr FILEID="ur8p7"/>
+</mets:div>
+<mets:div ID="ppbsc" ORDER="42" TYPE="LogicalMember">
+<mets:fptr FILEID="aipxr"/>
+</mets:div>
+<mets:div ID="h128i" ORDER="43" TYPE="LogicalMember">
+<mets:fptr FILEID="vo06f"/>
+</mets:div>
+<mets:div ID="a2zv2" ORDER="44" TYPE="LogicalMember">
+<mets:fptr FILEID="mzxyp"/>
+</mets:div>
+<mets:div ID="ssdde" ORDER="45" TYPE="LogicalMember">
+<mets:fptr FILEID="q71s3"/>
+</mets:div>
+<mets:div ID="uyvpg" ORDER="46" TYPE="LogicalMember">
+<mets:fptr FILEID="mv1av"/>
+</mets:div>
+<mets:div ID="q6e23" ORDER="47" TYPE="LogicalMember">
+<mets:fptr FILEID="d896r"/>
+</mets:div>
+<mets:div ID="oqqau" ORDER="48" TYPE="LogicalMember">
+<mets:fptr FILEID="zjs4p"/>
+</mets:div>
+<mets:div ID="xx3zj" ORDER="49" TYPE="LogicalMember">
+<mets:fptr FILEID="n0p8e"/>
+</mets:div>
+<mets:div ID="f5l6i" ORDER="50" TYPE="LogicalMember">
+<mets:fptr FILEID="gqmg9"/>
+</mets:div>
+<mets:div ID="rx4d5" ORDER="51" TYPE="LogicalMember">
+<mets:fptr FILEID="ak6qp"/>
+</mets:div>
+<mets:div ID="ys5l5" ORDER="52" TYPE="LogicalMember">
+<mets:fptr FILEID="b96hq"/>
+</mets:div>
+<mets:div ID="hh8uk" ORDER="53" TYPE="LogicalMember">
+<mets:fptr FILEID="ckp2v"/>
+</mets:div>
+<mets:div ID="h4lfr" ORDER="54" TYPE="LogicalMember">
+<mets:fptr FILEID="k0ro9"/>
+</mets:div>
+<mets:div ID="p2ldo" ORDER="55" TYPE="LogicalMember">
+<mets:fptr FILEID="gi3oe"/>
+</mets:div>
+<mets:div ID="kvqrm" ORDER="56" TYPE="LogicalMember">
+<mets:fptr FILEID="bzno0"/>
+</mets:div>
+<mets:div ID="xyu67" ORDER="57" TYPE="LogicalMember">
+<mets:fptr FILEID="qrfg2"/>
+</mets:div>
+<mets:div ID="kl1w4" ORDER="58" TYPE="LogicalMember">
+<mets:fptr FILEID="y8792"/>
+</mets:div>
+<mets:div ID="h1dza" ORDER="59" TYPE="LogicalMember">
+<mets:fptr FILEID="tc1m3"/>
+</mets:div>
+<mets:div ID="dg7p4" ORDER="60" TYPE="LogicalMember">
+<mets:fptr FILEID="tszb9"/>
+</mets:div>
+<mets:div ID="rq0yr" ORDER="61" TYPE="LogicalMember">
+<mets:fptr FILEID="ianjz"/>
+</mets:div>
+<mets:div ID="tvhky" ORDER="62" TYPE="LogicalMember">
+<mets:fptr FILEID="sk8ck"/>
+</mets:div>
+<mets:div ID="c0cml" ORDER="63" TYPE="LogicalMember">
+<mets:fptr FILEID="gsg0w"/>
+</mets:div>
+<mets:div ID="kh8n8" ORDER="64" TYPE="LogicalMember">
+<mets:fptr FILEID="m9dep"/>
+</mets:div>
+<mets:div ID="f44ct" ORDER="65" TYPE="LogicalMember">
+<mets:fptr FILEID="kqsjy"/>
+</mets:div>
+<mets:div ID="naon8" ORDER="66" TYPE="LogicalMember">
+<mets:fptr FILEID="rtsza"/>
+</mets:div>
+<mets:div ID="bekcm" ORDER="67" TYPE="LogicalMember">
+<mets:fptr FILEID="ucgi6"/>
+</mets:div>
+<mets:div ID="rtjvd" ORDER="68" TYPE="LogicalMember">
+<mets:fptr FILEID="ua7bc"/>
+</mets:div>
+<mets:div ID="jrhgl" ORDER="69" TYPE="LogicalMember">
+<mets:fptr FILEID="xtlk6"/>
+</mets:div>
+<mets:div ID="wfv67" ORDER="70" TYPE="LogicalMember">
+<mets:fptr FILEID="bqbs0"/>
+</mets:div>
+<mets:div ID="k68q3" ORDER="71" TYPE="LogicalMember">
+<mets:fptr FILEID="d1xg3"/>
+</mets:div>
+<mets:div ID="o1xkx" ORDER="72" TYPE="LogicalMember">
+<mets:fptr FILEID="q8wdo"/>
+</mets:div>
+<mets:div ID="cguck" ORDER="73" TYPE="LogicalMember">
+<mets:fptr FILEID="h909k"/>
+</mets:div>
+<mets:div ID="r7htx" ORDER="74" TYPE="LogicalMember">
+<mets:fptr FILEID="phmlq"/>
+</mets:div>
+<mets:div ID="v5sn4" ORDER="75" TYPE="LogicalMember">
+<mets:fptr FILEID="dlw45"/>
+</mets:div>
+<mets:div ID="g3fbo" ORDER="76" TYPE="LogicalMember">
+<mets:fptr FILEID="gavkf"/>
+</mets:div>
+<mets:div ID="vfidg" ORDER="77" TYPE="LogicalMember">
+<mets:fptr FILEID="oqg92"/>
+</mets:div>
+<mets:div ID="jlush" ORDER="78" TYPE="LogicalMember">
+<mets:fptr FILEID="pemfv"/>
+</mets:div>
+<mets:div ID="zhza6" ORDER="79" TYPE="LogicalMember">
+<mets:fptr FILEID="l3wo6"/>
+</mets:div>
+<mets:div ID="ro9jx" ORDER="80" TYPE="LogicalMember">
+<mets:fptr FILEID="vqmwl"/>
+</mets:div>
+<mets:div ID="az56f" ORDER="81" TYPE="LogicalMember">
+<mets:fptr FILEID="zu4np"/>
+</mets:div>
+<mets:div ID="xjdxr" ORDER="82" TYPE="LogicalMember">
+<mets:fptr FILEID="fhtd2"/>
+</mets:div>
+<mets:div ID="jfo08" ORDER="83" TYPE="LogicalMember">
+<mets:fptr FILEID="bbehu"/>
+</mets:div>
+<mets:div ID="i1qf5" ORDER="84" TYPE="LogicalMember">
+<mets:fptr FILEID="c78v3"/>
+</mets:div>
+<mets:div ID="su7h9" ORDER="85" TYPE="LogicalMember">
+<mets:fptr FILEID="ck93t"/>
+</mets:div>
+<mets:div ID="b666r" ORDER="86" TYPE="LogicalMember">
+<mets:fptr FILEID="axwvk"/>
+</mets:div>
+<mets:div ID="w9dbz" ORDER="87" TYPE="LogicalMember">
+<mets:fptr FILEID="s54gg"/>
+</mets:div>
+<mets:div ID="hk76g" ORDER="88" TYPE="LogicalMember">
+<mets:fptr FILEID="zmxdx"/>
+</mets:div>
+<mets:div ID="vgd3t" ORDER="89" TYPE="LogicalMember">
+<mets:fptr FILEID="if0kg"/>
+</mets:div>
+<mets:div ID="dqt4o" ORDER="90" TYPE="LogicalMember">
+<mets:fptr FILEID="hdipo"/>
+</mets:div>
+<mets:div ID="lyrtc" ORDER="91" TYPE="LogicalMember">
+<mets:fptr FILEID="dg2ew"/>
+</mets:div>
+<mets:div ID="dyx2i" ORDER="92" TYPE="LogicalMember">
+<mets:fptr FILEID="njufs"/>
+</mets:div>
+<mets:div ID="hpllc" ORDER="93" TYPE="LogicalMember">
+<mets:fptr FILEID="faxuy"/>
+</mets:div>
+<mets:div ID="x2d3e" ORDER="94" TYPE="LogicalMember">
+<mets:fptr FILEID="gtb81"/>
+</mets:div>
+<mets:div ID="zfmq9" ORDER="95" TYPE="LogicalMember">
+<mets:fptr FILEID="rlw5z"/>
+</mets:div>
+<mets:div ID="mynav" ORDER="96" TYPE="LogicalMember">
+<mets:fptr FILEID="geyq8"/>
+</mets:div>
+<mets:div ID="kz7ha" ORDER="97" TYPE="LogicalMember">
+<mets:fptr FILEID="avg3i"/>
+</mets:div>
+<mets:div ID="ejxs2" ORDER="98" TYPE="LogicalMember">
+<mets:fptr FILEID="fzmh3"/>
+</mets:div>
+<mets:div ID="au0lv" ORDER="99" TYPE="LogicalMember">
+<mets:fptr FILEID="qj5jw"/>
+</mets:div>
+<mets:div ID="r7i6n" ORDER="100" TYPE="LogicalMember">
+<mets:fptr FILEID="r8qvb"/>
+</mets:div>
+<mets:div ID="mdtcu" ORDER="101" TYPE="LogicalMember">
+<mets:fptr FILEID="wlnfj"/>
+</mets:div>
+<mets:div ID="dpgx2" ORDER="102" TYPE="LogicalMember">
+<mets:fptr FILEID="aftmq"/>
+</mets:div>
+<mets:div ID="iay3o" ORDER="103" TYPE="LogicalMember">
+<mets:fptr FILEID="ndx8x"/>
+</mets:div>
+<mets:div ID="ji5hx" ORDER="104" TYPE="LogicalMember">
+<mets:fptr FILEID="a5czr"/>
+</mets:div>
+<mets:div ID="x5mmc" ORDER="105" TYPE="LogicalMember">
+<mets:fptr FILEID="q0qis"/>
+</mets:div>
+<mets:div ID="xjspd" ORDER="106" TYPE="LogicalMember">
+<mets:fptr FILEID="nphyw"/>
+</mets:div>
+<mets:div ID="x2q9h" ORDER="107" TYPE="LogicalMember">
+<mets:fptr FILEID="kx0g8"/>
+</mets:div>
+<mets:div ID="vyxb8" ORDER="108" TYPE="LogicalMember">
+<mets:fptr FILEID="mpbts"/>
+</mets:div>
+<mets:div ID="t6okd" ORDER="109" TYPE="LogicalMember">
+<mets:fptr FILEID="nmtmc"/>
+</mets:div>
+<mets:div ID="eowpd" ORDER="110" TYPE="LogicalMember">
+<mets:fptr FILEID="zjbmq"/>
+</mets:div>
+<mets:div ID="y19rh" ORDER="111" TYPE="LogicalMember">
+<mets:fptr FILEID="mtooq"/>
+</mets:div>
+<mets:div ID="ylprk" ORDER="112" TYPE="LogicalMember">
+<mets:fptr FILEID="nclt6"/>
+</mets:div>
+<mets:div ID="mu1y3" ORDER="113" TYPE="LogicalMember">
+<mets:fptr FILEID="olxbi"/>
+</mets:div>
+<mets:div ID="jtkev" ORDER="114" TYPE="LogicalMember">
+<mets:fptr FILEID="clrsb"/>
+</mets:div>
+<mets:div ID="v3h63" ORDER="115" TYPE="LogicalMember">
+<mets:fptr FILEID="vt2ka"/>
+</mets:div>
+<mets:div ID="zdf9b" ORDER="116" TYPE="LogicalMember">
+<mets:fptr FILEID="vkf8r"/>
+</mets:div>
+<mets:div ID="qgh7j" ORDER="117" TYPE="LogicalMember">
+<mets:fptr FILEID="rxzsd"/>
+</mets:div>
+<mets:div ID="r0rkd" ORDER="118" TYPE="LogicalMember">
+<mets:fptr FILEID="hrnts"/>
+</mets:div>
+<mets:div ID="fgi3y" ORDER="119" TYPE="LogicalMember">
+<mets:fptr FILEID="yuoze"/>
+</mets:div>
+<mets:div ID="gxeh8" ORDER="120" TYPE="LogicalMember">
+<mets:fptr FILEID="h0syv"/>
+</mets:div>
+<mets:div ID="iaam9" ORDER="121" TYPE="LogicalMember">
+<mets:fptr FILEID="pwmml"/>
+</mets:div>
+<mets:div ID="ts5jj" ORDER="122" TYPE="LogicalMember">
+<mets:fptr FILEID="k8h8u"/>
+</mets:div>
+<mets:div ID="bh3gp" ORDER="123" TYPE="LogicalMember">
+<mets:fptr FILEID="abo4t"/>
+</mets:div>
+<mets:div ID="dn9c5" ORDER="124" TYPE="LogicalMember">
+<mets:fptr FILEID="d46z1"/>
+</mets:div>
+<mets:div ID="ns1ou" ORDER="125" TYPE="LogicalMember">
+<mets:fptr FILEID="yx8ds"/>
+</mets:div>
+<mets:div ID="syaal" ORDER="126" TYPE="LogicalMember">
+<mets:fptr FILEID="nelem"/>
+</mets:div>
+<mets:div ID="bkz4g" ORDER="127" TYPE="LogicalMember">
+<mets:fptr FILEID="rz75f"/>
+</mets:div>
+<mets:div ID="a49pc" ORDER="128" TYPE="LogicalMember">
+<mets:fptr FILEID="oub70"/>
+</mets:div>
+<mets:div ID="qh4e5" ORDER="129" TYPE="LogicalMember">
+<mets:fptr FILEID="r8ugl"/>
+</mets:div>
+<mets:div ID="a3yux" ORDER="130" TYPE="LogicalMember">
+<mets:fptr FILEID="li7po"/>
+</mets:div>
+<mets:div ID="bvmuq" ORDER="131" TYPE="LogicalMember">
+<mets:fptr FILEID="qcjvs"/>
+</mets:div>
+<mets:div ID="oanrz" ORDER="132" TYPE="LogicalMember">
+<mets:fptr FILEID="z88bb"/>
+</mets:div>
+</mets:div>
+<mets:div ID="v5log" LABEL="scrapbook 5" TYPE="BoundArt">
+<mets:div ID="ubdap" ORDER="1" TYPE="LogicalMember">
+<mets:fptr FILEID="l6bv7"/>
+</mets:div>
+<mets:div ID="phqag" ORDER="2" TYPE="LogicalMember">
+<mets:fptr FILEID="dq6jq"/>
+</mets:div>
+<mets:div ID="hen44" ORDER="3" TYPE="LogicalMember">
+<mets:fptr FILEID="cz5nc"/>
+</mets:div>
+<mets:div ID="kkljt" ORDER="4" TYPE="LogicalMember">
+<mets:fptr FILEID="asesw"/>
+</mets:div>
+<mets:div ID="no2sj" ORDER="5" TYPE="LogicalMember">
+<mets:fptr FILEID="snpci"/>
+</mets:div>
+<mets:div ID="tz8ta" ORDER="6" TYPE="LogicalMember">
+<mets:fptr FILEID="vum6x"/>
+</mets:div>
+<mets:div ID="edg16" ORDER="7" TYPE="LogicalMember">
+<mets:fptr FILEID="w6r8n"/>
+</mets:div>
+<mets:div ID="lz7gr" ORDER="8" TYPE="LogicalMember">
+<mets:fptr FILEID="iq7jx"/>
+</mets:div>
+<mets:div ID="kkn9x" ORDER="9" TYPE="LogicalMember">
+<mets:fptr FILEID="y5nkh"/>
+</mets:div>
+<mets:div ID="frivb" ORDER="10" TYPE="LogicalMember">
+<mets:fptr FILEID="dp9np"/>
+</mets:div>
+<mets:div ID="hkadw" ORDER="11" TYPE="LogicalMember">
+<mets:fptr FILEID="l43ke"/>
+</mets:div>
+<mets:div ID="wpf35" ORDER="12" TYPE="LogicalMember">
+<mets:fptr FILEID="sq0th"/>
+</mets:div>
+<mets:div ID="f0uf2" ORDER="13" TYPE="LogicalMember">
+<mets:fptr FILEID="nsrh6"/>
+</mets:div>
+<mets:div ID="vicl6" ORDER="14" TYPE="LogicalMember">
+<mets:fptr FILEID="xjrxs"/>
+</mets:div>
+<mets:div ID="atys4" ORDER="15" TYPE="LogicalMember">
+<mets:fptr FILEID="ld924"/>
+</mets:div>
+<mets:div ID="v5h1u" ORDER="16" TYPE="LogicalMember">
+<mets:fptr FILEID="boamg"/>
+</mets:div>
+<mets:div ID="ryhak" ORDER="17" TYPE="LogicalMember">
+<mets:fptr FILEID="f1pzl"/>
+</mets:div>
+<mets:div ID="cf44x" ORDER="18" TYPE="LogicalMember">
+<mets:fptr FILEID="n3y9e"/>
+</mets:div>
+<mets:div ID="gt5e0" ORDER="19" TYPE="LogicalMember">
+<mets:fptr FILEID="s58ay"/>
+</mets:div>
+<mets:div ID="mugft" ORDER="20" TYPE="LogicalMember">
+<mets:fptr FILEID="c9s4a"/>
+</mets:div>
+<mets:div ID="g6i4d" ORDER="21" TYPE="LogicalMember">
+<mets:fptr FILEID="c5mgk"/>
+</mets:div>
+<mets:div ID="ji72f" ORDER="22" TYPE="LogicalMember">
+<mets:fptr FILEID="jridz"/>
+</mets:div>
+<mets:div ID="k4obc" ORDER="23" TYPE="LogicalMember">
+<mets:fptr FILEID="d7lp7"/>
+</mets:div>
+<mets:div ID="v9ha0" ORDER="24" TYPE="LogicalMember">
+<mets:fptr FILEID="e9emc"/>
+</mets:div>
+<mets:div ID="r601m" ORDER="25" TYPE="LogicalMember">
+<mets:fptr FILEID="lpiug"/>
+</mets:div>
+<mets:div ID="gv9cm" ORDER="26" TYPE="LogicalMember">
+<mets:fptr FILEID="kl9ar"/>
+</mets:div>
+<mets:div ID="av3iu" ORDER="27" TYPE="LogicalMember">
+<mets:fptr FILEID="fcigj"/>
+</mets:div>
+<mets:div ID="pqn1s" ORDER="28" TYPE="LogicalMember">
+<mets:fptr FILEID="m1tbi"/>
+</mets:div>
+<mets:div ID="yrmhu" ORDER="29" TYPE="LogicalMember">
+<mets:fptr FILEID="dthum"/>
+</mets:div>
+<mets:div ID="n0y8h" ORDER="30" TYPE="LogicalMember">
+<mets:fptr FILEID="axnw8"/>
+</mets:div>
+<mets:div ID="mb02h" ORDER="31" TYPE="LogicalMember">
+<mets:fptr FILEID="avkzj"/>
+</mets:div>
+<mets:div ID="zi6t1" ORDER="32" TYPE="LogicalMember">
+<mets:fptr FILEID="xwk2l"/>
+</mets:div>
+<mets:div ID="s7dea" ORDER="33" TYPE="LogicalMember">
+<mets:fptr FILEID="p79g6"/>
+</mets:div>
+<mets:div ID="zj0zu" ORDER="34" TYPE="LogicalMember">
+<mets:fptr FILEID="fiaa7"/>
+</mets:div>
+<mets:div ID="xobsv" ORDER="35" TYPE="LogicalMember">
+<mets:fptr FILEID="zjpdw"/>
+</mets:div>
+<mets:div ID="v8ezl" ORDER="36" TYPE="LogicalMember">
+<mets:fptr FILEID="f3vui"/>
+</mets:div>
+<mets:div ID="tz7yh" ORDER="37" TYPE="LogicalMember">
+<mets:fptr FILEID="nutfr"/>
+</mets:div>
+<mets:div ID="elxqh" ORDER="38" TYPE="LogicalMember">
+<mets:fptr FILEID="b4jgf"/>
+</mets:div>
+<mets:div ID="ol2o3" ORDER="39" TYPE="LogicalMember">
+<mets:fptr FILEID="wiafv"/>
+</mets:div>
+<mets:div ID="ye3oc" ORDER="40" TYPE="LogicalMember">
+<mets:fptr FILEID="x28xs"/>
+</mets:div>
+<mets:div ID="a5n65" ORDER="41" TYPE="LogicalMember">
+<mets:fptr FILEID="apsww"/>
+</mets:div>
+<mets:div ID="p5b34" ORDER="42" TYPE="LogicalMember">
+<mets:fptr FILEID="xwrv3"/>
+</mets:div>
+<mets:div ID="azkj4" ORDER="43" TYPE="LogicalMember">
+<mets:fptr FILEID="tetm3"/>
+</mets:div>
+<mets:div ID="q7mpq" ORDER="44" TYPE="LogicalMember">
+<mets:fptr FILEID="aag2e"/>
+</mets:div>
+<mets:div ID="voka1" ORDER="45" TYPE="LogicalMember">
+<mets:fptr FILEID="pznb4"/>
+</mets:div>
+<mets:div ID="cc6m0" ORDER="46" TYPE="LogicalMember">
+<mets:fptr FILEID="hxmh0"/>
+</mets:div>
+<mets:div ID="vdsqq" ORDER="47" TYPE="LogicalMember">
+<mets:fptr FILEID="pzgqm"/>
+</mets:div>
+<mets:div ID="vvi5f" ORDER="48" TYPE="LogicalMember">
+<mets:fptr FILEID="bz2kn"/>
+</mets:div>
+<mets:div ID="hof8e" ORDER="49" TYPE="LogicalMember">
+<mets:fptr FILEID="namvv"/>
+</mets:div>
+<mets:div ID="seqri" ORDER="50" TYPE="LogicalMember">
+<mets:fptr FILEID="o7zf5"/>
+</mets:div>
+<mets:div ID="mqcmv" ORDER="51" TYPE="LogicalMember">
+<mets:fptr FILEID="aeo3u"/>
+</mets:div>
+<mets:div ID="pjd20" ORDER="52" TYPE="LogicalMember">
+<mets:fptr FILEID="p1ku7"/>
+</mets:div>
+<mets:div ID="n5d8x" ORDER="53" TYPE="LogicalMember">
+<mets:fptr FILEID="r2n0e"/>
+</mets:div>
+<mets:div ID="xtnvv" ORDER="54" TYPE="LogicalMember">
+<mets:fptr FILEID="mo9g4"/>
+</mets:div>
+<mets:div ID="wqzms" ORDER="55" TYPE="LogicalMember">
+<mets:fptr FILEID="eaa6t"/>
+</mets:div>
+<mets:div ID="mnjpg" ORDER="56" TYPE="LogicalMember">
+<mets:fptr FILEID="zpbmo"/>
+</mets:div>
+<mets:div ID="vd5qy" ORDER="57" TYPE="LogicalMember">
+<mets:fptr FILEID="ktlcq"/>
+</mets:div>
+<mets:div ID="bypml" ORDER="58" TYPE="LogicalMember">
+<mets:fptr FILEID="wk7hn"/>
+</mets:div>
+<mets:div ID="wbonp" ORDER="59" TYPE="LogicalMember">
+<mets:fptr FILEID="hqoix"/>
+</mets:div>
+<mets:div ID="ldtun" ORDER="60" TYPE="LogicalMember">
+<mets:fptr FILEID="jrzk6"/>
+</mets:div>
+<mets:div ID="spio1" ORDER="61" TYPE="LogicalMember">
+<mets:fptr FILEID="haql9"/>
+</mets:div>
+<mets:div ID="cjvl6" ORDER="62" TYPE="LogicalMember">
+<mets:fptr FILEID="r75cw"/>
+</mets:div>
+<mets:div ID="cwcve" ORDER="63" TYPE="LogicalMember">
+<mets:fptr FILEID="fggxk"/>
+</mets:div>
+<mets:div ID="i43k3" ORDER="64" TYPE="LogicalMember">
+<mets:fptr FILEID="naka0"/>
+</mets:div>
+<mets:div ID="wtuj5" ORDER="65" TYPE="LogicalMember">
+<mets:fptr FILEID="icc37"/>
+</mets:div>
+<mets:div ID="xo3cn" ORDER="66" TYPE="LogicalMember">
+<mets:fptr FILEID="hjwzr"/>
+</mets:div>
+<mets:div ID="chr5a" ORDER="67" TYPE="LogicalMember">
+<mets:fptr FILEID="jlkm4"/>
+</mets:div>
+<mets:div ID="eejpx" ORDER="68" TYPE="LogicalMember">
+<mets:fptr FILEID="yxebu"/>
+</mets:div>
+<mets:div ID="lk8h9" ORDER="69" TYPE="LogicalMember">
+<mets:fptr FILEID="a1wby"/>
+</mets:div>
+<mets:div ID="vb7hn" ORDER="70" TYPE="LogicalMember">
+<mets:fptr FILEID="ozyc8"/>
+</mets:div>
+<mets:div ID="tirxc" ORDER="71" TYPE="LogicalMember">
+<mets:fptr FILEID="dcsyg"/>
+</mets:div>
+<mets:div ID="mb7yb" ORDER="72" TYPE="LogicalMember">
+<mets:fptr FILEID="tidfl"/>
+</mets:div>
+<mets:div ID="ej813" ORDER="73" TYPE="LogicalMember">
+<mets:fptr FILEID="xxxw2"/>
+</mets:div>
+<mets:div ID="cmjw3" ORDER="74" TYPE="LogicalMember">
+<mets:fptr FILEID="md3o9"/>
+</mets:div>
+<mets:div ID="bm6n1" ORDER="75" TYPE="LogicalMember">
+<mets:fptr FILEID="sh7sc"/>
+</mets:div>
+<mets:div ID="t8aej" ORDER="76" TYPE="LogicalMember">
+<mets:fptr FILEID="vm529"/>
+</mets:div>
+<mets:div ID="jio68" ORDER="77" TYPE="LogicalMember">
+<mets:fptr FILEID="rupn1"/>
+</mets:div>
+<mets:div ID="hyuq1" ORDER="78" TYPE="LogicalMember">
+<mets:fptr FILEID="ql0i0"/>
+</mets:div>
+<mets:div ID="lk3rc" ORDER="79" TYPE="LogicalMember">
+<mets:fptr FILEID="f4yeh"/>
+</mets:div>
+<mets:div ID="dxsl4" ORDER="80" TYPE="LogicalMember">
+<mets:fptr FILEID="dlnqz"/>
+</mets:div>
+<mets:div ID="ucy2c" ORDER="81" TYPE="LogicalMember">
+<mets:fptr FILEID="ofo0v"/>
+</mets:div>
+<mets:div ID="da0o4" ORDER="82" TYPE="LogicalMember">
+<mets:fptr FILEID="y5fnf"/>
+</mets:div>
+<mets:div ID="w8x07" ORDER="83" TYPE="LogicalMember">
+<mets:fptr FILEID="z5n8y"/>
+</mets:div>
+<mets:div ID="gn48d" ORDER="84" TYPE="LogicalMember">
+<mets:fptr FILEID="odt3y"/>
+</mets:div>
+<mets:div ID="owab6" ORDER="85" TYPE="LogicalMember">
+<mets:fptr FILEID="knrhz"/>
+</mets:div>
+<mets:div ID="qajkb" ORDER="86" TYPE="LogicalMember">
+<mets:fptr FILEID="aeo5d"/>
+</mets:div>
+<mets:div ID="ccf62" ORDER="87" TYPE="LogicalMember">
+<mets:fptr FILEID="ejy60"/>
+</mets:div>
+<mets:div ID="xtuof" ORDER="88" TYPE="LogicalMember">
+<mets:fptr FILEID="zklad"/>
+</mets:div>
+<mets:div ID="fdicc" ORDER="89" TYPE="LogicalMember">
+<mets:fptr FILEID="lplo0"/>
+</mets:div>
+<mets:div ID="pbqcv" ORDER="90" TYPE="LogicalMember">
+<mets:fptr FILEID="o115b"/>
+</mets:div>
+<mets:div ID="burvb" ORDER="91" TYPE="LogicalMember">
+<mets:fptr FILEID="ojeo2"/>
+</mets:div>
+<mets:div ID="bl5gh" ORDER="92" TYPE="LogicalMember">
+<mets:fptr FILEID="tgax3"/>
+</mets:div>
+<mets:div ID="e0iit" ORDER="93" TYPE="LogicalMember">
+<mets:fptr FILEID="oj1t4"/>
+</mets:div>
+<mets:div ID="bkj7c" ORDER="94" TYPE="LogicalMember">
+<mets:fptr FILEID="ndyzb"/>
+</mets:div>
+<mets:div ID="h2a93" ORDER="95" TYPE="LogicalMember">
+<mets:fptr FILEID="l7dmh"/>
+</mets:div>
+<mets:div ID="nya93" ORDER="96" TYPE="LogicalMember">
+<mets:fptr FILEID="yw9m6"/>
+</mets:div>
+<mets:div ID="diujz" ORDER="97" TYPE="LogicalMember">
+<mets:fptr FILEID="vx12f"/>
+</mets:div>
+<mets:div ID="msxmo" ORDER="98" TYPE="LogicalMember">
+<mets:fptr FILEID="qp5ir"/>
+</mets:div>
+<mets:div ID="ghyyh" ORDER="99" TYPE="LogicalMember">
+<mets:fptr FILEID="b2r2t"/>
+</mets:div>
+<mets:div ID="nm1h8" ORDER="100" TYPE="LogicalMember">
+<mets:fptr FILEID="jqd9z"/>
+</mets:div>
+<mets:div ID="nt28l" ORDER="101" TYPE="LogicalMember">
+<mets:fptr FILEID="gho5w"/>
+</mets:div>
+<mets:div ID="bfhsu" ORDER="102" TYPE="LogicalMember">
+<mets:fptr FILEID="xwveo"/>
+</mets:div>
+<mets:div ID="qdcdk" ORDER="103" TYPE="LogicalMember">
+<mets:fptr FILEID="xrmfl"/>
+</mets:div>
+<mets:div ID="fjmfs" ORDER="104" TYPE="LogicalMember">
+<mets:fptr FILEID="igbls"/>
+</mets:div>
+</mets:div>
+<mets:div ID="v6log" LABEL="scrapbook 6" TYPE="BoundArt">
+<mets:div ID="dvx35" ORDER="1" TYPE="LogicalMember">
+<mets:fptr FILEID="qhdeb"/>
+</mets:div>
+<mets:div ID="vuirt" ORDER="2" TYPE="LogicalMember">
+<mets:fptr FILEID="nutcv"/>
+</mets:div>
+<mets:div ID="jx4k2" ORDER="3" TYPE="LogicalMember">
+<mets:fptr FILEID="pnhhq"/>
+</mets:div>
+<mets:div ID="zw9ma" ORDER="4" TYPE="LogicalMember">
+<mets:fptr FILEID="hhivk"/>
+</mets:div>
+<mets:div ID="ki9bq" ORDER="5" TYPE="LogicalMember">
+<mets:fptr FILEID="byg39"/>
+</mets:div>
+<mets:div ID="zowfd" ORDER="6" TYPE="LogicalMember">
+<mets:fptr FILEID="ju0a7"/>
+</mets:div>
+<mets:div ID="zde7c" ORDER="7" TYPE="LogicalMember">
+<mets:fptr FILEID="muc9s"/>
+</mets:div>
+<mets:div ID="np1o0" ORDER="8" TYPE="LogicalMember">
+<mets:fptr FILEID="ezk09"/>
+</mets:div>
+<mets:div ID="mzwsu" ORDER="9" TYPE="LogicalMember">
+<mets:fptr FILEID="h0o6b"/>
+</mets:div>
+<mets:div ID="cy7go" ORDER="10" TYPE="LogicalMember">
+<mets:fptr FILEID="mrhlc"/>
+</mets:div>
+<mets:div ID="miy4k" ORDER="11" TYPE="LogicalMember">
+<mets:fptr FILEID="tfpo8"/>
+</mets:div>
+<mets:div ID="kjqns" ORDER="12" TYPE="LogicalMember">
+<mets:fptr FILEID="abr5m"/>
+</mets:div>
+<mets:div ID="glxj4" ORDER="13" TYPE="LogicalMember">
+<mets:fptr FILEID="bl7vm"/>
+</mets:div>
+<mets:div ID="yftn3" ORDER="14" TYPE="LogicalMember">
+<mets:fptr FILEID="xhwg9"/>
+</mets:div>
+<mets:div ID="bw9vr" ORDER="15" TYPE="LogicalMember">
+<mets:fptr FILEID="nuu5z"/>
+</mets:div>
+<mets:div ID="gzpnb" ORDER="16" TYPE="LogicalMember">
+<mets:fptr FILEID="me7q5"/>
+</mets:div>
+<mets:div ID="vnmf3" ORDER="17" TYPE="LogicalMember">
+<mets:fptr FILEID="shgs4"/>
+</mets:div>
+<mets:div ID="g1hqs" ORDER="18" TYPE="LogicalMember">
+<mets:fptr FILEID="yblsu"/>
+</mets:div>
+<mets:div ID="gml24" ORDER="19" TYPE="LogicalMember">
+<mets:fptr FILEID="fu8kd"/>
+</mets:div>
+<mets:div ID="hxy7d" ORDER="20" TYPE="LogicalMember">
+<mets:fptr FILEID="asy6a"/>
+</mets:div>
+<mets:div ID="d2qja" ORDER="21" TYPE="LogicalMember">
+<mets:fptr FILEID="pphid"/>
+</mets:div>
+<mets:div ID="jcb6z" ORDER="22" TYPE="LogicalMember">
+<mets:fptr FILEID="lo1fn"/>
+</mets:div>
+<mets:div ID="tfjt2" ORDER="23" TYPE="LogicalMember">
+<mets:fptr FILEID="y40nj"/>
+</mets:div>
+<mets:div ID="iazjk" ORDER="24" TYPE="LogicalMember">
+<mets:fptr FILEID="t1ffw"/>
+</mets:div>
+<mets:div ID="se6k7" ORDER="25" TYPE="LogicalMember">
+<mets:fptr FILEID="eq8ru"/>
+</mets:div>
+<mets:div ID="cyh50" ORDER="26" TYPE="LogicalMember">
+<mets:fptr FILEID="pcd72"/>
+</mets:div>
+<mets:div ID="jj3ye" ORDER="27" TYPE="LogicalMember">
+<mets:fptr FILEID="ukely"/>
+</mets:div>
+<mets:div ID="lnof0" ORDER="28" TYPE="LogicalMember">
+<mets:fptr FILEID="z617f"/>
+</mets:div>
+<mets:div ID="dbkba" ORDER="29" TYPE="LogicalMember">
+<mets:fptr FILEID="r4dbx"/>
+</mets:div>
+<mets:div ID="v601w" ORDER="30" TYPE="LogicalMember">
+<mets:fptr FILEID="pt7yk"/>
+</mets:div>
+<mets:div ID="ltgv9" ORDER="31" TYPE="LogicalMember">
+<mets:fptr FILEID="lxwff"/>
+</mets:div>
+<mets:div ID="bx3ug" ORDER="32" TYPE="LogicalMember">
+<mets:fptr FILEID="f2mjo"/>
+</mets:div>
+<mets:div ID="y4wwm" ORDER="33" TYPE="LogicalMember">
+<mets:fptr FILEID="khuxu"/>
+</mets:div>
+<mets:div ID="qep8t" ORDER="34" TYPE="LogicalMember">
+<mets:fptr FILEID="bp2ah"/>
+</mets:div>
+<mets:div ID="azyqf" ORDER="35" TYPE="LogicalMember">
+<mets:fptr FILEID="hfjhl"/>
+</mets:div>
+<mets:div ID="smg5p" ORDER="36" TYPE="LogicalMember">
+<mets:fptr FILEID="dzw4u"/>
+</mets:div>
+<mets:div ID="pf0dw" ORDER="37" TYPE="LogicalMember">
+<mets:fptr FILEID="w199v"/>
+</mets:div>
+<mets:div ID="ztojc" ORDER="38" TYPE="LogicalMember">
+<mets:fptr FILEID="ogr8y"/>
+</mets:div>
+<mets:div ID="v8eg4" ORDER="39" TYPE="LogicalMember">
+<mets:fptr FILEID="qzmgo"/>
+</mets:div>
+<mets:div ID="atn2n" ORDER="40" TYPE="LogicalMember">
+<mets:fptr FILEID="z7yig"/>
+</mets:div>
+<mets:div ID="b8bll" ORDER="41" TYPE="LogicalMember">
+<mets:fptr FILEID="rh2ll"/>
+</mets:div>
+<mets:div ID="bndnq" ORDER="42" TYPE="LogicalMember">
+<mets:fptr FILEID="oreht"/>
+</mets:div>
+<mets:div ID="pul6v" ORDER="43" TYPE="LogicalMember">
+<mets:fptr FILEID="amget"/>
+</mets:div>
+<mets:div ID="zfal1" ORDER="44" TYPE="LogicalMember">
+<mets:fptr FILEID="ax17o"/>
+</mets:div>
+<mets:div ID="uejmn" ORDER="45" TYPE="LogicalMember">
+<mets:fptr FILEID="mmy64"/>
+</mets:div>
+<mets:div ID="qteq7" ORDER="46" TYPE="LogicalMember">
+<mets:fptr FILEID="d141t"/>
+</mets:div>
+</mets:div>
+<mets:div ID="v7log" LABEL="scrapbook 7" TYPE="BoundArt">
+<mets:div ID="ao9o5" ORDER="1" TYPE="LogicalMember">
+<mets:fptr FILEID="xjpzg"/>
+</mets:div>
+<mets:div ID="blijo" ORDER="2" TYPE="LogicalMember">
+<mets:fptr FILEID="vbm3m"/>
+</mets:div>
+<mets:div ID="hbg7m" ORDER="3" TYPE="LogicalMember">
+<mets:fptr FILEID="hlsda"/>
+</mets:div>
+<mets:div ID="x00rr" ORDER="4" TYPE="LogicalMember">
+<mets:fptr FILEID="t2r9q"/>
+</mets:div>
+<mets:div ID="xjps3" ORDER="5" TYPE="LogicalMember">
+<mets:fptr FILEID="yvhwk"/>
+</mets:div>
+<mets:div ID="y3ef0" ORDER="6" TYPE="LogicalMember">
+<mets:fptr FILEID="m4uf6"/>
+</mets:div>
+<mets:div ID="f4pcq" ORDER="7" TYPE="LogicalMember">
+<mets:fptr FILEID="jqjgw"/>
+</mets:div>
+<mets:div ID="l0jsj" ORDER="8" TYPE="LogicalMember">
+<mets:fptr FILEID="t98md"/>
+</mets:div>
+<mets:div ID="ulbid" ORDER="9" TYPE="LogicalMember">
+<mets:fptr FILEID="z0szl"/>
+</mets:div>
+<mets:div ID="dnqar" ORDER="10" TYPE="LogicalMember">
+<mets:fptr FILEID="q5dnx"/>
+</mets:div>
+<mets:div ID="z09fg" ORDER="11" TYPE="LogicalMember">
+<mets:fptr FILEID="vjg9z"/>
+</mets:div>
+<mets:div ID="s2j1c" ORDER="12" TYPE="LogicalMember">
+<mets:fptr FILEID="w0fnp"/>
+</mets:div>
+<mets:div ID="rhsfn" ORDER="13" TYPE="LogicalMember">
+<mets:fptr FILEID="epsr9"/>
+</mets:div>
+<mets:div ID="i2v6z" ORDER="14" TYPE="LogicalMember">
+<mets:fptr FILEID="x9dpw"/>
+</mets:div>
+<mets:div ID="tjyrz" ORDER="15" TYPE="LogicalMember">
+<mets:fptr FILEID="ejpro"/>
+</mets:div>
+<mets:div ID="iw0fb" ORDER="16" TYPE="LogicalMember">
+<mets:fptr FILEID="rcm5k"/>
+</mets:div>
+<mets:div ID="wagoi" ORDER="17" TYPE="LogicalMember">
+<mets:fptr FILEID="x1qfl"/>
+</mets:div>
+<mets:div ID="zgw7q" ORDER="18" TYPE="LogicalMember">
+<mets:fptr FILEID="tjd5u"/>
+</mets:div>
+<mets:div ID="z7fjy" ORDER="19" TYPE="LogicalMember">
+<mets:fptr FILEID="mh998"/>
+</mets:div>
+<mets:div ID="tmvid" ORDER="20" TYPE="LogicalMember">
+<mets:fptr FILEID="xomqh"/>
+</mets:div>
+<mets:div ID="itxl5" ORDER="21" TYPE="LogicalMember">
+<mets:fptr FILEID="dlc0x"/>
+</mets:div>
+<mets:div ID="gn175" ORDER="22" TYPE="LogicalMember">
+<mets:fptr FILEID="x4z1d"/>
+</mets:div>
+<mets:div ID="gn8pe" ORDER="23" TYPE="LogicalMember">
+<mets:fptr FILEID="jkko8"/>
+</mets:div>
+<mets:div ID="ni5xu" ORDER="24" TYPE="LogicalMember">
+<mets:fptr FILEID="lng8l"/>
+</mets:div>
+<mets:div ID="yefb5" ORDER="25" TYPE="LogicalMember">
+<mets:fptr FILEID="plzdt"/>
+</mets:div>
+<mets:div ID="nk8oe" ORDER="26" TYPE="LogicalMember">
+<mets:fptr FILEID="zfcpi"/>
+</mets:div>
+<mets:div ID="l4lrb" ORDER="27" TYPE="LogicalMember">
+<mets:fptr FILEID="e7llx"/>
+</mets:div>
+<mets:div ID="hskgh" ORDER="28" TYPE="LogicalMember">
+<mets:fptr FILEID="e4dsi"/>
+</mets:div>
+<mets:div ID="jelv0" ORDER="29" TYPE="LogicalMember">
+<mets:fptr FILEID="rk6os"/>
+</mets:div>
+<mets:div ID="v2drn" ORDER="30" TYPE="LogicalMember">
+<mets:fptr FILEID="kmb94"/>
+</mets:div>
+<mets:div ID="axfru" ORDER="31" TYPE="LogicalMember">
+<mets:fptr FILEID="n4eat"/>
+</mets:div>
+<mets:div ID="moe4z" ORDER="32" TYPE="LogicalMember">
+<mets:fptr FILEID="siapl"/>
+</mets:div>
+<mets:div ID="qcj6p" ORDER="33" TYPE="LogicalMember">
+<mets:fptr FILEID="zyd0k"/>
+</mets:div>
+<mets:div ID="bvcro" ORDER="34" TYPE="LogicalMember">
+<mets:fptr FILEID="l46r4"/>
+</mets:div>
+<mets:div ID="zc27o" ORDER="35" TYPE="LogicalMember">
+<mets:fptr FILEID="jyt4v"/>
+</mets:div>
+<mets:div ID="ptejp" ORDER="36" TYPE="LogicalMember">
+<mets:fptr FILEID="ky080"/>
+</mets:div>
+<mets:div ID="c339s" ORDER="37" TYPE="LogicalMember">
+<mets:fptr FILEID="kqyef"/>
+</mets:div>
+<mets:div ID="xopwm" ORDER="38" TYPE="LogicalMember">
+<mets:fptr FILEID="lmrck"/>
+</mets:div>
+<mets:div ID="afrk3" ORDER="39" TYPE="LogicalMember">
+<mets:fptr FILEID="aoqob"/>
+</mets:div>
+<mets:div ID="v7vec" ORDER="40" TYPE="LogicalMember">
+<mets:fptr FILEID="aykzw"/>
+</mets:div>
+<mets:div ID="yku9m" ORDER="41" TYPE="LogicalMember">
+<mets:fptr FILEID="hiviw"/>
+</mets:div>
+<mets:div ID="whbv3" ORDER="42" TYPE="LogicalMember">
+<mets:fptr FILEID="swcbj"/>
+</mets:div>
+<mets:div ID="x01sw" ORDER="43" TYPE="LogicalMember">
+<mets:fptr FILEID="qc203"/>
+</mets:div>
+<mets:div ID="ggfpo" ORDER="44" TYPE="LogicalMember">
+<mets:fptr FILEID="w28gk"/>
+</mets:div>
+<mets:div ID="zx1go" ORDER="45" TYPE="LogicalMember">
+<mets:fptr FILEID="vn2l3"/>
+</mets:div>
+<mets:div ID="zjakp" ORDER="46" TYPE="LogicalMember">
+<mets:fptr FILEID="crmfq"/>
+</mets:div>
+<mets:div ID="ck97i" ORDER="47" TYPE="LogicalMember">
+<mets:fptr FILEID="kj946"/>
+</mets:div>
+<mets:div ID="hl5u9" ORDER="48" TYPE="LogicalMember">
+<mets:fptr FILEID="psnh7"/>
+</mets:div>
+<mets:div ID="sk0om" ORDER="49" TYPE="LogicalMember">
+<mets:fptr FILEID="po3pl"/>
+</mets:div>
+<mets:div ID="resf6" ORDER="50" TYPE="LogicalMember">
+<mets:fptr FILEID="ynh4h"/>
+</mets:div>
+<mets:div ID="pj0p9" ORDER="51" TYPE="LogicalMember">
+<mets:fptr FILEID="a616s"/>
+</mets:div>
+<mets:div ID="mt0i1" ORDER="52" TYPE="LogicalMember">
+<mets:fptr FILEID="xdl46"/>
+</mets:div>
+<mets:div ID="nvb9n" ORDER="53" TYPE="LogicalMember">
+<mets:fptr FILEID="qmkaw"/>
+</mets:div>
+<mets:div ID="r7c02" ORDER="54" TYPE="LogicalMember">
+<mets:fptr FILEID="ckmq2"/>
+</mets:div>
+<mets:div ID="h9myj" ORDER="55" TYPE="LogicalMember">
+<mets:fptr FILEID="ucgcs"/>
+</mets:div>
+<mets:div ID="j8s9w" ORDER="56" TYPE="LogicalMember">
+<mets:fptr FILEID="v7omr"/>
+</mets:div>
+<mets:div ID="p24a3" ORDER="57" TYPE="LogicalMember">
+<mets:fptr FILEID="gug1q"/>
+</mets:div>
+<mets:div ID="mq6xg" ORDER="58" TYPE="LogicalMember">
+<mets:fptr FILEID="bufjw"/>
+</mets:div>
+<mets:div ID="sakoq" ORDER="59" TYPE="LogicalMember">
+<mets:fptr FILEID="dwpv8"/>
+</mets:div>
+<mets:div ID="e9noa" ORDER="60" TYPE="LogicalMember">
+<mets:fptr FILEID="tav4j"/>
+</mets:div>
+<mets:div ID="nbfdl" ORDER="61" TYPE="LogicalMember">
+<mets:fptr FILEID="m3v1n"/>
+</mets:div>
+<mets:div ID="j5m1k" ORDER="62" TYPE="LogicalMember">
+<mets:fptr FILEID="rujkd"/>
+</mets:div>
+<mets:div ID="aghb2" ORDER="63" TYPE="LogicalMember">
+<mets:fptr FILEID="z9frs"/>
+</mets:div>
+<mets:div ID="xkkx3" ORDER="64" TYPE="LogicalMember">
+<mets:fptr FILEID="oprak"/>
+</mets:div>
+<mets:div ID="zqu87" ORDER="65" TYPE="LogicalMember">
+<mets:fptr FILEID="w77k6"/>
+</mets:div>
+<mets:div ID="e620l" ORDER="66" TYPE="LogicalMember">
+<mets:fptr FILEID="ojy89"/>
+</mets:div>
+<mets:div ID="vymc2" ORDER="67" TYPE="LogicalMember">
+<mets:fptr FILEID="dugwz"/>
+</mets:div>
+<mets:div ID="gnssx" ORDER="68" TYPE="LogicalMember">
+<mets:fptr FILEID="osk5f"/>
+</mets:div>
+<mets:div ID="rw30k" ORDER="69" TYPE="LogicalMember">
+<mets:fptr FILEID="yvzsk"/>
+</mets:div>
+<mets:div ID="ev46n" ORDER="70" TYPE="LogicalMember">
+<mets:fptr FILEID="eg1hw"/>
+</mets:div>
+<mets:div ID="cx5bx" ORDER="71" TYPE="LogicalMember">
+<mets:fptr FILEID="ryno3"/>
+</mets:div>
+<mets:div ID="i82l3" ORDER="72" TYPE="LogicalMember">
+<mets:fptr FILEID="ndsim"/>
+</mets:div>
+<mets:div ID="wq7mm" ORDER="73" TYPE="LogicalMember">
+<mets:fptr FILEID="vei4g"/>
+</mets:div>
+<mets:div ID="t8f64" ORDER="74" TYPE="LogicalMember">
+<mets:fptr FILEID="kff0a"/>
+</mets:div>
+<mets:div ID="tf9ir" ORDER="75" TYPE="LogicalMember">
+<mets:fptr FILEID="duekt"/>
+</mets:div>
+<mets:div ID="xu2ab" ORDER="76" TYPE="LogicalMember">
+<mets:fptr FILEID="qc7cu"/>
+</mets:div>
+<mets:div ID="hswl8" ORDER="77" TYPE="LogicalMember">
+<mets:fptr FILEID="uk3av"/>
+</mets:div>
+<mets:div ID="exmsg" ORDER="78" TYPE="LogicalMember">
+<mets:fptr FILEID="b1s6e"/>
+</mets:div>
+<mets:div ID="c9grb" ORDER="79" TYPE="LogicalMember">
+<mets:fptr FILEID="q74m3"/>
+</mets:div>
+<mets:div ID="c5jbk" ORDER="80" TYPE="LogicalMember">
+<mets:fptr FILEID="px8ki"/>
+</mets:div>
+<mets:div ID="g0oe3" ORDER="81" TYPE="LogicalMember">
+<mets:fptr FILEID="n8znw"/>
+</mets:div>
+<mets:div ID="bzius" ORDER="82" TYPE="LogicalMember">
+<mets:fptr FILEID="ni2i6"/>
+</mets:div>
+<mets:div ID="fupir" ORDER="83" TYPE="LogicalMember">
+<mets:fptr FILEID="ra7lj"/>
+</mets:div>
+<mets:div ID="kz48q" ORDER="84" TYPE="LogicalMember">
+<mets:fptr FILEID="wr2gu"/>
+</mets:div>
+<mets:div ID="bl6al" ORDER="85" TYPE="LogicalMember">
+<mets:fptr FILEID="u4xo5"/>
+</mets:div>
+<mets:div ID="tp9rw" ORDER="86" TYPE="LogicalMember">
+<mets:fptr FILEID="hfq4h"/>
+</mets:div>
+<mets:div ID="kd5hc" ORDER="87" TYPE="LogicalMember">
+<mets:fptr FILEID="toi1y"/>
+</mets:div>
+<mets:div ID="gl138" ORDER="88" TYPE="LogicalMember">
+<mets:fptr FILEID="fgv25"/>
+</mets:div>
+<mets:div ID="fkmdm" ORDER="89" TYPE="LogicalMember">
+<mets:fptr FILEID="j5gdk"/>
+</mets:div>
+<mets:div ID="h0kax" ORDER="90" TYPE="LogicalMember">
+<mets:fptr FILEID="zo7ix"/>
+</mets:div>
+<mets:div ID="bkhp0" ORDER="91" TYPE="LogicalMember">
+<mets:fptr FILEID="b2opi"/>
+</mets:div>
+<mets:div ID="hfzvo" ORDER="92" TYPE="LogicalMember">
+<mets:fptr FILEID="wtcvb"/>
+</mets:div>
+<mets:div ID="v159h" ORDER="93" TYPE="LogicalMember">
+<mets:fptr FILEID="ppx2j"/>
+</mets:div>
+<mets:div ID="mzur2" ORDER="94" TYPE="LogicalMember">
+<mets:fptr FILEID="ehnek"/>
+</mets:div>
+<mets:div ID="yia1v" ORDER="95" TYPE="LogicalMember">
+<mets:fptr FILEID="gvbey"/>
+</mets:div>
+<mets:div ID="s1yun" ORDER="96" TYPE="LogicalMember">
+<mets:fptr FILEID="i02uz"/>
+</mets:div>
+<mets:div ID="ecbfj" ORDER="97" TYPE="LogicalMember">
+<mets:fptr FILEID="zqers"/>
+</mets:div>
+<mets:div ID="o1y9m" ORDER="98" TYPE="LogicalMember">
+<mets:fptr FILEID="s6rga"/>
+</mets:div>
+<mets:div ID="j35a1" ORDER="99" TYPE="LogicalMember">
+<mets:fptr FILEID="rzh99"/>
+</mets:div>
+<mets:div ID="visok" ORDER="100" TYPE="LogicalMember">
+<mets:fptr FILEID="defod"/>
+</mets:div>
+<mets:div ID="en1ni" ORDER="101" TYPE="LogicalMember">
+<mets:fptr FILEID="xrnh5"/>
+</mets:div>
+<mets:div ID="pa3sf" ORDER="102" TYPE="LogicalMember">
+<mets:fptr FILEID="dtbzd"/>
+</mets:div>
+<mets:div ID="hgi12" ORDER="103" TYPE="LogicalMember">
+<mets:fptr FILEID="zne2z"/>
+</mets:div>
+<mets:div ID="ujxwy" ORDER="104" TYPE="LogicalMember">
+<mets:fptr FILEID="mh2w0"/>
+</mets:div>
+<mets:div ID="kp7c5" ORDER="105" TYPE="LogicalMember">
+<mets:fptr FILEID="cjc1w"/>
+</mets:div>
+<mets:div ID="mh8x6" ORDER="106" TYPE="LogicalMember">
+<mets:fptr FILEID="vcz1c"/>
+</mets:div>
+<mets:div ID="kh0yb" ORDER="107" TYPE="LogicalMember">
+<mets:fptr FILEID="i0f5u"/>
+</mets:div>
+<mets:div ID="khjsd" ORDER="108" TYPE="LogicalMember">
+<mets:fptr FILEID="k4quw"/>
+</mets:div>
+<mets:div ID="xdeyj" ORDER="109" TYPE="LogicalMember">
+<mets:fptr FILEID="p70xr"/>
+</mets:div>
+<mets:div ID="ct35i" ORDER="110" TYPE="LogicalMember">
+<mets:fptr FILEID="qd684"/>
+</mets:div>
+<mets:div ID="hwknw" ORDER="111" TYPE="LogicalMember">
+<mets:fptr FILEID="ubc16"/>
+</mets:div>
+<mets:div ID="a018y" ORDER="112" TYPE="LogicalMember">
+<mets:fptr FILEID="cn2tp"/>
+</mets:div>
+<mets:div ID="y53yb" ORDER="113" TYPE="LogicalMember">
+<mets:fptr FILEID="sufwl"/>
+</mets:div>
+<mets:div ID="it4q1" ORDER="114" TYPE="LogicalMember">
+<mets:fptr FILEID="lkr9d"/>
+</mets:div>
+<mets:div ID="dofet" ORDER="115" TYPE="LogicalMember">
+<mets:fptr FILEID="yb2ct"/>
+</mets:div>
+<mets:div ID="h907c" ORDER="116" TYPE="LogicalMember">
+<mets:fptr FILEID="pq6me"/>
+</mets:div>
+<mets:div ID="hq5s0" ORDER="117" TYPE="LogicalMember">
+<mets:fptr FILEID="w8l42"/>
+</mets:div>
+<mets:div ID="jqiu2" ORDER="118" TYPE="LogicalMember">
+<mets:fptr FILEID="oxzlx"/>
+</mets:div>
+<mets:div ID="sf5oh" ORDER="119" TYPE="LogicalMember">
+<mets:fptr FILEID="foe73"/>
+</mets:div>
+<mets:div ID="lirbz" ORDER="120" TYPE="LogicalMember">
+<mets:fptr FILEID="iesca"/>
+</mets:div>
+<mets:div ID="dglwu" ORDER="121" TYPE="LogicalMember">
+<mets:fptr FILEID="cyhg3"/>
+</mets:div>
+<mets:div ID="bk52x" ORDER="122" TYPE="LogicalMember">
+<mets:fptr FILEID="khjsf"/>
+</mets:div>
+<mets:div ID="wyclf" ORDER="123" TYPE="LogicalMember">
+<mets:fptr FILEID="evg9a"/>
+</mets:div>
+<mets:div ID="opul0" ORDER="124" TYPE="LogicalMember">
+<mets:fptr FILEID="k14sf"/>
+</mets:div>
+<mets:div ID="tgcwx" ORDER="125" TYPE="LogicalMember">
+<mets:fptr FILEID="htxd3"/>
+</mets:div>
+<mets:div ID="wx89t" ORDER="126" TYPE="LogicalMember">
+<mets:fptr FILEID="rv3kd"/>
+</mets:div>
+<mets:div ID="qetho" ORDER="127" TYPE="LogicalMember">
+<mets:fptr FILEID="f5shi"/>
+</mets:div>
+<mets:div ID="giqxr" ORDER="128" TYPE="LogicalMember">
+<mets:fptr FILEID="qt0k5"/>
+</mets:div>
+<mets:div ID="sl1ux" ORDER="129" TYPE="LogicalMember">
+<mets:fptr FILEID="n8423"/>
+</mets:div>
+<mets:div ID="hszmv" ORDER="130" TYPE="LogicalMember">
+<mets:fptr FILEID="ygg5u"/>
+</mets:div>
+<mets:div ID="uobhu" ORDER="131" TYPE="LogicalMember">
+<mets:fptr FILEID="yfbf2"/>
+</mets:div>
+<mets:div ID="y3pcd" ORDER="132" TYPE="LogicalMember">
+<mets:fptr FILEID="k2spy"/>
+</mets:div>
+<mets:div ID="o8ah7" ORDER="133" TYPE="LogicalMember">
+<mets:fptr FILEID="qgvda"/>
+</mets:div>
+<mets:div ID="r5t0x" ORDER="134" TYPE="LogicalMember">
+<mets:fptr FILEID="rd5w4"/>
+</mets:div>
+<mets:div ID="eq6r4" ORDER="135" TYPE="LogicalMember">
+<mets:fptr FILEID="cpm1t"/>
+</mets:div>
+<mets:div ID="uzsj6" ORDER="136" TYPE="LogicalMember">
+<mets:fptr FILEID="omujt"/>
+</mets:div>
+<mets:div ID="j8dzj" ORDER="137" TYPE="LogicalMember">
+<mets:fptr FILEID="qse11"/>
+</mets:div>
+<mets:div ID="m2bnx" ORDER="138" TYPE="LogicalMember">
+<mets:fptr FILEID="lxzhy"/>
+</mets:div>
+<mets:div ID="mlco9" ORDER="139" TYPE="LogicalMember">
+<mets:fptr FILEID="npaje"/>
+</mets:div>
+<mets:div ID="rzbmb" ORDER="140" TYPE="LogicalMember">
+<mets:fptr FILEID="jlqd2"/>
+</mets:div>
+<mets:div ID="y6o3e" ORDER="141" TYPE="LogicalMember">
+<mets:fptr FILEID="v49s0"/>
+</mets:div>
+<mets:div ID="ky4wd" ORDER="142" TYPE="LogicalMember">
+<mets:fptr FILEID="e5h3z"/>
+</mets:div>
+<mets:div ID="orgsf" ORDER="143" TYPE="LogicalMember">
+<mets:fptr FILEID="d7u5r"/>
+</mets:div>
+<mets:div ID="h1w71" ORDER="144" TYPE="LogicalMember">
+<mets:fptr FILEID="qynoj"/>
+</mets:div>
+<mets:div ID="cbi1r" ORDER="145" TYPE="LogicalMember">
+<mets:fptr FILEID="p3f0i"/>
+</mets:div>
+<mets:div ID="rx9yk" ORDER="146" TYPE="LogicalMember">
+<mets:fptr FILEID="lt0oh"/>
+</mets:div>
+<mets:div ID="cyaxd" ORDER="147" TYPE="LogicalMember">
+<mets:fptr FILEID="v485l"/>
+</mets:div>
+<mets:div ID="mu3ka" ORDER="148" TYPE="LogicalMember">
+<mets:fptr FILEID="gakux"/>
+</mets:div>
+<mets:div ID="lssn7" ORDER="149" TYPE="LogicalMember">
+<mets:fptr FILEID="jfgwc"/>
+</mets:div>
+<mets:div ID="b1u3h" ORDER="150" TYPE="LogicalMember">
+<mets:fptr FILEID="er8bv"/>
+</mets:div>
+<mets:div ID="qvrdt" ORDER="151" TYPE="LogicalMember">
+<mets:fptr FILEID="gor76"/>
+</mets:div>
+<mets:div ID="x30up" ORDER="152" TYPE="LogicalMember">
+<mets:fptr FILEID="bmo8c"/>
+</mets:div>
+<mets:div ID="t70xb" ORDER="153" TYPE="LogicalMember">
+<mets:fptr FILEID="thg9a"/>
+</mets:div>
+<mets:div ID="u87pd" ORDER="154" TYPE="LogicalMember">
+<mets:fptr FILEID="hdojr"/>
+</mets:div>
+<mets:div ID="x59em" ORDER="155" TYPE="LogicalMember">
+<mets:fptr FILEID="f1pih"/>
+</mets:div>
+<mets:div ID="jj69l" ORDER="156" TYPE="LogicalMember">
+<mets:fptr FILEID="sbunq"/>
+</mets:div>
+<mets:div ID="k7p0j" ORDER="157" TYPE="LogicalMember">
+<mets:fptr FILEID="jfuz0"/>
+</mets:div>
+<mets:div ID="yjhrb" ORDER="158" TYPE="LogicalMember">
+<mets:fptr FILEID="zo1zv"/>
+</mets:div>
+<mets:div ID="nqjni" ORDER="159" TYPE="LogicalMember">
+<mets:fptr FILEID="nviid"/>
+</mets:div>
+<mets:div ID="opp83" ORDER="160" TYPE="LogicalMember">
+<mets:fptr FILEID="ajtwz"/>
+</mets:div>
+<mets:div ID="g1l2c" ORDER="161" TYPE="LogicalMember">
+<mets:fptr FILEID="m8qf2"/>
+</mets:div>
+<mets:div ID="pf1wh" ORDER="162" TYPE="LogicalMember">
+<mets:fptr FILEID="et3er"/>
+</mets:div>
+<mets:div ID="pb81f" ORDER="163" TYPE="LogicalMember">
+<mets:fptr FILEID="hgzay"/>
+</mets:div>
+<mets:div ID="vx7r1" ORDER="164" TYPE="LogicalMember">
+<mets:fptr FILEID="c6nh0"/>
+</mets:div>
+<mets:div ID="t74re" ORDER="165" TYPE="LogicalMember">
+<mets:fptr FILEID="z4yps"/>
+</mets:div>
+<mets:div ID="dmnou" ORDER="166" TYPE="LogicalMember">
+<mets:fptr FILEID="p8hmx"/>
+</mets:div>
+<mets:div ID="ulykj" ORDER="167" TYPE="LogicalMember">
+<mets:fptr FILEID="t38xa"/>
+</mets:div>
+<mets:div ID="rmz2v" ORDER="168" TYPE="LogicalMember">
+<mets:fptr FILEID="ewmca"/>
+</mets:div>
+<mets:div ID="ovi8w" ORDER="169" TYPE="LogicalMember">
+<mets:fptr FILEID="e20ki"/>
+</mets:div>
+<mets:div ID="mpw9m" ORDER="170" TYPE="LogicalMember">
+<mets:fptr FILEID="pgdmj"/>
+</mets:div>
+<mets:div ID="mcvwe" ORDER="171" TYPE="LogicalMember">
+<mets:fptr FILEID="krams"/>
+</mets:div>
+<mets:div ID="wzgld" ORDER="172" TYPE="LogicalMember">
+<mets:fptr FILEID="ljyjn"/>
+</mets:div>
+<mets:div ID="r953w" ORDER="173" TYPE="LogicalMember">
+<mets:fptr FILEID="yfpat"/>
+</mets:div>
+<mets:div ID="yhuua" ORDER="174" TYPE="LogicalMember">
+<mets:fptr FILEID="ushd8"/>
+</mets:div>
+<mets:div ID="boslg" ORDER="175" TYPE="LogicalMember">
+<mets:fptr FILEID="evhyk"/>
+</mets:div>
+<mets:div ID="iikaj" ORDER="176" TYPE="LogicalMember">
+<mets:fptr FILEID="m3vx1"/>
+</mets:div>
+<mets:div ID="r3o34" ORDER="177" TYPE="LogicalMember">
+<mets:fptr FILEID="dqj33"/>
+</mets:div>
+<mets:div ID="hcpnh" ORDER="178" TYPE="LogicalMember">
+<mets:fptr FILEID="zevnb"/>
+</mets:div>
+<mets:div ID="bnqy5" ORDER="179" TYPE="LogicalMember">
+<mets:fptr FILEID="ipuys"/>
+</mets:div>
+<mets:div ID="qyyvw" ORDER="180" TYPE="LogicalMember">
+<mets:fptr FILEID="mj5xl"/>
+</mets:div>
+<mets:div ID="w1nb3" ORDER="181" TYPE="LogicalMember">
+<mets:fptr FILEID="w8szf"/>
+</mets:div>
+<mets:div ID="gczwp" ORDER="182" TYPE="LogicalMember">
+<mets:fptr FILEID="gfddm"/>
+</mets:div>
+<mets:div ID="t96f9" ORDER="183" TYPE="LogicalMember">
+<mets:fptr FILEID="u46vg"/>
+</mets:div>
+<mets:div ID="e0ezf" ORDER="184" TYPE="LogicalMember">
+<mets:fptr FILEID="ivjjk"/>
+</mets:div>
+<mets:div ID="icczh" ORDER="185" TYPE="LogicalMember">
+<mets:fptr FILEID="omw6y"/>
+</mets:div>
+<mets:div ID="srtwk" ORDER="186" TYPE="LogicalMember">
+<mets:fptr FILEID="yoq6k"/>
+</mets:div>
+<mets:div ID="nko2t" ORDER="187" TYPE="LogicalMember">
+<mets:fptr FILEID="r7kk7"/>
+</mets:div>
+<mets:div ID="mmbfg" ORDER="188" TYPE="LogicalMember">
+<mets:fptr FILEID="ptioh"/>
+</mets:div>
+<mets:div ID="cbzjz" ORDER="189" TYPE="LogicalMember">
+<mets:fptr FILEID="joi92"/>
+</mets:div>
+<mets:div ID="kp09e" ORDER="190" TYPE="LogicalMember">
+<mets:fptr FILEID="zpaiv"/>
+</mets:div>
+<mets:div ID="owbk4" ORDER="191" TYPE="LogicalMember">
+<mets:fptr FILEID="yqq07"/>
+</mets:div>
+<mets:div ID="rxjmf" ORDER="192" TYPE="LogicalMember">
+<mets:fptr FILEID="xmgq5"/>
+</mets:div>
+<mets:div ID="xlzq6" ORDER="193" TYPE="LogicalMember">
+<mets:fptr FILEID="jh7w2"/>
+</mets:div>
+<mets:div ID="yigmr" ORDER="194" TYPE="LogicalMember">
+<mets:fptr FILEID="g1tve"/>
+</mets:div>
+<mets:div ID="ys41a" ORDER="195" TYPE="LogicalMember">
+<mets:fptr FILEID="jdtaw"/>
+</mets:div>
+<mets:div ID="b1ey3" ORDER="196" TYPE="LogicalMember">
+<mets:fptr FILEID="t8qu0"/>
+</mets:div>
+<mets:div ID="zvdjn" ORDER="197" TYPE="LogicalMember">
+<mets:fptr FILEID="he1jr"/>
+</mets:div>
+<mets:div ID="tzoui" ORDER="198" TYPE="LogicalMember">
+<mets:fptr FILEID="luhbr"/>
+</mets:div>
+<mets:div ID="kzads" ORDER="199" TYPE="LogicalMember">
+<mets:fptr FILEID="zi46d"/>
+</mets:div>
+<mets:div ID="iiule" ORDER="200" TYPE="LogicalMember">
+<mets:fptr FILEID="nn7cn"/>
+</mets:div>
+<mets:div ID="b3uvv" ORDER="201" TYPE="LogicalMember">
+<mets:fptr FILEID="zqhb0"/>
+</mets:div>
+<mets:div ID="n53pw" ORDER="202" TYPE="LogicalMember">
+<mets:fptr FILEID="uz3nx"/>
+</mets:div>
+<mets:div ID="pxied" ORDER="203" TYPE="LogicalMember">
+<mets:fptr FILEID="mdk3l"/>
+</mets:div>
+<mets:div ID="hmw9u" ORDER="204" TYPE="LogicalMember">
+<mets:fptr FILEID="wyo40"/>
+</mets:div>
+<mets:div ID="mrs8e" ORDER="205" TYPE="LogicalMember">
+<mets:fptr FILEID="cd9nr"/>
+</mets:div>
+<mets:div ID="vy4ps" ORDER="206" TYPE="LogicalMember">
+<mets:fptr FILEID="ay98v"/>
+</mets:div>
+<mets:div ID="tqxe5" ORDER="207" TYPE="LogicalMember">
+<mets:fptr FILEID="j3isb"/>
+</mets:div>
+<mets:div ID="h9wbv" ORDER="208" TYPE="LogicalMember">
+<mets:fptr FILEID="ksq0a"/>
+</mets:div>
+<mets:div ID="nref0" ORDER="209" TYPE="LogicalMember">
+<mets:fptr FILEID="xjqaq"/>
+</mets:div>
+<mets:div ID="ztc3p" ORDER="210" TYPE="LogicalMember">
+<mets:fptr FILEID="eiiqf"/>
+</mets:div>
+<mets:div ID="jgbn8" ORDER="211" TYPE="LogicalMember">
+<mets:fptr FILEID="hu71u"/>
+</mets:div>
+<mets:div ID="x2jgv" ORDER="212" TYPE="LogicalMember">
+<mets:fptr FILEID="uhxe7"/>
+</mets:div>
+<mets:div ID="je6wf" ORDER="213" TYPE="LogicalMember">
+<mets:fptr FILEID="ujeh6"/>
+</mets:div>
+<mets:div ID="ds5zi" ORDER="214" TYPE="LogicalMember">
+<mets:fptr FILEID="j70y7"/>
+</mets:div>
+<mets:div ID="llqr5" ORDER="215" TYPE="LogicalMember">
+<mets:fptr FILEID="scadl"/>
+</mets:div>
+<mets:div ID="tduyz" ORDER="216" TYPE="LogicalMember">
+<mets:fptr FILEID="mko05"/>
+</mets:div>
+<mets:div ID="x71gb" ORDER="217" TYPE="LogicalMember">
+<mets:fptr FILEID="whria"/>
+</mets:div>
+<mets:div ID="kh3qq" ORDER="218" TYPE="LogicalMember">
+<mets:fptr FILEID="yasdz"/>
+</mets:div>
+<mets:div ID="jkgu9" ORDER="219" TYPE="LogicalMember">
+<mets:fptr FILEID="fd9jf"/>
+</mets:div>
+<mets:div ID="dub1k" ORDER="220" TYPE="LogicalMember">
+<mets:fptr FILEID="pt9fn"/>
+</mets:div>
+<mets:div ID="v8av3" ORDER="221" TYPE="LogicalMember">
+<mets:fptr FILEID="c22e4"/>
+</mets:div>
+<mets:div ID="juyiv" ORDER="222" TYPE="LogicalMember">
+<mets:fptr FILEID="w819o"/>
+</mets:div>
+<mets:div ID="ciqrj" ORDER="223" TYPE="LogicalMember">
+<mets:fptr FILEID="tckbr"/>
+</mets:div>
+<mets:div ID="otjfo" ORDER="224" TYPE="LogicalMember">
+<mets:fptr FILEID="lmy6e"/>
+</mets:div>
+<mets:div ID="roafp" ORDER="225" TYPE="LogicalMember">
+<mets:fptr FILEID="ptswy"/>
+</mets:div>
+<mets:div ID="md05h" ORDER="226" TYPE="LogicalMember">
+<mets:fptr FILEID="dgtk6"/>
+</mets:div>
+<mets:div ID="qmb6q" ORDER="227" TYPE="LogicalMember">
+<mets:fptr FILEID="o2wnl"/>
+</mets:div>
+<mets:div ID="kyrx4" ORDER="228" TYPE="LogicalMember">
+<mets:fptr FILEID="pfiex"/>
+</mets:div>
+<mets:div ID="cm8yj" ORDER="229" TYPE="LogicalMember">
+<mets:fptr FILEID="hy4wa"/>
+</mets:div>
+<mets:div ID="ixx4h" ORDER="230" TYPE="LogicalMember">
+<mets:fptr FILEID="k3ud6"/>
+</mets:div>
+<mets:div ID="t6ck7" ORDER="231" TYPE="LogicalMember">
+<mets:fptr FILEID="p8xsz"/>
+</mets:div>
+<mets:div ID="wks89" ORDER="232" TYPE="LogicalMember">
+<mets:fptr FILEID="wjsur"/>
+</mets:div>
+<mets:div ID="vbtfq" ORDER="233" TYPE="LogicalMember">
+<mets:fptr FILEID="xg2pz"/>
+</mets:div>
+<mets:div ID="uypqo" ORDER="234" TYPE="LogicalMember">
+<mets:fptr FILEID="clpgh"/>
+</mets:div>
+<mets:div ID="n5ida" ORDER="235" TYPE="LogicalMember">
+<mets:fptr FILEID="fj8s9"/>
+</mets:div>
+</mets:div>
+</mets:div>
+</mets:structMap>
+<mets:structLink>
+<mets:smLink xlink:from="v1phys" xlink:to="v1log"/>
+<mets:smLink xlink:from="v2phys" xlink:to="v2log"/>
+<mets:smLink xlink:from="v3phys" xlink:to="v3log"/>
+<mets:smLink xlink:from="v4phys" xlink:to="v4log"/>
+<mets:smLink xlink:from="v5phys" xlink:to="v5log"/>
+<mets:smLink xlink:from="v6phys" xlink:to="v6log"/>
+<mets:smLink xlink:from="v7phys" xlink:to="v7log"/>
+</mets:structLink>
+</mets:mets>

--- a/spec/fixtures/mets/tsop_typed.mets
+++ b/spec/fixtures/mets/tsop_typed.mets
@@ -1,0 +1,2162 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" OBJID="ark:/88435/jw827c96v" TYPE="CompiledDigitalObject" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd">
+<mets:metsHdr CREATEDATE="2018-08-04T11:56:26.015-04:00" LASTMODDATE="2018-08-04T11:56:26.015-04:00">
+<mets:metsDocumentID TYPE="PUDL">pudl0044/831958/tsop_typed.mets</mets:metsDocumentID>
+</mets:metsHdr>
+<mets:dmdSec ID="xvh3r">
+<mets:mdWrap MDTYPE="MODS">
+<mets:xmlData>
+<mods xmlns="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods//v3/mods-3-3.xsd">
+   
+   <titleInfo>
+      
+      <title>This side of paradise</title>
+      
+   </titleInfo>
+   <name authority="naf" type="personal">
+      
+      <namePart type="family">Fitzgerald</namePart>
+      <namePart type="given">F. Scott (Francis Scott)</namePart>
+      <namePart type="date">1896-1940</namePart>
+      <role>
+         <roleTerm authority="marcrelator" type="code">aut</roleTerm>
+      </role>
+   </name>
+   <typeOfResource manuscript="yes">text</typeOfResource>
+   <originInfo>
+      <dateCreated encoding="w3cdtf" keyDate="yes">1918</dateCreated>
+    
+   </originInfo>
+   <language>
+      <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+   </language>
+   <physicalDescription>
+      <extent>224 typescript pages</extent>
+   </physicalDescription>
+   <abstract>F. Scott Fitzgerald, This Side of Paradise, autograph manuscripts and corrected typescripts (1917-1919). Fitzgerald began writing This Side of Paradise at Princeton, continued in November 1917 at Fort Leavenworth, Kansas, with the working title "The Romantic Egoist," and completed a first draft of the novel at Cottage Club in March 1918. After this draft had been twice rejected by the New York publisher Charles Scribner's Sons, Fitzgerald returned to his parents' home at 599 Summit Avenue in his native St. Paul, Minnesota, and added five new chapters to the four he had written the previous year. He changed the second title of the novel from "The Education of a Personage" to "This Side of Paradise" and sent the novel to Maxwell Perkins at Scribner's. The publisher accepted the novel on September 16, 1919, and published it on March 26, 1920. The author's corrected galleys and page proofs do not survive.
+      
+      F. Scott Fitzgerald, "The Romantic Egotist," chapters 1, 2, 5, 12, and 14. Fitzgerald corrected the five chapters in this early typescript version and sent them to Charles W. Donahoe in October 1918. Donahoe donated the typescript to Princeton in 1948. .</abstract>
+   <note>Typed manuscript</note>
+   <subject authority="lcsh">
+      <name authority="naf" type="personal">
+         <namePart type="family">Fitzgerald</namePart>
+         <namePart type="given">F. Scott (Francis Scott)</namePart>
+         <namePart type="date">1896-1940</namePart>
+      </name>
+      <genre>Manuscripts</genre>
+   </subject>
+   <relatedItem type="host">
+      <typeOfResource collection="yes">text</typeOfResource>
+      <titleInfo>
+         <title>F. Scott Fitzgerald papers, 1897-1944</title>
+      </titleInfo>
+      <!--<location>
+         <url note="Digital Collection">http://pudl.princeton.edu/collections/pudl0044</url>
+      </location>-->
+   </relatedItem>
+   <location>
+      <physicalLocation type="text">Princeton University Library. Department of Rare Books and Special Collections</physicalLocation>
+      <physicalLocation authority="marcorg" type="code">NjP</physicalLocation>
+      <holdingSimple>
+         <copyInformation>
+            <subLocation>mss</subLocation>
+            <shelfLocator>C0187</shelfLocator>
+         </copyInformation>
+      </holdingSimple>
+   </location>
+   <accessCondition type="useAndReproduction">Not to be published, reproduced, or broadcast without the written permission of the Princeton University Library.  Selected items in the F. Scott Fitzgerald Papers can
+      be photoduplicated at the expense of the researcher requesting photoduplication. Advanced
+      estimates and payment are required. For general information on photoduplication and
+      permissions, go to http://www.princeton.edu/~rbsc Requests to to reproduce, publish, or
+      broadcast material from the F. Scott Fitzgerald Papers should be addressed Public Services
+      staff, rbsc@princeton.edu The correct form of citation includes the name of the collection,
+      box and folder numbers, and an indication that the originals are in the "Manuscripts Division,
+      Department of Rare Books and Special Collections, Princeton University Library." The
+      manuscript of The Great Gatsby and other writings of F. Scott Fitzgerald are not to be quoted,
+      published, reproduced, or broadcast without the written permission of the Princeton University
+      Library as owner of the physical object, and of the Fitzgerald Literary Trust (copyright
+      holder), c/o Harold Ober Associates, 425 Madison Avenue, New York, New York 10017 (Telephone:
+      212-759-8600; FAX: 212-759-9428). The Library is not responsible for copyright infringement or
+      other legal problems resulting from unauthorized publication of the words of F. Scott
+      Fitzgerald.</accessCondition>
+   <accessCondition type="restrictionOnAccess">For legal and conservation reasons, access to F.
+      Scott Fitzgerald’s original manuscripts (including corrected galleys and scrapbooks) is
+      strictly restricted. Scottie Fitzgerald Lanahan, daughter of F. Scott Fitzgerald and Zelda
+      Fitzgerald, donated the Fitzgerald Papers to the Princeton University Library in 1950,
+      stipulating that surrogates of the original manuscripts were to be made available to
+      researchers instead of the originals. This was done to preserve the originals, which are not
+      on good paper. Originally, the surrogates were in the form of microfilm. Facsimiles editions of This Side of Paradise and 
+      other manuscripts of books and short
+      stories followed a multi-volume series: F. Scott Fitzgerald Manuscripts, edited by Matthew J.
+      Bruccoli and Alan Margolies (New York: Garland Publishing Company, 1990). Complete sets of the
+      facsimile edition are available at more than 50 research libraries (including Firestone
+      Library). </accessCondition>
+   
+   
+   <recordInfo>
+      <recordContentSource authority="marcorg">NjP</recordContentSource>
+     <!-- <recordOrigin>http://catalog.princeton.edu/cgi-bin/Pwebrecon.cgi?BBID=</recordOrigin>-->
+      <recordIdentifier>http://diglib.princeton.edu/mdata/pudl0044/831958/tsop_typed.mods</recordIdentifier>
+      <languageOfCataloging>
+         <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+      </languageOfCataloging>
+   </recordInfo>
+</mods>
+</mets:xmlData>
+</mets:mdWrap>
+</mets:dmdSec>
+<mets:fileSec>
+<mets:fileGrp USE="thumbnail">
+<mets:file ID="d962c" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000001.tif"/>
+</mets:file>
+</mets:fileGrp>
+<mets:fileGrp USE="masters">
+<mets:file CHECKSUM="985b3106065f5bce06178212cdd5ea74" CHECKSUMTYPE="MD5" ID="afoc8" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000001.tif"/>
+</mets:file>
+<mets:file CHECKSUM="22434a0afda4d00d3af79ccb74966632" CHECKSUMTYPE="MD5" ID="o3cu9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000002.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b3a9612019a7c4e399cc8360142d4e40" CHECKSUMTYPE="MD5" ID="mfxyv" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000003.tif"/>
+</mets:file>
+<mets:file CHECKSUM="37fd5fd88be0388e4c0af5d473717d12" CHECKSUMTYPE="MD5" ID="hiyq3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000004.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9fc5f49ab0df97c0e057dbebdbfdfb1a" CHECKSUMTYPE="MD5" ID="rt7cu" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000005.tif"/>
+</mets:file>
+<mets:file CHECKSUM="581913800c5bc6dd634b0354354487ec" CHECKSUMTYPE="MD5" ID="wpdaz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000006.tif"/>
+</mets:file>
+<mets:file CHECKSUM="486f176ea825f4f89ba173a457c8e3f1" CHECKSUMTYPE="MD5" ID="vd770" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000007.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e49639fbbc0021afc3fac74c5427ed03" CHECKSUMTYPE="MD5" ID="p5bz8" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000008.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2af46704e1db6072bf0ec665ec519f67" CHECKSUMTYPE="MD5" ID="a2l99" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000009.tif"/>
+</mets:file>
+<mets:file CHECKSUM="652b0c645571fe17f069d9a6cdae5725" CHECKSUMTYPE="MD5" ID="i7d75" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000010.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e23adcad92c03a9f624055669973b4d5" CHECKSUMTYPE="MD5" ID="qidbi" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000011.tif"/>
+</mets:file>
+<mets:file CHECKSUM="cc977b0b4d39a18c25e9b7a3890105e6" CHECKSUMTYPE="MD5" ID="hu641" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000012.tif"/>
+</mets:file>
+<mets:file CHECKSUM="80568f134c89b5f0cbd1fa318eb51e06" CHECKSUMTYPE="MD5" ID="ud5zj" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000013.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d1f4945bfb29954f33c0f9b032fae248" CHECKSUMTYPE="MD5" ID="b6ths" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000014.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6430df0128065c27c5eddcfbf3569458" CHECKSUMTYPE="MD5" ID="vo8he" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000015.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3763dfe5d8cdb71c35eb5d5241781136" CHECKSUMTYPE="MD5" ID="qza75" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000016.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9e8de9401f86ae2048c59168fe66aef" CHECKSUMTYPE="MD5" ID="blhlc" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000017.tif"/>
+</mets:file>
+<mets:file CHECKSUM="661ebb074b1195193fba30d34dc6c867" CHECKSUMTYPE="MD5" ID="ygym9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000018.tif"/>
+</mets:file>
+<mets:file CHECKSUM="94ccf5b98bc7eb7108598d197cc1aa1b" CHECKSUMTYPE="MD5" ID="w4uem" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000019.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1ac8a79886dfa4dabea934be99b6dad3" CHECKSUMTYPE="MD5" ID="zrpn3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000020.tif"/>
+</mets:file>
+<mets:file CHECKSUM="68e53dbc05bae258ce4bc166389ec04d" CHECKSUMTYPE="MD5" ID="vqvnx" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000021.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bc4c0f5b42623c054b9bb0f634b55d68" CHECKSUMTYPE="MD5" ID="twyb2" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000022.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f29b503a080b6278102b797e30755514" CHECKSUMTYPE="MD5" ID="bhg7z" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000023.tif"/>
+</mets:file>
+<mets:file CHECKSUM="810e68cc5097d7a4f2ac2261093e6fda" CHECKSUMTYPE="MD5" ID="kq6f4" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000024.tif"/>
+</mets:file>
+<mets:file CHECKSUM="77d12e4bef70cb70ff0e2b60228762a0" CHECKSUMTYPE="MD5" ID="dfcw8" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000025.tif"/>
+</mets:file>
+<mets:file CHECKSUM="809ac62fc35ee4435e00da7da478ddb2" CHECKSUMTYPE="MD5" ID="wyggp" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000026.tif"/>
+</mets:file>
+<mets:file CHECKSUM="831f7786885ce9cbe6c9e7a3e1a6eb55" CHECKSUMTYPE="MD5" ID="a4goe" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000027.tif"/>
+</mets:file>
+<mets:file CHECKSUM="875490aac0d0794881f904639215aef1" CHECKSUMTYPE="MD5" ID="php7d" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000028.tif"/>
+</mets:file>
+<mets:file CHECKSUM="59623d18c35c535d48db84449e767310" CHECKSUMTYPE="MD5" ID="mob7q" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000029.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2648bfad662266d3c5efcf277af80624" CHECKSUMTYPE="MD5" ID="hesd2" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000030.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e47b4d883e6f475970f6f587d90a628c" CHECKSUMTYPE="MD5" ID="s0rwi" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000031.tif"/>
+</mets:file>
+<mets:file CHECKSUM="58b1feb6c32959951da67d3d9e843152" CHECKSUMTYPE="MD5" ID="sgl8m" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000032.tif"/>
+</mets:file>
+<mets:file CHECKSUM="538b00e519cda418e10e5d03d1187242" CHECKSUMTYPE="MD5" ID="fcijz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000033.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a8da6b4e5c6760df87cccb94b09e9750" CHECKSUMTYPE="MD5" ID="ymggl" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000034.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e65fca6cc9d4bfd13a0704d4f12b0399" CHECKSUMTYPE="MD5" ID="ngzxk" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000035.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f0c3b4f77b172a361f2f05e8f61000d" CHECKSUMTYPE="MD5" ID="rbxh3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000036.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e1c5f0571a751d4c890afb57364d6d0" CHECKSUMTYPE="MD5" ID="mgpg5" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000037.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f730551c16ee150e77092f6c491796a0" CHECKSUMTYPE="MD5" ID="l2v4a" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000038.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9e5cdeb1698657bc2fce22184a936a56" CHECKSUMTYPE="MD5" ID="ra2jr" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000039.tif"/>
+</mets:file>
+<mets:file CHECKSUM="10709e70eac89c5fc5768c664c1dd1fc" CHECKSUMTYPE="MD5" ID="y4aaj" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000040.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2f10bd6ed96933efa8782956fdaf4564" CHECKSUMTYPE="MD5" ID="ug9dc" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000041.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f3aba1260fdc0d93e950ad7f9e44dde6" CHECKSUMTYPE="MD5" ID="ex2dy" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000042.tif"/>
+</mets:file>
+<mets:file CHECKSUM="328b134e99ee0fc39e17154415729bbd" CHECKSUMTYPE="MD5" ID="ec5az" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000043.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a0da6e464344fa6908c9122f956d19e8" CHECKSUMTYPE="MD5" ID="o52xb" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000044.tif"/>
+</mets:file>
+<mets:file CHECKSUM="649d593422c676ceb9c446e3010748f3" CHECKSUMTYPE="MD5" ID="xn55y" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000045.tif"/>
+</mets:file>
+<mets:file CHECKSUM="cd3b0c260008c1e289929549c6a8b404" CHECKSUMTYPE="MD5" ID="i6924" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000046.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1b1c32bdd73432d585163e11bd30a2bb" CHECKSUMTYPE="MD5" ID="fe2la" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000047.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3c051063f56477927863b0d51efddd2b" CHECKSUMTYPE="MD5" ID="dk09i" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000048.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5d9da732b35bfa170560c38282865f1a" CHECKSUMTYPE="MD5" ID="ejo95" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000049.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4e423b833fdcf69afd6c9b247d1964d7" CHECKSUMTYPE="MD5" ID="v196l" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000050.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bcf31402c37f6774607ec7b6deb20254" CHECKSUMTYPE="MD5" ID="l46jl" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000051.tif"/>
+</mets:file>
+<mets:file CHECKSUM="99ba75564ffcd5abbf72743c20a02883" CHECKSUMTYPE="MD5" ID="x00po" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000052.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8f45a09559038d9bc1b3227d16b5186a" CHECKSUMTYPE="MD5" ID="yg5az" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000053.tif"/>
+</mets:file>
+<mets:file CHECKSUM="34e63d5c0fb1f88eff536dacbddca0b0" CHECKSUMTYPE="MD5" ID="pe1ka" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000054.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2d6e92e9bba12f6352e4c628aa395847" CHECKSUMTYPE="MD5" ID="if3y3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000055.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bb7b0046596f11fa12108a70f63925f5" CHECKSUMTYPE="MD5" ID="b2vy6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000056.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2cd19f64b6bdf1f749f36cf69e793b2f" CHECKSUMTYPE="MD5" ID="fko5d" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000057.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8d4f2a9e56ac16029c8520afe97bc578" CHECKSUMTYPE="MD5" ID="l2gru" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000058.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e799af33a0e6cd27d37c47c4d9cca4f4" CHECKSUMTYPE="MD5" ID="rpe0i" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000059.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2f0e075ba2050d6d0138e1fb7f117b93" CHECKSUMTYPE="MD5" ID="c7hio" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000060.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e1938e22d2c4bba1963c89de57de07a3" CHECKSUMTYPE="MD5" ID="axjgl" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000061.tif"/>
+</mets:file>
+<mets:file CHECKSUM="17a723d3cd722f346204ad5b5c2aed6b" CHECKSUMTYPE="MD5" ID="snpyg" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000062.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ff9dcaedc741ae4a43b050236da5aafa" CHECKSUMTYPE="MD5" ID="rb9s7" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000063.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d12210f076c898a29e1e4daf9d99a0df" CHECKSUMTYPE="MD5" ID="n6xea" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000064.tif"/>
+</mets:file>
+<mets:file CHECKSUM="53910e08f11fd46d29f219231facf66a" CHECKSUMTYPE="MD5" ID="gcy3x" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000065.tif"/>
+</mets:file>
+<mets:file CHECKSUM="caf3e83a161cd08a4517fd8a425ef2d8" CHECKSUMTYPE="MD5" ID="rqbx5" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000066.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3ca8e4da957d55cd83e15cd36738632d" CHECKSUMTYPE="MD5" ID="b0ms9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000067.tif"/>
+</mets:file>
+<mets:file CHECKSUM="78045afd59a5511f72cdab980ac5ac4e" CHECKSUMTYPE="MD5" ID="mokxy" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000068.tif"/>
+</mets:file>
+<mets:file CHECKSUM="fad5d40d77032c6896ad99b6c8603ffe" CHECKSUMTYPE="MD5" ID="xihxy" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000069.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1cd376c7dbdb87e0a8db5fc4139f622a" CHECKSUMTYPE="MD5" ID="pc8zn" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000070.tif"/>
+</mets:file>
+<mets:file CHECKSUM="90fbf57e4413dab4da3752ac774e7b90" CHECKSUMTYPE="MD5" ID="l01my" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000071.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bd0d07c5c7803fc2b81009c84a4b1057" CHECKSUMTYPE="MD5" ID="a9itj" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000072.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a040882927ce83572d7ec4409c8ab607" CHECKSUMTYPE="MD5" ID="pzueq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000073.tif"/>
+</mets:file>
+<mets:file CHECKSUM="76aaf597952a0125f97ebdd1cccc60f3" CHECKSUMTYPE="MD5" ID="grlin" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000074.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ae4e0026a5d6125185d84dc0c604151d" CHECKSUMTYPE="MD5" ID="nod0x" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000075.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4ada33543f63d211ae3f312d08c6161b" CHECKSUMTYPE="MD5" ID="i6qef" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000076.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bc548ecc0af7478cd001338fcc7563b8" CHECKSUMTYPE="MD5" ID="hgw98" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000077.tif"/>
+</mets:file>
+<mets:file CHECKSUM="32a686b3eec6fba45a6f24369aeaaeac" CHECKSUMTYPE="MD5" ID="jzjq4" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000078.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ab402aa37ad42acdbc623e9d21007b3c" CHECKSUMTYPE="MD5" ID="ays1e" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000079.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8c16c8b074763eba3f315247c1d7a664" CHECKSUMTYPE="MD5" ID="oflvx" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000080.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9daedbec72353cbd170a9cfdad32c1b" CHECKSUMTYPE="MD5" ID="c6cxg" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000081.tif"/>
+</mets:file>
+<mets:file CHECKSUM="28f4f131d1f12e220038b4592d21c399" CHECKSUMTYPE="MD5" ID="lwzw0" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000082.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6a28ec1962a6b4d6c90080a5820f0f21" CHECKSUMTYPE="MD5" ID="hbuz1" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000083.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9a57f6660355afb4fc13a1da45a9ccfe" CHECKSUMTYPE="MD5" ID="aw0mz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000084.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c0d323f3ebe90bf100ce541bb6b1b44f" CHECKSUMTYPE="MD5" ID="oqjao" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000085.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ce919113b676fe1c5f52c01b6d5ff87" CHECKSUMTYPE="MD5" ID="s8b2e" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000086.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c1087a05349216e826b5e173846e9789" CHECKSUMTYPE="MD5" ID="f229i" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000087.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a53f864db3936c9a56f6bc616487758f" CHECKSUMTYPE="MD5" ID="pqh2y" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000088.tif"/>
+</mets:file>
+<mets:file CHECKSUM="78519730c7b18fc4c9ecbc217c865e3" CHECKSUMTYPE="MD5" ID="u8yq0" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000089.tif"/>
+</mets:file>
+<mets:file CHECKSUM="38f7691d08a71d49b2101b7faf48109f" CHECKSUMTYPE="MD5" ID="cfjxe" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000090.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5de61a7ada392d7bd3b1e2e8b09d9235" CHECKSUMTYPE="MD5" ID="qgwgu" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000091.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b57b2173144adc38266275565c5cc892" CHECKSUMTYPE="MD5" ID="yneio" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000092.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4c4e0e5f00b9ec68a968d8b892f80397" CHECKSUMTYPE="MD5" ID="i7gam" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000093.tif"/>
+</mets:file>
+<mets:file CHECKSUM="eea5ae641ca86967c47852737e1f9c98" CHECKSUMTYPE="MD5" ID="bk0dm" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000094.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c7563d6c2075ef8c8361a7338af5819c" CHECKSUMTYPE="MD5" ID="bkfso" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000095.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ff110829d4b5af546d098fe9dcb482ac" CHECKSUMTYPE="MD5" ID="zb9go" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000096.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a3651fc1d5fdc9034defa9fd1b43c487" CHECKSUMTYPE="MD5" ID="wlzwm" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000097.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ba6f52ea1a8ee7607e73c11fa9cb21fb" CHECKSUMTYPE="MD5" ID="w3ccg" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000098.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c110f75434fb50c2c967dcba63bfa87f" CHECKSUMTYPE="MD5" ID="n6kt4" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000099.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ea8995e84a8f978cea07332231e7508e" CHECKSUMTYPE="MD5" ID="dsokl" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000100.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8f870b24b609f7b437076fe589ea194b" CHECKSUMTYPE="MD5" ID="wgzsm" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000101.tif"/>
+</mets:file>
+<mets:file CHECKSUM="735141118294fe38a3db7250525ad822" CHECKSUMTYPE="MD5" ID="l7zhp" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000102.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4a2fd4d6101d025bfe2861553c9dfe01" CHECKSUMTYPE="MD5" ID="n5goz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000103.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f70d3b7181c400a238c00288185daee4" CHECKSUMTYPE="MD5" ID="tem01" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000104.tif"/>
+</mets:file>
+<mets:file CHECKSUM="76eaf5a9d3dcc10d397b42198c2c0abb" CHECKSUMTYPE="MD5" ID="m58ti" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000105.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bc335bd6ecfafb3ab41bb197363d1d40" CHECKSUMTYPE="MD5" ID="qmewn" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000106.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1245437429cc4af1d6fde39dc72c2762" CHECKSUMTYPE="MD5" ID="ladt3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000107.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2704bc220ad75f784afdea673fc37f4e" CHECKSUMTYPE="MD5" ID="izjco" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000108.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1a3f45fd947986699d4c8dafa89f79e0" CHECKSUMTYPE="MD5" ID="gq0i5" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000109.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e8db1642daffb1d54d1d701cd8a439ce" CHECKSUMTYPE="MD5" ID="bmwhn" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000110.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4100fcc91e044350a7257dd9f4268bfe" CHECKSUMTYPE="MD5" ID="pcakz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000111.tif"/>
+</mets:file>
+<mets:file CHECKSUM="39139801b0a17968853ec6bb8665a7d5" CHECKSUMTYPE="MD5" ID="g6892" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000112.tif"/>
+</mets:file>
+<mets:file CHECKSUM="fa6cf70ea69a12a25342f0192fe3f728" CHECKSUMTYPE="MD5" ID="i92zq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000113.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ec8474e627db90cd04f60bd434de1ab9" CHECKSUMTYPE="MD5" ID="lnoon" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000114.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c463972006888cc42faa22dd9ba140dc" CHECKSUMTYPE="MD5" ID="hsmma" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000115.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9c314264ecae927e384ed55bbd8ba602" CHECKSUMTYPE="MD5" ID="pjgz4" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000116.tif"/>
+</mets:file>
+<mets:file CHECKSUM="fbca9db2e04cf3055ffbc26547260620" CHECKSUMTYPE="MD5" ID="ftwjs" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000117.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9c2bdeecf6099a3bb5f6527c152983b9" CHECKSUMTYPE="MD5" ID="j8o3x" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000118.tif"/>
+</mets:file>
+<mets:file CHECKSUM="980a32c7472812f46460d765a65529bb" CHECKSUMTYPE="MD5" ID="b48bz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000119.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b706b47db59ba8e2f0a7a0d0a6b6ac00" CHECKSUMTYPE="MD5" ID="x4ohz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000120.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c02a11ba6a6d2d1ab6bd1a400ed3635d" CHECKSUMTYPE="MD5" ID="yppll" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000121.tif"/>
+</mets:file>
+<mets:file CHECKSUM="cc93f246d994ad3ff33a77101177f184" CHECKSUMTYPE="MD5" ID="alope" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000122.tif"/>
+</mets:file>
+<mets:file CHECKSUM="173bbafa4f7ffa8cd9fd6af92f8bf1fa" CHECKSUMTYPE="MD5" ID="f22r2" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000123.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5ddb48f889bf8aef59cc6c1e067b4fc1" CHECKSUMTYPE="MD5" ID="uor1e" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000124.tif"/>
+</mets:file>
+<mets:file CHECKSUM="50116520e6929052e61dadb8eea364f4" CHECKSUMTYPE="MD5" ID="h8jxm" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000125.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b633e20664bee8265ad47bf9c1ddfb27" CHECKSUMTYPE="MD5" ID="friyb" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000126.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a1e8c4e57ddcf9b518f8e5606dd71b7f" CHECKSUMTYPE="MD5" ID="absax" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000127.tif"/>
+</mets:file>
+<mets:file CHECKSUM="774df6e074a7ab6b003e324f74f28f07" CHECKSUMTYPE="MD5" ID="xniio" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000128.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e6124234c5762908f15354a972ef8931" CHECKSUMTYPE="MD5" ID="nm6ih" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000129.tif"/>
+</mets:file>
+<mets:file CHECKSUM="97e16fab0d23443d97f3b12eb99cbcb" CHECKSUMTYPE="MD5" ID="p93ab" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000130.tif"/>
+</mets:file>
+<mets:file CHECKSUM="503d79065acad9692a65495340ed7061" CHECKSUMTYPE="MD5" ID="fm9yz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000131.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9133425d3270bf9d327682faa96445d" CHECKSUMTYPE="MD5" ID="cqh0n" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000132.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c9f1893a6ac4c7362f3556e552bc738b" CHECKSUMTYPE="MD5" ID="jfan1" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000133.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d8b717823dc0d8b0c8baa9a21217e804" CHECKSUMTYPE="MD5" ID="v7lgq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000134.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6f82b0842390ced4697af316bcff6046" CHECKSUMTYPE="MD5" ID="ro2hf" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000135.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d43044f0f12425c7ecb44784a9c1d8bf" CHECKSUMTYPE="MD5" ID="dez4h" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000136.tif"/>
+</mets:file>
+<mets:file CHECKSUM="78aa4a9d59be5856ce1abb890f4f00af" CHECKSUMTYPE="MD5" ID="w88g9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000137.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e1cc1e374ba35c2adff7f4ac7d8f27dd" CHECKSUMTYPE="MD5" ID="n7bt3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000138.tif"/>
+</mets:file>
+<mets:file CHECKSUM="988b4e565b1d53b0804f0744449bca41" CHECKSUMTYPE="MD5" ID="lnphz" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000139.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c28c943be0c7cfa1cf1c2ca1c1904a44" CHECKSUMTYPE="MD5" ID="ey5yv" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000140.tif"/>
+</mets:file>
+<mets:file CHECKSUM="875fa0794b1d5d2e66947ed8c917657f" CHECKSUMTYPE="MD5" ID="ljqsl" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000141.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e8d3a041d6adc96932d5ba65a9232769" CHECKSUMTYPE="MD5" ID="k139m" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000142.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f734b27852d210d80f40675012aa27ac" CHECKSUMTYPE="MD5" ID="x9zut" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000143.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5b4e1f66fd150eb10cdc2191b6cf32c8" CHECKSUMTYPE="MD5" ID="mkzs0" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000144.tif"/>
+</mets:file>
+<mets:file CHECKSUM="fb78c8993739bec24202776994b00b83" CHECKSUMTYPE="MD5" ID="tc62e" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000145.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b6335b88cbe9baa6fb22e83ddc644b01" CHECKSUMTYPE="MD5" ID="kwjaa" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000146.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9a7cfa2319eaa69d829d45bf49b2df54" CHECKSUMTYPE="MD5" ID="vzxsf" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000147.tif"/>
+</mets:file>
+<mets:file CHECKSUM="20f49ef147e33e40b27363081a28058c" CHECKSUMTYPE="MD5" ID="tuppq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000148.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7a698e96aac8abbd726bbf2ed692b093" CHECKSUMTYPE="MD5" ID="ijml2" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000149.tif"/>
+</mets:file>
+<mets:file CHECKSUM="61fb9206e83ec564eaa8c1401b28a2a" CHECKSUMTYPE="MD5" ID="psbyo" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000150.tif"/>
+</mets:file>
+<mets:file CHECKSUM="51688d3e60be88aa31235ec264579c43" CHECKSUMTYPE="MD5" ID="kwy70" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000151.tif"/>
+</mets:file>
+<mets:file CHECKSUM="598a445ad40bbebfd5cd6697cb020c96" CHECKSUMTYPE="MD5" ID="deb4x" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000152.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bcb67f1f9f5ae0b9ab913ff118a09055" CHECKSUMTYPE="MD5" ID="yeed1" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000153.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5c49de2e36d2f5fd5bac3920c5686517" CHECKSUMTYPE="MD5" ID="ugzuq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000154.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e68ae02215a4ba8b668d21939933b32" CHECKSUMTYPE="MD5" ID="mpf98" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000155.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a0ec5e01886a6df70ebde6eb93b9ed0" CHECKSUMTYPE="MD5" ID="d3phu" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000156.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1264ea85b95e1d834adc82c9270c4236" CHECKSUMTYPE="MD5" ID="yy415" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000157.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ba151b69103351dfb902e0b0af92d1b5" CHECKSUMTYPE="MD5" ID="z3bhc" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000158.tif"/>
+</mets:file>
+<mets:file CHECKSUM="54793c95ae8950d656530bc0aef4e2f5" CHECKSUMTYPE="MD5" ID="x5pkc" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000159.tif"/>
+</mets:file>
+<mets:file CHECKSUM="cdd304c1f41ffd5c683f5dd466f73056" CHECKSUMTYPE="MD5" ID="brz9h" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000160.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9594d2d3db09a4b98fac12cb60ebe67c" CHECKSUMTYPE="MD5" ID="cz2li" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000161.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8d282f3d47f8f2c171d09450b482b60a" CHECKSUMTYPE="MD5" ID="pp6t5" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000162.tif"/>
+</mets:file>
+<mets:file CHECKSUM="54d19981fed4979cd0d7620428f7b656" CHECKSUMTYPE="MD5" ID="ps2t6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000163.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2cec35cb7df7f930283ecdb5d9a9b82c" CHECKSUMTYPE="MD5" ID="so6ka" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000164.tif"/>
+</mets:file>
+<mets:file CHECKSUM="4311c6c12de453c57edb51fdea29a020" CHECKSUMTYPE="MD5" ID="girge" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000165.tif"/>
+</mets:file>
+<mets:file CHECKSUM="7b274b01675ea2b111f9b237ffd6c5a5" CHECKSUMTYPE="MD5" ID="oct27" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000166.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2e592fa823978e15de77457560835e20" CHECKSUMTYPE="MD5" ID="fx8xd" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000167.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b24bbd5255c65dd1a295d18c28ff5fb" CHECKSUMTYPE="MD5" ID="oi977" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000168.tif"/>
+</mets:file>
+<mets:file CHECKSUM="267b45ec9b77f4d38c92c3423b795b9e" CHECKSUMTYPE="MD5" ID="qbqha" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000169.tif"/>
+</mets:file>
+<mets:file CHECKSUM="da6ff7ce8db8af8f10d81c98e6d1df8b" CHECKSUMTYPE="MD5" ID="ikysu" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000170.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b41498c1bc3a2e486574120b51edad1" CHECKSUMTYPE="MD5" ID="gx0h2" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000171.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1efebafaed9f118691b1218ddf00eb29" CHECKSUMTYPE="MD5" ID="f9czr" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000172.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c33cb0023fb69c492082a162e1cfe00a" CHECKSUMTYPE="MD5" ID="d1pb3" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000173.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e017d2336060889c53f88717ed2a0c3f" CHECKSUMTYPE="MD5" ID="bidz9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000174.tif"/>
+</mets:file>
+<mets:file CHECKSUM="318e98a5b4d448ecafb43a4c67b7c49d" CHECKSUMTYPE="MD5" ID="wz4fg" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000175.tif"/>
+</mets:file>
+<mets:file CHECKSUM="76eecf81b35f88eebe0c18186cfb72ab" CHECKSUMTYPE="MD5" ID="vl32k" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000176.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d404779ecb6cc9d6679a19163f3c5499" CHECKSUMTYPE="MD5" ID="nf3yt" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000177.tif"/>
+</mets:file>
+<mets:file CHECKSUM="908978cb43f8797b60d35d9ad0468b33" CHECKSUMTYPE="MD5" ID="cmo6l" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000178.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e15b14401d70bfb1b2803583b816ec6a" CHECKSUMTYPE="MD5" ID="hssp1" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000179.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ce9774cd52e6de93be3a2a92cf904ffa" CHECKSUMTYPE="MD5" ID="rzjze" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000180.tif"/>
+</mets:file>
+<mets:file CHECKSUM="d38183eef44b233a524629c040760412" CHECKSUMTYPE="MD5" ID="u6igm" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000181.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b159919b6b1f1bcd2c80718b7d5ae92e" CHECKSUMTYPE="MD5" ID="cuo6u" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000182.tif"/>
+</mets:file>
+<mets:file CHECKSUM="375b8946d5d5f94e6d53b7f4732ea696" CHECKSUMTYPE="MD5" ID="ragf6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000183.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1a935ceb52b5f4fc093ef87323f63299" CHECKSUMTYPE="MD5" ID="mibsi" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000184.tif"/>
+</mets:file>
+<mets:file CHECKSUM="fe03b0aca42bdc6b7f8e1cb5409743c1" CHECKSUMTYPE="MD5" ID="pfda4" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000185.tif"/>
+</mets:file>
+<mets:file CHECKSUM="21e8fd24a257e3212c89c0bbc6f0a41b" CHECKSUMTYPE="MD5" ID="uc6y9" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000186.tif"/>
+</mets:file>
+<mets:file CHECKSUM="66cfee8305c8ed274e8cbc8f4877db47" CHECKSUMTYPE="MD5" ID="v7kq6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000187.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b4271a515fded02c9904840fda8abb1" CHECKSUMTYPE="MD5" ID="ol01v" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000188.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1920e518161df141c463324b77e18b5a" CHECKSUMTYPE="MD5" ID="ucuj2" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000189.tif"/>
+</mets:file>
+<mets:file CHECKSUM="43f83b43358783bb0257b5aa7abdab60" CHECKSUMTYPE="MD5" ID="rse38" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000190.tif"/>
+</mets:file>
+<mets:file CHECKSUM="5ec6e1ec9212466afffc09fd5f39da02" CHECKSUMTYPE="MD5" ID="b4qs6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000191.tif"/>
+</mets:file>
+<mets:file CHECKSUM="347bf78c0c3f130b4894dd5541f7d344" CHECKSUMTYPE="MD5" ID="kli7f" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000192.tif"/>
+</mets:file>
+<mets:file CHECKSUM="38897442a4a1a08fc761f8b50e639130" CHECKSUMTYPE="MD5" ID="iscqr" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000193.tif"/>
+</mets:file>
+<mets:file CHECKSUM="cce4211f7c8dd67b856af85ce531e239" CHECKSUMTYPE="MD5" ID="dpju4" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000194.tif"/>
+</mets:file>
+<mets:file CHECKSUM="77089b5fa7682a911a03b3d47f4d6782" CHECKSUMTYPE="MD5" ID="d8fou" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000195.tif"/>
+</mets:file>
+<mets:file CHECKSUM="26f6687ec9dfc9224f11a2f7ff840f94" CHECKSUMTYPE="MD5" ID="kmobn" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000196.tif"/>
+</mets:file>
+<mets:file CHECKSUM="fb4ed30d8bd1e6dfbee4636cef945e50" CHECKSUMTYPE="MD5" ID="eweae" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000197.tif"/>
+</mets:file>
+<mets:file CHECKSUM="741d69edd7a51f15852ac7025de198cf" CHECKSUMTYPE="MD5" ID="l7kmv" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000198.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a7c0b2e750368b81cb6216a6d6157950" CHECKSUMTYPE="MD5" ID="twypr" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000199.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6cd77f9efab9da173859068217454743" CHECKSUMTYPE="MD5" ID="d43ze" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000200.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6608e83b21778e3167b399a48f274cf3" CHECKSUMTYPE="MD5" ID="ze2y2" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000201.tif"/>
+</mets:file>
+<mets:file CHECKSUM="2ff50a1d413458803db263631878928f" CHECKSUMTYPE="MD5" ID="a7vph" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000202.tif"/>
+</mets:file>
+<mets:file CHECKSUM="9e75867070c7e8809fc959cf4196e1bb" CHECKSUMTYPE="MD5" ID="wq3bv" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000203.tif"/>
+</mets:file>
+<mets:file CHECKSUM="696b1cf92818ef93a6d24d728bc5d7a9" CHECKSUMTYPE="MD5" ID="ivfxt" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000204.tif"/>
+</mets:file>
+<mets:file CHECKSUM="bc738de88066cb00ee0262f753f67425" CHECKSUMTYPE="MD5" ID="nzivf" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000205.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1681eb88b33b045603aa9d286f702538" CHECKSUMTYPE="MD5" ID="hrywv" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000206.tif"/>
+</mets:file>
+<mets:file CHECKSUM="dbdb8794fbd54d761727f2319edb6dfc" CHECKSUMTYPE="MD5" ID="dcg37" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000207.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8c944e683ce9f9fc5f977bd81f522421" CHECKSUMTYPE="MD5" ID="opv56" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000208.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b71e46b900eac1f00841a9bab89b4006" CHECKSUMTYPE="MD5" ID="f2e3b" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000209.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8d629ba816adbb16107936be235fe42d" CHECKSUMTYPE="MD5" ID="ilgdr" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000210.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6ca51cb8d34cdc014653fbfc46ac1124" CHECKSUMTYPE="MD5" ID="hzrin" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000211.tif"/>
+</mets:file>
+<mets:file CHECKSUM="fba0cecc64d2543c13efcc8316432daf" CHECKSUMTYPE="MD5" ID="v0h9w" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000212.tif"/>
+</mets:file>
+<mets:file CHECKSUM="b1ccbe38572dea223f5e005b1ef0819f" CHECKSUMTYPE="MD5" ID="udbcm" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000213.tif"/>
+</mets:file>
+<mets:file CHECKSUM="57e29aa972257aab29afef7300f17475" CHECKSUMTYPE="MD5" ID="xhtpp" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000214.tif"/>
+</mets:file>
+<mets:file CHECKSUM="a0b8d7836ea71c9c32647aaacdae169e" CHECKSUMTYPE="MD5" ID="nuhuc" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000215.tif"/>
+</mets:file>
+<mets:file CHECKSUM="6827ec1ce83fdde7c61827dccf7183a1" CHECKSUMTYPE="MD5" ID="x6s0g" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000216.tif"/>
+</mets:file>
+<mets:file CHECKSUM="1f5da1b9887ad4e8d29b317e68c496a6" CHECKSUMTYPE="MD5" ID="eo95l" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000217.tif"/>
+</mets:file>
+<mets:file CHECKSUM="fb570ad45e371356fe02c4189c9b2716" CHECKSUMTYPE="MD5" ID="z2fw0" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000218.tif"/>
+</mets:file>
+<mets:file CHECKSUM="3ab46dd5c4ec02da696cc97c34eea617" CHECKSUMTYPE="MD5" ID="ci0as" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000219.tif"/>
+</mets:file>
+<mets:file CHECKSUM="27737cf734c8bc9b87e62382332d923f" CHECKSUMTYPE="MD5" ID="fr8ty" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000220.tif"/>
+</mets:file>
+<mets:file CHECKSUM="313845bd85bc0274fd64d1a1f8107ef4" CHECKSUMTYPE="MD5" ID="pqeuy" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000221.tif"/>
+</mets:file>
+<mets:file CHECKSUM="e8a1eb4cf72903395ff82d9532651c4a" CHECKSUMTYPE="MD5" ID="gb4yk" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000222.tif"/>
+</mets:file>
+<mets:file CHECKSUM="ef725ea2ec566dfced59d00e50d9ba8" CHECKSUMTYPE="MD5" ID="haasu" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000223.tif"/>
+</mets:file>
+<mets:file CHECKSUM="c2c1805903f63cfb0ac3e60cb22823f9" CHECKSUMTYPE="MD5" ID="nf4a0" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000224.tif"/>
+</mets:file>
+<mets:file CHECKSUM="555fcd6072036b27475fa7410d75040b" CHECKSUMTYPE="MD5" ID="qp0f6" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000225.tif"/>
+</mets:file>
+<mets:file CHECKSUM="8e9616842158df56dabf66bf488d00e" CHECKSUMTYPE="MD5" ID="xvqq1" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000226.tif"/>
+</mets:file>
+</mets:fileGrp>
+</mets:fileSec>
+<mets:structMap TYPE="RelatedObjects">
+<mets:div DMDID="xvh3r xvh3r" ID="vxm2n" LABEL="Default">
+<mets:div CONTENTIDS="pudl0044" TYPE="IsPartOf"/>
+<mets:div ID="aggregates" TYPE="OrderedList">
+<mets:div ID="q4udb" LABEL="image 1" ORDER="225" TYPE="Static">
+<mets:fptr FILEID="afoc8"/>
+</mets:div>
+<mets:div ID="qmu2r" LABEL="image 2" ORDER="226" TYPE="Static">
+<mets:fptr FILEID="o3cu9"/>
+</mets:div>
+<mets:div ID="xxq9z" LABEL="image 3" ORDER="1" TYPE="Static">
+<mets:fptr FILEID="mfxyv"/>
+</mets:div>
+<mets:div ID="a14tx" LABEL="image 4" ORDER="2" TYPE="Static">
+<mets:fptr FILEID="hiyq3"/>
+</mets:div>
+<mets:div ID="d7sk7" LABEL="image 5" ORDER="3" TYPE="Static">
+<mets:fptr FILEID="rt7cu"/>
+</mets:div>
+<mets:div ID="salr4" LABEL="image 6" ORDER="4" TYPE="Static">
+<mets:fptr FILEID="wpdaz"/>
+</mets:div>
+<mets:div ID="pszrm" LABEL="image 7" ORDER="5" TYPE="Static">
+<mets:fptr FILEID="vd770"/>
+</mets:div>
+<mets:div ID="r2yve" LABEL="image 8" ORDER="6" TYPE="Static">
+<mets:fptr FILEID="p5bz8"/>
+</mets:div>
+<mets:div ID="d5fmx" LABEL="image 9" ORDER="7" TYPE="Static">
+<mets:fptr FILEID="a2l99"/>
+</mets:div>
+<mets:div ID="jjbsi" LABEL="image 10" ORDER="8" TYPE="Static">
+<mets:fptr FILEID="i7d75"/>
+</mets:div>
+<mets:div ID="rprva" LABEL="image 11" ORDER="9" TYPE="Static">
+<mets:fptr FILEID="qidbi"/>
+</mets:div>
+<mets:div ID="gibma" LABEL="image 12" ORDER="10" TYPE="Static">
+<mets:fptr FILEID="hu641"/>
+</mets:div>
+<mets:div ID="joc4i" LABEL="image 13" ORDER="11" TYPE="Static">
+<mets:fptr FILEID="ud5zj"/>
+</mets:div>
+<mets:div ID="p6bkt" LABEL="image 14" ORDER="12" TYPE="Static">
+<mets:fptr FILEID="b6ths"/>
+</mets:div>
+<mets:div ID="g5gat" LABEL="image 15" ORDER="13" TYPE="Static">
+<mets:fptr FILEID="vo8he"/>
+</mets:div>
+<mets:div ID="ysmy1" LABEL="image 16" ORDER="14" TYPE="Static">
+<mets:fptr FILEID="qza75"/>
+</mets:div>
+<mets:div ID="ls9wx" LABEL="image 17" ORDER="15" TYPE="Static">
+<mets:fptr FILEID="blhlc"/>
+</mets:div>
+<mets:div ID="samn7" LABEL="image 18" ORDER="16" TYPE="Static">
+<mets:fptr FILEID="ygym9"/>
+</mets:div>
+<mets:div ID="sup9e" LABEL="image 19" ORDER="17" TYPE="Static">
+<mets:fptr FILEID="w4uem"/>
+</mets:div>
+<mets:div ID="h5qm4" LABEL="image 20" ORDER="18" TYPE="Static">
+<mets:fptr FILEID="zrpn3"/>
+</mets:div>
+<mets:div ID="a03no" LABEL="image 21" ORDER="19" TYPE="Static">
+<mets:fptr FILEID="vqvnx"/>
+</mets:div>
+<mets:div ID="qih64" LABEL="image 22" ORDER="20" TYPE="Static">
+<mets:fptr FILEID="twyb2"/>
+</mets:div>
+<mets:div ID="oy55h" LABEL="image 23" ORDER="21" TYPE="Static">
+<mets:fptr FILEID="bhg7z"/>
+</mets:div>
+<mets:div ID="kajg2" LABEL="image 24" ORDER="22" TYPE="Static">
+<mets:fptr FILEID="kq6f4"/>
+</mets:div>
+<mets:div ID="fydom" LABEL="image 25" ORDER="23" TYPE="Static">
+<mets:fptr FILEID="dfcw8"/>
+</mets:div>
+<mets:div ID="hs39m" LABEL="image 26" ORDER="24" TYPE="Static">
+<mets:fptr FILEID="wyggp"/>
+</mets:div>
+<mets:div ID="r03l9" LABEL="image 27" ORDER="25" TYPE="Static">
+<mets:fptr FILEID="a4goe"/>
+</mets:div>
+<mets:div ID="lnbpi" LABEL="image 28" ORDER="26" TYPE="Static">
+<mets:fptr FILEID="php7d"/>
+</mets:div>
+<mets:div ID="huc61" LABEL="image 29" ORDER="27" TYPE="Static">
+<mets:fptr FILEID="mob7q"/>
+</mets:div>
+<mets:div ID="vctz8" LABEL="image 30" ORDER="28" TYPE="Static">
+<mets:fptr FILEID="hesd2"/>
+</mets:div>
+<mets:div ID="m65f4" LABEL="image 31" ORDER="29" TYPE="Static">
+<mets:fptr FILEID="s0rwi"/>
+</mets:div>
+<mets:div ID="f9ca2" LABEL="image 32" ORDER="30" TYPE="Static">
+<mets:fptr FILEID="sgl8m"/>
+</mets:div>
+<mets:div ID="jfvdr" LABEL="image 33" ORDER="31" TYPE="Static">
+<mets:fptr FILEID="fcijz"/>
+</mets:div>
+<mets:div ID="ac8hd" LABEL="image 34" ORDER="32" TYPE="Static">
+<mets:fptr FILEID="ymggl"/>
+</mets:div>
+<mets:div ID="f97b8" LABEL="image 35" ORDER="33" TYPE="Static">
+<mets:fptr FILEID="ngzxk"/>
+</mets:div>
+<mets:div ID="agyko" LABEL="image 36" ORDER="34" TYPE="Static">
+<mets:fptr FILEID="rbxh3"/>
+</mets:div>
+<mets:div ID="yrf6m" LABEL="image 37" ORDER="35" TYPE="Static">
+<mets:fptr FILEID="mgpg5"/>
+</mets:div>
+<mets:div ID="tru3v" LABEL="image 38" ORDER="36" TYPE="Static">
+<mets:fptr FILEID="l2v4a"/>
+</mets:div>
+<mets:div ID="l8zqu" LABEL="image 39" ORDER="37" TYPE="Static">
+<mets:fptr FILEID="ra2jr"/>
+</mets:div>
+<mets:div ID="n5ok4" LABEL="image 40" ORDER="38" TYPE="Static">
+<mets:fptr FILEID="y4aaj"/>
+</mets:div>
+<mets:div ID="mvipx" LABEL="image 41" ORDER="39" TYPE="Static">
+<mets:fptr FILEID="ug9dc"/>
+</mets:div>
+<mets:div ID="s9mpu" LABEL="image 42" ORDER="40" TYPE="Static">
+<mets:fptr FILEID="ex2dy"/>
+</mets:div>
+<mets:div ID="jc4gj" LABEL="image 43" ORDER="41" TYPE="Static">
+<mets:fptr FILEID="ec5az"/>
+</mets:div>
+<mets:div ID="zap7e" LABEL="image 44" ORDER="42" TYPE="Static">
+<mets:fptr FILEID="o52xb"/>
+</mets:div>
+<mets:div ID="m0xha" LABEL="image 45" ORDER="43" TYPE="Static">
+<mets:fptr FILEID="xn55y"/>
+</mets:div>
+<mets:div ID="pojbg" LABEL="image 46" ORDER="44" TYPE="Static">
+<mets:fptr FILEID="i6924"/>
+</mets:div>
+<mets:div ID="wg8e9" LABEL="image 47" ORDER="45" TYPE="Static">
+<mets:fptr FILEID="fe2la"/>
+</mets:div>
+<mets:div ID="mgkb6" LABEL="image 48" ORDER="46" TYPE="Static">
+<mets:fptr FILEID="dk09i"/>
+</mets:div>
+<mets:div ID="bbaow" LABEL="image 49" ORDER="47" TYPE="Static">
+<mets:fptr FILEID="ejo95"/>
+</mets:div>
+<mets:div ID="oeiwc" LABEL="image 50" ORDER="48" TYPE="Static">
+<mets:fptr FILEID="v196l"/>
+</mets:div>
+<mets:div ID="pyg8k" LABEL="image 51" ORDER="49" TYPE="Static">
+<mets:fptr FILEID="l46jl"/>
+</mets:div>
+<mets:div ID="qjjb0" LABEL="image 52" ORDER="50" TYPE="Static">
+<mets:fptr FILEID="x00po"/>
+</mets:div>
+<mets:div ID="tt0vo" LABEL="image 53" ORDER="51" TYPE="Static">
+<mets:fptr FILEID="yg5az"/>
+</mets:div>
+<mets:div ID="hsmme" LABEL="image 54" ORDER="52" TYPE="Static">
+<mets:fptr FILEID="pe1ka"/>
+</mets:div>
+<mets:div ID="p84vn" LABEL="image 55" ORDER="53" TYPE="Static">
+<mets:fptr FILEID="if3y3"/>
+</mets:div>
+<mets:div ID="gq97z" LABEL="image 56" ORDER="54" TYPE="Static">
+<mets:fptr FILEID="b2vy6"/>
+</mets:div>
+<mets:div ID="pbpry" LABEL="image 57" ORDER="55" TYPE="Static">
+<mets:fptr FILEID="fko5d"/>
+</mets:div>
+<mets:div ID="uz9s6" LABEL="image 58" ORDER="56" TYPE="Static">
+<mets:fptr FILEID="l2gru"/>
+</mets:div>
+<mets:div ID="w7y8q" LABEL="image 59" ORDER="57" TYPE="Static">
+<mets:fptr FILEID="rpe0i"/>
+</mets:div>
+<mets:div ID="ypl9w" LABEL="image 60" ORDER="58" TYPE="Static">
+<mets:fptr FILEID="c7hio"/>
+</mets:div>
+<mets:div ID="hjk1a" LABEL="image 61" ORDER="59" TYPE="Static">
+<mets:fptr FILEID="axjgl"/>
+</mets:div>
+<mets:div ID="ouhz6" LABEL="image 62" ORDER="60" TYPE="Static">
+<mets:fptr FILEID="snpyg"/>
+</mets:div>
+<mets:div ID="lb2ur" LABEL="image 63" ORDER="61" TYPE="Static">
+<mets:fptr FILEID="rb9s7"/>
+</mets:div>
+<mets:div ID="v23g6" LABEL="image 64" ORDER="62" TYPE="Static">
+<mets:fptr FILEID="n6xea"/>
+</mets:div>
+<mets:div ID="k9mlx" LABEL="image 65" ORDER="63" TYPE="Static">
+<mets:fptr FILEID="gcy3x"/>
+</mets:div>
+<mets:div ID="lqx52" LABEL="image 66" ORDER="64" TYPE="Static">
+<mets:fptr FILEID="rqbx5"/>
+</mets:div>
+<mets:div ID="nd0v3" LABEL="image 67" ORDER="65" TYPE="Static">
+<mets:fptr FILEID="b0ms9"/>
+</mets:div>
+<mets:div ID="xxqhw" LABEL="image 68" ORDER="66" TYPE="Static">
+<mets:fptr FILEID="mokxy"/>
+</mets:div>
+<mets:div ID="dyzj7" LABEL="image 69" ORDER="67" TYPE="Static">
+<mets:fptr FILEID="xihxy"/>
+</mets:div>
+<mets:div ID="ekn4v" LABEL="image 70" ORDER="68" TYPE="Static">
+<mets:fptr FILEID="pc8zn"/>
+</mets:div>
+<mets:div ID="y3yo3" LABEL="image 71" ORDER="69" TYPE="Static">
+<mets:fptr FILEID="l01my"/>
+</mets:div>
+<mets:div ID="k6qg4" LABEL="image 72" ORDER="70" TYPE="Static">
+<mets:fptr FILEID="a9itj"/>
+</mets:div>
+<mets:div ID="pfmo0" LABEL="image 73" ORDER="71" TYPE="Static">
+<mets:fptr FILEID="pzueq"/>
+</mets:div>
+<mets:div ID="lad3j" LABEL="image 74" ORDER="72" TYPE="Static">
+<mets:fptr FILEID="grlin"/>
+</mets:div>
+<mets:div ID="rr189" LABEL="image 75" ORDER="73" TYPE="Static">
+<mets:fptr FILEID="nod0x"/>
+</mets:div>
+<mets:div ID="pbl7g" LABEL="image 76" ORDER="74" TYPE="Static">
+<mets:fptr FILEID="i6qef"/>
+</mets:div>
+<mets:div ID="nbwet" LABEL="image 77" ORDER="75" TYPE="Static">
+<mets:fptr FILEID="hgw98"/>
+</mets:div>
+<mets:div ID="fab2c" LABEL="image 78" ORDER="76" TYPE="Static">
+<mets:fptr FILEID="jzjq4"/>
+</mets:div>
+<mets:div ID="uwhoa" LABEL="image 79" ORDER="77" TYPE="Static">
+<mets:fptr FILEID="ays1e"/>
+</mets:div>
+<mets:div ID="je4z1" LABEL="image 80" ORDER="78" TYPE="Static">
+<mets:fptr FILEID="oflvx"/>
+</mets:div>
+<mets:div ID="qonge" LABEL="image 81" ORDER="79" TYPE="Static">
+<mets:fptr FILEID="c6cxg"/>
+</mets:div>
+<mets:div ID="uhtqa" LABEL="image 82" ORDER="80" TYPE="Static">
+<mets:fptr FILEID="lwzw0"/>
+</mets:div>
+<mets:div ID="v6bl7" LABEL="image 83" ORDER="81" TYPE="Static">
+<mets:fptr FILEID="hbuz1"/>
+</mets:div>
+<mets:div ID="r7xoq" LABEL="image 84" ORDER="82" TYPE="Static">
+<mets:fptr FILEID="aw0mz"/>
+</mets:div>
+<mets:div ID="ze01v" LABEL="image 85" ORDER="83" TYPE="Static">
+<mets:fptr FILEID="oqjao"/>
+</mets:div>
+<mets:div ID="h1a78" LABEL="image 86" ORDER="84" TYPE="Static">
+<mets:fptr FILEID="s8b2e"/>
+</mets:div>
+<mets:div ID="hego7" LABEL="image 87" ORDER="85" TYPE="Static">
+<mets:fptr FILEID="f229i"/>
+</mets:div>
+<mets:div ID="i784b" LABEL="image 88" ORDER="86" TYPE="Static">
+<mets:fptr FILEID="pqh2y"/>
+</mets:div>
+<mets:div ID="or25w" LABEL="image 89" ORDER="87" TYPE="Static">
+<mets:fptr FILEID="u8yq0"/>
+</mets:div>
+<mets:div ID="imdsf" LABEL="image 90" ORDER="88" TYPE="Static">
+<mets:fptr FILEID="cfjxe"/>
+</mets:div>
+<mets:div ID="fj9g8" LABEL="image 91" ORDER="89" TYPE="Static">
+<mets:fptr FILEID="qgwgu"/>
+</mets:div>
+<mets:div ID="atvwj" LABEL="image 92" ORDER="90" TYPE="Static">
+<mets:fptr FILEID="yneio"/>
+</mets:div>
+<mets:div ID="uficr" LABEL="image 93" ORDER="91" TYPE="Static">
+<mets:fptr FILEID="i7gam"/>
+</mets:div>
+<mets:div ID="pcoys" LABEL="image 94" ORDER="92" TYPE="Static">
+<mets:fptr FILEID="bk0dm"/>
+</mets:div>
+<mets:div ID="nmi3b" LABEL="image 95" ORDER="93" TYPE="Static">
+<mets:fptr FILEID="bkfso"/>
+</mets:div>
+<mets:div ID="ddkhs" LABEL="image 96" ORDER="94" TYPE="Static">
+<mets:fptr FILEID="zb9go"/>
+</mets:div>
+<mets:div ID="h979a" LABEL="image 97" ORDER="95" TYPE="Static">
+<mets:fptr FILEID="wlzwm"/>
+</mets:div>
+<mets:div ID="c3l1k" LABEL="image 98" ORDER="96" TYPE="Static">
+<mets:fptr FILEID="w3ccg"/>
+</mets:div>
+<mets:div ID="lu95m" LABEL="image 99" ORDER="97" TYPE="Static">
+<mets:fptr FILEID="n6kt4"/>
+</mets:div>
+<mets:div ID="sofon" LABEL="image 100" ORDER="98" TYPE="Static">
+<mets:fptr FILEID="dsokl"/>
+</mets:div>
+<mets:div ID="hkqzg" LABEL="image 101" ORDER="99" TYPE="Static">
+<mets:fptr FILEID="wgzsm"/>
+</mets:div>
+<mets:div ID="xhrdb" LABEL="image 102" ORDER="100" TYPE="Static">
+<mets:fptr FILEID="l7zhp"/>
+</mets:div>
+<mets:div ID="nsa3h" LABEL="image 103" ORDER="101" TYPE="Static">
+<mets:fptr FILEID="n5goz"/>
+</mets:div>
+<mets:div ID="q5yfz" LABEL="image 104" ORDER="102" TYPE="Static">
+<mets:fptr FILEID="tem01"/>
+</mets:div>
+<mets:div ID="zzd3u" LABEL="image 105" ORDER="103" TYPE="Static">
+<mets:fptr FILEID="m58ti"/>
+</mets:div>
+<mets:div ID="g3vdj" LABEL="image 106" ORDER="104" TYPE="Static">
+<mets:fptr FILEID="qmewn"/>
+</mets:div>
+<mets:div ID="nry0g" LABEL="image 107" ORDER="105" TYPE="Static">
+<mets:fptr FILEID="ladt3"/>
+</mets:div>
+<mets:div ID="b2a99" LABEL="image 108" ORDER="106" TYPE="Static">
+<mets:fptr FILEID="izjco"/>
+</mets:div>
+<mets:div ID="kstj0" LABEL="image 109" ORDER="107" TYPE="Static">
+<mets:fptr FILEID="gq0i5"/>
+</mets:div>
+<mets:div ID="moh3w" LABEL="image 110" ORDER="108" TYPE="Static">
+<mets:fptr FILEID="bmwhn"/>
+</mets:div>
+<mets:div ID="asq7x" LABEL="image 111" ORDER="109" TYPE="Static">
+<mets:fptr FILEID="pcakz"/>
+</mets:div>
+<mets:div ID="lylpy" LABEL="image 112" ORDER="110" TYPE="Static">
+<mets:fptr FILEID="g6892"/>
+</mets:div>
+<mets:div ID="e4dz3" LABEL="image 113" ORDER="111" TYPE="Static">
+<mets:fptr FILEID="i92zq"/>
+</mets:div>
+<mets:div ID="y4mpk" LABEL="image 114" ORDER="112" TYPE="Static">
+<mets:fptr FILEID="lnoon"/>
+</mets:div>
+<mets:div ID="u8mz4" LABEL="image 115" ORDER="113" TYPE="Static">
+<mets:fptr FILEID="hsmma"/>
+</mets:div>
+<mets:div ID="g4gnm" LABEL="image 116" ORDER="114" TYPE="Static">
+<mets:fptr FILEID="pjgz4"/>
+</mets:div>
+<mets:div ID="slm85" LABEL="image 117" ORDER="115" TYPE="Static">
+<mets:fptr FILEID="ftwjs"/>
+</mets:div>
+<mets:div ID="j5m5y" LABEL="image 118" ORDER="116" TYPE="Static">
+<mets:fptr FILEID="j8o3x"/>
+</mets:div>
+<mets:div ID="e14tr" LABEL="image 119" ORDER="117" TYPE="Static">
+<mets:fptr FILEID="b48bz"/>
+</mets:div>
+<mets:div ID="v2wgg" LABEL="image 120" ORDER="118" TYPE="Static">
+<mets:fptr FILEID="x4ohz"/>
+</mets:div>
+<mets:div ID="lu2k2" LABEL="image 121" ORDER="119" TYPE="Static">
+<mets:fptr FILEID="yppll"/>
+</mets:div>
+<mets:div ID="axhtc" LABEL="image 122" ORDER="120" TYPE="Static">
+<mets:fptr FILEID="alope"/>
+</mets:div>
+<mets:div ID="nwoas" LABEL="image 123" ORDER="121" TYPE="Static">
+<mets:fptr FILEID="f22r2"/>
+</mets:div>
+<mets:div ID="x73qp" LABEL="image 124" ORDER="122" TYPE="Static">
+<mets:fptr FILEID="uor1e"/>
+</mets:div>
+<mets:div ID="u6zn3" LABEL="image 125" ORDER="123" TYPE="Static">
+<mets:fptr FILEID="h8jxm"/>
+</mets:div>
+<mets:div ID="zyybq" LABEL="image 126" ORDER="124" TYPE="Static">
+<mets:fptr FILEID="friyb"/>
+</mets:div>
+<mets:div ID="mobpg" LABEL="image 127" ORDER="125" TYPE="Static">
+<mets:fptr FILEID="absax"/>
+</mets:div>
+<mets:div ID="kaxxc" LABEL="image 128" ORDER="126" TYPE="Static">
+<mets:fptr FILEID="xniio"/>
+</mets:div>
+<mets:div ID="cgfgj" LABEL="image 129" ORDER="127" TYPE="Static">
+<mets:fptr FILEID="nm6ih"/>
+</mets:div>
+<mets:div ID="vsp6u" LABEL="image 130" ORDER="128" TYPE="Static">
+<mets:fptr FILEID="p93ab"/>
+</mets:div>
+<mets:div ID="skaon" LABEL="image 131" ORDER="129" TYPE="Static">
+<mets:fptr FILEID="fm9yz"/>
+</mets:div>
+<mets:div ID="qslz0" LABEL="image 132" ORDER="130" TYPE="Static">
+<mets:fptr FILEID="cqh0n"/>
+</mets:div>
+<mets:div ID="rgj0n" LABEL="image 133" ORDER="131" TYPE="Static">
+<mets:fptr FILEID="jfan1"/>
+</mets:div>
+<mets:div ID="kaemf" LABEL="image 134" ORDER="132" TYPE="Static">
+<mets:fptr FILEID="v7lgq"/>
+</mets:div>
+<mets:div ID="ut23l" LABEL="image 135" ORDER="133" TYPE="Static">
+<mets:fptr FILEID="ro2hf"/>
+</mets:div>
+<mets:div ID="gtfoj" LABEL="image 136" ORDER="134" TYPE="Static">
+<mets:fptr FILEID="dez4h"/>
+</mets:div>
+<mets:div ID="ycidc" LABEL="image 137" ORDER="135" TYPE="Static">
+<mets:fptr FILEID="w88g9"/>
+</mets:div>
+<mets:div ID="sc984" LABEL="image 138" ORDER="136" TYPE="Static">
+<mets:fptr FILEID="n7bt3"/>
+</mets:div>
+<mets:div ID="tcf7s" LABEL="image 139" ORDER="137" TYPE="Static">
+<mets:fptr FILEID="lnphz"/>
+</mets:div>
+<mets:div ID="g2pi7" LABEL="image 140" ORDER="138" TYPE="Static">
+<mets:fptr FILEID="ey5yv"/>
+</mets:div>
+<mets:div ID="fco7t" LABEL="image 141" ORDER="139" TYPE="Static">
+<mets:fptr FILEID="ljqsl"/>
+</mets:div>
+<mets:div ID="ct3o8" LABEL="image 142" ORDER="140" TYPE="Static">
+<mets:fptr FILEID="k139m"/>
+</mets:div>
+<mets:div ID="ger8w" LABEL="image 143" ORDER="141" TYPE="Static">
+<mets:fptr FILEID="x9zut"/>
+</mets:div>
+<mets:div ID="r4nyx" LABEL="image 144" ORDER="142" TYPE="Static">
+<mets:fptr FILEID="mkzs0"/>
+</mets:div>
+<mets:div ID="bilu3" LABEL="image 145" ORDER="143" TYPE="Static">
+<mets:fptr FILEID="tc62e"/>
+</mets:div>
+<mets:div ID="evzc5" LABEL="image 146" ORDER="144" TYPE="Static">
+<mets:fptr FILEID="kwjaa"/>
+</mets:div>
+<mets:div ID="xehvt" LABEL="image 147" ORDER="145" TYPE="Static">
+<mets:fptr FILEID="vzxsf"/>
+</mets:div>
+<mets:div ID="nrl8k" LABEL="image 148" ORDER="146" TYPE="Static">
+<mets:fptr FILEID="tuppq"/>
+</mets:div>
+<mets:div ID="ou9qy" LABEL="image 149" ORDER="147" TYPE="Static">
+<mets:fptr FILEID="ijml2"/>
+</mets:div>
+<mets:div ID="jyofs" LABEL="image 150" ORDER="148" TYPE="Static">
+<mets:fptr FILEID="psbyo"/>
+</mets:div>
+<mets:div ID="zo85l" LABEL="image 151" ORDER="149" TYPE="Static">
+<mets:fptr FILEID="kwy70"/>
+</mets:div>
+<mets:div ID="pzdbs" LABEL="image 152" ORDER="150" TYPE="Static">
+<mets:fptr FILEID="deb4x"/>
+</mets:div>
+<mets:div ID="kbw1n" LABEL="image 153" ORDER="151" TYPE="Static">
+<mets:fptr FILEID="yeed1"/>
+</mets:div>
+<mets:div ID="rwf6c" LABEL="image 154" ORDER="152" TYPE="Static">
+<mets:fptr FILEID="ugzuq"/>
+</mets:div>
+<mets:div ID="w179d" LABEL="image 155" ORDER="153" TYPE="Static">
+<mets:fptr FILEID="mpf98"/>
+</mets:div>
+<mets:div ID="fioyc" LABEL="image 156" ORDER="154" TYPE="Static">
+<mets:fptr FILEID="d3phu"/>
+</mets:div>
+<mets:div ID="mr9pq" LABEL="image 157" ORDER="155" TYPE="Static">
+<mets:fptr FILEID="yy415"/>
+</mets:div>
+<mets:div ID="e3scc" LABEL="image 158" ORDER="156" TYPE="Static">
+<mets:fptr FILEID="z3bhc"/>
+</mets:div>
+<mets:div ID="ikcxe" LABEL="image 159" ORDER="157" TYPE="Static">
+<mets:fptr FILEID="x5pkc"/>
+</mets:div>
+<mets:div ID="ekw7m" LABEL="image 160" ORDER="158" TYPE="Static">
+<mets:fptr FILEID="brz9h"/>
+</mets:div>
+<mets:div ID="jiorb" LABEL="image 161" ORDER="159" TYPE="Static">
+<mets:fptr FILEID="cz2li"/>
+</mets:div>
+<mets:div ID="ac7zz" LABEL="image 162" ORDER="160" TYPE="Static">
+<mets:fptr FILEID="pp6t5"/>
+</mets:div>
+<mets:div ID="fi7th" LABEL="image 163" ORDER="161" TYPE="Static">
+<mets:fptr FILEID="ps2t6"/>
+</mets:div>
+<mets:div ID="blc3g" LABEL="image 164" ORDER="162" TYPE="Static">
+<mets:fptr FILEID="so6ka"/>
+</mets:div>
+<mets:div ID="zj2ky" LABEL="image 165" ORDER="163" TYPE="Static">
+<mets:fptr FILEID="girge"/>
+</mets:div>
+<mets:div ID="x6ot7" LABEL="image 166" ORDER="164" TYPE="Static">
+<mets:fptr FILEID="oct27"/>
+</mets:div>
+<mets:div ID="qaqyd" LABEL="image 167" ORDER="165" TYPE="Static">
+<mets:fptr FILEID="fx8xd"/>
+</mets:div>
+<mets:div ID="lado6" LABEL="image 168" ORDER="166" TYPE="Static">
+<mets:fptr FILEID="oi977"/>
+</mets:div>
+<mets:div ID="ylc68" LABEL="image 169" ORDER="167" TYPE="Static">
+<mets:fptr FILEID="qbqha"/>
+</mets:div>
+<mets:div ID="fkxg5" LABEL="image 170" ORDER="168" TYPE="Static">
+<mets:fptr FILEID="ikysu"/>
+</mets:div>
+<mets:div ID="jq07h" LABEL="image 171" ORDER="169" TYPE="Static">
+<mets:fptr FILEID="gx0h2"/>
+</mets:div>
+<mets:div ID="o8098" LABEL="image 172" ORDER="170" TYPE="Static">
+<mets:fptr FILEID="f9czr"/>
+</mets:div>
+<mets:div ID="hai32" LABEL="image 173" ORDER="171" TYPE="Static">
+<mets:fptr FILEID="d1pb3"/>
+</mets:div>
+<mets:div ID="daol8" LABEL="image 174" ORDER="172" TYPE="Static">
+<mets:fptr FILEID="bidz9"/>
+</mets:div>
+<mets:div ID="krcfp" LABEL="image 175" ORDER="173" TYPE="Static">
+<mets:fptr FILEID="wz4fg"/>
+</mets:div>
+<mets:div ID="ujamu" LABEL="image 176" ORDER="174" TYPE="Static">
+<mets:fptr FILEID="vl32k"/>
+</mets:div>
+<mets:div ID="h8cta" LABEL="image 177" ORDER="175" TYPE="Static">
+<mets:fptr FILEID="nf3yt"/>
+</mets:div>
+<mets:div ID="clz0n" LABEL="image 178" ORDER="176" TYPE="Static">
+<mets:fptr FILEID="cmo6l"/>
+</mets:div>
+<mets:div ID="goxd0" LABEL="image 179" ORDER="177" TYPE="Static">
+<mets:fptr FILEID="hssp1"/>
+</mets:div>
+<mets:div ID="rbqks" LABEL="image 180" ORDER="178" TYPE="Static">
+<mets:fptr FILEID="rzjze"/>
+</mets:div>
+<mets:div ID="f2bsb" LABEL="image 181" ORDER="179" TYPE="Static">
+<mets:fptr FILEID="u6igm"/>
+</mets:div>
+<mets:div ID="r6e92" LABEL="image 182" ORDER="180" TYPE="Static">
+<mets:fptr FILEID="cuo6u"/>
+</mets:div>
+<mets:div ID="uo064" LABEL="image 183" ORDER="181" TYPE="Static">
+<mets:fptr FILEID="ragf6"/>
+</mets:div>
+<mets:div ID="umksi" LABEL="image 184" ORDER="182" TYPE="Static">
+<mets:fptr FILEID="mibsi"/>
+</mets:div>
+<mets:div ID="lzo7j" LABEL="image 185" ORDER="183" TYPE="Static">
+<mets:fptr FILEID="pfda4"/>
+</mets:div>
+<mets:div ID="aep4p" LABEL="image 186" ORDER="184" TYPE="Static">
+<mets:fptr FILEID="uc6y9"/>
+</mets:div>
+<mets:div ID="u7jyi" LABEL="image 187" ORDER="185" TYPE="Static">
+<mets:fptr FILEID="v7kq6"/>
+</mets:div>
+<mets:div ID="vfy9a" LABEL="image 188" ORDER="186" TYPE="Static">
+<mets:fptr FILEID="ol01v"/>
+</mets:div>
+<mets:div ID="i3224" LABEL="image 189" ORDER="187" TYPE="Static">
+<mets:fptr FILEID="ucuj2"/>
+</mets:div>
+<mets:div ID="ygs6u" LABEL="image 190" ORDER="188" TYPE="Static">
+<mets:fptr FILEID="rse38"/>
+</mets:div>
+<mets:div ID="bg26x" LABEL="image 191" ORDER="189" TYPE="Static">
+<mets:fptr FILEID="b4qs6"/>
+</mets:div>
+<mets:div ID="z0r0a" LABEL="image 192" ORDER="190" TYPE="Static">
+<mets:fptr FILEID="kli7f"/>
+</mets:div>
+<mets:div ID="qj0lh" LABEL="image 193" ORDER="191" TYPE="Static">
+<mets:fptr FILEID="iscqr"/>
+</mets:div>
+<mets:div ID="rw99x" LABEL="image 194" ORDER="192" TYPE="Static">
+<mets:fptr FILEID="dpju4"/>
+</mets:div>
+<mets:div ID="odhvc" LABEL="image 195" ORDER="193" TYPE="Static">
+<mets:fptr FILEID="d8fou"/>
+</mets:div>
+<mets:div ID="ad4rp" LABEL="image 196" ORDER="194" TYPE="Static">
+<mets:fptr FILEID="kmobn"/>
+</mets:div>
+<mets:div ID="vkvjk" LABEL="image 197" ORDER="195" TYPE="Static">
+<mets:fptr FILEID="eweae"/>
+</mets:div>
+<mets:div ID="kdukf" LABEL="image 198" ORDER="196" TYPE="Static">
+<mets:fptr FILEID="l7kmv"/>
+</mets:div>
+<mets:div ID="p4mte" LABEL="image 199" ORDER="197" TYPE="Static">
+<mets:fptr FILEID="twypr"/>
+</mets:div>
+<mets:div ID="sd0nv" LABEL="image 200" ORDER="198" TYPE="Static">
+<mets:fptr FILEID="d43ze"/>
+</mets:div>
+<mets:div ID="fcezs" LABEL="image 201" ORDER="199" TYPE="Static">
+<mets:fptr FILEID="ze2y2"/>
+</mets:div>
+<mets:div ID="b844a" LABEL="image 202" ORDER="200" TYPE="Static">
+<mets:fptr FILEID="a7vph"/>
+</mets:div>
+<mets:div ID="vcmpc" LABEL="image 203" ORDER="201" TYPE="Static">
+<mets:fptr FILEID="wq3bv"/>
+</mets:div>
+<mets:div ID="k80on" LABEL="image 204" ORDER="202" TYPE="Static">
+<mets:fptr FILEID="ivfxt"/>
+</mets:div>
+<mets:div ID="yc979" LABEL="image 205" ORDER="203" TYPE="Static">
+<mets:fptr FILEID="nzivf"/>
+</mets:div>
+<mets:div ID="arojp" LABEL="image 206" ORDER="204" TYPE="Static">
+<mets:fptr FILEID="hrywv"/>
+</mets:div>
+<mets:div ID="fy5rv" LABEL="image 207" ORDER="205" TYPE="Static">
+<mets:fptr FILEID="dcg37"/>
+</mets:div>
+<mets:div ID="xzv0y" LABEL="image 208" ORDER="206" TYPE="Static">
+<mets:fptr FILEID="opv56"/>
+</mets:div>
+<mets:div ID="p343h" LABEL="image 209" ORDER="207" TYPE="Static">
+<mets:fptr FILEID="f2e3b"/>
+</mets:div>
+<mets:div ID="sbfg5" LABEL="image 210" ORDER="208" TYPE="Static">
+<mets:fptr FILEID="ilgdr"/>
+</mets:div>
+<mets:div ID="xwkkn" LABEL="image 211" ORDER="209" TYPE="Static">
+<mets:fptr FILEID="hzrin"/>
+</mets:div>
+<mets:div ID="s1hze" LABEL="image 212" ORDER="210" TYPE="Static">
+<mets:fptr FILEID="v0h9w"/>
+</mets:div>
+<mets:div ID="htjha" LABEL="image 213" ORDER="211" TYPE="Static">
+<mets:fptr FILEID="udbcm"/>
+</mets:div>
+<mets:div ID="dpzog" LABEL="image 214" ORDER="212" TYPE="Static">
+<mets:fptr FILEID="xhtpp"/>
+</mets:div>
+<mets:div ID="z0990" LABEL="image 215" ORDER="213" TYPE="Static">
+<mets:fptr FILEID="nuhuc"/>
+</mets:div>
+<mets:div ID="uu08i" LABEL="image 216" ORDER="214" TYPE="Static">
+<mets:fptr FILEID="x6s0g"/>
+</mets:div>
+<mets:div ID="sdu4q" LABEL="image 217" ORDER="215" TYPE="Static">
+<mets:fptr FILEID="eo95l"/>
+</mets:div>
+<mets:div ID="m8i7a" LABEL="image 218" ORDER="216" TYPE="Static">
+<mets:fptr FILEID="z2fw0"/>
+</mets:div>
+<mets:div ID="ihi11" LABEL="image 219" ORDER="217" TYPE="Static">
+<mets:fptr FILEID="ci0as"/>
+</mets:div>
+<mets:div ID="iidm2" LABEL="image 220" ORDER="218" TYPE="Static">
+<mets:fptr FILEID="fr8ty"/>
+</mets:div>
+<mets:div ID="e5oki" LABEL="image 221" ORDER="219" TYPE="Static">
+<mets:fptr FILEID="pqeuy"/>
+</mets:div>
+<mets:div ID="mcksg" LABEL="image 222" ORDER="220" TYPE="Static">
+<mets:fptr FILEID="gb4yk"/>
+</mets:div>
+<mets:div ID="yx3et" LABEL="image 223" ORDER="221" TYPE="Static">
+<mets:fptr FILEID="haasu"/>
+</mets:div>
+<mets:div ID="yx8wx" LABEL="image 224" ORDER="222" TYPE="Static">
+<mets:fptr FILEID="nf4a0"/>
+</mets:div>
+<mets:div ID="sqpnj" LABEL="image 225" ORDER="223" TYPE="Static">
+<mets:fptr FILEID="qp0f6"/>
+</mets:div>
+<mets:div ID="n81kc" LABEL="image 226" ORDER="224" TYPE="Static">
+<mets:fptr FILEID="xvqq1"/>
+</mets:div>
+</mets:div>
+</mets:div>
+</mets:structMap>
+<mets:structMap TYPE="Physical">
+<mets:div DMDID="xvh3r xvh3r" ID="lkvjk" TYPE="BoundVolume">
+<mets:div ID="ryzqr" LABEL="image 1" ORDER="1" TYPE="Static">
+<mets:fptr FILEID="afoc8"/>
+</mets:div>
+<mets:div ID="mahlc" LABEL="image 2" ORDER="2" TYPE="Static">
+<mets:fptr FILEID="o3cu9"/>
+</mets:div>
+<mets:div ID="kurfx" LABEL="image 3" ORDER="3" TYPE="Static">
+<mets:fptr FILEID="mfxyv"/>
+</mets:div>
+<mets:div ID="go6ux" LABEL="image 4" ORDER="4" TYPE="Static">
+<mets:fptr FILEID="hiyq3"/>
+</mets:div>
+<mets:div ID="lbeld" LABEL="image 5" ORDER="5" TYPE="Static">
+<mets:fptr FILEID="rt7cu"/>
+</mets:div>
+<mets:div ID="pdi7c" LABEL="image 6" ORDER="6" TYPE="Static">
+<mets:fptr FILEID="wpdaz"/>
+</mets:div>
+<mets:div ID="myqcb" LABEL="image 7" ORDER="7" TYPE="Static">
+<mets:fptr FILEID="vd770"/>
+</mets:div>
+<mets:div ID="ejrnl" LABEL="image 8" ORDER="8" TYPE="Static">
+<mets:fptr FILEID="p5bz8"/>
+</mets:div>
+<mets:div ID="mtjr9" LABEL="image 9" ORDER="9" TYPE="Static">
+<mets:fptr FILEID="a2l99"/>
+</mets:div>
+<mets:div ID="omcki" LABEL="image 10" ORDER="10" TYPE="Static">
+<mets:fptr FILEID="i7d75"/>
+</mets:div>
+<mets:div ID="e9mzv" LABEL="image 11" ORDER="11" TYPE="Static">
+<mets:fptr FILEID="qidbi"/>
+</mets:div>
+<mets:div ID="tmhgz" LABEL="image 12" ORDER="12" TYPE="Static">
+<mets:fptr FILEID="hu641"/>
+</mets:div>
+<mets:div ID="j57h1" LABEL="image 13" ORDER="13" TYPE="Static">
+<mets:fptr FILEID="ud5zj"/>
+</mets:div>
+<mets:div ID="z0ft3" LABEL="image 14" ORDER="14" TYPE="Static">
+<mets:fptr FILEID="b6ths"/>
+</mets:div>
+<mets:div ID="qbwks" LABEL="image 15" ORDER="15" TYPE="Static">
+<mets:fptr FILEID="vo8he"/>
+</mets:div>
+<mets:div ID="iqs0f" LABEL="image 16" ORDER="16" TYPE="Static">
+<mets:fptr FILEID="qza75"/>
+</mets:div>
+<mets:div ID="ilptr" LABEL="image 17" ORDER="17" TYPE="Static">
+<mets:fptr FILEID="blhlc"/>
+</mets:div>
+<mets:div ID="ftqgk" LABEL="image 18" ORDER="18" TYPE="Static">
+<mets:fptr FILEID="ygym9"/>
+</mets:div>
+<mets:div ID="yovrt" LABEL="image 19" ORDER="19" TYPE="Static">
+<mets:fptr FILEID="w4uem"/>
+</mets:div>
+<mets:div ID="gj7qk" LABEL="image 20" ORDER="20" TYPE="Static">
+<mets:fptr FILEID="zrpn3"/>
+</mets:div>
+<mets:div ID="ql5k3" LABEL="image 21" ORDER="21" TYPE="Static">
+<mets:fptr FILEID="vqvnx"/>
+</mets:div>
+<mets:div ID="vv3e9" LABEL="image 22" ORDER="22" TYPE="Static">
+<mets:fptr FILEID="twyb2"/>
+</mets:div>
+<mets:div ID="fulih" LABEL="image 23" ORDER="23" TYPE="Static">
+<mets:fptr FILEID="bhg7z"/>
+</mets:div>
+<mets:div ID="x5b59" LABEL="image 24" ORDER="24" TYPE="Static">
+<mets:fptr FILEID="kq6f4"/>
+</mets:div>
+<mets:div ID="zfkvb" LABEL="image 25" ORDER="25" TYPE="Static">
+<mets:fptr FILEID="dfcw8"/>
+</mets:div>
+<mets:div ID="t64pn" LABEL="image 26" ORDER="26" TYPE="Static">
+<mets:fptr FILEID="wyggp"/>
+</mets:div>
+<mets:div ID="dskb9" LABEL="image 27" ORDER="27" TYPE="Static">
+<mets:fptr FILEID="a4goe"/>
+</mets:div>
+<mets:div ID="ry3tm" LABEL="image 28" ORDER="28" TYPE="Static">
+<mets:fptr FILEID="php7d"/>
+</mets:div>
+<mets:div ID="mpbtz" LABEL="image 29" ORDER="29" TYPE="Static">
+<mets:fptr FILEID="mob7q"/>
+</mets:div>
+<mets:div ID="eod1s" LABEL="image 30" ORDER="30" TYPE="Static">
+<mets:fptr FILEID="hesd2"/>
+</mets:div>
+<mets:div ID="vl35o" LABEL="image 31" ORDER="31" TYPE="Static">
+<mets:fptr FILEID="s0rwi"/>
+</mets:div>
+<mets:div ID="sf09g" LABEL="image 32" ORDER="32" TYPE="Static">
+<mets:fptr FILEID="sgl8m"/>
+</mets:div>
+<mets:div ID="ro5h2" LABEL="image 33" ORDER="33" TYPE="Static">
+<mets:fptr FILEID="fcijz"/>
+</mets:div>
+<mets:div ID="q91t7" LABEL="image 34" ORDER="34" TYPE="Static">
+<mets:fptr FILEID="ymggl"/>
+</mets:div>
+<mets:div ID="kwg33" LABEL="image 35" ORDER="35" TYPE="Static">
+<mets:fptr FILEID="ngzxk"/>
+</mets:div>
+<mets:div ID="jeeq9" LABEL="image 36" ORDER="36" TYPE="Static">
+<mets:fptr FILEID="rbxh3"/>
+</mets:div>
+<mets:div ID="l8i6c" LABEL="image 37" ORDER="37" TYPE="Static">
+<mets:fptr FILEID="mgpg5"/>
+</mets:div>
+<mets:div ID="i8jkn" LABEL="image 38" ORDER="38" TYPE="Static">
+<mets:fptr FILEID="l2v4a"/>
+</mets:div>
+<mets:div ID="x14eu" LABEL="image 39" ORDER="39" TYPE="Static">
+<mets:fptr FILEID="ra2jr"/>
+</mets:div>
+<mets:div ID="jp1tt" LABEL="image 40" ORDER="40" TYPE="Static">
+<mets:fptr FILEID="y4aaj"/>
+</mets:div>
+<mets:div ID="jdy8j" LABEL="image 41" ORDER="41" TYPE="Static">
+<mets:fptr FILEID="ug9dc"/>
+</mets:div>
+<mets:div ID="r3cy4" LABEL="image 42" ORDER="42" TYPE="Static">
+<mets:fptr FILEID="ex2dy"/>
+</mets:div>
+<mets:div ID="ihxn7" LABEL="image 43" ORDER="43" TYPE="Static">
+<mets:fptr FILEID="ec5az"/>
+</mets:div>
+<mets:div ID="zqyp5" LABEL="image 44" ORDER="44" TYPE="Static">
+<mets:fptr FILEID="o52xb"/>
+</mets:div>
+<mets:div ID="kirol" LABEL="image 45" ORDER="45" TYPE="Static">
+<mets:fptr FILEID="xn55y"/>
+</mets:div>
+<mets:div ID="xpau0" LABEL="image 46" ORDER="46" TYPE="Static">
+<mets:fptr FILEID="i6924"/>
+</mets:div>
+<mets:div ID="sg6gq" LABEL="image 47" ORDER="47" TYPE="Static">
+<mets:fptr FILEID="fe2la"/>
+</mets:div>
+<mets:div ID="u469t" LABEL="image 48" ORDER="48" TYPE="Static">
+<mets:fptr FILEID="dk09i"/>
+</mets:div>
+<mets:div ID="z8sxs" LABEL="image 49" ORDER="49" TYPE="Static">
+<mets:fptr FILEID="ejo95"/>
+</mets:div>
+<mets:div ID="em56w" LABEL="image 50" ORDER="50" TYPE="Static">
+<mets:fptr FILEID="v196l"/>
+</mets:div>
+<mets:div ID="zv4x6" LABEL="image 51" ORDER="51" TYPE="Static">
+<mets:fptr FILEID="l46jl"/>
+</mets:div>
+<mets:div ID="qe912" LABEL="image 52" ORDER="52" TYPE="Static">
+<mets:fptr FILEID="x00po"/>
+</mets:div>
+<mets:div ID="qwf5t" LABEL="image 53" ORDER="53" TYPE="Static">
+<mets:fptr FILEID="yg5az"/>
+</mets:div>
+<mets:div ID="o0fzj" LABEL="image 54" ORDER="54" TYPE="Static">
+<mets:fptr FILEID="pe1ka"/>
+</mets:div>
+<mets:div ID="retgg" LABEL="image 55" ORDER="55" TYPE="Static">
+<mets:fptr FILEID="if3y3"/>
+</mets:div>
+<mets:div ID="f6guv" LABEL="image 56" ORDER="56" TYPE="Static">
+<mets:fptr FILEID="b2vy6"/>
+</mets:div>
+<mets:div ID="ga676" LABEL="image 57" ORDER="57" TYPE="Static">
+<mets:fptr FILEID="fko5d"/>
+</mets:div>
+<mets:div ID="iwuud" LABEL="image 58" ORDER="58" TYPE="Static">
+<mets:fptr FILEID="l2gru"/>
+</mets:div>
+<mets:div ID="x001a" LABEL="image 59" ORDER="59" TYPE="Static">
+<mets:fptr FILEID="rpe0i"/>
+</mets:div>
+<mets:div ID="v7h5t" LABEL="image 60" ORDER="60" TYPE="Static">
+<mets:fptr FILEID="c7hio"/>
+</mets:div>
+<mets:div ID="hmuqs" LABEL="image 61" ORDER="61" TYPE="Static">
+<mets:fptr FILEID="axjgl"/>
+</mets:div>
+<mets:div ID="yz1ou" LABEL="image 62" ORDER="62" TYPE="Static">
+<mets:fptr FILEID="snpyg"/>
+</mets:div>
+<mets:div ID="ots7n" LABEL="image 63" ORDER="63" TYPE="Static">
+<mets:fptr FILEID="rb9s7"/>
+</mets:div>
+<mets:div ID="w0k12" LABEL="image 64" ORDER="64" TYPE="Static">
+<mets:fptr FILEID="n6xea"/>
+</mets:div>
+<mets:div ID="larn4" LABEL="image 65" ORDER="65" TYPE="Static">
+<mets:fptr FILEID="gcy3x"/>
+</mets:div>
+<mets:div ID="hckii" LABEL="image 66" ORDER="66" TYPE="Static">
+<mets:fptr FILEID="rqbx5"/>
+</mets:div>
+<mets:div ID="vpao5" LABEL="image 67" ORDER="67" TYPE="Static">
+<mets:fptr FILEID="b0ms9"/>
+</mets:div>
+<mets:div ID="g73d2" LABEL="image 68" ORDER="68" TYPE="Static">
+<mets:fptr FILEID="mokxy"/>
+</mets:div>
+<mets:div ID="n285i" LABEL="image 69" ORDER="69" TYPE="Static">
+<mets:fptr FILEID="xihxy"/>
+</mets:div>
+<mets:div ID="zka80" LABEL="image 70" ORDER="70" TYPE="Static">
+<mets:fptr FILEID="pc8zn"/>
+</mets:div>
+<mets:div ID="w36ov" LABEL="image 71" ORDER="71" TYPE="Static">
+<mets:fptr FILEID="l01my"/>
+</mets:div>
+<mets:div ID="bbzy9" LABEL="image 72" ORDER="72" TYPE="Static">
+<mets:fptr FILEID="a9itj"/>
+</mets:div>
+<mets:div ID="gl0h8" LABEL="image 73" ORDER="73" TYPE="Static">
+<mets:fptr FILEID="pzueq"/>
+</mets:div>
+<mets:div ID="t118z" LABEL="image 74" ORDER="74" TYPE="Static">
+<mets:fptr FILEID="grlin"/>
+</mets:div>
+<mets:div ID="mudid" LABEL="image 75" ORDER="75" TYPE="Static">
+<mets:fptr FILEID="nod0x"/>
+</mets:div>
+<mets:div ID="kqihs" LABEL="image 76" ORDER="76" TYPE="Static">
+<mets:fptr FILEID="i6qef"/>
+</mets:div>
+<mets:div ID="h5ud2" LABEL="image 77" ORDER="77" TYPE="Static">
+<mets:fptr FILEID="hgw98"/>
+</mets:div>
+<mets:div ID="drxi8" LABEL="image 78" ORDER="78" TYPE="Static">
+<mets:fptr FILEID="jzjq4"/>
+</mets:div>
+<mets:div ID="q0mdm" LABEL="image 79" ORDER="79" TYPE="Static">
+<mets:fptr FILEID="ays1e"/>
+</mets:div>
+<mets:div ID="oapqw" LABEL="image 80" ORDER="80" TYPE="Static">
+<mets:fptr FILEID="oflvx"/>
+</mets:div>
+<mets:div ID="r9jmh" LABEL="image 81" ORDER="81" TYPE="Static">
+<mets:fptr FILEID="c6cxg"/>
+</mets:div>
+<mets:div ID="copsb" LABEL="image 82" ORDER="82" TYPE="Static">
+<mets:fptr FILEID="lwzw0"/>
+</mets:div>
+<mets:div ID="ycn1q" LABEL="image 83" ORDER="83" TYPE="Static">
+<mets:fptr FILEID="hbuz1"/>
+</mets:div>
+<mets:div ID="xi30y" LABEL="image 84" ORDER="84" TYPE="Static">
+<mets:fptr FILEID="aw0mz"/>
+</mets:div>
+<mets:div ID="tjlm5" LABEL="image 85" ORDER="85" TYPE="Static">
+<mets:fptr FILEID="oqjao"/>
+</mets:div>
+<mets:div ID="ejepe" LABEL="image 86" ORDER="86" TYPE="Static">
+<mets:fptr FILEID="s8b2e"/>
+</mets:div>
+<mets:div ID="zmnfi" LABEL="image 87" ORDER="87" TYPE="Static">
+<mets:fptr FILEID="f229i"/>
+</mets:div>
+<mets:div ID="sk0dl" LABEL="image 88" ORDER="88" TYPE="Static">
+<mets:fptr FILEID="pqh2y"/>
+</mets:div>
+<mets:div ID="lcc17" LABEL="image 89" ORDER="89" TYPE="Static">
+<mets:fptr FILEID="u8yq0"/>
+</mets:div>
+<mets:div ID="qhj4n" LABEL="image 90" ORDER="90" TYPE="Static">
+<mets:fptr FILEID="cfjxe"/>
+</mets:div>
+<mets:div ID="nu2ee" LABEL="image 91" ORDER="91" TYPE="Static">
+<mets:fptr FILEID="qgwgu"/>
+</mets:div>
+<mets:div ID="rfsiv" LABEL="image 92" ORDER="92" TYPE="Static">
+<mets:fptr FILEID="yneio"/>
+</mets:div>
+<mets:div ID="rgdgu" LABEL="image 93" ORDER="93" TYPE="Static">
+<mets:fptr FILEID="i7gam"/>
+</mets:div>
+<mets:div ID="jxv7i" LABEL="image 94" ORDER="94" TYPE="Static">
+<mets:fptr FILEID="bk0dm"/>
+</mets:div>
+<mets:div ID="dvt4d" LABEL="image 95" ORDER="95" TYPE="Static">
+<mets:fptr FILEID="bkfso"/>
+</mets:div>
+<mets:div ID="ls4b6" LABEL="image 96" ORDER="96" TYPE="Static">
+<mets:fptr FILEID="zb9go"/>
+</mets:div>
+<mets:div ID="bkvom" LABEL="image 97" ORDER="97" TYPE="Static">
+<mets:fptr FILEID="wlzwm"/>
+</mets:div>
+<mets:div ID="dqqte" LABEL="image 98" ORDER="98" TYPE="Static">
+<mets:fptr FILEID="w3ccg"/>
+</mets:div>
+<mets:div ID="rvcpr" LABEL="image 99" ORDER="99" TYPE="Static">
+<mets:fptr FILEID="n6kt4"/>
+</mets:div>
+<mets:div ID="njqb7" LABEL="image 100" ORDER="100" TYPE="Static">
+<mets:fptr FILEID="dsokl"/>
+</mets:div>
+<mets:div ID="rz3ls" LABEL="image 101" ORDER="101" TYPE="Static">
+<mets:fptr FILEID="wgzsm"/>
+</mets:div>
+<mets:div ID="wzadp" LABEL="image 102" ORDER="102" TYPE="Static">
+<mets:fptr FILEID="l7zhp"/>
+</mets:div>
+<mets:div ID="avxuc" LABEL="image 103" ORDER="103" TYPE="Static">
+<mets:fptr FILEID="n5goz"/>
+</mets:div>
+<mets:div ID="irivv" LABEL="image 104" ORDER="104" TYPE="Static">
+<mets:fptr FILEID="tem01"/>
+</mets:div>
+<mets:div ID="c9zei" LABEL="image 105" ORDER="105" TYPE="Static">
+<mets:fptr FILEID="m58ti"/>
+</mets:div>
+<mets:div ID="yvqsw" LABEL="image 106" ORDER="106" TYPE="Static">
+<mets:fptr FILEID="qmewn"/>
+</mets:div>
+<mets:div ID="wjzns" LABEL="image 107" ORDER="107" TYPE="Static">
+<mets:fptr FILEID="ladt3"/>
+</mets:div>
+<mets:div ID="l6cxa" LABEL="image 108" ORDER="108" TYPE="Static">
+<mets:fptr FILEID="izjco"/>
+</mets:div>
+<mets:div ID="obv9k" LABEL="image 109" ORDER="109" TYPE="Static">
+<mets:fptr FILEID="gq0i5"/>
+</mets:div>
+<mets:div ID="iqa2p" LABEL="image 110" ORDER="110" TYPE="Static">
+<mets:fptr FILEID="bmwhn"/>
+</mets:div>
+<mets:div ID="v0s7o" LABEL="image 111" ORDER="111" TYPE="Static">
+<mets:fptr FILEID="pcakz"/>
+</mets:div>
+<mets:div ID="s0irv" LABEL="image 112" ORDER="112" TYPE="Static">
+<mets:fptr FILEID="g6892"/>
+</mets:div>
+<mets:div ID="hw4gc" LABEL="image 113" ORDER="113" TYPE="Static">
+<mets:fptr FILEID="i92zq"/>
+</mets:div>
+<mets:div ID="pkqts" LABEL="image 114" ORDER="114" TYPE="Static">
+<mets:fptr FILEID="lnoon"/>
+</mets:div>
+<mets:div ID="bvg99" LABEL="image 115" ORDER="115" TYPE="Static">
+<mets:fptr FILEID="hsmma"/>
+</mets:div>
+<mets:div ID="ai49e" LABEL="image 116" ORDER="116" TYPE="Static">
+<mets:fptr FILEID="pjgz4"/>
+</mets:div>
+<mets:div ID="gq2e2" LABEL="image 117" ORDER="117" TYPE="Static">
+<mets:fptr FILEID="ftwjs"/>
+</mets:div>
+<mets:div ID="ywt7d" LABEL="image 118" ORDER="118" TYPE="Static">
+<mets:fptr FILEID="j8o3x"/>
+</mets:div>
+<mets:div ID="h6wo3" LABEL="image 119" ORDER="119" TYPE="Static">
+<mets:fptr FILEID="b48bz"/>
+</mets:div>
+<mets:div ID="ooad1" LABEL="image 120" ORDER="120" TYPE="Static">
+<mets:fptr FILEID="x4ohz"/>
+</mets:div>
+<mets:div ID="ms5pn" LABEL="image 121" ORDER="121" TYPE="Static">
+<mets:fptr FILEID="yppll"/>
+</mets:div>
+<mets:div ID="ttyr0" LABEL="image 122" ORDER="122" TYPE="Static">
+<mets:fptr FILEID="alope"/>
+</mets:div>
+<mets:div ID="sjowt" LABEL="image 123" ORDER="123" TYPE="Static">
+<mets:fptr FILEID="f22r2"/>
+</mets:div>
+<mets:div ID="kgj6h" LABEL="image 124" ORDER="124" TYPE="Static">
+<mets:fptr FILEID="uor1e"/>
+</mets:div>
+<mets:div ID="rb5q8" LABEL="image 125" ORDER="125" TYPE="Static">
+<mets:fptr FILEID="h8jxm"/>
+</mets:div>
+<mets:div ID="qmgsg" LABEL="image 126" ORDER="126" TYPE="Static">
+<mets:fptr FILEID="friyb"/>
+</mets:div>
+<mets:div ID="xdpbk" LABEL="image 127" ORDER="127" TYPE="Static">
+<mets:fptr FILEID="absax"/>
+</mets:div>
+<mets:div ID="c1m8s" LABEL="image 128" ORDER="128" TYPE="Static">
+<mets:fptr FILEID="xniio"/>
+</mets:div>
+<mets:div ID="uxrf6" LABEL="image 129" ORDER="129" TYPE="Static">
+<mets:fptr FILEID="nm6ih"/>
+</mets:div>
+<mets:div ID="f87xm" LABEL="image 130" ORDER="130" TYPE="Static">
+<mets:fptr FILEID="p93ab"/>
+</mets:div>
+<mets:div ID="ko6ce" LABEL="image 131" ORDER="131" TYPE="Static">
+<mets:fptr FILEID="fm9yz"/>
+</mets:div>
+<mets:div ID="xha4t" LABEL="image 132" ORDER="132" TYPE="Static">
+<mets:fptr FILEID="cqh0n"/>
+</mets:div>
+<mets:div ID="pmzei" LABEL="image 133" ORDER="133" TYPE="Static">
+<mets:fptr FILEID="jfan1"/>
+</mets:div>
+<mets:div ID="ma0wh" LABEL="image 134" ORDER="134" TYPE="Static">
+<mets:fptr FILEID="v7lgq"/>
+</mets:div>
+<mets:div ID="a5h7i" LABEL="image 135" ORDER="135" TYPE="Static">
+<mets:fptr FILEID="ro2hf"/>
+</mets:div>
+<mets:div ID="tns7q" LABEL="image 136" ORDER="136" TYPE="Static">
+<mets:fptr FILEID="dez4h"/>
+</mets:div>
+<mets:div ID="hqo6o" LABEL="image 137" ORDER="137" TYPE="Static">
+<mets:fptr FILEID="w88g9"/>
+</mets:div>
+<mets:div ID="clj6q" LABEL="image 138" ORDER="138" TYPE="Static">
+<mets:fptr FILEID="n7bt3"/>
+</mets:div>
+<mets:div ID="wx1id" LABEL="image 139" ORDER="139" TYPE="Static">
+<mets:fptr FILEID="lnphz"/>
+</mets:div>
+<mets:div ID="l9l9d" LABEL="image 140" ORDER="140" TYPE="Static">
+<mets:fptr FILEID="ey5yv"/>
+</mets:div>
+<mets:div ID="coqai" LABEL="image 141" ORDER="141" TYPE="Static">
+<mets:fptr FILEID="ljqsl"/>
+</mets:div>
+<mets:div ID="l2dpi" LABEL="image 142" ORDER="142" TYPE="Static">
+<mets:fptr FILEID="k139m"/>
+</mets:div>
+<mets:div ID="destk" LABEL="image 143" ORDER="143" TYPE="Static">
+<mets:fptr FILEID="x9zut"/>
+</mets:div>
+<mets:div ID="virga" LABEL="image 144" ORDER="144" TYPE="Static">
+<mets:fptr FILEID="mkzs0"/>
+</mets:div>
+<mets:div ID="bk0er" LABEL="image 145" ORDER="145" TYPE="Static">
+<mets:fptr FILEID="tc62e"/>
+</mets:div>
+<mets:div ID="s50ag" LABEL="image 146" ORDER="146" TYPE="Static">
+<mets:fptr FILEID="kwjaa"/>
+</mets:div>
+<mets:div ID="ucckd" LABEL="image 147" ORDER="147" TYPE="Static">
+<mets:fptr FILEID="vzxsf"/>
+</mets:div>
+<mets:div ID="wb4nn" LABEL="image 148" ORDER="148" TYPE="Static">
+<mets:fptr FILEID="tuppq"/>
+</mets:div>
+<mets:div ID="gljul" LABEL="image 149" ORDER="149" TYPE="Static">
+<mets:fptr FILEID="ijml2"/>
+</mets:div>
+<mets:div ID="l3zhy" LABEL="image 150" ORDER="150" TYPE="Static">
+<mets:fptr FILEID="psbyo"/>
+</mets:div>
+<mets:div ID="ovgib" LABEL="image 151" ORDER="151" TYPE="Static">
+<mets:fptr FILEID="kwy70"/>
+</mets:div>
+<mets:div ID="z5qav" LABEL="image 152" ORDER="152" TYPE="Static">
+<mets:fptr FILEID="deb4x"/>
+</mets:div>
+<mets:div ID="aj3z4" LABEL="image 153" ORDER="153" TYPE="Static">
+<mets:fptr FILEID="yeed1"/>
+</mets:div>
+<mets:div ID="hvze1" LABEL="image 154" ORDER="154" TYPE="Static">
+<mets:fptr FILEID="ugzuq"/>
+</mets:div>
+<mets:div ID="dw0xc" LABEL="image 155" ORDER="155" TYPE="Static">
+<mets:fptr FILEID="mpf98"/>
+</mets:div>
+<mets:div ID="u6zbi" LABEL="image 156" ORDER="156" TYPE="Static">
+<mets:fptr FILEID="d3phu"/>
+</mets:div>
+<mets:div ID="pgps0" LABEL="image 157" ORDER="157" TYPE="Static">
+<mets:fptr FILEID="yy415"/>
+</mets:div>
+<mets:div ID="wqnxs" LABEL="image 158" ORDER="158" TYPE="Static">
+<mets:fptr FILEID="z3bhc"/>
+</mets:div>
+<mets:div ID="txp9u" LABEL="image 159" ORDER="159" TYPE="Static">
+<mets:fptr FILEID="x5pkc"/>
+</mets:div>
+<mets:div ID="xpkv5" LABEL="image 160" ORDER="160" TYPE="Static">
+<mets:fptr FILEID="brz9h"/>
+</mets:div>
+<mets:div ID="qhceq" LABEL="image 161" ORDER="161" TYPE="Static">
+<mets:fptr FILEID="cz2li"/>
+</mets:div>
+<mets:div ID="rhsju" LABEL="image 162" ORDER="162" TYPE="Static">
+<mets:fptr FILEID="pp6t5"/>
+</mets:div>
+<mets:div ID="gd8jy" LABEL="image 163" ORDER="163" TYPE="Static">
+<mets:fptr FILEID="ps2t6"/>
+</mets:div>
+<mets:div ID="tls3o" LABEL="image 164" ORDER="164" TYPE="Static">
+<mets:fptr FILEID="so6ka"/>
+</mets:div>
+<mets:div ID="pq5ov" LABEL="image 165" ORDER="165" TYPE="Static">
+<mets:fptr FILEID="girge"/>
+</mets:div>
+<mets:div ID="txsu8" LABEL="image 166" ORDER="166" TYPE="Static">
+<mets:fptr FILEID="oct27"/>
+</mets:div>
+<mets:div ID="a9xrx" LABEL="image 167" ORDER="167" TYPE="Static">
+<mets:fptr FILEID="fx8xd"/>
+</mets:div>
+<mets:div ID="cmmib" LABEL="image 168" ORDER="168" TYPE="Static">
+<mets:fptr FILEID="oi977"/>
+</mets:div>
+<mets:div ID="a4jqm" LABEL="image 169" ORDER="169" TYPE="Static">
+<mets:fptr FILEID="qbqha"/>
+</mets:div>
+<mets:div ID="zgtze" LABEL="image 170" ORDER="170" TYPE="Static">
+<mets:fptr FILEID="ikysu"/>
+</mets:div>
+<mets:div ID="oo53b" LABEL="image 171" ORDER="171" TYPE="Static">
+<mets:fptr FILEID="gx0h2"/>
+</mets:div>
+<mets:div ID="qkt1b" LABEL="image 172" ORDER="172" TYPE="Static">
+<mets:fptr FILEID="f9czr"/>
+</mets:div>
+<mets:div ID="mcsa1" LABEL="image 173" ORDER="173" TYPE="Static">
+<mets:fptr FILEID="d1pb3"/>
+</mets:div>
+<mets:div ID="o20ib" LABEL="image 174" ORDER="174" TYPE="Static">
+<mets:fptr FILEID="bidz9"/>
+</mets:div>
+<mets:div ID="jwl7u" LABEL="image 175" ORDER="175" TYPE="Static">
+<mets:fptr FILEID="wz4fg"/>
+</mets:div>
+<mets:div ID="sg2mx" LABEL="image 176" ORDER="176" TYPE="Static">
+<mets:fptr FILEID="vl32k"/>
+</mets:div>
+<mets:div ID="yiztw" LABEL="image 177" ORDER="177" TYPE="Static">
+<mets:fptr FILEID="nf3yt"/>
+</mets:div>
+<mets:div ID="qzoer" LABEL="image 178" ORDER="178" TYPE="Static">
+<mets:fptr FILEID="cmo6l"/>
+</mets:div>
+<mets:div ID="luyp4" LABEL="image 179" ORDER="179" TYPE="Static">
+<mets:fptr FILEID="hssp1"/>
+</mets:div>
+<mets:div ID="xchlg" LABEL="image 180" ORDER="180" TYPE="Static">
+<mets:fptr FILEID="rzjze"/>
+</mets:div>
+<mets:div ID="zgnwi" LABEL="image 181" ORDER="181" TYPE="Static">
+<mets:fptr FILEID="u6igm"/>
+</mets:div>
+<mets:div ID="k7unc" LABEL="image 182" ORDER="182" TYPE="Static">
+<mets:fptr FILEID="cuo6u"/>
+</mets:div>
+<mets:div ID="toe92" LABEL="image 183" ORDER="183" TYPE="Static">
+<mets:fptr FILEID="ragf6"/>
+</mets:div>
+<mets:div ID="i6ohp" LABEL="image 184" ORDER="184" TYPE="Static">
+<mets:fptr FILEID="mibsi"/>
+</mets:div>
+<mets:div ID="gsoqg" LABEL="image 185" ORDER="185" TYPE="Static">
+<mets:fptr FILEID="pfda4"/>
+</mets:div>
+<mets:div ID="vvumd" LABEL="image 186" ORDER="186" TYPE="Static">
+<mets:fptr FILEID="uc6y9"/>
+</mets:div>
+<mets:div ID="v2cbz" LABEL="image 187" ORDER="187" TYPE="Static">
+<mets:fptr FILEID="v7kq6"/>
+</mets:div>
+<mets:div ID="rmbrg" LABEL="image 188" ORDER="188" TYPE="Static">
+<mets:fptr FILEID="ol01v"/>
+</mets:div>
+<mets:div ID="plh3n" LABEL="image 189" ORDER="189" TYPE="Static">
+<mets:fptr FILEID="ucuj2"/>
+</mets:div>
+<mets:div ID="r8jwb" LABEL="image 190" ORDER="190" TYPE="Static">
+<mets:fptr FILEID="rse38"/>
+</mets:div>
+<mets:div ID="catx0" LABEL="image 191" ORDER="191" TYPE="Static">
+<mets:fptr FILEID="b4qs6"/>
+</mets:div>
+<mets:div ID="inwxw" LABEL="image 192" ORDER="192" TYPE="Static">
+<mets:fptr FILEID="kli7f"/>
+</mets:div>
+<mets:div ID="b6yfl" LABEL="image 193" ORDER="193" TYPE="Static">
+<mets:fptr FILEID="iscqr"/>
+</mets:div>
+<mets:div ID="deorz" LABEL="image 194" ORDER="194" TYPE="Static">
+<mets:fptr FILEID="dpju4"/>
+</mets:div>
+<mets:div ID="wpagm" LABEL="image 195" ORDER="195" TYPE="Static">
+<mets:fptr FILEID="d8fou"/>
+</mets:div>
+<mets:div ID="n1g67" LABEL="image 196" ORDER="196" TYPE="Static">
+<mets:fptr FILEID="kmobn"/>
+</mets:div>
+<mets:div ID="j5ks9" LABEL="image 197" ORDER="197" TYPE="Static">
+<mets:fptr FILEID="eweae"/>
+</mets:div>
+<mets:div ID="e1qi6" LABEL="image 198" ORDER="198" TYPE="Static">
+<mets:fptr FILEID="l7kmv"/>
+</mets:div>
+<mets:div ID="z76vp" LABEL="image 199" ORDER="199" TYPE="Static">
+<mets:fptr FILEID="twypr"/>
+</mets:div>
+<mets:div ID="fglxo" LABEL="image 200" ORDER="200" TYPE="Static">
+<mets:fptr FILEID="d43ze"/>
+</mets:div>
+<mets:div ID="m64ed" LABEL="image 201" ORDER="201" TYPE="Static">
+<mets:fptr FILEID="ze2y2"/>
+</mets:div>
+<mets:div ID="jvvrb" LABEL="image 202" ORDER="202" TYPE="Static">
+<mets:fptr FILEID="a7vph"/>
+</mets:div>
+<mets:div ID="ykybj" LABEL="image 203" ORDER="203" TYPE="Static">
+<mets:fptr FILEID="wq3bv"/>
+</mets:div>
+<mets:div ID="pzv9l" LABEL="image 204" ORDER="204" TYPE="Static">
+<mets:fptr FILEID="ivfxt"/>
+</mets:div>
+<mets:div ID="h0op1" LABEL="image 205" ORDER="205" TYPE="Static">
+<mets:fptr FILEID="nzivf"/>
+</mets:div>
+<mets:div ID="tkhvf" LABEL="image 206" ORDER="206" TYPE="Static">
+<mets:fptr FILEID="hrywv"/>
+</mets:div>
+<mets:div ID="e602m" LABEL="image 207" ORDER="207" TYPE="Static">
+<mets:fptr FILEID="dcg37"/>
+</mets:div>
+<mets:div ID="ze5xw" LABEL="image 208" ORDER="208" TYPE="Static">
+<mets:fptr FILEID="opv56"/>
+</mets:div>
+<mets:div ID="dyylq" LABEL="image 209" ORDER="209" TYPE="Static">
+<mets:fptr FILEID="f2e3b"/>
+</mets:div>
+<mets:div ID="pjhqb" LABEL="image 210" ORDER="210" TYPE="Static">
+<mets:fptr FILEID="ilgdr"/>
+</mets:div>
+<mets:div ID="nu96q" LABEL="image 211" ORDER="211" TYPE="Static">
+<mets:fptr FILEID="hzrin"/>
+</mets:div>
+<mets:div ID="lm9lo" LABEL="image 212" ORDER="212" TYPE="Static">
+<mets:fptr FILEID="v0h9w"/>
+</mets:div>
+<mets:div ID="nzqu0" LABEL="image 213" ORDER="213" TYPE="Static">
+<mets:fptr FILEID="udbcm"/>
+</mets:div>
+<mets:div ID="mu0e7" LABEL="image 214" ORDER="214" TYPE="Static">
+<mets:fptr FILEID="xhtpp"/>
+</mets:div>
+<mets:div ID="p5fb0" LABEL="image 215" ORDER="215" TYPE="Static">
+<mets:fptr FILEID="nuhuc"/>
+</mets:div>
+<mets:div ID="sh0p9" LABEL="image 216" ORDER="216" TYPE="Static">
+<mets:fptr FILEID="x6s0g"/>
+</mets:div>
+<mets:div ID="ywqn2" LABEL="image 217" ORDER="217" TYPE="Static">
+<mets:fptr FILEID="eo95l"/>
+</mets:div>
+<mets:div ID="jy7nc" LABEL="image 218" ORDER="218" TYPE="Static">
+<mets:fptr FILEID="z2fw0"/>
+</mets:div>
+<mets:div ID="ckn90" LABEL="image 219" ORDER="219" TYPE="Static">
+<mets:fptr FILEID="ci0as"/>
+</mets:div>
+<mets:div ID="hgs49" LABEL="image 220" ORDER="220" TYPE="Static">
+<mets:fptr FILEID="fr8ty"/>
+</mets:div>
+<mets:div ID="anu6w" LABEL="image 221" ORDER="221" TYPE="Static">
+<mets:fptr FILEID="pqeuy"/>
+</mets:div>
+<mets:div ID="cy3wj" LABEL="image 222" ORDER="222" TYPE="Static">
+<mets:fptr FILEID="gb4yk"/>
+</mets:div>
+<mets:div ID="mh4wj" LABEL="image 223" ORDER="223" TYPE="Static">
+<mets:fptr FILEID="haasu"/>
+</mets:div>
+<mets:div ID="qvcx9" LABEL="image 224" ORDER="224" TYPE="Static">
+<mets:fptr FILEID="nf4a0"/>
+</mets:div>
+<mets:div ID="cd1f3" LABEL="image 225" ORDER="225" TYPE="Static">
+<mets:fptr FILEID="qp0f6"/>
+</mets:div>
+<mets:div ID="zq3dx" LABEL="image 226" ORDER="226" TYPE="Static">
+<mets:fptr FILEID="xvqq1"/>
+</mets:div>
+</mets:div>
+</mets:structMap>
+</mets:mets>

--- a/spec/fixtures/mets/tsop_typed_mvw_no_files.mets
+++ b/spec/fixtures/mets/tsop_typed_mvw_no_files.mets
@@ -1,0 +1,840 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" OBJID="ark:/88435/jw827c96v" TYPE="CompiledDigitalObject" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd">
+<mets:metsHdr CREATEDATE="2018-08-04T11:56:26.015-04:00" LASTMODDATE="2018-08-04T11:56:26.015-04:00">
+<mets:metsDocumentID TYPE="PUDL">pudl0044/831958/tsop_typed.mets</mets:metsDocumentID>
+</mets:metsHdr>
+<mets:dmdSec ID="xvh3r">
+<mets:mdWrap MDTYPE="MODS">
+<mets:xmlData>
+<mods xmlns="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods//v3/mods-3-3.xsd">
+
+   <titleInfo>
+
+      <title>This side of paradise</title>
+
+   </titleInfo>
+   <name authority="naf" type="personal">
+
+      <namePart type="family">Fitzgerald</namePart>
+      <namePart type="given">F. Scott (Francis Scott)</namePart>
+      <namePart type="date">1896-1940</namePart>
+      <role>
+         <roleTerm authority="marcrelator" type="code">aut</roleTerm>
+      </role>
+   </name>
+   <typeOfResource manuscript="yes">text</typeOfResource>
+   <originInfo>
+      <dateCreated encoding="w3cdtf" keyDate="yes">1918</dateCreated>
+
+   </originInfo>
+   <language>
+      <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+   </language>
+   <physicalDescription>
+      <extent>224 typescript pages</extent>
+   </physicalDescription>
+   <abstract>F. Scott Fitzgerald, This Side of Paradise, autograph manuscripts and corrected typescripts (1917-1919). Fitzgerald began writing This Side of Paradise at Princeton, continued in November 1917 at Fort Leavenworth, Kansas, with the working title "The Romantic Egoist," and completed a first draft of the novel at Cottage Club in March 1918. After this draft had been twice rejected by the New York publisher Charles Scribner's Sons, Fitzgerald returned to his parents' home at 599 Summit Avenue in his native St. Paul, Minnesota, and added five new chapters to the four he had written the previous year. He changed the second title of the novel from "The Education of a Personage" to "This Side of Paradise" and sent the novel to Maxwell Perkins at Scribner's. The publisher accepted the novel on September 16, 1919, and published it on March 26, 1920. The author's corrected galleys and page proofs do not survive.
+
+      F. Scott Fitzgerald, "The Romantic Egotist," chapters 1, 2, 5, 12, and 14. Fitzgerald corrected the five chapters in this early typescript version and sent them to Charles W. Donahoe in October 1918. Donahoe donated the typescript to Princeton in 1948. .</abstract>
+   <note>Typed manuscript</note>
+   <subject authority="lcsh">
+      <name authority="naf" type="personal">
+         <namePart type="family">Fitzgerald</namePart>
+         <namePart type="given">F. Scott (Francis Scott)</namePart>
+         <namePart type="date">1896-1940</namePart>
+      </name>
+      <genre>Manuscripts</genre>
+   </subject>
+   <relatedItem type="host">
+      <typeOfResource collection="yes">text</typeOfResource>
+      <titleInfo>
+         <title>F. Scott Fitzgerald papers, 1897-1944</title>
+      </titleInfo>
+      <!--<location>
+         <url note="Digital Collection">http://pudl.princeton.edu/collections/pudl0044</url>
+      </location>-->
+   </relatedItem>
+   <location>
+      <physicalLocation type="text">Princeton University Library. Department of Rare Books and Special Collections</physicalLocation>
+      <physicalLocation authority="marcorg" type="code">NjP</physicalLocation>
+      <holdingSimple>
+         <copyInformation>
+            <subLocation>mss</subLocation>
+            <shelfLocator>C0187</shelfLocator>
+         </copyInformation>
+      </holdingSimple>
+   </location>
+   <accessCondition type="useAndReproduction">Not to be published, reproduced, or broadcast without the written permission of the Princeton University Library.  Selected items in the F. Scott Fitzgerald Papers can
+      be photoduplicated at the expense of the researcher requesting photoduplication. Advanced
+      estimates and payment are required. For general information on photoduplication and
+      permissions, go to http://www.princeton.edu/~rbsc Requests to to reproduce, publish, or
+      broadcast material from the F. Scott Fitzgerald Papers should be addressed Public Services
+      staff, rbsc@princeton.edu The correct form of citation includes the name of the collection,
+      box and folder numbers, and an indication that the originals are in the "Manuscripts Division,
+      Department of Rare Books and Special Collections, Princeton University Library." The
+      manuscript of The Great Gatsby and other writings of F. Scott Fitzgerald are not to be quoted,
+      published, reproduced, or broadcast without the written permission of the Princeton University
+      Library as owner of the physical object, and of the Fitzgerald Literary Trust (copyright
+      holder), c/o Harold Ober Associates, 425 Madison Avenue, New York, New York 10017 (Telephone:
+      212-759-8600; FAX: 212-759-9428). The Library is not responsible for copyright infringement or
+      other legal problems resulting from unauthorized publication of the words of F. Scott
+      Fitzgerald.</accessCondition>
+   <accessCondition type="restrictionOnAccess">For legal and conservation reasons, access to F.
+      Scott Fitzgerald’s original manuscripts (including corrected galleys and scrapbooks) is
+      strictly restricted. Scottie Fitzgerald Lanahan, daughter of F. Scott Fitzgerald and Zelda
+      Fitzgerald, donated the Fitzgerald Papers to the Princeton University Library in 1950,
+      stipulating that surrogates of the original manuscripts were to be made available to
+      researchers instead of the originals. This was done to preserve the originals, which are not
+      on good paper. Originally, the surrogates were in the form of microfilm. Facsimiles editions of This Side of Paradise and
+      other manuscripts of books and short
+      stories followed a multi-volume series: F. Scott Fitzgerald Manuscripts, edited by Matthew J.
+      Bruccoli and Alan Margolies (New York: Garland Publishing Company, 1990). Complete sets of the
+      facsimile edition are available at more than 50 research libraries (including Firestone
+      Library). </accessCondition>
+
+
+   <recordInfo>
+      <recordContentSource authority="marcorg">NjP</recordContentSource>
+     <!-- <recordOrigin>http://catalog.princeton.edu/cgi-bin/Pwebrecon.cgi?BBID=</recordOrigin>-->
+      <recordIdentifier>http://diglib.princeton.edu/mdata/pudl0044/831958/tsop_typed.mods</recordIdentifier>
+      <languageOfCataloging>
+         <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+      </languageOfCataloging>
+   </recordInfo>
+</mods>
+</mets:xmlData>
+</mets:mdWrap>
+</mets:dmdSec>
+<mets:fileSec>
+<mets:fileGrp USE="thumbnail">
+<mets:file ID="d962c" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000001.tif"/>
+</mets:file>
+</mets:fileGrp>
+<mets:fileGrp USE="masters">
+</mets:fileGrp>
+</mets:fileSec>
+<mets:structMap TYPE="RelatedObjects">
+  <mets:div DMDID="xvh3r xvh3r" ID="vxm2n" LABEL="Default">
+<mets:div CONTENTIDS="pudl0044" TYPE="IsPartOf"/>
+<mets:div ID="aggregates" TYPE="OrderedList">
+<mets:div ID="q4udb" LABEL="image 1" ORDER="225" TYPE="Static">
+<mets:fptr FILEID="afoc8"/>
+</mets:div>
+<mets:div ID="qmu2r" LABEL="image 2" ORDER="226" TYPE="Static">
+<mets:fptr FILEID="o3cu9"/>
+</mets:div>
+<mets:div ID="xxq9z" LABEL="image 3" ORDER="1" TYPE="Static">
+<mets:fptr FILEID="mfxyv"/>
+</mets:div>
+<mets:div ID="a14tx" LABEL="image 4" ORDER="2" TYPE="Static">
+<mets:fptr FILEID="hiyq3"/>
+</mets:div>
+<mets:div ID="d7sk7" LABEL="image 5" ORDER="3" TYPE="Static">
+<mets:fptr FILEID="rt7cu"/>
+</mets:div>
+<mets:div ID="salr4" LABEL="image 6" ORDER="4" TYPE="Static">
+<mets:fptr FILEID="wpdaz"/>
+</mets:div>
+<mets:div ID="pszrm" LABEL="image 7" ORDER="5" TYPE="Static">
+<mets:fptr FILEID="vd770"/>
+</mets:div>
+<mets:div ID="r2yve" LABEL="image 8" ORDER="6" TYPE="Static">
+<mets:fptr FILEID="p5bz8"/>
+</mets:div>
+<mets:div ID="d5fmx" LABEL="image 9" ORDER="7" TYPE="Static">
+<mets:fptr FILEID="a2l99"/>
+</mets:div>
+<mets:div ID="jjbsi" LABEL="image 10" ORDER="8" TYPE="Static">
+<mets:fptr FILEID="i7d75"/>
+</mets:div>
+<mets:div ID="rprva" LABEL="image 11" ORDER="9" TYPE="Static">
+<mets:fptr FILEID="qidbi"/>
+</mets:div>
+<mets:div ID="gibma" LABEL="image 12" ORDER="10" TYPE="Static">
+<mets:fptr FILEID="hu641"/>
+</mets:div>
+<mets:div ID="joc4i" LABEL="image 13" ORDER="11" TYPE="Static">
+<mets:fptr FILEID="ud5zj"/>
+</mets:div>
+<mets:div ID="p6bkt" LABEL="image 14" ORDER="12" TYPE="Static">
+<mets:fptr FILEID="b6ths"/>
+</mets:div>
+<mets:div ID="g5gat" LABEL="image 15" ORDER="13" TYPE="Static">
+<mets:fptr FILEID="vo8he"/>
+</mets:div>
+<mets:div ID="ysmy1" LABEL="image 16" ORDER="14" TYPE="Static">
+<mets:fptr FILEID="qza75"/>
+</mets:div>
+<mets:div ID="ls9wx" LABEL="image 17" ORDER="15" TYPE="Static">
+<mets:fptr FILEID="blhlc"/>
+</mets:div>
+<mets:div ID="samn7" LABEL="image 18" ORDER="16" TYPE="Static">
+<mets:fptr FILEID="ygym9"/>
+</mets:div>
+<mets:div ID="sup9e" LABEL="image 19" ORDER="17" TYPE="Static">
+<mets:fptr FILEID="w4uem"/>
+</mets:div>
+<mets:div ID="h5qm4" LABEL="image 20" ORDER="18" TYPE="Static">
+<mets:fptr FILEID="zrpn3"/>
+</mets:div>
+<mets:div ID="a03no" LABEL="image 21" ORDER="19" TYPE="Static">
+<mets:fptr FILEID="vqvnx"/>
+</mets:div>
+<mets:div ID="qih64" LABEL="image 22" ORDER="20" TYPE="Static">
+<mets:fptr FILEID="twyb2"/>
+</mets:div>
+<mets:div ID="oy55h" LABEL="image 23" ORDER="21" TYPE="Static">
+<mets:fptr FILEID="bhg7z"/>
+</mets:div>
+<mets:div ID="kajg2" LABEL="image 24" ORDER="22" TYPE="Static">
+<mets:fptr FILEID="kq6f4"/>
+</mets:div>
+<mets:div ID="fydom" LABEL="image 25" ORDER="23" TYPE="Static">
+<mets:fptr FILEID="dfcw8"/>
+</mets:div>
+<mets:div ID="hs39m" LABEL="image 26" ORDER="24" TYPE="Static">
+<mets:fptr FILEID="wyggp"/>
+</mets:div>
+<mets:div ID="r03l9" LABEL="image 27" ORDER="25" TYPE="Static">
+<mets:fptr FILEID="a4goe"/>
+</mets:div>
+<mets:div ID="lnbpi" LABEL="image 28" ORDER="26" TYPE="Static">
+<mets:fptr FILEID="php7d"/>
+</mets:div>
+<mets:div ID="huc61" LABEL="image 29" ORDER="27" TYPE="Static">
+<mets:fptr FILEID="mob7q"/>
+</mets:div>
+<mets:div ID="vctz8" LABEL="image 30" ORDER="28" TYPE="Static">
+<mets:fptr FILEID="hesd2"/>
+</mets:div>
+<mets:div ID="m65f4" LABEL="image 31" ORDER="29" TYPE="Static">
+<mets:fptr FILEID="s0rwi"/>
+</mets:div>
+<mets:div ID="f9ca2" LABEL="image 32" ORDER="30" TYPE="Static">
+<mets:fptr FILEID="sgl8m"/>
+</mets:div>
+<mets:div ID="jfvdr" LABEL="image 33" ORDER="31" TYPE="Static">
+<mets:fptr FILEID="fcijz"/>
+</mets:div>
+<mets:div ID="ac8hd" LABEL="image 34" ORDER="32" TYPE="Static">
+<mets:fptr FILEID="ymggl"/>
+</mets:div>
+<mets:div ID="f97b8" LABEL="image 35" ORDER="33" TYPE="Static">
+<mets:fptr FILEID="ngzxk"/>
+</mets:div>
+<mets:div ID="agyko" LABEL="image 36" ORDER="34" TYPE="Static">
+<mets:fptr FILEID="rbxh3"/>
+</mets:div>
+<mets:div ID="yrf6m" LABEL="image 37" ORDER="35" TYPE="Static">
+<mets:fptr FILEID="mgpg5"/>
+</mets:div>
+<mets:div ID="tru3v" LABEL="image 38" ORDER="36" TYPE="Static">
+<mets:fptr FILEID="l2v4a"/>
+</mets:div>
+<mets:div ID="l8zqu" LABEL="image 39" ORDER="37" TYPE="Static">
+<mets:fptr FILEID="ra2jr"/>
+</mets:div>
+<mets:div ID="n5ok4" LABEL="image 40" ORDER="38" TYPE="Static">
+<mets:fptr FILEID="y4aaj"/>
+</mets:div>
+<mets:div ID="mvipx" LABEL="image 41" ORDER="39" TYPE="Static">
+<mets:fptr FILEID="ug9dc"/>
+</mets:div>
+<mets:div ID="s9mpu" LABEL="image 42" ORDER="40" TYPE="Static">
+<mets:fptr FILEID="ex2dy"/>
+</mets:div>
+<mets:div ID="jc4gj" LABEL="image 43" ORDER="41" TYPE="Static">
+<mets:fptr FILEID="ec5az"/>
+</mets:div>
+<mets:div ID="zap7e" LABEL="image 44" ORDER="42" TYPE="Static">
+<mets:fptr FILEID="o52xb"/>
+</mets:div>
+<mets:div ID="m0xha" LABEL="image 45" ORDER="43" TYPE="Static">
+<mets:fptr FILEID="xn55y"/>
+</mets:div>
+<mets:div ID="pojbg" LABEL="image 46" ORDER="44" TYPE="Static">
+<mets:fptr FILEID="i6924"/>
+</mets:div>
+<mets:div ID="wg8e9" LABEL="image 47" ORDER="45" TYPE="Static">
+<mets:fptr FILEID="fe2la"/>
+</mets:div>
+<mets:div ID="mgkb6" LABEL="image 48" ORDER="46" TYPE="Static">
+<mets:fptr FILEID="dk09i"/>
+</mets:div>
+<mets:div ID="bbaow" LABEL="image 49" ORDER="47" TYPE="Static">
+<mets:fptr FILEID="ejo95"/>
+</mets:div>
+<mets:div ID="oeiwc" LABEL="image 50" ORDER="48" TYPE="Static">
+<mets:fptr FILEID="v196l"/>
+</mets:div>
+<mets:div ID="pyg8k" LABEL="image 51" ORDER="49" TYPE="Static">
+<mets:fptr FILEID="l46jl"/>
+</mets:div>
+<mets:div ID="qjjb0" LABEL="image 52" ORDER="50" TYPE="Static">
+<mets:fptr FILEID="x00po"/>
+</mets:div>
+<mets:div ID="tt0vo" LABEL="image 53" ORDER="51" TYPE="Static">
+<mets:fptr FILEID="yg5az"/>
+</mets:div>
+<mets:div ID="hsmme" LABEL="image 54" ORDER="52" TYPE="Static">
+<mets:fptr FILEID="pe1ka"/>
+</mets:div>
+<mets:div ID="p84vn" LABEL="image 55" ORDER="53" TYPE="Static">
+<mets:fptr FILEID="if3y3"/>
+</mets:div>
+<mets:div ID="gq97z" LABEL="image 56" ORDER="54" TYPE="Static">
+<mets:fptr FILEID="b2vy6"/>
+</mets:div>
+<mets:div ID="pbpry" LABEL="image 57" ORDER="55" TYPE="Static">
+<mets:fptr FILEID="fko5d"/>
+</mets:div>
+<mets:div ID="uz9s6" LABEL="image 58" ORDER="56" TYPE="Static">
+<mets:fptr FILEID="l2gru"/>
+</mets:div>
+<mets:div ID="w7y8q" LABEL="image 59" ORDER="57" TYPE="Static">
+<mets:fptr FILEID="rpe0i"/>
+</mets:div>
+<mets:div ID="ypl9w" LABEL="image 60" ORDER="58" TYPE="Static">
+<mets:fptr FILEID="c7hio"/>
+</mets:div>
+<mets:div ID="hjk1a" LABEL="image 61" ORDER="59" TYPE="Static">
+<mets:fptr FILEID="axjgl"/>
+</mets:div>
+<mets:div ID="ouhz6" LABEL="image 62" ORDER="60" TYPE="Static">
+<mets:fptr FILEID="snpyg"/>
+</mets:div>
+<mets:div ID="lb2ur" LABEL="image 63" ORDER="61" TYPE="Static">
+<mets:fptr FILEID="rb9s7"/>
+</mets:div>
+<mets:div ID="v23g6" LABEL="image 64" ORDER="62" TYPE="Static">
+<mets:fptr FILEID="n6xea"/>
+</mets:div>
+<mets:div ID="k9mlx" LABEL="image 65" ORDER="63" TYPE="Static">
+<mets:fptr FILEID="gcy3x"/>
+</mets:div>
+<mets:div ID="lqx52" LABEL="image 66" ORDER="64" TYPE="Static">
+<mets:fptr FILEID="rqbx5"/>
+</mets:div>
+<mets:div ID="nd0v3" LABEL="image 67" ORDER="65" TYPE="Static">
+<mets:fptr FILEID="b0ms9"/>
+</mets:div>
+<mets:div ID="xxqhw" LABEL="image 68" ORDER="66" TYPE="Static">
+<mets:fptr FILEID="mokxy"/>
+</mets:div>
+<mets:div ID="dyzj7" LABEL="image 69" ORDER="67" TYPE="Static">
+<mets:fptr FILEID="xihxy"/>
+</mets:div>
+<mets:div ID="ekn4v" LABEL="image 70" ORDER="68" TYPE="Static">
+<mets:fptr FILEID="pc8zn"/>
+</mets:div>
+<mets:div ID="y3yo3" LABEL="image 71" ORDER="69" TYPE="Static">
+<mets:fptr FILEID="l01my"/>
+</mets:div>
+<mets:div ID="k6qg4" LABEL="image 72" ORDER="70" TYPE="Static">
+<mets:fptr FILEID="a9itj"/>
+</mets:div>
+<mets:div ID="pfmo0" LABEL="image 73" ORDER="71" TYPE="Static">
+<mets:fptr FILEID="pzueq"/>
+</mets:div>
+<mets:div ID="lad3j" LABEL="image 74" ORDER="72" TYPE="Static">
+<mets:fptr FILEID="grlin"/>
+</mets:div>
+<mets:div ID="rr189" LABEL="image 75" ORDER="73" TYPE="Static">
+<mets:fptr FILEID="nod0x"/>
+</mets:div>
+<mets:div ID="pbl7g" LABEL="image 76" ORDER="74" TYPE="Static">
+<mets:fptr FILEID="i6qef"/>
+</mets:div>
+<mets:div ID="nbwet" LABEL="image 77" ORDER="75" TYPE="Static">
+<mets:fptr FILEID="hgw98"/>
+</mets:div>
+<mets:div ID="fab2c" LABEL="image 78" ORDER="76" TYPE="Static">
+<mets:fptr FILEID="jzjq4"/>
+</mets:div>
+<mets:div ID="uwhoa" LABEL="image 79" ORDER="77" TYPE="Static">
+<mets:fptr FILEID="ays1e"/>
+</mets:div>
+<mets:div ID="je4z1" LABEL="image 80" ORDER="78" TYPE="Static">
+<mets:fptr FILEID="oflvx"/>
+</mets:div>
+<mets:div ID="qonge" LABEL="image 81" ORDER="79" TYPE="Static">
+<mets:fptr FILEID="c6cxg"/>
+</mets:div>
+<mets:div ID="uhtqa" LABEL="image 82" ORDER="80" TYPE="Static">
+<mets:fptr FILEID="lwzw0"/>
+</mets:div>
+<mets:div ID="v6bl7" LABEL="image 83" ORDER="81" TYPE="Static">
+<mets:fptr FILEID="hbuz1"/>
+</mets:div>
+<mets:div ID="r7xoq" LABEL="image 84" ORDER="82" TYPE="Static">
+<mets:fptr FILEID="aw0mz"/>
+</mets:div>
+<mets:div ID="ze01v" LABEL="image 85" ORDER="83" TYPE="Static">
+<mets:fptr FILEID="oqjao"/>
+</mets:div>
+<mets:div ID="h1a78" LABEL="image 86" ORDER="84" TYPE="Static">
+<mets:fptr FILEID="s8b2e"/>
+</mets:div>
+<mets:div ID="hego7" LABEL="image 87" ORDER="85" TYPE="Static">
+<mets:fptr FILEID="f229i"/>
+</mets:div>
+<mets:div ID="i784b" LABEL="image 88" ORDER="86" TYPE="Static">
+<mets:fptr FILEID="pqh2y"/>
+</mets:div>
+<mets:div ID="or25w" LABEL="image 89" ORDER="87" TYPE="Static">
+<mets:fptr FILEID="u8yq0"/>
+</mets:div>
+<mets:div ID="imdsf" LABEL="image 90" ORDER="88" TYPE="Static">
+<mets:fptr FILEID="cfjxe"/>
+</mets:div>
+<mets:div ID="fj9g8" LABEL="image 91" ORDER="89" TYPE="Static">
+<mets:fptr FILEID="qgwgu"/>
+</mets:div>
+<mets:div ID="atvwj" LABEL="image 92" ORDER="90" TYPE="Static">
+<mets:fptr FILEID="yneio"/>
+</mets:div>
+<mets:div ID="uficr" LABEL="image 93" ORDER="91" TYPE="Static">
+<mets:fptr FILEID="i7gam"/>
+</mets:div>
+<mets:div ID="pcoys" LABEL="image 94" ORDER="92" TYPE="Static">
+<mets:fptr FILEID="bk0dm"/>
+</mets:div>
+<mets:div ID="nmi3b" LABEL="image 95" ORDER="93" TYPE="Static">
+<mets:fptr FILEID="bkfso"/>
+</mets:div>
+<mets:div ID="ddkhs" LABEL="image 96" ORDER="94" TYPE="Static">
+<mets:fptr FILEID="zb9go"/>
+</mets:div>
+<mets:div ID="h979a" LABEL="image 97" ORDER="95" TYPE="Static">
+<mets:fptr FILEID="wlzwm"/>
+</mets:div>
+<mets:div ID="c3l1k" LABEL="image 98" ORDER="96" TYPE="Static">
+<mets:fptr FILEID="w3ccg"/>
+</mets:div>
+<mets:div ID="lu95m" LABEL="image 99" ORDER="97" TYPE="Static">
+<mets:fptr FILEID="n6kt4"/>
+</mets:div>
+<mets:div ID="sofon" LABEL="image 100" ORDER="98" TYPE="Static">
+<mets:fptr FILEID="dsokl"/>
+</mets:div>
+<mets:div ID="hkqzg" LABEL="image 101" ORDER="99" TYPE="Static">
+<mets:fptr FILEID="wgzsm"/>
+</mets:div>
+<mets:div ID="xhrdb" LABEL="image 102" ORDER="100" TYPE="Static">
+<mets:fptr FILEID="l7zhp"/>
+</mets:div>
+<mets:div ID="nsa3h" LABEL="image 103" ORDER="101" TYPE="Static">
+<mets:fptr FILEID="n5goz"/>
+</mets:div>
+<mets:div ID="q5yfz" LABEL="image 104" ORDER="102" TYPE="Static">
+<mets:fptr FILEID="tem01"/>
+</mets:div>
+<mets:div ID="zzd3u" LABEL="image 105" ORDER="103" TYPE="Static">
+<mets:fptr FILEID="m58ti"/>
+</mets:div>
+<mets:div ID="g3vdj" LABEL="image 106" ORDER="104" TYPE="Static">
+<mets:fptr FILEID="qmewn"/>
+</mets:div>
+<mets:div ID="nry0g" LABEL="image 107" ORDER="105" TYPE="Static">
+<mets:fptr FILEID="ladt3"/>
+</mets:div>
+<mets:div ID="b2a99" LABEL="image 108" ORDER="106" TYPE="Static">
+<mets:fptr FILEID="izjco"/>
+</mets:div>
+<mets:div ID="kstj0" LABEL="image 109" ORDER="107" TYPE="Static">
+<mets:fptr FILEID="gq0i5"/>
+</mets:div>
+<mets:div ID="moh3w" LABEL="image 110" ORDER="108" TYPE="Static">
+<mets:fptr FILEID="bmwhn"/>
+</mets:div>
+<mets:div ID="asq7x" LABEL="image 111" ORDER="109" TYPE="Static">
+<mets:fptr FILEID="pcakz"/>
+</mets:div>
+<mets:div ID="lylpy" LABEL="image 112" ORDER="110" TYPE="Static">
+<mets:fptr FILEID="g6892"/>
+</mets:div>
+<mets:div ID="e4dz3" LABEL="image 113" ORDER="111" TYPE="Static">
+<mets:fptr FILEID="i92zq"/>
+</mets:div>
+<mets:div ID="y4mpk" LABEL="image 114" ORDER="112" TYPE="Static">
+<mets:fptr FILEID="lnoon"/>
+</mets:div>
+<mets:div ID="u8mz4" LABEL="image 115" ORDER="113" TYPE="Static">
+<mets:fptr FILEID="hsmma"/>
+</mets:div>
+<mets:div ID="g4gnm" LABEL="image 116" ORDER="114" TYPE="Static">
+<mets:fptr FILEID="pjgz4"/>
+</mets:div>
+<mets:div ID="slm85" LABEL="image 117" ORDER="115" TYPE="Static">
+<mets:fptr FILEID="ftwjs"/>
+</mets:div>
+<mets:div ID="j5m5y" LABEL="image 118" ORDER="116" TYPE="Static">
+<mets:fptr FILEID="j8o3x"/>
+</mets:div>
+<mets:div ID="e14tr" LABEL="image 119" ORDER="117" TYPE="Static">
+<mets:fptr FILEID="b48bz"/>
+</mets:div>
+<mets:div ID="v2wgg" LABEL="image 120" ORDER="118" TYPE="Static">
+<mets:fptr FILEID="x4ohz"/>
+</mets:div>
+<mets:div ID="lu2k2" LABEL="image 121" ORDER="119" TYPE="Static">
+<mets:fptr FILEID="yppll"/>
+</mets:div>
+<mets:div ID="axhtc" LABEL="image 122" ORDER="120" TYPE="Static">
+<mets:fptr FILEID="alope"/>
+</mets:div>
+<mets:div ID="nwoas" LABEL="image 123" ORDER="121" TYPE="Static">
+<mets:fptr FILEID="f22r2"/>
+</mets:div>
+<mets:div ID="x73qp" LABEL="image 124" ORDER="122" TYPE="Static">
+<mets:fptr FILEID="uor1e"/>
+</mets:div>
+<mets:div ID="u6zn3" LABEL="image 125" ORDER="123" TYPE="Static">
+<mets:fptr FILEID="h8jxm"/>
+</mets:div>
+<mets:div ID="zyybq" LABEL="image 126" ORDER="124" TYPE="Static">
+<mets:fptr FILEID="friyb"/>
+</mets:div>
+<mets:div ID="mobpg" LABEL="image 127" ORDER="125" TYPE="Static">
+<mets:fptr FILEID="absax"/>
+</mets:div>
+<mets:div ID="kaxxc" LABEL="image 128" ORDER="126" TYPE="Static">
+<mets:fptr FILEID="xniio"/>
+</mets:div>
+<mets:div ID="cgfgj" LABEL="image 129" ORDER="127" TYPE="Static">
+<mets:fptr FILEID="nm6ih"/>
+</mets:div>
+<mets:div ID="vsp6u" LABEL="image 130" ORDER="128" TYPE="Static">
+<mets:fptr FILEID="p93ab"/>
+</mets:div>
+<mets:div ID="skaon" LABEL="image 131" ORDER="129" TYPE="Static">
+<mets:fptr FILEID="fm9yz"/>
+</mets:div>
+<mets:div ID="qslz0" LABEL="image 132" ORDER="130" TYPE="Static">
+<mets:fptr FILEID="cqh0n"/>
+</mets:div>
+<mets:div ID="rgj0n" LABEL="image 133" ORDER="131" TYPE="Static">
+<mets:fptr FILEID="jfan1"/>
+</mets:div>
+<mets:div ID="kaemf" LABEL="image 134" ORDER="132" TYPE="Static">
+<mets:fptr FILEID="v7lgq"/>
+</mets:div>
+<mets:div ID="ut23l" LABEL="image 135" ORDER="133" TYPE="Static">
+<mets:fptr FILEID="ro2hf"/>
+</mets:div>
+<mets:div ID="gtfoj" LABEL="image 136" ORDER="134" TYPE="Static">
+<mets:fptr FILEID="dez4h"/>
+</mets:div>
+<mets:div ID="ycidc" LABEL="image 137" ORDER="135" TYPE="Static">
+<mets:fptr FILEID="w88g9"/>
+</mets:div>
+<mets:div ID="sc984" LABEL="image 138" ORDER="136" TYPE="Static">
+<mets:fptr FILEID="n7bt3"/>
+</mets:div>
+<mets:div ID="tcf7s" LABEL="image 139" ORDER="137" TYPE="Static">
+<mets:fptr FILEID="lnphz"/>
+</mets:div>
+<mets:div ID="g2pi7" LABEL="image 140" ORDER="138" TYPE="Static">
+<mets:fptr FILEID="ey5yv"/>
+</mets:div>
+<mets:div ID="fco7t" LABEL="image 141" ORDER="139" TYPE="Static">
+<mets:fptr FILEID="ljqsl"/>
+</mets:div>
+<mets:div ID="ct3o8" LABEL="image 142" ORDER="140" TYPE="Static">
+<mets:fptr FILEID="k139m"/>
+</mets:div>
+<mets:div ID="ger8w" LABEL="image 143" ORDER="141" TYPE="Static">
+<mets:fptr FILEID="x9zut"/>
+</mets:div>
+<mets:div ID="r4nyx" LABEL="image 144" ORDER="142" TYPE="Static">
+<mets:fptr FILEID="mkzs0"/>
+</mets:div>
+<mets:div ID="bilu3" LABEL="image 145" ORDER="143" TYPE="Static">
+<mets:fptr FILEID="tc62e"/>
+</mets:div>
+<mets:div ID="evzc5" LABEL="image 146" ORDER="144" TYPE="Static">
+<mets:fptr FILEID="kwjaa"/>
+</mets:div>
+<mets:div ID="xehvt" LABEL="image 147" ORDER="145" TYPE="Static">
+<mets:fptr FILEID="vzxsf"/>
+</mets:div>
+<mets:div ID="nrl8k" LABEL="image 148" ORDER="146" TYPE="Static">
+<mets:fptr FILEID="tuppq"/>
+</mets:div>
+<mets:div ID="ou9qy" LABEL="image 149" ORDER="147" TYPE="Static">
+<mets:fptr FILEID="ijml2"/>
+</mets:div>
+<mets:div ID="jyofs" LABEL="image 150" ORDER="148" TYPE="Static">
+<mets:fptr FILEID="psbyo"/>
+</mets:div>
+<mets:div ID="zo85l" LABEL="image 151" ORDER="149" TYPE="Static">
+<mets:fptr FILEID="kwy70"/>
+</mets:div>
+<mets:div ID="pzdbs" LABEL="image 152" ORDER="150" TYPE="Static">
+<mets:fptr FILEID="deb4x"/>
+</mets:div>
+<mets:div ID="kbw1n" LABEL="image 153" ORDER="151" TYPE="Static">
+<mets:fptr FILEID="yeed1"/>
+</mets:div>
+<mets:div ID="rwf6c" LABEL="image 154" ORDER="152" TYPE="Static">
+<mets:fptr FILEID="ugzuq"/>
+</mets:div>
+<mets:div ID="w179d" LABEL="image 155" ORDER="153" TYPE="Static">
+<mets:fptr FILEID="mpf98"/>
+</mets:div>
+<mets:div ID="fioyc" LABEL="image 156" ORDER="154" TYPE="Static">
+<mets:fptr FILEID="d3phu"/>
+</mets:div>
+<mets:div ID="mr9pq" LABEL="image 157" ORDER="155" TYPE="Static">
+<mets:fptr FILEID="yy415"/>
+</mets:div>
+<mets:div ID="e3scc" LABEL="image 158" ORDER="156" TYPE="Static">
+<mets:fptr FILEID="z3bhc"/>
+</mets:div>
+<mets:div ID="ikcxe" LABEL="image 159" ORDER="157" TYPE="Static">
+<mets:fptr FILEID="x5pkc"/>
+</mets:div>
+<mets:div ID="ekw7m" LABEL="image 160" ORDER="158" TYPE="Static">
+<mets:fptr FILEID="brz9h"/>
+</mets:div>
+<mets:div ID="jiorb" LABEL="image 161" ORDER="159" TYPE="Static">
+<mets:fptr FILEID="cz2li"/>
+</mets:div>
+<mets:div ID="ac7zz" LABEL="image 162" ORDER="160" TYPE="Static">
+<mets:fptr FILEID="pp6t5"/>
+</mets:div>
+<mets:div ID="fi7th" LABEL="image 163" ORDER="161" TYPE="Static">
+<mets:fptr FILEID="ps2t6"/>
+</mets:div>
+<mets:div ID="blc3g" LABEL="image 164" ORDER="162" TYPE="Static">
+<mets:fptr FILEID="so6ka"/>
+</mets:div>
+<mets:div ID="zj2ky" LABEL="image 165" ORDER="163" TYPE="Static">
+<mets:fptr FILEID="girge"/>
+</mets:div>
+<mets:div ID="x6ot7" LABEL="image 166" ORDER="164" TYPE="Static">
+<mets:fptr FILEID="oct27"/>
+</mets:div>
+<mets:div ID="qaqyd" LABEL="image 167" ORDER="165" TYPE="Static">
+<mets:fptr FILEID="fx8xd"/>
+</mets:div>
+<mets:div ID="lado6" LABEL="image 168" ORDER="166" TYPE="Static">
+<mets:fptr FILEID="oi977"/>
+</mets:div>
+<mets:div ID="ylc68" LABEL="image 169" ORDER="167" TYPE="Static">
+<mets:fptr FILEID="qbqha"/>
+</mets:div>
+<mets:div ID="fkxg5" LABEL="image 170" ORDER="168" TYPE="Static">
+<mets:fptr FILEID="ikysu"/>
+</mets:div>
+<mets:div ID="jq07h" LABEL="image 171" ORDER="169" TYPE="Static">
+<mets:fptr FILEID="gx0h2"/>
+</mets:div>
+<mets:div ID="o8098" LABEL="image 172" ORDER="170" TYPE="Static">
+<mets:fptr FILEID="f9czr"/>
+</mets:div>
+<mets:div ID="hai32" LABEL="image 173" ORDER="171" TYPE="Static">
+<mets:fptr FILEID="d1pb3"/>
+</mets:div>
+<mets:div ID="daol8" LABEL="image 174" ORDER="172" TYPE="Static">
+<mets:fptr FILEID="bidz9"/>
+</mets:div>
+<mets:div ID="krcfp" LABEL="image 175" ORDER="173" TYPE="Static">
+<mets:fptr FILEID="wz4fg"/>
+</mets:div>
+<mets:div ID="ujamu" LABEL="image 176" ORDER="174" TYPE="Static">
+<mets:fptr FILEID="vl32k"/>
+</mets:div>
+<mets:div ID="h8cta" LABEL="image 177" ORDER="175" TYPE="Static">
+<mets:fptr FILEID="nf3yt"/>
+</mets:div>
+<mets:div ID="clz0n" LABEL="image 178" ORDER="176" TYPE="Static">
+<mets:fptr FILEID="cmo6l"/>
+</mets:div>
+<mets:div ID="goxd0" LABEL="image 179" ORDER="177" TYPE="Static">
+<mets:fptr FILEID="hssp1"/>
+</mets:div>
+<mets:div ID="rbqks" LABEL="image 180" ORDER="178" TYPE="Static">
+<mets:fptr FILEID="rzjze"/>
+</mets:div>
+<mets:div ID="f2bsb" LABEL="image 181" ORDER="179" TYPE="Static">
+<mets:fptr FILEID="u6igm"/>
+</mets:div>
+<mets:div ID="r6e92" LABEL="image 182" ORDER="180" TYPE="Static">
+<mets:fptr FILEID="cuo6u"/>
+</mets:div>
+<mets:div ID="uo064" LABEL="image 183" ORDER="181" TYPE="Static">
+<mets:fptr FILEID="ragf6"/>
+</mets:div>
+<mets:div ID="umksi" LABEL="image 184" ORDER="182" TYPE="Static">
+<mets:fptr FILEID="mibsi"/>
+</mets:div>
+<mets:div ID="lzo7j" LABEL="image 185" ORDER="183" TYPE="Static">
+<mets:fptr FILEID="pfda4"/>
+</mets:div>
+<mets:div ID="aep4p" LABEL="image 186" ORDER="184" TYPE="Static">
+<mets:fptr FILEID="uc6y9"/>
+</mets:div>
+<mets:div ID="u7jyi" LABEL="image 187" ORDER="185" TYPE="Static">
+<mets:fptr FILEID="v7kq6"/>
+</mets:div>
+<mets:div ID="vfy9a" LABEL="image 188" ORDER="186" TYPE="Static">
+<mets:fptr FILEID="ol01v"/>
+</mets:div>
+<mets:div ID="i3224" LABEL="image 189" ORDER="187" TYPE="Static">
+<mets:fptr FILEID="ucuj2"/>
+</mets:div>
+<mets:div ID="ygs6u" LABEL="image 190" ORDER="188" TYPE="Static">
+<mets:fptr FILEID="rse38"/>
+</mets:div>
+<mets:div ID="bg26x" LABEL="image 191" ORDER="189" TYPE="Static">
+<mets:fptr FILEID="b4qs6"/>
+</mets:div>
+<mets:div ID="z0r0a" LABEL="image 192" ORDER="190" TYPE="Static">
+<mets:fptr FILEID="kli7f"/>
+</mets:div>
+<mets:div ID="qj0lh" LABEL="image 193" ORDER="191" TYPE="Static">
+<mets:fptr FILEID="iscqr"/>
+</mets:div>
+<mets:div ID="rw99x" LABEL="image 194" ORDER="192" TYPE="Static">
+<mets:fptr FILEID="dpju4"/>
+</mets:div>
+<mets:div ID="odhvc" LABEL="image 195" ORDER="193" TYPE="Static">
+<mets:fptr FILEID="d8fou"/>
+</mets:div>
+<mets:div ID="ad4rp" LABEL="image 196" ORDER="194" TYPE="Static">
+<mets:fptr FILEID="kmobn"/>
+</mets:div>
+<mets:div ID="vkvjk" LABEL="image 197" ORDER="195" TYPE="Static">
+<mets:fptr FILEID="eweae"/>
+</mets:div>
+<mets:div ID="kdukf" LABEL="image 198" ORDER="196" TYPE="Static">
+<mets:fptr FILEID="l7kmv"/>
+</mets:div>
+<mets:div ID="p4mte" LABEL="image 199" ORDER="197" TYPE="Static">
+<mets:fptr FILEID="twypr"/>
+</mets:div>
+<mets:div ID="sd0nv" LABEL="image 200" ORDER="198" TYPE="Static">
+<mets:fptr FILEID="d43ze"/>
+</mets:div>
+<mets:div ID="fcezs" LABEL="image 201" ORDER="199" TYPE="Static">
+<mets:fptr FILEID="ze2y2"/>
+</mets:div>
+<mets:div ID="b844a" LABEL="image 202" ORDER="200" TYPE="Static">
+<mets:fptr FILEID="a7vph"/>
+</mets:div>
+<mets:div ID="vcmpc" LABEL="image 203" ORDER="201" TYPE="Static">
+<mets:fptr FILEID="wq3bv"/>
+</mets:div>
+<mets:div ID="k80on" LABEL="image 204" ORDER="202" TYPE="Static">
+<mets:fptr FILEID="ivfxt"/>
+</mets:div>
+<mets:div ID="yc979" LABEL="image 205" ORDER="203" TYPE="Static">
+<mets:fptr FILEID="nzivf"/>
+</mets:div>
+<mets:div ID="arojp" LABEL="image 206" ORDER="204" TYPE="Static">
+<mets:fptr FILEID="hrywv"/>
+</mets:div>
+<mets:div ID="fy5rv" LABEL="image 207" ORDER="205" TYPE="Static">
+<mets:fptr FILEID="dcg37"/>
+</mets:div>
+<mets:div ID="xzv0y" LABEL="image 208" ORDER="206" TYPE="Static">
+<mets:fptr FILEID="opv56"/>
+</mets:div>
+<mets:div ID="p343h" LABEL="image 209" ORDER="207" TYPE="Static">
+<mets:fptr FILEID="f2e3b"/>
+</mets:div>
+<mets:div ID="sbfg5" LABEL="image 210" ORDER="208" TYPE="Static">
+<mets:fptr FILEID="ilgdr"/>
+</mets:div>
+<mets:div ID="xwkkn" LABEL="image 211" ORDER="209" TYPE="Static">
+<mets:fptr FILEID="hzrin"/>
+</mets:div>
+<mets:div ID="s1hze" LABEL="image 212" ORDER="210" TYPE="Static">
+<mets:fptr FILEID="v0h9w"/>
+</mets:div>
+<mets:div ID="htjha" LABEL="image 213" ORDER="211" TYPE="Static">
+<mets:fptr FILEID="udbcm"/>
+</mets:div>
+<mets:div ID="dpzog" LABEL="image 214" ORDER="212" TYPE="Static">
+<mets:fptr FILEID="xhtpp"/>
+</mets:div>
+<mets:div ID="z0990" LABEL="image 215" ORDER="213" TYPE="Static">
+<mets:fptr FILEID="nuhuc"/>
+</mets:div>
+<mets:div ID="uu08i" LABEL="image 216" ORDER="214" TYPE="Static">
+<mets:fptr FILEID="x6s0g"/>
+</mets:div>
+<mets:div ID="sdu4q" LABEL="image 217" ORDER="215" TYPE="Static">
+<mets:fptr FILEID="eo95l"/>
+</mets:div>
+<mets:div ID="m8i7a" LABEL="image 218" ORDER="216" TYPE="Static">
+<mets:fptr FILEID="z2fw0"/>
+</mets:div>
+<mets:div ID="ihi11" LABEL="image 219" ORDER="217" TYPE="Static">
+<mets:fptr FILEID="ci0as"/>
+</mets:div>
+<mets:div ID="iidm2" LABEL="image 220" ORDER="218" TYPE="Static">
+<mets:fptr FILEID="fr8ty"/>
+</mets:div>
+<mets:div ID="e5oki" LABEL="image 221" ORDER="219" TYPE="Static">
+<mets:fptr FILEID="pqeuy"/>
+</mets:div>
+<mets:div ID="mcksg" LABEL="image 222" ORDER="220" TYPE="Static">
+<mets:fptr FILEID="gb4yk"/>
+</mets:div>
+<mets:div ID="yx3et" LABEL="image 223" ORDER="221" TYPE="Static">
+<mets:fptr FILEID="haasu"/>
+</mets:div>
+<mets:div ID="yx8wx" LABEL="image 224" ORDER="222" TYPE="Static">
+<mets:fptr FILEID="nf4a0"/>
+</mets:div>
+<mets:div ID="sqpnj" LABEL="image 225" ORDER="223" TYPE="Static">
+<mets:fptr FILEID="qp0f6"/>
+</mets:div>
+<mets:div ID="n81kc" LABEL="image 226" ORDER="224" TYPE="Static">
+<mets:fptr FILEID="xvqq1"/>
+</mets:div>
+</mets:div>
+</mets:div>
+</mets:structMap>
+<mets:structMap TYPE="Physical">
+  <mets:div ID="tu1zb" TYPE="MultiVolumeSet">
+    <mets:div ID="phys1" LABEL="first volume" TYPE="BoundVolume">
+      <mets:div ID="xsu9k" LABEL="upper cover" TYPE="UpperCover">
+        <mets:div ID="uel37" LABEL="cover" ORDER="1" TYPE="CoverOutside">
+
+        </mets:div>
+        <mets:div ID="y9sd8" LABEL="pastedown" ORDER="2" TYPE="Pastedown">
+
+        </mets:div>
+      </mets:div>
+      <mets:div ID="sj69e" LABEL="gathering 1" TYPE="Gathering">
+        <mets:div ID="w19h0" LABEL="leaf 1, gathering 1/1" TYPE="Leaf">
+          <mets:div ID="tjppa" LABEL="recto" ORDER="3" TYPE="Side">
+
+          </mets:div>
+        </mets:div>
+      </mets:div>
+    </mets:div>
+    <mets:div ID="phys2" LABEL="second volume" TYPE="BoundVolume">
+      <mets:div ID="cd0nv" LABEL="upper cover" TYPE="UpperCover">
+        <mets:div ID="wdrhr" LABEL="pastedown" ORDER="2" TYPE="Pastedown">
+
+        </mets:div>
+      </mets:div>
+      <mets:div ID="hresd" LABEL="gathering 1" TYPE="Gathering">
+        <mets:div ID="jvt8x" LABEL="leaf 1, gathering 1/1" TYPE="Leaf">
+          <mets:div ID="yx262" LABEL="recto" ORDER="3" TYPE="Side">
+
+          </mets:div>
+          <mets:div ID="sz6nc" LABEL="verso" ORDER="4" TYPE="Side">
+
+          </mets:div>
+        </mets:div>
+      </mets:div>
+    </mets:div>
+  </mets:div>
+</mets:structMap>
+</mets:mets>

--- a/spec/fixtures/mets/tsop_typed_no_files.mets
+++ b/spec/fixtures/mets/tsop_typed_no_files.mets
@@ -1,0 +1,1484 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" OBJID="ark:/88435/jw827c96v" TYPE="CompiledDigitalObject" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd">
+<mets:metsHdr CREATEDATE="2018-08-04T11:56:26.015-04:00" LASTMODDATE="2018-08-04T11:56:26.015-04:00">
+<mets:metsDocumentID TYPE="PUDL">pudl0044/831958/tsop_typed.mets</mets:metsDocumentID>
+</mets:metsHdr>
+<mets:dmdSec ID="xvh3r">
+<mets:mdWrap MDTYPE="MODS">
+<mets:xmlData>
+<mods xmlns="http://www.loc.gov/mods/v3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods//v3/mods-3-3.xsd">
+
+   <titleInfo>
+
+      <title>This side of paradise</title>
+
+   </titleInfo>
+   <name authority="naf" type="personal">
+
+      <namePart type="family">Fitzgerald</namePart>
+      <namePart type="given">F. Scott (Francis Scott)</namePart>
+      <namePart type="date">1896-1940</namePart>
+      <role>
+         <roleTerm authority="marcrelator" type="code">aut</roleTerm>
+      </role>
+   </name>
+   <typeOfResource manuscript="yes">text</typeOfResource>
+   <originInfo>
+      <dateCreated encoding="w3cdtf" keyDate="yes">1918</dateCreated>
+
+   </originInfo>
+   <language>
+      <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+   </language>
+   <physicalDescription>
+      <extent>224 typescript pages</extent>
+   </physicalDescription>
+   <abstract>F. Scott Fitzgerald, This Side of Paradise, autograph manuscripts and corrected typescripts (1917-1919). Fitzgerald began writing This Side of Paradise at Princeton, continued in November 1917 at Fort Leavenworth, Kansas, with the working title "The Romantic Egoist," and completed a first draft of the novel at Cottage Club in March 1918. After this draft had been twice rejected by the New York publisher Charles Scribner's Sons, Fitzgerald returned to his parents' home at 599 Summit Avenue in his native St. Paul, Minnesota, and added five new chapters to the four he had written the previous year. He changed the second title of the novel from "The Education of a Personage" to "This Side of Paradise" and sent the novel to Maxwell Perkins at Scribner's. The publisher accepted the novel on September 16, 1919, and published it on March 26, 1920. The author's corrected galleys and page proofs do not survive.
+
+      F. Scott Fitzgerald, "The Romantic Egotist," chapters 1, 2, 5, 12, and 14. Fitzgerald corrected the five chapters in this early typescript version and sent them to Charles W. Donahoe in October 1918. Donahoe donated the typescript to Princeton in 1948. .</abstract>
+   <note>Typed manuscript</note>
+   <subject authority="lcsh">
+      <name authority="naf" type="personal">
+         <namePart type="family">Fitzgerald</namePart>
+         <namePart type="given">F. Scott (Francis Scott)</namePart>
+         <namePart type="date">1896-1940</namePart>
+      </name>
+      <genre>Manuscripts</genre>
+   </subject>
+   <relatedItem type="host">
+      <typeOfResource collection="yes">text</typeOfResource>
+      <titleInfo>
+         <title>F. Scott Fitzgerald papers, 1897-1944</title>
+      </titleInfo>
+      <!--<location>
+         <url note="Digital Collection">http://pudl.princeton.edu/collections/pudl0044</url>
+      </location>-->
+   </relatedItem>
+   <location>
+      <physicalLocation type="text">Princeton University Library. Department of Rare Books and Special Collections</physicalLocation>
+      <physicalLocation authority="marcorg" type="code">NjP</physicalLocation>
+      <holdingSimple>
+         <copyInformation>
+            <subLocation>mss</subLocation>
+            <shelfLocator>C0187</shelfLocator>
+         </copyInformation>
+      </holdingSimple>
+   </location>
+   <accessCondition type="useAndReproduction">Not to be published, reproduced, or broadcast without the written permission of the Princeton University Library.  Selected items in the F. Scott Fitzgerald Papers can
+      be photoduplicated at the expense of the researcher requesting photoduplication. Advanced
+      estimates and payment are required. For general information on photoduplication and
+      permissions, go to http://www.princeton.edu/~rbsc Requests to to reproduce, publish, or
+      broadcast material from the F. Scott Fitzgerald Papers should be addressed Public Services
+      staff, rbsc@princeton.edu The correct form of citation includes the name of the collection,
+      box and folder numbers, and an indication that the originals are in the "Manuscripts Division,
+      Department of Rare Books and Special Collections, Princeton University Library." The
+      manuscript of The Great Gatsby and other writings of F. Scott Fitzgerald are not to be quoted,
+      published, reproduced, or broadcast without the written permission of the Princeton University
+      Library as owner of the physical object, and of the Fitzgerald Literary Trust (copyright
+      holder), c/o Harold Ober Associates, 425 Madison Avenue, New York, New York 10017 (Telephone:
+      212-759-8600; FAX: 212-759-9428). The Library is not responsible for copyright infringement or
+      other legal problems resulting from unauthorized publication of the words of F. Scott
+      Fitzgerald.</accessCondition>
+   <accessCondition type="restrictionOnAccess">For legal and conservation reasons, access to F.
+      Scott Fitzgerald’s original manuscripts (including corrected galleys and scrapbooks) is
+      strictly restricted. Scottie Fitzgerald Lanahan, daughter of F. Scott Fitzgerald and Zelda
+      Fitzgerald, donated the Fitzgerald Papers to the Princeton University Library in 1950,
+      stipulating that surrogates of the original manuscripts were to be made available to
+      researchers instead of the originals. This was done to preserve the originals, which are not
+      on good paper. Originally, the surrogates were in the form of microfilm. Facsimiles editions of This Side of Paradise and
+      other manuscripts of books and short
+      stories followed a multi-volume series: F. Scott Fitzgerald Manuscripts, edited by Matthew J.
+      Bruccoli and Alan Margolies (New York: Garland Publishing Company, 1990). Complete sets of the
+      facsimile edition are available at more than 50 research libraries (including Firestone
+      Library). </accessCondition>
+
+
+   <recordInfo>
+      <recordContentSource authority="marcorg">NjP</recordContentSource>
+     <!-- <recordOrigin>http://catalog.princeton.edu/cgi-bin/Pwebrecon.cgi?BBID=</recordOrigin>-->
+      <recordIdentifier>http://diglib.princeton.edu/mdata/pudl0044/831958/tsop_typed.mods</recordIdentifier>
+      <languageOfCataloging>
+         <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+      </languageOfCataloging>
+   </recordInfo>
+</mods>
+</mets:xmlData>
+</mets:mdWrap>
+</mets:dmdSec>
+<mets:fileSec>
+<mets:fileGrp USE="thumbnail">
+<mets:file ID="d962c" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0044/831958/tsop_typed/00000001.tif"/>
+</mets:file>
+</mets:fileGrp>
+<mets:fileGrp USE="masters">
+</mets:fileGrp>
+</mets:fileSec>
+<mets:structMap TYPE="RelatedObjects">
+<mets:div DMDID="xvh3r xvh3r" ID="vxm2n" LABEL="Default">
+<mets:div CONTENTIDS="pudl0044" TYPE="IsPartOf"/>
+<mets:div ID="aggregates" TYPE="OrderedList">
+<mets:div ID="q4udb" LABEL="image 1" ORDER="225" TYPE="Static">
+<mets:fptr FILEID="afoc8"/>
+</mets:div>
+<mets:div ID="qmu2r" LABEL="image 2" ORDER="226" TYPE="Static">
+<mets:fptr FILEID="o3cu9"/>
+</mets:div>
+<mets:div ID="xxq9z" LABEL="image 3" ORDER="1" TYPE="Static">
+<mets:fptr FILEID="mfxyv"/>
+</mets:div>
+<mets:div ID="a14tx" LABEL="image 4" ORDER="2" TYPE="Static">
+<mets:fptr FILEID="hiyq3"/>
+</mets:div>
+<mets:div ID="d7sk7" LABEL="image 5" ORDER="3" TYPE="Static">
+<mets:fptr FILEID="rt7cu"/>
+</mets:div>
+<mets:div ID="salr4" LABEL="image 6" ORDER="4" TYPE="Static">
+<mets:fptr FILEID="wpdaz"/>
+</mets:div>
+<mets:div ID="pszrm" LABEL="image 7" ORDER="5" TYPE="Static">
+<mets:fptr FILEID="vd770"/>
+</mets:div>
+<mets:div ID="r2yve" LABEL="image 8" ORDER="6" TYPE="Static">
+<mets:fptr FILEID="p5bz8"/>
+</mets:div>
+<mets:div ID="d5fmx" LABEL="image 9" ORDER="7" TYPE="Static">
+<mets:fptr FILEID="a2l99"/>
+</mets:div>
+<mets:div ID="jjbsi" LABEL="image 10" ORDER="8" TYPE="Static">
+<mets:fptr FILEID="i7d75"/>
+</mets:div>
+<mets:div ID="rprva" LABEL="image 11" ORDER="9" TYPE="Static">
+<mets:fptr FILEID="qidbi"/>
+</mets:div>
+<mets:div ID="gibma" LABEL="image 12" ORDER="10" TYPE="Static">
+<mets:fptr FILEID="hu641"/>
+</mets:div>
+<mets:div ID="joc4i" LABEL="image 13" ORDER="11" TYPE="Static">
+<mets:fptr FILEID="ud5zj"/>
+</mets:div>
+<mets:div ID="p6bkt" LABEL="image 14" ORDER="12" TYPE="Static">
+<mets:fptr FILEID="b6ths"/>
+</mets:div>
+<mets:div ID="g5gat" LABEL="image 15" ORDER="13" TYPE="Static">
+<mets:fptr FILEID="vo8he"/>
+</mets:div>
+<mets:div ID="ysmy1" LABEL="image 16" ORDER="14" TYPE="Static">
+<mets:fptr FILEID="qza75"/>
+</mets:div>
+<mets:div ID="ls9wx" LABEL="image 17" ORDER="15" TYPE="Static">
+<mets:fptr FILEID="blhlc"/>
+</mets:div>
+<mets:div ID="samn7" LABEL="image 18" ORDER="16" TYPE="Static">
+<mets:fptr FILEID="ygym9"/>
+</mets:div>
+<mets:div ID="sup9e" LABEL="image 19" ORDER="17" TYPE="Static">
+<mets:fptr FILEID="w4uem"/>
+</mets:div>
+<mets:div ID="h5qm4" LABEL="image 20" ORDER="18" TYPE="Static">
+<mets:fptr FILEID="zrpn3"/>
+</mets:div>
+<mets:div ID="a03no" LABEL="image 21" ORDER="19" TYPE="Static">
+<mets:fptr FILEID="vqvnx"/>
+</mets:div>
+<mets:div ID="qih64" LABEL="image 22" ORDER="20" TYPE="Static">
+<mets:fptr FILEID="twyb2"/>
+</mets:div>
+<mets:div ID="oy55h" LABEL="image 23" ORDER="21" TYPE="Static">
+<mets:fptr FILEID="bhg7z"/>
+</mets:div>
+<mets:div ID="kajg2" LABEL="image 24" ORDER="22" TYPE="Static">
+<mets:fptr FILEID="kq6f4"/>
+</mets:div>
+<mets:div ID="fydom" LABEL="image 25" ORDER="23" TYPE="Static">
+<mets:fptr FILEID="dfcw8"/>
+</mets:div>
+<mets:div ID="hs39m" LABEL="image 26" ORDER="24" TYPE="Static">
+<mets:fptr FILEID="wyggp"/>
+</mets:div>
+<mets:div ID="r03l9" LABEL="image 27" ORDER="25" TYPE="Static">
+<mets:fptr FILEID="a4goe"/>
+</mets:div>
+<mets:div ID="lnbpi" LABEL="image 28" ORDER="26" TYPE="Static">
+<mets:fptr FILEID="php7d"/>
+</mets:div>
+<mets:div ID="huc61" LABEL="image 29" ORDER="27" TYPE="Static">
+<mets:fptr FILEID="mob7q"/>
+</mets:div>
+<mets:div ID="vctz8" LABEL="image 30" ORDER="28" TYPE="Static">
+<mets:fptr FILEID="hesd2"/>
+</mets:div>
+<mets:div ID="m65f4" LABEL="image 31" ORDER="29" TYPE="Static">
+<mets:fptr FILEID="s0rwi"/>
+</mets:div>
+<mets:div ID="f9ca2" LABEL="image 32" ORDER="30" TYPE="Static">
+<mets:fptr FILEID="sgl8m"/>
+</mets:div>
+<mets:div ID="jfvdr" LABEL="image 33" ORDER="31" TYPE="Static">
+<mets:fptr FILEID="fcijz"/>
+</mets:div>
+<mets:div ID="ac8hd" LABEL="image 34" ORDER="32" TYPE="Static">
+<mets:fptr FILEID="ymggl"/>
+</mets:div>
+<mets:div ID="f97b8" LABEL="image 35" ORDER="33" TYPE="Static">
+<mets:fptr FILEID="ngzxk"/>
+</mets:div>
+<mets:div ID="agyko" LABEL="image 36" ORDER="34" TYPE="Static">
+<mets:fptr FILEID="rbxh3"/>
+</mets:div>
+<mets:div ID="yrf6m" LABEL="image 37" ORDER="35" TYPE="Static">
+<mets:fptr FILEID="mgpg5"/>
+</mets:div>
+<mets:div ID="tru3v" LABEL="image 38" ORDER="36" TYPE="Static">
+<mets:fptr FILEID="l2v4a"/>
+</mets:div>
+<mets:div ID="l8zqu" LABEL="image 39" ORDER="37" TYPE="Static">
+<mets:fptr FILEID="ra2jr"/>
+</mets:div>
+<mets:div ID="n5ok4" LABEL="image 40" ORDER="38" TYPE="Static">
+<mets:fptr FILEID="y4aaj"/>
+</mets:div>
+<mets:div ID="mvipx" LABEL="image 41" ORDER="39" TYPE="Static">
+<mets:fptr FILEID="ug9dc"/>
+</mets:div>
+<mets:div ID="s9mpu" LABEL="image 42" ORDER="40" TYPE="Static">
+<mets:fptr FILEID="ex2dy"/>
+</mets:div>
+<mets:div ID="jc4gj" LABEL="image 43" ORDER="41" TYPE="Static">
+<mets:fptr FILEID="ec5az"/>
+</mets:div>
+<mets:div ID="zap7e" LABEL="image 44" ORDER="42" TYPE="Static">
+<mets:fptr FILEID="o52xb"/>
+</mets:div>
+<mets:div ID="m0xha" LABEL="image 45" ORDER="43" TYPE="Static">
+<mets:fptr FILEID="xn55y"/>
+</mets:div>
+<mets:div ID="pojbg" LABEL="image 46" ORDER="44" TYPE="Static">
+<mets:fptr FILEID="i6924"/>
+</mets:div>
+<mets:div ID="wg8e9" LABEL="image 47" ORDER="45" TYPE="Static">
+<mets:fptr FILEID="fe2la"/>
+</mets:div>
+<mets:div ID="mgkb6" LABEL="image 48" ORDER="46" TYPE="Static">
+<mets:fptr FILEID="dk09i"/>
+</mets:div>
+<mets:div ID="bbaow" LABEL="image 49" ORDER="47" TYPE="Static">
+<mets:fptr FILEID="ejo95"/>
+</mets:div>
+<mets:div ID="oeiwc" LABEL="image 50" ORDER="48" TYPE="Static">
+<mets:fptr FILEID="v196l"/>
+</mets:div>
+<mets:div ID="pyg8k" LABEL="image 51" ORDER="49" TYPE="Static">
+<mets:fptr FILEID="l46jl"/>
+</mets:div>
+<mets:div ID="qjjb0" LABEL="image 52" ORDER="50" TYPE="Static">
+<mets:fptr FILEID="x00po"/>
+</mets:div>
+<mets:div ID="tt0vo" LABEL="image 53" ORDER="51" TYPE="Static">
+<mets:fptr FILEID="yg5az"/>
+</mets:div>
+<mets:div ID="hsmme" LABEL="image 54" ORDER="52" TYPE="Static">
+<mets:fptr FILEID="pe1ka"/>
+</mets:div>
+<mets:div ID="p84vn" LABEL="image 55" ORDER="53" TYPE="Static">
+<mets:fptr FILEID="if3y3"/>
+</mets:div>
+<mets:div ID="gq97z" LABEL="image 56" ORDER="54" TYPE="Static">
+<mets:fptr FILEID="b2vy6"/>
+</mets:div>
+<mets:div ID="pbpry" LABEL="image 57" ORDER="55" TYPE="Static">
+<mets:fptr FILEID="fko5d"/>
+</mets:div>
+<mets:div ID="uz9s6" LABEL="image 58" ORDER="56" TYPE="Static">
+<mets:fptr FILEID="l2gru"/>
+</mets:div>
+<mets:div ID="w7y8q" LABEL="image 59" ORDER="57" TYPE="Static">
+<mets:fptr FILEID="rpe0i"/>
+</mets:div>
+<mets:div ID="ypl9w" LABEL="image 60" ORDER="58" TYPE="Static">
+<mets:fptr FILEID="c7hio"/>
+</mets:div>
+<mets:div ID="hjk1a" LABEL="image 61" ORDER="59" TYPE="Static">
+<mets:fptr FILEID="axjgl"/>
+</mets:div>
+<mets:div ID="ouhz6" LABEL="image 62" ORDER="60" TYPE="Static">
+<mets:fptr FILEID="snpyg"/>
+</mets:div>
+<mets:div ID="lb2ur" LABEL="image 63" ORDER="61" TYPE="Static">
+<mets:fptr FILEID="rb9s7"/>
+</mets:div>
+<mets:div ID="v23g6" LABEL="image 64" ORDER="62" TYPE="Static">
+<mets:fptr FILEID="n6xea"/>
+</mets:div>
+<mets:div ID="k9mlx" LABEL="image 65" ORDER="63" TYPE="Static">
+<mets:fptr FILEID="gcy3x"/>
+</mets:div>
+<mets:div ID="lqx52" LABEL="image 66" ORDER="64" TYPE="Static">
+<mets:fptr FILEID="rqbx5"/>
+</mets:div>
+<mets:div ID="nd0v3" LABEL="image 67" ORDER="65" TYPE="Static">
+<mets:fptr FILEID="b0ms9"/>
+</mets:div>
+<mets:div ID="xxqhw" LABEL="image 68" ORDER="66" TYPE="Static">
+<mets:fptr FILEID="mokxy"/>
+</mets:div>
+<mets:div ID="dyzj7" LABEL="image 69" ORDER="67" TYPE="Static">
+<mets:fptr FILEID="xihxy"/>
+</mets:div>
+<mets:div ID="ekn4v" LABEL="image 70" ORDER="68" TYPE="Static">
+<mets:fptr FILEID="pc8zn"/>
+</mets:div>
+<mets:div ID="y3yo3" LABEL="image 71" ORDER="69" TYPE="Static">
+<mets:fptr FILEID="l01my"/>
+</mets:div>
+<mets:div ID="k6qg4" LABEL="image 72" ORDER="70" TYPE="Static">
+<mets:fptr FILEID="a9itj"/>
+</mets:div>
+<mets:div ID="pfmo0" LABEL="image 73" ORDER="71" TYPE="Static">
+<mets:fptr FILEID="pzueq"/>
+</mets:div>
+<mets:div ID="lad3j" LABEL="image 74" ORDER="72" TYPE="Static">
+<mets:fptr FILEID="grlin"/>
+</mets:div>
+<mets:div ID="rr189" LABEL="image 75" ORDER="73" TYPE="Static">
+<mets:fptr FILEID="nod0x"/>
+</mets:div>
+<mets:div ID="pbl7g" LABEL="image 76" ORDER="74" TYPE="Static">
+<mets:fptr FILEID="i6qef"/>
+</mets:div>
+<mets:div ID="nbwet" LABEL="image 77" ORDER="75" TYPE="Static">
+<mets:fptr FILEID="hgw98"/>
+</mets:div>
+<mets:div ID="fab2c" LABEL="image 78" ORDER="76" TYPE="Static">
+<mets:fptr FILEID="jzjq4"/>
+</mets:div>
+<mets:div ID="uwhoa" LABEL="image 79" ORDER="77" TYPE="Static">
+<mets:fptr FILEID="ays1e"/>
+</mets:div>
+<mets:div ID="je4z1" LABEL="image 80" ORDER="78" TYPE="Static">
+<mets:fptr FILEID="oflvx"/>
+</mets:div>
+<mets:div ID="qonge" LABEL="image 81" ORDER="79" TYPE="Static">
+<mets:fptr FILEID="c6cxg"/>
+</mets:div>
+<mets:div ID="uhtqa" LABEL="image 82" ORDER="80" TYPE="Static">
+<mets:fptr FILEID="lwzw0"/>
+</mets:div>
+<mets:div ID="v6bl7" LABEL="image 83" ORDER="81" TYPE="Static">
+<mets:fptr FILEID="hbuz1"/>
+</mets:div>
+<mets:div ID="r7xoq" LABEL="image 84" ORDER="82" TYPE="Static">
+<mets:fptr FILEID="aw0mz"/>
+</mets:div>
+<mets:div ID="ze01v" LABEL="image 85" ORDER="83" TYPE="Static">
+<mets:fptr FILEID="oqjao"/>
+</mets:div>
+<mets:div ID="h1a78" LABEL="image 86" ORDER="84" TYPE="Static">
+<mets:fptr FILEID="s8b2e"/>
+</mets:div>
+<mets:div ID="hego7" LABEL="image 87" ORDER="85" TYPE="Static">
+<mets:fptr FILEID="f229i"/>
+</mets:div>
+<mets:div ID="i784b" LABEL="image 88" ORDER="86" TYPE="Static">
+<mets:fptr FILEID="pqh2y"/>
+</mets:div>
+<mets:div ID="or25w" LABEL="image 89" ORDER="87" TYPE="Static">
+<mets:fptr FILEID="u8yq0"/>
+</mets:div>
+<mets:div ID="imdsf" LABEL="image 90" ORDER="88" TYPE="Static">
+<mets:fptr FILEID="cfjxe"/>
+</mets:div>
+<mets:div ID="fj9g8" LABEL="image 91" ORDER="89" TYPE="Static">
+<mets:fptr FILEID="qgwgu"/>
+</mets:div>
+<mets:div ID="atvwj" LABEL="image 92" ORDER="90" TYPE="Static">
+<mets:fptr FILEID="yneio"/>
+</mets:div>
+<mets:div ID="uficr" LABEL="image 93" ORDER="91" TYPE="Static">
+<mets:fptr FILEID="i7gam"/>
+</mets:div>
+<mets:div ID="pcoys" LABEL="image 94" ORDER="92" TYPE="Static">
+<mets:fptr FILEID="bk0dm"/>
+</mets:div>
+<mets:div ID="nmi3b" LABEL="image 95" ORDER="93" TYPE="Static">
+<mets:fptr FILEID="bkfso"/>
+</mets:div>
+<mets:div ID="ddkhs" LABEL="image 96" ORDER="94" TYPE="Static">
+<mets:fptr FILEID="zb9go"/>
+</mets:div>
+<mets:div ID="h979a" LABEL="image 97" ORDER="95" TYPE="Static">
+<mets:fptr FILEID="wlzwm"/>
+</mets:div>
+<mets:div ID="c3l1k" LABEL="image 98" ORDER="96" TYPE="Static">
+<mets:fptr FILEID="w3ccg"/>
+</mets:div>
+<mets:div ID="lu95m" LABEL="image 99" ORDER="97" TYPE="Static">
+<mets:fptr FILEID="n6kt4"/>
+</mets:div>
+<mets:div ID="sofon" LABEL="image 100" ORDER="98" TYPE="Static">
+<mets:fptr FILEID="dsokl"/>
+</mets:div>
+<mets:div ID="hkqzg" LABEL="image 101" ORDER="99" TYPE="Static">
+<mets:fptr FILEID="wgzsm"/>
+</mets:div>
+<mets:div ID="xhrdb" LABEL="image 102" ORDER="100" TYPE="Static">
+<mets:fptr FILEID="l7zhp"/>
+</mets:div>
+<mets:div ID="nsa3h" LABEL="image 103" ORDER="101" TYPE="Static">
+<mets:fptr FILEID="n5goz"/>
+</mets:div>
+<mets:div ID="q5yfz" LABEL="image 104" ORDER="102" TYPE="Static">
+<mets:fptr FILEID="tem01"/>
+</mets:div>
+<mets:div ID="zzd3u" LABEL="image 105" ORDER="103" TYPE="Static">
+<mets:fptr FILEID="m58ti"/>
+</mets:div>
+<mets:div ID="g3vdj" LABEL="image 106" ORDER="104" TYPE="Static">
+<mets:fptr FILEID="qmewn"/>
+</mets:div>
+<mets:div ID="nry0g" LABEL="image 107" ORDER="105" TYPE="Static">
+<mets:fptr FILEID="ladt3"/>
+</mets:div>
+<mets:div ID="b2a99" LABEL="image 108" ORDER="106" TYPE="Static">
+<mets:fptr FILEID="izjco"/>
+</mets:div>
+<mets:div ID="kstj0" LABEL="image 109" ORDER="107" TYPE="Static">
+<mets:fptr FILEID="gq0i5"/>
+</mets:div>
+<mets:div ID="moh3w" LABEL="image 110" ORDER="108" TYPE="Static">
+<mets:fptr FILEID="bmwhn"/>
+</mets:div>
+<mets:div ID="asq7x" LABEL="image 111" ORDER="109" TYPE="Static">
+<mets:fptr FILEID="pcakz"/>
+</mets:div>
+<mets:div ID="lylpy" LABEL="image 112" ORDER="110" TYPE="Static">
+<mets:fptr FILEID="g6892"/>
+</mets:div>
+<mets:div ID="e4dz3" LABEL="image 113" ORDER="111" TYPE="Static">
+<mets:fptr FILEID="i92zq"/>
+</mets:div>
+<mets:div ID="y4mpk" LABEL="image 114" ORDER="112" TYPE="Static">
+<mets:fptr FILEID="lnoon"/>
+</mets:div>
+<mets:div ID="u8mz4" LABEL="image 115" ORDER="113" TYPE="Static">
+<mets:fptr FILEID="hsmma"/>
+</mets:div>
+<mets:div ID="g4gnm" LABEL="image 116" ORDER="114" TYPE="Static">
+<mets:fptr FILEID="pjgz4"/>
+</mets:div>
+<mets:div ID="slm85" LABEL="image 117" ORDER="115" TYPE="Static">
+<mets:fptr FILEID="ftwjs"/>
+</mets:div>
+<mets:div ID="j5m5y" LABEL="image 118" ORDER="116" TYPE="Static">
+<mets:fptr FILEID="j8o3x"/>
+</mets:div>
+<mets:div ID="e14tr" LABEL="image 119" ORDER="117" TYPE="Static">
+<mets:fptr FILEID="b48bz"/>
+</mets:div>
+<mets:div ID="v2wgg" LABEL="image 120" ORDER="118" TYPE="Static">
+<mets:fptr FILEID="x4ohz"/>
+</mets:div>
+<mets:div ID="lu2k2" LABEL="image 121" ORDER="119" TYPE="Static">
+<mets:fptr FILEID="yppll"/>
+</mets:div>
+<mets:div ID="axhtc" LABEL="image 122" ORDER="120" TYPE="Static">
+<mets:fptr FILEID="alope"/>
+</mets:div>
+<mets:div ID="nwoas" LABEL="image 123" ORDER="121" TYPE="Static">
+<mets:fptr FILEID="f22r2"/>
+</mets:div>
+<mets:div ID="x73qp" LABEL="image 124" ORDER="122" TYPE="Static">
+<mets:fptr FILEID="uor1e"/>
+</mets:div>
+<mets:div ID="u6zn3" LABEL="image 125" ORDER="123" TYPE="Static">
+<mets:fptr FILEID="h8jxm"/>
+</mets:div>
+<mets:div ID="zyybq" LABEL="image 126" ORDER="124" TYPE="Static">
+<mets:fptr FILEID="friyb"/>
+</mets:div>
+<mets:div ID="mobpg" LABEL="image 127" ORDER="125" TYPE="Static">
+<mets:fptr FILEID="absax"/>
+</mets:div>
+<mets:div ID="kaxxc" LABEL="image 128" ORDER="126" TYPE="Static">
+<mets:fptr FILEID="xniio"/>
+</mets:div>
+<mets:div ID="cgfgj" LABEL="image 129" ORDER="127" TYPE="Static">
+<mets:fptr FILEID="nm6ih"/>
+</mets:div>
+<mets:div ID="vsp6u" LABEL="image 130" ORDER="128" TYPE="Static">
+<mets:fptr FILEID="p93ab"/>
+</mets:div>
+<mets:div ID="skaon" LABEL="image 131" ORDER="129" TYPE="Static">
+<mets:fptr FILEID="fm9yz"/>
+</mets:div>
+<mets:div ID="qslz0" LABEL="image 132" ORDER="130" TYPE="Static">
+<mets:fptr FILEID="cqh0n"/>
+</mets:div>
+<mets:div ID="rgj0n" LABEL="image 133" ORDER="131" TYPE="Static">
+<mets:fptr FILEID="jfan1"/>
+</mets:div>
+<mets:div ID="kaemf" LABEL="image 134" ORDER="132" TYPE="Static">
+<mets:fptr FILEID="v7lgq"/>
+</mets:div>
+<mets:div ID="ut23l" LABEL="image 135" ORDER="133" TYPE="Static">
+<mets:fptr FILEID="ro2hf"/>
+</mets:div>
+<mets:div ID="gtfoj" LABEL="image 136" ORDER="134" TYPE="Static">
+<mets:fptr FILEID="dez4h"/>
+</mets:div>
+<mets:div ID="ycidc" LABEL="image 137" ORDER="135" TYPE="Static">
+<mets:fptr FILEID="w88g9"/>
+</mets:div>
+<mets:div ID="sc984" LABEL="image 138" ORDER="136" TYPE="Static">
+<mets:fptr FILEID="n7bt3"/>
+</mets:div>
+<mets:div ID="tcf7s" LABEL="image 139" ORDER="137" TYPE="Static">
+<mets:fptr FILEID="lnphz"/>
+</mets:div>
+<mets:div ID="g2pi7" LABEL="image 140" ORDER="138" TYPE="Static">
+<mets:fptr FILEID="ey5yv"/>
+</mets:div>
+<mets:div ID="fco7t" LABEL="image 141" ORDER="139" TYPE="Static">
+<mets:fptr FILEID="ljqsl"/>
+</mets:div>
+<mets:div ID="ct3o8" LABEL="image 142" ORDER="140" TYPE="Static">
+<mets:fptr FILEID="k139m"/>
+</mets:div>
+<mets:div ID="ger8w" LABEL="image 143" ORDER="141" TYPE="Static">
+<mets:fptr FILEID="x9zut"/>
+</mets:div>
+<mets:div ID="r4nyx" LABEL="image 144" ORDER="142" TYPE="Static">
+<mets:fptr FILEID="mkzs0"/>
+</mets:div>
+<mets:div ID="bilu3" LABEL="image 145" ORDER="143" TYPE="Static">
+<mets:fptr FILEID="tc62e"/>
+</mets:div>
+<mets:div ID="evzc5" LABEL="image 146" ORDER="144" TYPE="Static">
+<mets:fptr FILEID="kwjaa"/>
+</mets:div>
+<mets:div ID="xehvt" LABEL="image 147" ORDER="145" TYPE="Static">
+<mets:fptr FILEID="vzxsf"/>
+</mets:div>
+<mets:div ID="nrl8k" LABEL="image 148" ORDER="146" TYPE="Static">
+<mets:fptr FILEID="tuppq"/>
+</mets:div>
+<mets:div ID="ou9qy" LABEL="image 149" ORDER="147" TYPE="Static">
+<mets:fptr FILEID="ijml2"/>
+</mets:div>
+<mets:div ID="jyofs" LABEL="image 150" ORDER="148" TYPE="Static">
+<mets:fptr FILEID="psbyo"/>
+</mets:div>
+<mets:div ID="zo85l" LABEL="image 151" ORDER="149" TYPE="Static">
+<mets:fptr FILEID="kwy70"/>
+</mets:div>
+<mets:div ID="pzdbs" LABEL="image 152" ORDER="150" TYPE="Static">
+<mets:fptr FILEID="deb4x"/>
+</mets:div>
+<mets:div ID="kbw1n" LABEL="image 153" ORDER="151" TYPE="Static">
+<mets:fptr FILEID="yeed1"/>
+</mets:div>
+<mets:div ID="rwf6c" LABEL="image 154" ORDER="152" TYPE="Static">
+<mets:fptr FILEID="ugzuq"/>
+</mets:div>
+<mets:div ID="w179d" LABEL="image 155" ORDER="153" TYPE="Static">
+<mets:fptr FILEID="mpf98"/>
+</mets:div>
+<mets:div ID="fioyc" LABEL="image 156" ORDER="154" TYPE="Static">
+<mets:fptr FILEID="d3phu"/>
+</mets:div>
+<mets:div ID="mr9pq" LABEL="image 157" ORDER="155" TYPE="Static">
+<mets:fptr FILEID="yy415"/>
+</mets:div>
+<mets:div ID="e3scc" LABEL="image 158" ORDER="156" TYPE="Static">
+<mets:fptr FILEID="z3bhc"/>
+</mets:div>
+<mets:div ID="ikcxe" LABEL="image 159" ORDER="157" TYPE="Static">
+<mets:fptr FILEID="x5pkc"/>
+</mets:div>
+<mets:div ID="ekw7m" LABEL="image 160" ORDER="158" TYPE="Static">
+<mets:fptr FILEID="brz9h"/>
+</mets:div>
+<mets:div ID="jiorb" LABEL="image 161" ORDER="159" TYPE="Static">
+<mets:fptr FILEID="cz2li"/>
+</mets:div>
+<mets:div ID="ac7zz" LABEL="image 162" ORDER="160" TYPE="Static">
+<mets:fptr FILEID="pp6t5"/>
+</mets:div>
+<mets:div ID="fi7th" LABEL="image 163" ORDER="161" TYPE="Static">
+<mets:fptr FILEID="ps2t6"/>
+</mets:div>
+<mets:div ID="blc3g" LABEL="image 164" ORDER="162" TYPE="Static">
+<mets:fptr FILEID="so6ka"/>
+</mets:div>
+<mets:div ID="zj2ky" LABEL="image 165" ORDER="163" TYPE="Static">
+<mets:fptr FILEID="girge"/>
+</mets:div>
+<mets:div ID="x6ot7" LABEL="image 166" ORDER="164" TYPE="Static">
+<mets:fptr FILEID="oct27"/>
+</mets:div>
+<mets:div ID="qaqyd" LABEL="image 167" ORDER="165" TYPE="Static">
+<mets:fptr FILEID="fx8xd"/>
+</mets:div>
+<mets:div ID="lado6" LABEL="image 168" ORDER="166" TYPE="Static">
+<mets:fptr FILEID="oi977"/>
+</mets:div>
+<mets:div ID="ylc68" LABEL="image 169" ORDER="167" TYPE="Static">
+<mets:fptr FILEID="qbqha"/>
+</mets:div>
+<mets:div ID="fkxg5" LABEL="image 170" ORDER="168" TYPE="Static">
+<mets:fptr FILEID="ikysu"/>
+</mets:div>
+<mets:div ID="jq07h" LABEL="image 171" ORDER="169" TYPE="Static">
+<mets:fptr FILEID="gx0h2"/>
+</mets:div>
+<mets:div ID="o8098" LABEL="image 172" ORDER="170" TYPE="Static">
+<mets:fptr FILEID="f9czr"/>
+</mets:div>
+<mets:div ID="hai32" LABEL="image 173" ORDER="171" TYPE="Static">
+<mets:fptr FILEID="d1pb3"/>
+</mets:div>
+<mets:div ID="daol8" LABEL="image 174" ORDER="172" TYPE="Static">
+<mets:fptr FILEID="bidz9"/>
+</mets:div>
+<mets:div ID="krcfp" LABEL="image 175" ORDER="173" TYPE="Static">
+<mets:fptr FILEID="wz4fg"/>
+</mets:div>
+<mets:div ID="ujamu" LABEL="image 176" ORDER="174" TYPE="Static">
+<mets:fptr FILEID="vl32k"/>
+</mets:div>
+<mets:div ID="h8cta" LABEL="image 177" ORDER="175" TYPE="Static">
+<mets:fptr FILEID="nf3yt"/>
+</mets:div>
+<mets:div ID="clz0n" LABEL="image 178" ORDER="176" TYPE="Static">
+<mets:fptr FILEID="cmo6l"/>
+</mets:div>
+<mets:div ID="goxd0" LABEL="image 179" ORDER="177" TYPE="Static">
+<mets:fptr FILEID="hssp1"/>
+</mets:div>
+<mets:div ID="rbqks" LABEL="image 180" ORDER="178" TYPE="Static">
+<mets:fptr FILEID="rzjze"/>
+</mets:div>
+<mets:div ID="f2bsb" LABEL="image 181" ORDER="179" TYPE="Static">
+<mets:fptr FILEID="u6igm"/>
+</mets:div>
+<mets:div ID="r6e92" LABEL="image 182" ORDER="180" TYPE="Static">
+<mets:fptr FILEID="cuo6u"/>
+</mets:div>
+<mets:div ID="uo064" LABEL="image 183" ORDER="181" TYPE="Static">
+<mets:fptr FILEID="ragf6"/>
+</mets:div>
+<mets:div ID="umksi" LABEL="image 184" ORDER="182" TYPE="Static">
+<mets:fptr FILEID="mibsi"/>
+</mets:div>
+<mets:div ID="lzo7j" LABEL="image 185" ORDER="183" TYPE="Static">
+<mets:fptr FILEID="pfda4"/>
+</mets:div>
+<mets:div ID="aep4p" LABEL="image 186" ORDER="184" TYPE="Static">
+<mets:fptr FILEID="uc6y9"/>
+</mets:div>
+<mets:div ID="u7jyi" LABEL="image 187" ORDER="185" TYPE="Static">
+<mets:fptr FILEID="v7kq6"/>
+</mets:div>
+<mets:div ID="vfy9a" LABEL="image 188" ORDER="186" TYPE="Static">
+<mets:fptr FILEID="ol01v"/>
+</mets:div>
+<mets:div ID="i3224" LABEL="image 189" ORDER="187" TYPE="Static">
+<mets:fptr FILEID="ucuj2"/>
+</mets:div>
+<mets:div ID="ygs6u" LABEL="image 190" ORDER="188" TYPE="Static">
+<mets:fptr FILEID="rse38"/>
+</mets:div>
+<mets:div ID="bg26x" LABEL="image 191" ORDER="189" TYPE="Static">
+<mets:fptr FILEID="b4qs6"/>
+</mets:div>
+<mets:div ID="z0r0a" LABEL="image 192" ORDER="190" TYPE="Static">
+<mets:fptr FILEID="kli7f"/>
+</mets:div>
+<mets:div ID="qj0lh" LABEL="image 193" ORDER="191" TYPE="Static">
+<mets:fptr FILEID="iscqr"/>
+</mets:div>
+<mets:div ID="rw99x" LABEL="image 194" ORDER="192" TYPE="Static">
+<mets:fptr FILEID="dpju4"/>
+</mets:div>
+<mets:div ID="odhvc" LABEL="image 195" ORDER="193" TYPE="Static">
+<mets:fptr FILEID="d8fou"/>
+</mets:div>
+<mets:div ID="ad4rp" LABEL="image 196" ORDER="194" TYPE="Static">
+<mets:fptr FILEID="kmobn"/>
+</mets:div>
+<mets:div ID="vkvjk" LABEL="image 197" ORDER="195" TYPE="Static">
+<mets:fptr FILEID="eweae"/>
+</mets:div>
+<mets:div ID="kdukf" LABEL="image 198" ORDER="196" TYPE="Static">
+<mets:fptr FILEID="l7kmv"/>
+</mets:div>
+<mets:div ID="p4mte" LABEL="image 199" ORDER="197" TYPE="Static">
+<mets:fptr FILEID="twypr"/>
+</mets:div>
+<mets:div ID="sd0nv" LABEL="image 200" ORDER="198" TYPE="Static">
+<mets:fptr FILEID="d43ze"/>
+</mets:div>
+<mets:div ID="fcezs" LABEL="image 201" ORDER="199" TYPE="Static">
+<mets:fptr FILEID="ze2y2"/>
+</mets:div>
+<mets:div ID="b844a" LABEL="image 202" ORDER="200" TYPE="Static">
+<mets:fptr FILEID="a7vph"/>
+</mets:div>
+<mets:div ID="vcmpc" LABEL="image 203" ORDER="201" TYPE="Static">
+<mets:fptr FILEID="wq3bv"/>
+</mets:div>
+<mets:div ID="k80on" LABEL="image 204" ORDER="202" TYPE="Static">
+<mets:fptr FILEID="ivfxt"/>
+</mets:div>
+<mets:div ID="yc979" LABEL="image 205" ORDER="203" TYPE="Static">
+<mets:fptr FILEID="nzivf"/>
+</mets:div>
+<mets:div ID="arojp" LABEL="image 206" ORDER="204" TYPE="Static">
+<mets:fptr FILEID="hrywv"/>
+</mets:div>
+<mets:div ID="fy5rv" LABEL="image 207" ORDER="205" TYPE="Static">
+<mets:fptr FILEID="dcg37"/>
+</mets:div>
+<mets:div ID="xzv0y" LABEL="image 208" ORDER="206" TYPE="Static">
+<mets:fptr FILEID="opv56"/>
+</mets:div>
+<mets:div ID="p343h" LABEL="image 209" ORDER="207" TYPE="Static">
+<mets:fptr FILEID="f2e3b"/>
+</mets:div>
+<mets:div ID="sbfg5" LABEL="image 210" ORDER="208" TYPE="Static">
+<mets:fptr FILEID="ilgdr"/>
+</mets:div>
+<mets:div ID="xwkkn" LABEL="image 211" ORDER="209" TYPE="Static">
+<mets:fptr FILEID="hzrin"/>
+</mets:div>
+<mets:div ID="s1hze" LABEL="image 212" ORDER="210" TYPE="Static">
+<mets:fptr FILEID="v0h9w"/>
+</mets:div>
+<mets:div ID="htjha" LABEL="image 213" ORDER="211" TYPE="Static">
+<mets:fptr FILEID="udbcm"/>
+</mets:div>
+<mets:div ID="dpzog" LABEL="image 214" ORDER="212" TYPE="Static">
+<mets:fptr FILEID="xhtpp"/>
+</mets:div>
+<mets:div ID="z0990" LABEL="image 215" ORDER="213" TYPE="Static">
+<mets:fptr FILEID="nuhuc"/>
+</mets:div>
+<mets:div ID="uu08i" LABEL="image 216" ORDER="214" TYPE="Static">
+<mets:fptr FILEID="x6s0g"/>
+</mets:div>
+<mets:div ID="sdu4q" LABEL="image 217" ORDER="215" TYPE="Static">
+<mets:fptr FILEID="eo95l"/>
+</mets:div>
+<mets:div ID="m8i7a" LABEL="image 218" ORDER="216" TYPE="Static">
+<mets:fptr FILEID="z2fw0"/>
+</mets:div>
+<mets:div ID="ihi11" LABEL="image 219" ORDER="217" TYPE="Static">
+<mets:fptr FILEID="ci0as"/>
+</mets:div>
+<mets:div ID="iidm2" LABEL="image 220" ORDER="218" TYPE="Static">
+<mets:fptr FILEID="fr8ty"/>
+</mets:div>
+<mets:div ID="e5oki" LABEL="image 221" ORDER="219" TYPE="Static">
+<mets:fptr FILEID="pqeuy"/>
+</mets:div>
+<mets:div ID="mcksg" LABEL="image 222" ORDER="220" TYPE="Static">
+<mets:fptr FILEID="gb4yk"/>
+</mets:div>
+<mets:div ID="yx3et" LABEL="image 223" ORDER="221" TYPE="Static">
+<mets:fptr FILEID="haasu"/>
+</mets:div>
+<mets:div ID="yx8wx" LABEL="image 224" ORDER="222" TYPE="Static">
+<mets:fptr FILEID="nf4a0"/>
+</mets:div>
+<mets:div ID="sqpnj" LABEL="image 225" ORDER="223" TYPE="Static">
+<mets:fptr FILEID="qp0f6"/>
+</mets:div>
+<mets:div ID="n81kc" LABEL="image 226" ORDER="224" TYPE="Static">
+<mets:fptr FILEID="xvqq1"/>
+</mets:div>
+</mets:div>
+</mets:div>
+</mets:structMap>
+<mets:structMap TYPE="Physical">
+<mets:div DMDID="xvh3r xvh3r" ID="lkvjk" TYPE="BoundVolume">
+<mets:div ID="ryzqr" LABEL="image 1" ORDER="1" TYPE="Static">
+<mets:fptr FILEID="afoc8"/>
+</mets:div>
+<mets:div ID="mahlc" LABEL="image 2" ORDER="2" TYPE="Static">
+<mets:fptr FILEID="o3cu9"/>
+</mets:div>
+<mets:div ID="kurfx" LABEL="image 3" ORDER="3" TYPE="Static">
+<mets:fptr FILEID="mfxyv"/>
+</mets:div>
+<mets:div ID="go6ux" LABEL="image 4" ORDER="4" TYPE="Static">
+<mets:fptr FILEID="hiyq3"/>
+</mets:div>
+<mets:div ID="lbeld" LABEL="image 5" ORDER="5" TYPE="Static">
+<mets:fptr FILEID="rt7cu"/>
+</mets:div>
+<mets:div ID="pdi7c" LABEL="image 6" ORDER="6" TYPE="Static">
+<mets:fptr FILEID="wpdaz"/>
+</mets:div>
+<mets:div ID="myqcb" LABEL="image 7" ORDER="7" TYPE="Static">
+<mets:fptr FILEID="vd770"/>
+</mets:div>
+<mets:div ID="ejrnl" LABEL="image 8" ORDER="8" TYPE="Static">
+<mets:fptr FILEID="p5bz8"/>
+</mets:div>
+<mets:div ID="mtjr9" LABEL="image 9" ORDER="9" TYPE="Static">
+<mets:fptr FILEID="a2l99"/>
+</mets:div>
+<mets:div ID="omcki" LABEL="image 10" ORDER="10" TYPE="Static">
+<mets:fptr FILEID="i7d75"/>
+</mets:div>
+<mets:div ID="e9mzv" LABEL="image 11" ORDER="11" TYPE="Static">
+<mets:fptr FILEID="qidbi"/>
+</mets:div>
+<mets:div ID="tmhgz" LABEL="image 12" ORDER="12" TYPE="Static">
+<mets:fptr FILEID="hu641"/>
+</mets:div>
+<mets:div ID="j57h1" LABEL="image 13" ORDER="13" TYPE="Static">
+<mets:fptr FILEID="ud5zj"/>
+</mets:div>
+<mets:div ID="z0ft3" LABEL="image 14" ORDER="14" TYPE="Static">
+<mets:fptr FILEID="b6ths"/>
+</mets:div>
+<mets:div ID="qbwks" LABEL="image 15" ORDER="15" TYPE="Static">
+<mets:fptr FILEID="vo8he"/>
+</mets:div>
+<mets:div ID="iqs0f" LABEL="image 16" ORDER="16" TYPE="Static">
+<mets:fptr FILEID="qza75"/>
+</mets:div>
+<mets:div ID="ilptr" LABEL="image 17" ORDER="17" TYPE="Static">
+<mets:fptr FILEID="blhlc"/>
+</mets:div>
+<mets:div ID="ftqgk" LABEL="image 18" ORDER="18" TYPE="Static">
+<mets:fptr FILEID="ygym9"/>
+</mets:div>
+<mets:div ID="yovrt" LABEL="image 19" ORDER="19" TYPE="Static">
+<mets:fptr FILEID="w4uem"/>
+</mets:div>
+<mets:div ID="gj7qk" LABEL="image 20" ORDER="20" TYPE="Static">
+<mets:fptr FILEID="zrpn3"/>
+</mets:div>
+<mets:div ID="ql5k3" LABEL="image 21" ORDER="21" TYPE="Static">
+<mets:fptr FILEID="vqvnx"/>
+</mets:div>
+<mets:div ID="vv3e9" LABEL="image 22" ORDER="22" TYPE="Static">
+<mets:fptr FILEID="twyb2"/>
+</mets:div>
+<mets:div ID="fulih" LABEL="image 23" ORDER="23" TYPE="Static">
+<mets:fptr FILEID="bhg7z"/>
+</mets:div>
+<mets:div ID="x5b59" LABEL="image 24" ORDER="24" TYPE="Static">
+<mets:fptr FILEID="kq6f4"/>
+</mets:div>
+<mets:div ID="zfkvb" LABEL="image 25" ORDER="25" TYPE="Static">
+<mets:fptr FILEID="dfcw8"/>
+</mets:div>
+<mets:div ID="t64pn" LABEL="image 26" ORDER="26" TYPE="Static">
+<mets:fptr FILEID="wyggp"/>
+</mets:div>
+<mets:div ID="dskb9" LABEL="image 27" ORDER="27" TYPE="Static">
+<mets:fptr FILEID="a4goe"/>
+</mets:div>
+<mets:div ID="ry3tm" LABEL="image 28" ORDER="28" TYPE="Static">
+<mets:fptr FILEID="php7d"/>
+</mets:div>
+<mets:div ID="mpbtz" LABEL="image 29" ORDER="29" TYPE="Static">
+<mets:fptr FILEID="mob7q"/>
+</mets:div>
+<mets:div ID="eod1s" LABEL="image 30" ORDER="30" TYPE="Static">
+<mets:fptr FILEID="hesd2"/>
+</mets:div>
+<mets:div ID="vl35o" LABEL="image 31" ORDER="31" TYPE="Static">
+<mets:fptr FILEID="s0rwi"/>
+</mets:div>
+<mets:div ID="sf09g" LABEL="image 32" ORDER="32" TYPE="Static">
+<mets:fptr FILEID="sgl8m"/>
+</mets:div>
+<mets:div ID="ro5h2" LABEL="image 33" ORDER="33" TYPE="Static">
+<mets:fptr FILEID="fcijz"/>
+</mets:div>
+<mets:div ID="q91t7" LABEL="image 34" ORDER="34" TYPE="Static">
+<mets:fptr FILEID="ymggl"/>
+</mets:div>
+<mets:div ID="kwg33" LABEL="image 35" ORDER="35" TYPE="Static">
+<mets:fptr FILEID="ngzxk"/>
+</mets:div>
+<mets:div ID="jeeq9" LABEL="image 36" ORDER="36" TYPE="Static">
+<mets:fptr FILEID="rbxh3"/>
+</mets:div>
+<mets:div ID="l8i6c" LABEL="image 37" ORDER="37" TYPE="Static">
+<mets:fptr FILEID="mgpg5"/>
+</mets:div>
+<mets:div ID="i8jkn" LABEL="image 38" ORDER="38" TYPE="Static">
+<mets:fptr FILEID="l2v4a"/>
+</mets:div>
+<mets:div ID="x14eu" LABEL="image 39" ORDER="39" TYPE="Static">
+<mets:fptr FILEID="ra2jr"/>
+</mets:div>
+<mets:div ID="jp1tt" LABEL="image 40" ORDER="40" TYPE="Static">
+<mets:fptr FILEID="y4aaj"/>
+</mets:div>
+<mets:div ID="jdy8j" LABEL="image 41" ORDER="41" TYPE="Static">
+<mets:fptr FILEID="ug9dc"/>
+</mets:div>
+<mets:div ID="r3cy4" LABEL="image 42" ORDER="42" TYPE="Static">
+<mets:fptr FILEID="ex2dy"/>
+</mets:div>
+<mets:div ID="ihxn7" LABEL="image 43" ORDER="43" TYPE="Static">
+<mets:fptr FILEID="ec5az"/>
+</mets:div>
+<mets:div ID="zqyp5" LABEL="image 44" ORDER="44" TYPE="Static">
+<mets:fptr FILEID="o52xb"/>
+</mets:div>
+<mets:div ID="kirol" LABEL="image 45" ORDER="45" TYPE="Static">
+<mets:fptr FILEID="xn55y"/>
+</mets:div>
+<mets:div ID="xpau0" LABEL="image 46" ORDER="46" TYPE="Static">
+<mets:fptr FILEID="i6924"/>
+</mets:div>
+<mets:div ID="sg6gq" LABEL="image 47" ORDER="47" TYPE="Static">
+<mets:fptr FILEID="fe2la"/>
+</mets:div>
+<mets:div ID="u469t" LABEL="image 48" ORDER="48" TYPE="Static">
+<mets:fptr FILEID="dk09i"/>
+</mets:div>
+<mets:div ID="z8sxs" LABEL="image 49" ORDER="49" TYPE="Static">
+<mets:fptr FILEID="ejo95"/>
+</mets:div>
+<mets:div ID="em56w" LABEL="image 50" ORDER="50" TYPE="Static">
+<mets:fptr FILEID="v196l"/>
+</mets:div>
+<mets:div ID="zv4x6" LABEL="image 51" ORDER="51" TYPE="Static">
+<mets:fptr FILEID="l46jl"/>
+</mets:div>
+<mets:div ID="qe912" LABEL="image 52" ORDER="52" TYPE="Static">
+<mets:fptr FILEID="x00po"/>
+</mets:div>
+<mets:div ID="qwf5t" LABEL="image 53" ORDER="53" TYPE="Static">
+<mets:fptr FILEID="yg5az"/>
+</mets:div>
+<mets:div ID="o0fzj" LABEL="image 54" ORDER="54" TYPE="Static">
+<mets:fptr FILEID="pe1ka"/>
+</mets:div>
+<mets:div ID="retgg" LABEL="image 55" ORDER="55" TYPE="Static">
+<mets:fptr FILEID="if3y3"/>
+</mets:div>
+<mets:div ID="f6guv" LABEL="image 56" ORDER="56" TYPE="Static">
+<mets:fptr FILEID="b2vy6"/>
+</mets:div>
+<mets:div ID="ga676" LABEL="image 57" ORDER="57" TYPE="Static">
+<mets:fptr FILEID="fko5d"/>
+</mets:div>
+<mets:div ID="iwuud" LABEL="image 58" ORDER="58" TYPE="Static">
+<mets:fptr FILEID="l2gru"/>
+</mets:div>
+<mets:div ID="x001a" LABEL="image 59" ORDER="59" TYPE="Static">
+<mets:fptr FILEID="rpe0i"/>
+</mets:div>
+<mets:div ID="v7h5t" LABEL="image 60" ORDER="60" TYPE="Static">
+<mets:fptr FILEID="c7hio"/>
+</mets:div>
+<mets:div ID="hmuqs" LABEL="image 61" ORDER="61" TYPE="Static">
+<mets:fptr FILEID="axjgl"/>
+</mets:div>
+<mets:div ID="yz1ou" LABEL="image 62" ORDER="62" TYPE="Static">
+<mets:fptr FILEID="snpyg"/>
+</mets:div>
+<mets:div ID="ots7n" LABEL="image 63" ORDER="63" TYPE="Static">
+<mets:fptr FILEID="rb9s7"/>
+</mets:div>
+<mets:div ID="w0k12" LABEL="image 64" ORDER="64" TYPE="Static">
+<mets:fptr FILEID="n6xea"/>
+</mets:div>
+<mets:div ID="larn4" LABEL="image 65" ORDER="65" TYPE="Static">
+<mets:fptr FILEID="gcy3x"/>
+</mets:div>
+<mets:div ID="hckii" LABEL="image 66" ORDER="66" TYPE="Static">
+<mets:fptr FILEID="rqbx5"/>
+</mets:div>
+<mets:div ID="vpao5" LABEL="image 67" ORDER="67" TYPE="Static">
+<mets:fptr FILEID="b0ms9"/>
+</mets:div>
+<mets:div ID="g73d2" LABEL="image 68" ORDER="68" TYPE="Static">
+<mets:fptr FILEID="mokxy"/>
+</mets:div>
+<mets:div ID="n285i" LABEL="image 69" ORDER="69" TYPE="Static">
+<mets:fptr FILEID="xihxy"/>
+</mets:div>
+<mets:div ID="zka80" LABEL="image 70" ORDER="70" TYPE="Static">
+<mets:fptr FILEID="pc8zn"/>
+</mets:div>
+<mets:div ID="w36ov" LABEL="image 71" ORDER="71" TYPE="Static">
+<mets:fptr FILEID="l01my"/>
+</mets:div>
+<mets:div ID="bbzy9" LABEL="image 72" ORDER="72" TYPE="Static">
+<mets:fptr FILEID="a9itj"/>
+</mets:div>
+<mets:div ID="gl0h8" LABEL="image 73" ORDER="73" TYPE="Static">
+<mets:fptr FILEID="pzueq"/>
+</mets:div>
+<mets:div ID="t118z" LABEL="image 74" ORDER="74" TYPE="Static">
+<mets:fptr FILEID="grlin"/>
+</mets:div>
+<mets:div ID="mudid" LABEL="image 75" ORDER="75" TYPE="Static">
+<mets:fptr FILEID="nod0x"/>
+</mets:div>
+<mets:div ID="kqihs" LABEL="image 76" ORDER="76" TYPE="Static">
+<mets:fptr FILEID="i6qef"/>
+</mets:div>
+<mets:div ID="h5ud2" LABEL="image 77" ORDER="77" TYPE="Static">
+<mets:fptr FILEID="hgw98"/>
+</mets:div>
+<mets:div ID="drxi8" LABEL="image 78" ORDER="78" TYPE="Static">
+<mets:fptr FILEID="jzjq4"/>
+</mets:div>
+<mets:div ID="q0mdm" LABEL="image 79" ORDER="79" TYPE="Static">
+<mets:fptr FILEID="ays1e"/>
+</mets:div>
+<mets:div ID="oapqw" LABEL="image 80" ORDER="80" TYPE="Static">
+<mets:fptr FILEID="oflvx"/>
+</mets:div>
+<mets:div ID="r9jmh" LABEL="image 81" ORDER="81" TYPE="Static">
+<mets:fptr FILEID="c6cxg"/>
+</mets:div>
+<mets:div ID="copsb" LABEL="image 82" ORDER="82" TYPE="Static">
+<mets:fptr FILEID="lwzw0"/>
+</mets:div>
+<mets:div ID="ycn1q" LABEL="image 83" ORDER="83" TYPE="Static">
+<mets:fptr FILEID="hbuz1"/>
+</mets:div>
+<mets:div ID="xi30y" LABEL="image 84" ORDER="84" TYPE="Static">
+<mets:fptr FILEID="aw0mz"/>
+</mets:div>
+<mets:div ID="tjlm5" LABEL="image 85" ORDER="85" TYPE="Static">
+<mets:fptr FILEID="oqjao"/>
+</mets:div>
+<mets:div ID="ejepe" LABEL="image 86" ORDER="86" TYPE="Static">
+<mets:fptr FILEID="s8b2e"/>
+</mets:div>
+<mets:div ID="zmnfi" LABEL="image 87" ORDER="87" TYPE="Static">
+<mets:fptr FILEID="f229i"/>
+</mets:div>
+<mets:div ID="sk0dl" LABEL="image 88" ORDER="88" TYPE="Static">
+<mets:fptr FILEID="pqh2y"/>
+</mets:div>
+<mets:div ID="lcc17" LABEL="image 89" ORDER="89" TYPE="Static">
+<mets:fptr FILEID="u8yq0"/>
+</mets:div>
+<mets:div ID="qhj4n" LABEL="image 90" ORDER="90" TYPE="Static">
+<mets:fptr FILEID="cfjxe"/>
+</mets:div>
+<mets:div ID="nu2ee" LABEL="image 91" ORDER="91" TYPE="Static">
+<mets:fptr FILEID="qgwgu"/>
+</mets:div>
+<mets:div ID="rfsiv" LABEL="image 92" ORDER="92" TYPE="Static">
+<mets:fptr FILEID="yneio"/>
+</mets:div>
+<mets:div ID="rgdgu" LABEL="image 93" ORDER="93" TYPE="Static">
+<mets:fptr FILEID="i7gam"/>
+</mets:div>
+<mets:div ID="jxv7i" LABEL="image 94" ORDER="94" TYPE="Static">
+<mets:fptr FILEID="bk0dm"/>
+</mets:div>
+<mets:div ID="dvt4d" LABEL="image 95" ORDER="95" TYPE="Static">
+<mets:fptr FILEID="bkfso"/>
+</mets:div>
+<mets:div ID="ls4b6" LABEL="image 96" ORDER="96" TYPE="Static">
+<mets:fptr FILEID="zb9go"/>
+</mets:div>
+<mets:div ID="bkvom" LABEL="image 97" ORDER="97" TYPE="Static">
+<mets:fptr FILEID="wlzwm"/>
+</mets:div>
+<mets:div ID="dqqte" LABEL="image 98" ORDER="98" TYPE="Static">
+<mets:fptr FILEID="w3ccg"/>
+</mets:div>
+<mets:div ID="rvcpr" LABEL="image 99" ORDER="99" TYPE="Static">
+<mets:fptr FILEID="n6kt4"/>
+</mets:div>
+<mets:div ID="njqb7" LABEL="image 100" ORDER="100" TYPE="Static">
+<mets:fptr FILEID="dsokl"/>
+</mets:div>
+<mets:div ID="rz3ls" LABEL="image 101" ORDER="101" TYPE="Static">
+<mets:fptr FILEID="wgzsm"/>
+</mets:div>
+<mets:div ID="wzadp" LABEL="image 102" ORDER="102" TYPE="Static">
+<mets:fptr FILEID="l7zhp"/>
+</mets:div>
+<mets:div ID="avxuc" LABEL="image 103" ORDER="103" TYPE="Static">
+<mets:fptr FILEID="n5goz"/>
+</mets:div>
+<mets:div ID="irivv" LABEL="image 104" ORDER="104" TYPE="Static">
+<mets:fptr FILEID="tem01"/>
+</mets:div>
+<mets:div ID="c9zei" LABEL="image 105" ORDER="105" TYPE="Static">
+<mets:fptr FILEID="m58ti"/>
+</mets:div>
+<mets:div ID="yvqsw" LABEL="image 106" ORDER="106" TYPE="Static">
+<mets:fptr FILEID="qmewn"/>
+</mets:div>
+<mets:div ID="wjzns" LABEL="image 107" ORDER="107" TYPE="Static">
+<mets:fptr FILEID="ladt3"/>
+</mets:div>
+<mets:div ID="l6cxa" LABEL="image 108" ORDER="108" TYPE="Static">
+<mets:fptr FILEID="izjco"/>
+</mets:div>
+<mets:div ID="obv9k" LABEL="image 109" ORDER="109" TYPE="Static">
+<mets:fptr FILEID="gq0i5"/>
+</mets:div>
+<mets:div ID="iqa2p" LABEL="image 110" ORDER="110" TYPE="Static">
+<mets:fptr FILEID="bmwhn"/>
+</mets:div>
+<mets:div ID="v0s7o" LABEL="image 111" ORDER="111" TYPE="Static">
+<mets:fptr FILEID="pcakz"/>
+</mets:div>
+<mets:div ID="s0irv" LABEL="image 112" ORDER="112" TYPE="Static">
+<mets:fptr FILEID="g6892"/>
+</mets:div>
+<mets:div ID="hw4gc" LABEL="image 113" ORDER="113" TYPE="Static">
+<mets:fptr FILEID="i92zq"/>
+</mets:div>
+<mets:div ID="pkqts" LABEL="image 114" ORDER="114" TYPE="Static">
+<mets:fptr FILEID="lnoon"/>
+</mets:div>
+<mets:div ID="bvg99" LABEL="image 115" ORDER="115" TYPE="Static">
+<mets:fptr FILEID="hsmma"/>
+</mets:div>
+<mets:div ID="ai49e" LABEL="image 116" ORDER="116" TYPE="Static">
+<mets:fptr FILEID="pjgz4"/>
+</mets:div>
+<mets:div ID="gq2e2" LABEL="image 117" ORDER="117" TYPE="Static">
+<mets:fptr FILEID="ftwjs"/>
+</mets:div>
+<mets:div ID="ywt7d" LABEL="image 118" ORDER="118" TYPE="Static">
+<mets:fptr FILEID="j8o3x"/>
+</mets:div>
+<mets:div ID="h6wo3" LABEL="image 119" ORDER="119" TYPE="Static">
+<mets:fptr FILEID="b48bz"/>
+</mets:div>
+<mets:div ID="ooad1" LABEL="image 120" ORDER="120" TYPE="Static">
+<mets:fptr FILEID="x4ohz"/>
+</mets:div>
+<mets:div ID="ms5pn" LABEL="image 121" ORDER="121" TYPE="Static">
+<mets:fptr FILEID="yppll"/>
+</mets:div>
+<mets:div ID="ttyr0" LABEL="image 122" ORDER="122" TYPE="Static">
+<mets:fptr FILEID="alope"/>
+</mets:div>
+<mets:div ID="sjowt" LABEL="image 123" ORDER="123" TYPE="Static">
+<mets:fptr FILEID="f22r2"/>
+</mets:div>
+<mets:div ID="kgj6h" LABEL="image 124" ORDER="124" TYPE="Static">
+<mets:fptr FILEID="uor1e"/>
+</mets:div>
+<mets:div ID="rb5q8" LABEL="image 125" ORDER="125" TYPE="Static">
+<mets:fptr FILEID="h8jxm"/>
+</mets:div>
+<mets:div ID="qmgsg" LABEL="image 126" ORDER="126" TYPE="Static">
+<mets:fptr FILEID="friyb"/>
+</mets:div>
+<mets:div ID="xdpbk" LABEL="image 127" ORDER="127" TYPE="Static">
+<mets:fptr FILEID="absax"/>
+</mets:div>
+<mets:div ID="c1m8s" LABEL="image 128" ORDER="128" TYPE="Static">
+<mets:fptr FILEID="xniio"/>
+</mets:div>
+<mets:div ID="uxrf6" LABEL="image 129" ORDER="129" TYPE="Static">
+<mets:fptr FILEID="nm6ih"/>
+</mets:div>
+<mets:div ID="f87xm" LABEL="image 130" ORDER="130" TYPE="Static">
+<mets:fptr FILEID="p93ab"/>
+</mets:div>
+<mets:div ID="ko6ce" LABEL="image 131" ORDER="131" TYPE="Static">
+<mets:fptr FILEID="fm9yz"/>
+</mets:div>
+<mets:div ID="xha4t" LABEL="image 132" ORDER="132" TYPE="Static">
+<mets:fptr FILEID="cqh0n"/>
+</mets:div>
+<mets:div ID="pmzei" LABEL="image 133" ORDER="133" TYPE="Static">
+<mets:fptr FILEID="jfan1"/>
+</mets:div>
+<mets:div ID="ma0wh" LABEL="image 134" ORDER="134" TYPE="Static">
+<mets:fptr FILEID="v7lgq"/>
+</mets:div>
+<mets:div ID="a5h7i" LABEL="image 135" ORDER="135" TYPE="Static">
+<mets:fptr FILEID="ro2hf"/>
+</mets:div>
+<mets:div ID="tns7q" LABEL="image 136" ORDER="136" TYPE="Static">
+<mets:fptr FILEID="dez4h"/>
+</mets:div>
+<mets:div ID="hqo6o" LABEL="image 137" ORDER="137" TYPE="Static">
+<mets:fptr FILEID="w88g9"/>
+</mets:div>
+<mets:div ID="clj6q" LABEL="image 138" ORDER="138" TYPE="Static">
+<mets:fptr FILEID="n7bt3"/>
+</mets:div>
+<mets:div ID="wx1id" LABEL="image 139" ORDER="139" TYPE="Static">
+<mets:fptr FILEID="lnphz"/>
+</mets:div>
+<mets:div ID="l9l9d" LABEL="image 140" ORDER="140" TYPE="Static">
+<mets:fptr FILEID="ey5yv"/>
+</mets:div>
+<mets:div ID="coqai" LABEL="image 141" ORDER="141" TYPE="Static">
+<mets:fptr FILEID="ljqsl"/>
+</mets:div>
+<mets:div ID="l2dpi" LABEL="image 142" ORDER="142" TYPE="Static">
+<mets:fptr FILEID="k139m"/>
+</mets:div>
+<mets:div ID="destk" LABEL="image 143" ORDER="143" TYPE="Static">
+<mets:fptr FILEID="x9zut"/>
+</mets:div>
+<mets:div ID="virga" LABEL="image 144" ORDER="144" TYPE="Static">
+<mets:fptr FILEID="mkzs0"/>
+</mets:div>
+<mets:div ID="bk0er" LABEL="image 145" ORDER="145" TYPE="Static">
+<mets:fptr FILEID="tc62e"/>
+</mets:div>
+<mets:div ID="s50ag" LABEL="image 146" ORDER="146" TYPE="Static">
+<mets:fptr FILEID="kwjaa"/>
+</mets:div>
+<mets:div ID="ucckd" LABEL="image 147" ORDER="147" TYPE="Static">
+<mets:fptr FILEID="vzxsf"/>
+</mets:div>
+<mets:div ID="wb4nn" LABEL="image 148" ORDER="148" TYPE="Static">
+<mets:fptr FILEID="tuppq"/>
+</mets:div>
+<mets:div ID="gljul" LABEL="image 149" ORDER="149" TYPE="Static">
+<mets:fptr FILEID="ijml2"/>
+</mets:div>
+<mets:div ID="l3zhy" LABEL="image 150" ORDER="150" TYPE="Static">
+<mets:fptr FILEID="psbyo"/>
+</mets:div>
+<mets:div ID="ovgib" LABEL="image 151" ORDER="151" TYPE="Static">
+<mets:fptr FILEID="kwy70"/>
+</mets:div>
+<mets:div ID="z5qav" LABEL="image 152" ORDER="152" TYPE="Static">
+<mets:fptr FILEID="deb4x"/>
+</mets:div>
+<mets:div ID="aj3z4" LABEL="image 153" ORDER="153" TYPE="Static">
+<mets:fptr FILEID="yeed1"/>
+</mets:div>
+<mets:div ID="hvze1" LABEL="image 154" ORDER="154" TYPE="Static">
+<mets:fptr FILEID="ugzuq"/>
+</mets:div>
+<mets:div ID="dw0xc" LABEL="image 155" ORDER="155" TYPE="Static">
+<mets:fptr FILEID="mpf98"/>
+</mets:div>
+<mets:div ID="u6zbi" LABEL="image 156" ORDER="156" TYPE="Static">
+<mets:fptr FILEID="d3phu"/>
+</mets:div>
+<mets:div ID="pgps0" LABEL="image 157" ORDER="157" TYPE="Static">
+<mets:fptr FILEID="yy415"/>
+</mets:div>
+<mets:div ID="wqnxs" LABEL="image 158" ORDER="158" TYPE="Static">
+<mets:fptr FILEID="z3bhc"/>
+</mets:div>
+<mets:div ID="txp9u" LABEL="image 159" ORDER="159" TYPE="Static">
+<mets:fptr FILEID="x5pkc"/>
+</mets:div>
+<mets:div ID="xpkv5" LABEL="image 160" ORDER="160" TYPE="Static">
+<mets:fptr FILEID="brz9h"/>
+</mets:div>
+<mets:div ID="qhceq" LABEL="image 161" ORDER="161" TYPE="Static">
+<mets:fptr FILEID="cz2li"/>
+</mets:div>
+<mets:div ID="rhsju" LABEL="image 162" ORDER="162" TYPE="Static">
+<mets:fptr FILEID="pp6t5"/>
+</mets:div>
+<mets:div ID="gd8jy" LABEL="image 163" ORDER="163" TYPE="Static">
+<mets:fptr FILEID="ps2t6"/>
+</mets:div>
+<mets:div ID="tls3o" LABEL="image 164" ORDER="164" TYPE="Static">
+<mets:fptr FILEID="so6ka"/>
+</mets:div>
+<mets:div ID="pq5ov" LABEL="image 165" ORDER="165" TYPE="Static">
+<mets:fptr FILEID="girge"/>
+</mets:div>
+<mets:div ID="txsu8" LABEL="image 166" ORDER="166" TYPE="Static">
+<mets:fptr FILEID="oct27"/>
+</mets:div>
+<mets:div ID="a9xrx" LABEL="image 167" ORDER="167" TYPE="Static">
+<mets:fptr FILEID="fx8xd"/>
+</mets:div>
+<mets:div ID="cmmib" LABEL="image 168" ORDER="168" TYPE="Static">
+<mets:fptr FILEID="oi977"/>
+</mets:div>
+<mets:div ID="a4jqm" LABEL="image 169" ORDER="169" TYPE="Static">
+<mets:fptr FILEID="qbqha"/>
+</mets:div>
+<mets:div ID="zgtze" LABEL="image 170" ORDER="170" TYPE="Static">
+<mets:fptr FILEID="ikysu"/>
+</mets:div>
+<mets:div ID="oo53b" LABEL="image 171" ORDER="171" TYPE="Static">
+<mets:fptr FILEID="gx0h2"/>
+</mets:div>
+<mets:div ID="qkt1b" LABEL="image 172" ORDER="172" TYPE="Static">
+<mets:fptr FILEID="f9czr"/>
+</mets:div>
+<mets:div ID="mcsa1" LABEL="image 173" ORDER="173" TYPE="Static">
+<mets:fptr FILEID="d1pb3"/>
+</mets:div>
+<mets:div ID="o20ib" LABEL="image 174" ORDER="174" TYPE="Static">
+<mets:fptr FILEID="bidz9"/>
+</mets:div>
+<mets:div ID="jwl7u" LABEL="image 175" ORDER="175" TYPE="Static">
+<mets:fptr FILEID="wz4fg"/>
+</mets:div>
+<mets:div ID="sg2mx" LABEL="image 176" ORDER="176" TYPE="Static">
+<mets:fptr FILEID="vl32k"/>
+</mets:div>
+<mets:div ID="yiztw" LABEL="image 177" ORDER="177" TYPE="Static">
+<mets:fptr FILEID="nf3yt"/>
+</mets:div>
+<mets:div ID="qzoer" LABEL="image 178" ORDER="178" TYPE="Static">
+<mets:fptr FILEID="cmo6l"/>
+</mets:div>
+<mets:div ID="luyp4" LABEL="image 179" ORDER="179" TYPE="Static">
+<mets:fptr FILEID="hssp1"/>
+</mets:div>
+<mets:div ID="xchlg" LABEL="image 180" ORDER="180" TYPE="Static">
+<mets:fptr FILEID="rzjze"/>
+</mets:div>
+<mets:div ID="zgnwi" LABEL="image 181" ORDER="181" TYPE="Static">
+<mets:fptr FILEID="u6igm"/>
+</mets:div>
+<mets:div ID="k7unc" LABEL="image 182" ORDER="182" TYPE="Static">
+<mets:fptr FILEID="cuo6u"/>
+</mets:div>
+<mets:div ID="toe92" LABEL="image 183" ORDER="183" TYPE="Static">
+<mets:fptr FILEID="ragf6"/>
+</mets:div>
+<mets:div ID="i6ohp" LABEL="image 184" ORDER="184" TYPE="Static">
+<mets:fptr FILEID="mibsi"/>
+</mets:div>
+<mets:div ID="gsoqg" LABEL="image 185" ORDER="185" TYPE="Static">
+<mets:fptr FILEID="pfda4"/>
+</mets:div>
+<mets:div ID="vvumd" LABEL="image 186" ORDER="186" TYPE="Static">
+<mets:fptr FILEID="uc6y9"/>
+</mets:div>
+<mets:div ID="v2cbz" LABEL="image 187" ORDER="187" TYPE="Static">
+<mets:fptr FILEID="v7kq6"/>
+</mets:div>
+<mets:div ID="rmbrg" LABEL="image 188" ORDER="188" TYPE="Static">
+<mets:fptr FILEID="ol01v"/>
+</mets:div>
+<mets:div ID="plh3n" LABEL="image 189" ORDER="189" TYPE="Static">
+<mets:fptr FILEID="ucuj2"/>
+</mets:div>
+<mets:div ID="r8jwb" LABEL="image 190" ORDER="190" TYPE="Static">
+<mets:fptr FILEID="rse38"/>
+</mets:div>
+<mets:div ID="catx0" LABEL="image 191" ORDER="191" TYPE="Static">
+<mets:fptr FILEID="b4qs6"/>
+</mets:div>
+<mets:div ID="inwxw" LABEL="image 192" ORDER="192" TYPE="Static">
+<mets:fptr FILEID="kli7f"/>
+</mets:div>
+<mets:div ID="b6yfl" LABEL="image 193" ORDER="193" TYPE="Static">
+<mets:fptr FILEID="iscqr"/>
+</mets:div>
+<mets:div ID="deorz" LABEL="image 194" ORDER="194" TYPE="Static">
+<mets:fptr FILEID="dpju4"/>
+</mets:div>
+<mets:div ID="wpagm" LABEL="image 195" ORDER="195" TYPE="Static">
+<mets:fptr FILEID="d8fou"/>
+</mets:div>
+<mets:div ID="n1g67" LABEL="image 196" ORDER="196" TYPE="Static">
+<mets:fptr FILEID="kmobn"/>
+</mets:div>
+<mets:div ID="j5ks9" LABEL="image 197" ORDER="197" TYPE="Static">
+<mets:fptr FILEID="eweae"/>
+</mets:div>
+<mets:div ID="e1qi6" LABEL="image 198" ORDER="198" TYPE="Static">
+<mets:fptr FILEID="l7kmv"/>
+</mets:div>
+<mets:div ID="z76vp" LABEL="image 199" ORDER="199" TYPE="Static">
+<mets:fptr FILEID="twypr"/>
+</mets:div>
+<mets:div ID="fglxo" LABEL="image 200" ORDER="200" TYPE="Static">
+<mets:fptr FILEID="d43ze"/>
+</mets:div>
+<mets:div ID="m64ed" LABEL="image 201" ORDER="201" TYPE="Static">
+<mets:fptr FILEID="ze2y2"/>
+</mets:div>
+<mets:div ID="jvvrb" LABEL="image 202" ORDER="202" TYPE="Static">
+<mets:fptr FILEID="a7vph"/>
+</mets:div>
+<mets:div ID="ykybj" LABEL="image 203" ORDER="203" TYPE="Static">
+<mets:fptr FILEID="wq3bv"/>
+</mets:div>
+<mets:div ID="pzv9l" LABEL="image 204" ORDER="204" TYPE="Static">
+<mets:fptr FILEID="ivfxt"/>
+</mets:div>
+<mets:div ID="h0op1" LABEL="image 205" ORDER="205" TYPE="Static">
+<mets:fptr FILEID="nzivf"/>
+</mets:div>
+<mets:div ID="tkhvf" LABEL="image 206" ORDER="206" TYPE="Static">
+<mets:fptr FILEID="hrywv"/>
+</mets:div>
+<mets:div ID="e602m" LABEL="image 207" ORDER="207" TYPE="Static">
+<mets:fptr FILEID="dcg37"/>
+</mets:div>
+<mets:div ID="ze5xw" LABEL="image 208" ORDER="208" TYPE="Static">
+<mets:fptr FILEID="opv56"/>
+</mets:div>
+<mets:div ID="dyylq" LABEL="image 209" ORDER="209" TYPE="Static">
+<mets:fptr FILEID="f2e3b"/>
+</mets:div>
+<mets:div ID="pjhqb" LABEL="image 210" ORDER="210" TYPE="Static">
+<mets:fptr FILEID="ilgdr"/>
+</mets:div>
+<mets:div ID="nu96q" LABEL="image 211" ORDER="211" TYPE="Static">
+<mets:fptr FILEID="hzrin"/>
+</mets:div>
+<mets:div ID="lm9lo" LABEL="image 212" ORDER="212" TYPE="Static">
+<mets:fptr FILEID="v0h9w"/>
+</mets:div>
+<mets:div ID="nzqu0" LABEL="image 213" ORDER="213" TYPE="Static">
+<mets:fptr FILEID="udbcm"/>
+</mets:div>
+<mets:div ID="mu0e7" LABEL="image 214" ORDER="214" TYPE="Static">
+<mets:fptr FILEID="xhtpp"/>
+</mets:div>
+<mets:div ID="p5fb0" LABEL="image 215" ORDER="215" TYPE="Static">
+<mets:fptr FILEID="nuhuc"/>
+</mets:div>
+<mets:div ID="sh0p9" LABEL="image 216" ORDER="216" TYPE="Static">
+<mets:fptr FILEID="x6s0g"/>
+</mets:div>
+<mets:div ID="ywqn2" LABEL="image 217" ORDER="217" TYPE="Static">
+<mets:fptr FILEID="eo95l"/>
+</mets:div>
+<mets:div ID="jy7nc" LABEL="image 218" ORDER="218" TYPE="Static">
+<mets:fptr FILEID="z2fw0"/>
+</mets:div>
+<mets:div ID="ckn90" LABEL="image 219" ORDER="219" TYPE="Static">
+<mets:fptr FILEID="ci0as"/>
+</mets:div>
+<mets:div ID="hgs49" LABEL="image 220" ORDER="220" TYPE="Static">
+<mets:fptr FILEID="fr8ty"/>
+</mets:div>
+<mets:div ID="anu6w" LABEL="image 221" ORDER="221" TYPE="Static">
+<mets:fptr FILEID="pqeuy"/>
+</mets:div>
+<mets:div ID="cy3wj" LABEL="image 222" ORDER="222" TYPE="Static">
+<mets:fptr FILEID="gb4yk"/>
+</mets:div>
+<mets:div ID="mh4wj" LABEL="image 223" ORDER="223" TYPE="Static">
+<mets:fptr FILEID="haasu"/>
+</mets:div>
+<mets:div ID="qvcx9" LABEL="image 224" ORDER="224" TYPE="Static">
+<mets:fptr FILEID="nf4a0"/>
+</mets:div>
+<mets:div ID="cd1f3" LABEL="image 225" ORDER="225" TYPE="Static">
+<mets:fptr FILEID="qp0f6"/>
+</mets:div>
+<mets:div ID="zq3dx" LABEL="image 226" ORDER="226" TYPE="Static">
+<mets:fptr FILEID="xvqq1"/>
+</mets:div>
+</mets:div>
+</mets:structMap>
+</mets:mets>

--- a/spec/models/mets_document/mods_document_spec.rb
+++ b/spec/models/mets_document/mods_document_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe METSDocument::MODSDocument do
+  subject(:mods_document) { described_class.from(mets: mets, xpath: xpath) }
+
+  let(:mets_file) { Rails.root.join("spec", "fixtures", "mets", "pudl0001-4609321-s42.mets") }
+  let(:mets) { File.open(mets_file) { |f| Nokogiri::XML(f) } }
+  let(:xpath) { "/mets:mets/mets:dmdSec/mets:mdWrap/mets:xmlData/mods:mods" }
+
+  describe ".from" do
+    it "constructs a MODSDocument from a METSDocument and an XPath" do
+      expect(mods_document).to be_a described_class
+    end
+  end
+
+  describe "#title" do
+    it "accesses the title within the MODS-encoded metadata" do
+      expect(mods_document.title).to include "Biblia Latina"
+    end
+  end
+
+  describe "#alternative_title" do
+    it "accesses the alternative title within the MODS-encoded metadata" do
+      expect(mods_document.alternative_title).to include "Gutenberg Bible"
+    end
+  end
+
+  describe "#uniform_title" do
+    it "accesses the uniform title within the MODS-encoded metadata" do
+      expect(mods_document.uniform_title).to include "Bible. Latin. 1456"
+    end
+  end
+
+  describe "#date_created" do
+    let(:mets_file) { Rails.root.join("spec", "fixtures", "mets", "tsop_typed.mets") }
+
+    it "accesses the date of creation within the MODS-encoded metadata" do
+      expect(mods_document.date_created).to include "1918"
+    end
+  end
+
+  describe "#type_of_resource" do
+    it "accesses the resource type within the MODS-encoded metadata" do
+      expect(mods_document.type_of_resource).to include "text"
+    end
+  end
+
+  describe "#extent" do
+    it "accesses the extent within the MODS-encoded metadata" do
+      expect(mods_document.extent).to include "2 v. (324; 319 leaves) ; 40.5 × 28.8 cm. (fol.)"
+    end
+  end
+
+  describe "#access_condition" do
+    let(:mets_file) { Rails.root.join("spec", "fixtures", "mets", "tsop_typed.mets") }
+
+    it "accesses the access conditions within the MODS-encoded metadata" do
+      expect(mods_document.access_condition).not_to be_empty
+      expect(mods_document.access_condition.first).to include "Not to be published, reproduced"
+    end
+  end
+
+  describe "#restriction_on_access" do
+    let(:mets_file) { Rails.root.join("spec", "fixtures", "mets", "tsop_typed.mets") }
+
+    it "accesses the access restrictions within the MODS-encoded metadata" do
+      expect(mods_document.restriction_on_access).not_to be_empty
+      expect(mods_document.restriction_on_access.first).to include "For legal and conservation reasons, access to F."
+    end
+  end
+
+  context "when the URIs are encoded for access conditions and restrictions" do
+    let(:mets_file) { Rails.root.join("spec", "fixtures", "mets", "pudl0001-4609321-s42.mets") }
+
+    describe "#access_condition" do
+      it "accesses the access conditions within the MODS-encoded metadata" do
+        expect(mods_document.access_condition).to include "http://www.princeton.edu/~rbsc/research/rights.html"
+      end
+    end
+
+    describe "#restriction_on_access" do
+      it "accesses the access restrictions within the MODS-encoded metadata" do
+        expect(mods_document.restriction_on_access).to include "http://www.princeton.edu/~rbsc/research/rules.html"
+      end
+    end
+  end
+
+  describe "#note" do
+    it "accesses the note within the MODS-encoded metadata" do
+      expect(mods_document.note).to include "Commonly known in English as Gutenberg Bible, formerly known as Mazarin or Mazarine Bible."
+    end
+  end
+
+  describe "#subject" do
+    let(:mets_file) { Rails.root.join("spec", "fixtures", "mets", "tsop_typed.mets") }
+
+    it "accesses the title within the MODS-encoded metadata" do
+      expect(mods_document.subject).to include "F. Scott (Francis Scott)"
+    end
+  end
+
+  describe "#abstract" do
+    let(:mets_file) { Rails.root.join("spec", "fixtures", "mets", "pudl0001-4612596.mets") }
+
+    it "accesses the abstract within the MODS-encoded metadata" do
+      expect(mods_document.abstract).not_to be_empty
+      expect(mods_document.abstract.first).to include "Although printed with the same type as the Scheide fragment Goff D-325a, this fragment clearly belongs"
+    end
+  end
+
+  describe "#table_of_contents" do
+    let(:mets_file) { Rails.root.join("spec", "fixtures", "mets", "scrapbooks.mets") }
+
+    it "accesses the title within the MODS-encoded metadata" do
+      expect(mods_document.table_of_contents).to include "I. This Side of Paradise (1920)."
+    end
+  end
+end


### PR DESCRIPTION
This is necessary for ingesting items without MARC records