### PR TITLE
Fix geoblacklight iiif references for map sets

### DIFF
--- a/app/services/geo_discovery/document_builder/document_path.rb
+++ b/app/services/geo_discovery/document_builder/document_path.rb
@@ -70,10 +70,13 @@ module GeoDiscovery
         # Returns a map set's thumbnail file set decorator.
         # @return [FileSetDecorator] thumbnail file set decorator
         def map_set_file_set
-          member_id = Array.wrap(resource_decorator.thumbnail_id).first
-          return unless member_id
-          file_set = query_service.find_by(id: member_id)
-          file_set.decorate if file_set && file_set.is_a?(FileSet)
+          @map_set_file_set ||= begin
+            member_id = Array.wrap(resource_decorator.thumbnail_id).first
+            return unless member_id
+            member = query_service.find_by(id: member_id)
+            return member.decorate if member && member.is_a?(FileSet)
+            member.decorate.geo_members.try(:first)
+          end
         rescue Valkyrie::Persistence::ObjectNotFoundError
           nil
         end

--- a/app/services/geo_discovery/document_builder/iiif_builder.rb
+++ b/app/services/geo_discovery/document_builder/iiif_builder.rb
@@ -66,8 +66,9 @@ module GeoDiscovery
           @map_set_file_set ||= begin
             member_id = Array.wrap(resource_decorator.thumbnail_id).first
             return unless member_id
-            file_set = query_service.find_by(id: member_id)
-            file_set.decorate if file_set && file_set.is_a?(FileSet)
+            member = query_service.find_by(id: member_id)
+            return member.decorate if member && member.is_a?(FileSet)
+            member.decorate.geo_members.try(:first)
           end
         rescue Valkyrie::Persistence::ObjectNotFoundError
           nil

--- a/spec/services/geo_discovery/document_builder_spec.rb
+++ b/spec/services/geo_discovery/document_builder_spec.rb
@@ -244,7 +244,7 @@ describe GeoDiscovery::DocumentBuilder do
 
       before do
         change_set = ScannedMapChangeSet.new(geo_work)
-        change_set.validate(thumbnail_id: child.member_ids[0])
+        change_set.validate(thumbnail_id: child.id)
         change_set_persister.save(change_set: change_set)
       end
 


### PR DESCRIPTION
It appears that a map set's thumbnail id _should_ be set to the id of a child scanned map. Changes here detect if the thumbnail id is a FileSet or a child member and returns the correct FileSet.

Closes #1726 