### PR TITLE
Changes for PUDL0100

### DIFF
--- a/app/change_sets/simple_resource_change_set.rb
+++ b/app/change_sets/simple_resource_change_set.rb
@@ -38,6 +38,8 @@ class SimpleResourceChangeSet < ChangeSet
   property :coverage, multiple: true, required: false, default: []
   property :creator, multiple: true, required: false, default: []
   property :photographer, multiple: true, required: false, default: []
+  property :actor, multiple: true, required: false, default: []
+  property :director, multiple: true, required: false, default: []
   property :date, multiple: true, required: false, default: []
   property :description, multiple: true, required: false, default: []
   property :keyword, multiple: true, required: false, default: []

--- a/app/decorators/ephemera_vocabulary_decorator.rb
+++ b/app/decorators/ephemera_vocabulary_decorator.rb
@@ -11,8 +11,6 @@ class EphemeraVocabularyDecorator < Valkyrie::ResourceDecorator
   # TODO: Rename to decorated_vocabularies
   def categories
     @categories ||= wayfinder.decorated_vocabularies.sort_by(&:label)
-  rescue
-    @categories ||= []
   end
 
   # TODO: Rename to decorated_ephemera_terms

--- a/app/decorators/scanned_resource_decorator.rb
+++ b/app/decorators/scanned_resource_decorator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class ScannedResourceDecorator < Valkyrie::ResourceDecorator
-  display Schema::Common.attributes, :rendered_ocr_language, :rendered_holding_location, :member_of_collections
-  suppress :thumbnail_id, :imported_author, :source_jsonld, :source_metadata, :sort_title, :ocr_language, :rights_statement
+  display Schema::Common.attributes, :rendered_ocr_language, :rendered_holding_location, :member_of_collections, :rendered_actors
+  suppress :thumbnail_id, :imported_author, :source_jsonld, :source_metadata, :sort_title, :ocr_language, :rights_statement, :actor
 
   display_in_manifest displayed_attributes, :location
   suppress_from_manifest Schema::IIIF.attributes,
@@ -129,5 +129,17 @@ class ScannedResourceDecorator < Valkyrie::ResourceDecorator
 
   def pdf_file
     file_metadata.find { |x| x.mime_type == ["application/pdf"] }
+  end
+
+  def rendered_actors
+    Array.wrap(actor).flat_map do |actor|
+      if actor.is_a?(String)
+        actor
+      elsif actor.is_a?(Grouping)
+        actor.elements.map(&:to_s)
+      else
+        actor.to_s
+      end
+    end
   end
 end

--- a/app/models/mets_document.rb
+++ b/app/models/mets_document.rb
@@ -213,7 +213,9 @@ class METSDocument
       part_of: mods.finding_aid_identifier,
       replaces: mods.replaces,
       photographer: mods.photographer,
-      local_identifier: mods.local_identifier
+      local_identifier: mods.local_identifier,
+      actor: mods.actor,
+      director: mods.director
     }
   end
   # rubocop:enable Metrics/AbcSize

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -19,7 +19,7 @@ class SolrDocument
   use_extension(LinkedData)
 
   def resource
-    @resource ||= Valkyrie::MetadataAdapter.find(:index_solr).resource_factory.to_resource(object: to_h)
+    @resource ||= Valkyrie::MetadataAdapter.find(:indexing_persister).query_service.find_by(id: id)
   end
 
   def decorated_resource

--- a/spec/decorators/scanned_resource_decorator_spec.rb
+++ b/spec/decorators/scanned_resource_decorator_spec.rb
@@ -129,4 +129,28 @@ RSpec.describe ScannedResourceDecorator do
       end
     end
   end
+
+  describe "#rendered_actors" do
+    context "when given groupings of actors along with RDF literals" do
+      let(:resource) do
+        FactoryBot.create_for_repository(
+          :scanned_resource,
+          actor: [
+            RDF::Literal.new("Test", language: "eng-Latn"),
+            Grouping.new(
+              elements: [
+                "Test",
+                "Test2"
+              ]
+            )
+          ]
+        )
+      end
+      it "returns all elements in order for rendering as strings" do
+        expect(decorator.rendered_actors).to eq [
+          "Test", "Test", "Test2"
+        ]
+      end
+    end
+  end
 end

