### PR TITLE
Implements the `bulk:link_invalid_thumbnails` Rake task for linking resources with invalid thumbnail IDs

### DIFF
--- a/app/queries/find_invalid_thumbnail_resources.rb
+++ b/app/queries/find_invalid_thumbnail_resources.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+class FindInvalidThumbnailResources
+  # Access the list of methods exposed for the query
+  # @return [Array<Symbol>] query method signatures
+  def self.queries
+    [:find_invalid_thumbnail_resources]
+  end
+
+  attr_reader :query_service
+  delegate :connection, to: :query_service
+  delegate :resource_factory, to: :query_service
+  # Constructor
+  # @param query_service [Valkyrie::Persistence::Solr::QueryService] the query service for Solr
+  def initialize(query_service:)
+    @query_service = query_service
+  end
+
+  # Method for finding all resources with invalid thumbnail IDs
+  # @param model [Resource] the model for the resources
+  def find_invalid_thumbnail_resources(model: ScannedResource)
+    run(model)
+  end
+
+  private
+
+    # The query for Solr
+    # @param model [Resource] the model for the resources
+    def query(model)
+      "#{Valkyrie::Persistence::Solr::Queries::MODEL}:#{model} AND thumbnail_id_ssim:*intermediate_file*"
+    end
+
+    # Iterate through the results of the query
+    # @param model [Resource] the model for the resources
+    # @yield [Resource] a resource with an invalid thumbnail ID
+    def each(model)
+      docs = Valkyrie::Persistence::Solr::Queries::DefaultPaginator.new
+      while docs.has_next?
+        docs = connection.paginate(docs.next_page, docs.per_page, "select", params: { q: query(model) })["response"]["docs"]
+        docs.each do |doc|
+          yield resource_factory.to_resource(object: doc)
+        end
+      end
+    end
+
+    # Execute the query
+    # @param model [Resource] the model for the resources
+    def run(model)
+      enum_for(:each, model)
+    end
+end

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -250,7 +250,7 @@ Rails.application.config.to_prepare do
 
   # Register custom queries for the Valkyrie Solr metadata adapter used for indexing
   # (see Valkyrie::Persistence::CustomQueryContainer)
-  [FindMissingThumbnailResources].each do |solr_query_handler|
+  [FindMissingThumbnailResources, FindInvalidThumbnailResources].each do |solr_query_handler|
     Valkyrie::MetadataAdapter.find(:index_solr).query_service.custom_queries.register_query_handler(solr_query_handler)
   end
 

--- a/spec/queries/find_invalid_thumbnail_resources_spec.rb
+++ b/spec/queries/find_invalid_thumbnail_resources_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require "rails_helper"
+include ActionDispatch::TestProcess
+
+RSpec.describe FindInvalidThumbnailResources do
+  subject(:query) { described_class.new(query_service: query_service) }
+  let(:metadata_adapter) { Valkyrie::MetadataAdapter.find(:index_solr) }
+  let(:query_service) { metadata_adapter.query_service }
+  let(:resource) do
+    sr = FactoryBot.create_for_repository(:scanned_resource)
+    change_set = ScannedResourceChangeSet.new(sr)
+    change_set.thumbnail_id = "https://libimages1.princeton.edu/loris/figgy_prod/d7%2F44%2F84%2Fd74484d965664f95a9ac2634bd583775%2Fintermediate_file.jp2/full/!200,150/0/default.jpg"
+    change_set.prepopulate!
+    change_set_persister.save(change_set: change_set)
+  end
+  let(:file) { fixture_file_upload("files/color-landscape.tif", "image/tiff") }
+  let(:resource2) { FactoryBot.create_for_repository(:scanned_resource, files: [file]) }
+  let(:change_set_persister) { ChangeSetPersister.new(metadata_adapter: metadata_adapter, storage_adapter: Valkyrie.config.storage_adapter) }
+
+  before do
+    stub_bibdata(bib_id: "123456")
+    stub_ezid(shoulder: "99999/fk4", blade: "8675309")
+  end
+
+  describe "#find_invalid_thumbnail_resources" do
+    let(:connection) { Blacklight.default_index.connection }
+    before do
+      resource
+    end
+    it "only finds resources with invalid thumbnails" do
+      output = query.find_invalid_thumbnail_resources(model: ScannedResource)
+      ids = output.map(&:id)
+      expect(ids).to include resource.id
+      expect(ids).not_to include resource2.id
+    end
+  end
+end


### PR DESCRIPTION
Resolves #1732 by addressing the following:
- Implements the `bulk:link_invalid_thumbnails` Rake task for linking resource thumbnails (where the IDs are corrupted)
- Implements the `FindInvalidThumbnailResources` query in order to find resources with these invalid thumbnail IDs