--- a/spec/fixtures/mets/pudl0100-lc-egx_0003.mets
+++ b/spec/fixtures/mets/pudl0100-lc-egx_0003.mets
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" OBJID="ark:/88435/pc289j82b" TYPE="CompiledDigitalObject" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/mets.xsd">
+<mets:metsHdr CREATEDATE="2018-08-04T11:56:27.391-04:00" LASTMODDATE="2018-08-04T11:56:27.391-04:00">
+<mets:metsDocumentID TYPE="PUDL">pudl0100/lc/egx_0003.mets</mets:metsDocumentID>
+</mets:metsHdr>
+<mets:dmdSec ID="imny5">
+<mets:mdWrap MDTYPE="MODS">
+<mets:xmlData>
+<mods:mods xmlns:mods="http://www.loc.gov/mods/v3" version="3.4" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd">
+   <mods:titleInfo lang="ara" script="Arab">
+      <mods:title>الاختيار</mods:title>
+   </mods:titleInfo>
+   <mods:name altRepGroup="01" authority="naf" lang="ara" script="Latn" type="personal">
+      <mods:namePart type="family">Ḥusnī</mods:namePart>
+      <mods:namePart type="given">Suʻād</mods:namePart>
+      <mods:role>
+         <mods:roleTerm authority="marcrelator" type="code">act</mods:roleTerm>
+      </mods:role>
+   </mods:name>
+   <mods:name altRepGroup="01" authority="local" lang="ara" script="Arab" type="personal">
+      <mods:namePart type="family">سعاد حسني</mods:namePart>
+      <mods:role>
+         <mods:roleTerm authority="marcrelator" type="code">act</mods:roleTerm>
+      </mods:role>
+   </mods:name>
+   <mods:name altRepGroup="02" authority="naf" lang="ara" script="Latn" type="personal">
+      <mods:namePart type="family">ʻAlāyilī</mods:namePart>
+      <mods:namePart type="given">ʻIzzat</mods:namePart>
+      <mods:namePart type="date">1934-</mods:namePart>
+      <mods:role>
+         <mods:roleTerm authority="marcrelator" type="code">act</mods:roleTerm>
+      </mods:role>
+   </mods:name>
+   <mods:name altRepGroup="02" authority="local" lang="ara" script="Arab" type="personal">
+      <mods:namePart type="family">عزت العلايلي</mods:namePart>
+      <mods:role>
+         <mods:roleTerm authority="marcrelator" type="code">act</mods:roleTerm>
+      </mods:role>
+   </mods:name>
+   <mods:name authority="local" lang="ara" script="Arab" type="personal">
+      <mods:namePart type="family">هدى سلطان</mods:namePart>
+      <mods:role>
+         <mods:roleTerm authority="marcrelator" type="code">act</mods:roleTerm>
+      </mods:role>
+   </mods:name>
+   <mods:name altRepGroup="04" authority="naf" lang="ara" script="Latn" type="personal">
+      <mods:namePart type="family">Milījī</mods:namePart>
+      <mods:namePart type="given">Maḥmūd</mods:namePart>
+      <mods:role>
+         <mods:roleTerm authority="marcrelator" type="code">act</mods:roleTerm>
+      </mods:role>
+   </mods:name>
+   <mods:name altRepGroup="04" authority="local" lang="ara" script="Arab" type="personal">
+      <mods:namePart type="family">محمود المليجي</mods:namePart>
+      <mods:role>
+         <mods:roleTerm authority="marcrelator" type="code">act</mods:roleTerm>
+      </mods:role>
+   </mods:name>
+   <mods:name authority="local" type="personal">
+      <mods:namePart type="family">Test</mods:namePart>
+      <mods:role>
+         <mods:roleTerm authority="marcrelator" type="code">act</mods:roleTerm>
+      </mods:role>
+   </mods:name>
+   <mods:name authority="local" lang="ara" script="Arab" type="personal">
+      <mods:namePart type="family">يوسف شاهين</mods:namePart>
+      <mods:role>
+         <mods:roleTerm authority="marcrelator" type="code">drt</mods:roleTerm>
+      </mods:role>
+   </mods:name>
+   <mods:typeOfResource>still image</mods:typeOfResource>
+   <mods:genre authority="aat">Lobby Cards</mods:genre>
+   <mods:originInfo>
+      <mods:place>
+         <mods:placeTerm type="text">Egypt</mods:placeTerm>
+      </mods:place>
+      <mods:dateCreated encoding="w3cdtf" keyDate="yes" point="start" qualifier="approximate">1901</mods:dateCreated>
+      <mods:dateCreated encoding="w3cdtf" point="end" qualifier="approximate">2000</mods:dateCreated>
+   </mods:originInfo>
+   <mods:language>
+      <mods:languageTerm authority="iso639-2b" type="code">ara</mods:languageTerm>
+   </mods:language>
+   <mods:physicalDescription>
+      <mods:extent>4 pieces ; approximately 50 x 37 cm.</mods:extent>
+   </mods:physicalDescription>
+   <mods:relatedItem type="host">
+      <mods:typeOfResource>still image</mods:typeOfResource>
+      <mods:titleInfo>
+         <mods:title>Middle Eastern Film Posters Digitization Initiative</mods:title>
+      </mods:titleInfo>
+      <mods:location>
+         <mods:url>http://pudl.princeton.edu/collections/pudl0100</mods:url>
+      </mods:location>
+   </mods:relatedItem>
+   <mods:relatedItem type="host">
+      <mods:typeOfResource collection="yes" manuscript="yes">still image</mods:typeOfResource>
+      <mods:location>
+         <mods:url>http://arks.princeton.edu/ark:/</mods:url>
+      </mods:location>
+   </mods:relatedItem>
+   <mods:identifier type="local">egx-0003</mods:identifier>
+   <mods:location>
+      <mods:physicalLocation type="text">Princeton University Library. Firestone Library.</mods:physicalLocation>
+      <mods:physicalLocation authority="marcorg" type="code">NjP</mods:physicalLocation>
+      <mods:holdingSimple>
+         <mods:copyInformation>
+            <mods:subLocation>Curator's office</mods:subLocation>
+            <mods:shelfLocator>Cabinet 11/06</mods:shelfLocator>
+         </mods:copyInformation>
+      </mods:holdingSimple>
+   </mods:location>
+   <mods:accessCondition type="useAndReproduction" xlink:href="http://www.princeton.edu/~rbsc/research/rights.html">Use and reproduction</mods:accessCondition>
+   <mods:accessCondition type="restrictionOnAccess" xlink:href="http://www.princeton.edu/~rbsc/research/rules.html">Restrictions on access</mods:accessCondition>  
+   <mods:recordInfo>
+      <mods:recordContentSource authority="marcorg">NjP</mods:recordContentSource>
+      <mods:recordIdentifier>http://diglib.princeton.edu/mdata/pudl0100/lc/egx_0003.mods</mods:recordIdentifier>
+      <mods:languageOfCataloging>
+         <mods:languageTerm authority="iso639-2b" type="code">ara</mods:languageTerm>
+      </mods:languageOfCataloging>
+   </mods:recordInfo>
+</mods:mods>
+</mets:xmlData>
+</mets:mdWrap>
+</mets:dmdSec>
+<mets:fileSec>
+<mets:fileGrp USE="thumbnail">
+<mets:file ID="t0qiq" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0100/lc/egx_0003/00000001.tif"/>
+</mets:file>
+</mets:fileGrp>
+<mets:fileGrp USE="masters">
+<mets:file CHECKSUM="8208c6d4b76dd48c2d7777731371b80" CHECKSUMTYPE="MD5" ID="m14m2" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0100/lc/egx_0003/00000001.tif"/>
+</mets:file>
+<mets:file CHECKSUM="de880bfca762958916bddd9c8ef3169e" CHECKSUMTYPE="MD5" ID="qtcor" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0100/lc/egx_0003/00000002.tif"/>
+</mets:file>
+<mets:file CHECKSUM="be566dcd022cbc36b58e8e95bb4f5943" CHECKSUMTYPE="MD5" ID="t9sfn" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0100/lc/egx_0003/00000003.tif"/>
+</mets:file>
+<mets:file CHECKSUM="f276ac2568fa32ac8cd9bbafa613b5ca" CHECKSUMTYPE="MD5" ID="dixia" MIMETYPE="image/tiff">
+<mets:FLocat LOCTYPE="URL" xlink:href="file:///mnt/diglibdata/pudl/pudl0100/lc/egx_0003/00000004.tif"/>
+</mets:file>
+</mets:fileGrp>
+</mets:fileSec>
+<mets:structMap TYPE="RelatedObjects">
+<mets:div DMDID="imny5 imny5" ID="lmsty" LABEL="Default">
+<mets:div CONTENTIDS="pudl0100" TYPE="IsPartOf"/>
+<mets:div ID="aggregates" TYPE="OrderedList">
+<mets:div ID="nbrpg" LABEL="image 1" ORDER="1" TYPE="Static">
+<mets:fptr FILEID="m14m2"/>
+</mets:div>
+<mets:div ID="dvzk1" LABEL="image 2" ORDER="2" TYPE="Static">
+<mets:fptr FILEID="qtcor"/>
+</mets:div>
+<mets:div ID="ghu69" LABEL="image 3" ORDER="3" TYPE="Static">
+<mets:fptr FILEID="t9sfn"/>
+</mets:div>
+<mets:div ID="b1ixo" LABEL="image 4" ORDER="4" TYPE="Static">
+<mets:fptr FILEID="dixia"/>
+</mets:div>
+</mets:div>
+</mets:div>
+</mets:structMap>
+<mets:structMap LABEL="Pagination" TYPE="Physical">
+<mets:div DMDID="imny5 imny5" ID="qwlrx" LABEL="" TYPE="BoundArt"/>
+</mets:structMap>
+<mets:structMap LABEL="Contents" TYPE="Logical">
+<mets:div DMDID="imny5 imny5" ID="vxnbp" LABEL="" TYPE="BoundArt">
+<mets:div ID="vo7z2" ORDER="1" TYPE="LogicalMember">
+<mets:fptr FILEID="m14m2"/>
+</mets:div>
+<mets:div ID="lnn8v" ORDER="2" TYPE="LogicalMember">
+<mets:fptr FILEID="qtcor"/>
+</mets:div>
+<mets:div ID="kcy9z" ORDER="3" TYPE="LogicalMember">
+<mets:fptr FILEID="t9sfn"/>
+</mets:div>
+<mets:div ID="eyofs" ORDER="4" TYPE="LogicalMember">
+<mets:fptr FILEID="dixia"/>
+</mets:div>
+</mets:div>
+</mets:structMap>
+</mets:mets>

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe ::BlacklightHelper do
   describe "#render_document_heading" do
-    let(:model) { FactoryBot.build(:ephemera_term, id: "test", label: "Test") }
+    let(:model) { FactoryBot.create_for_repository(:ephemera_term, id: "test", label: "Test") }
     let(:solr_document) { Valkyrie::MetadataAdapter.find(:index_solr).resource_factory.from_resource(resource: model) }
     let(:document) { SolrDocument.new(solr_document) }
     before do
@@ -16,19 +16,19 @@ RSpec.describe ::BlacklightHelper do
       end
     end
     context "when given a Vocabulary" do
-      let(:model) { FactoryBot.build(:ephemera_vocabulary, id: "test", label: "Test") }
+      let(:model) { FactoryBot.create_for_repository(:ephemera_vocabulary, id: "test", label: "Test") }
       it "renders the label" do
         expect(helper.render_document_heading(document, tag: :h1)).to eq "<h1 itemprop=\"name\" dir=\"ltr\">Test</h1>"
       end
     end
     context "when given a value with RTL text" do
-      let(:model) { FactoryBot.build(:ephemera_vocabulary, id: "test", label: "للفاسق") }
+      let(:model) { FactoryBot.create_for_repository(:ephemera_vocabulary, id: "test", label: "للفاسق") }
       it "renders the label" do
         expect(helper.render_document_heading(document, tag: :h1)).to eq "<h1 itemprop=\"name\" dir=\"rtl\">للفاسق</h1>"
       end
     end
     context "when given a resource with multiple titles" do
-      let(:model) { FactoryBot.build(:scanned_resource, title: ["There and back again", "A hobbit's tale"]) }
+      let(:model) { FactoryBot.create_for_repository(:scanned_resource, title: ["There and back again", "A hobbit's tale"]) }
       it "renders all titles, on separate lines" do
         expect(helper.render_document_heading(document, tag: :h1)).to eq "<h1 itemprop=\"name\" dir=\"ltr\">There and back again<br />A hobbit&#39;s tale</h1>"
       end

--- a/spec/jobs/ingest_mets_job_spec.rb
+++ b/spec/jobs/ingest_mets_job_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe IngestMETSJob do
         described_class.perform_now(mets_file, user, true)
 
         book = adapter.query_service.find_all_of_model(model: ScannedResource).first
-        expect(book.location).to contain_exactly("Box AD01, Item 7350")
+        expect(book.location).to contain_exactly("Mudd, Box AD01, Item 7350")
       end
     end
   end

--- a/spec/models/mets_document/mods_document_spec.rb
+++ b/spec/models/mets_document/mods_document_spec.rb
@@ -27,11 +27,53 @@ RSpec.describe METSDocument::MODSDocument do
         expect(mods_document.series).to eq ["The Subway Sun. Volume 3. Number 6"]
         expect(mods_document.access_condition).not_to be_blank
         expect(mods_document.holding_simple_sublocation).to eq ["Mudd"]
-        expect(mods_document.shelf_locator).to eq ["MC085. Box 135"]
+        expect(mods_document.shelf_locator).to eq ["Mudd, MC085. Box 135"]
         finding_aid_identifier = mods_document.finding_aid_identifier.first
         expect(finding_aid_identifier.identifier).to eq "http://arks.princeton.edu/ark:/88435/m039k489x"
         expect(finding_aid_identifier.title).to eq "Ivy Ledbetter Lee Papers, 1881-1989 (bulk 1915-1946)"
         expect(mods_document.replaces).to eq "http://pudl.princeton.edu/objects/4d52d496-f15e-405d-863b-32fb880f13d8"
+      end
+    end
+  end
+
+  context "pudl0100" do
+    let(:mets_file) { Rails.root.join("spec", "fixtures", "mets", "pudl0100-lc-egx_0003.mets") }
+    describe "attributes" do
+      it "returns known values for each attribute" do
+        expect(mods_document.title).to eq [RDF::Literal.new("الاختيار", language: "ara-Arab")]
+        expect(mods_document.actor).to contain_exactly(
+          Grouping.new(
+            elements: [
+              RDF::Literal.new("Ḥusnī, Suʻād", language: "ara-Latn"),
+              RDF::Literal.new("سعاد حسني", language: "ara-Arab")
+            ]
+          ),
+          Grouping.new(
+            elements: [
+              RDF::Literal.new("ʻAlāyilī, ʻIzzat, 1934-", language: "ara-Latn"),
+              RDF::Literal.new("عزت العلايلي", language: "ara-Arab")
+            ]
+          ),
+          RDF::Literal.new("هدى سلطان", language: "ara-Arab"),
+          Grouping.new(
+            elements: [
+              RDF::Literal.new("Milījī, Maḥmūd", language: "ara-Latn"),
+              RDF::Literal.new("محمود المليجي", language: "ara-Arab")
+            ]
+          ),
+          "Test"
+        )
+        expect(mods_document.director).to contain_exactly(
+          RDF::Literal.new("يوسف شاهين", language: "ara-Arab")
+        )
+        expect(mods_document.type_of_resource).to eq ["still image"]
+        expect(mods_document.genre).to eq ["Lobby Cards"]
+        expect(mods_document.geographic_origin).to eq ["Egypt"]
+        expect(mods_document.language).to eq ["ara"]
+        expect(mods_document.extent).to eq ["4 pieces ; approximately 50 x 37 cm."]
+        expect(mods_document.local_identifier).to eq ["egx-0003"]
+        expect(mods_document.date_created).to eq ["1901 - 2000"]
+        expect(mods_document.shelf_locator).to eq ["Curator's office, Cabinet 11/06"]
       end
     end
   end
@@ -54,7 +96,7 @@ RSpec.describe METSDocument::MODSDocument do
         expect(mods_document.subject).to eq ["San Francisco Earthquake and Fire, Calif., 1906", "Natural disasters", "Architecture"]
         expect(mods_document.local_identifier).to eq ["WA 1998:223"]
         expect(mods_document.holding_simple_sublocation).to eq ["WA"]
-        expect(mods_document.shelf_locator).to eq ["(WA) WC064, H0030"]
+        expect(mods_document.shelf_locator).to eq ["WA, (WA) WC064, H0030"]
         expect(mods_document.finding_aid_identifier).to eq []
         expect(mods_document.replaces).to eq nil
       end
@@ -200,7 +242,7 @@ RSpec.describe METSDocument::MODSDocument do
     let(:mets_file) { Rails.root.join("spec", "fixtures", "mets", "pudl0038-7350.mets") }
 
     it "accesses the shelfLocator field" do
-      expect(mods_document.shelf_locator).to contain_exactly "Box AD01, Item 7350"
+      expect(mods_document.shelf_locator).to contain_exactly "Mudd, Box AD01, Item 7350"
     end
   end
 end


### PR DESCRIPTION
Allows for transliterated actors and does the rendering for it. Due to a
bug in solr's conversion of RDF::Literals and nested objects together (tracked at https://github.com/samvera-labs/valkyrie/issues/596),
this PR also converts the catalog show page to use a record out of
Postgres instead of Solr. I doubt there'll be any noticeable performance implications, but we should keep an eye on it.

References #1612