### PR TITLE
Fix show page rendered coverage

### DIFF
--- a/app/decorators/raster_resource_decorator.rb
+++ b/app/decorators/raster_resource_decorator.rb
@@ -66,7 +66,7 @@ class RasterResourceDecorator < Valkyrie::ResourceDecorator
   end
 
   def rendered_coverage
-    display_coverage = coverage || imported_metadata.try(:first).try(:coverage)
+    display_coverage = Array.wrap(coverage).first || imported_metadata.try(:first).try(:coverage)
     h.bbox_display(display_coverage)
   end
 

--- a/app/decorators/scanned_map_decorator.rb
+++ b/app/decorators/scanned_map_decorator.rb
@@ -111,7 +111,7 @@ class ScannedMapDecorator < Valkyrie::ResourceDecorator
   end
 
   def rendered_coverage
-    display_coverage = coverage || imported_metadata.try(:first).try(:coverage)
+    display_coverage = Array.wrap(coverage).first || imported_metadata.try(:first).try(:coverage)
     h.bbox_display(display_coverage)
   end
 

--- a/app/decorators/vector_resource_decorator.rb
+++ b/app/decorators/vector_resource_decorator.rb
@@ -67,7 +67,7 @@ class VectorResourceDecorator < Valkyrie::ResourceDecorator
   end
 
   def rendered_coverage
-    display_coverage = coverage || imported_metadata.try(:first).try(:coverage)
+    display_coverage = Array.wrap(coverage).first || imported_metadata.try(:first).try(:coverage)
     h.bbox_display(display_coverage)
   end
 

--- a/spec/decorators/raster_resource_decorator_spec.rb
+++ b/spec/decorators/raster_resource_decorator_spec.rb
@@ -3,14 +3,20 @@ require "rails_helper"
 
 RSpec.describe RasterResourceDecorator do
   subject(:decorator) { described_class.new(resource) }
+  let(:coverage) { "northlimit=07.033333; eastlimit=011.583333; southlimit=03.917778; westlimit=008.497222; units=degrees; projection=EPSG:4326" }
+  let(:imported_coverage) { "northlimit=-00.500000; eastlimit=040.841667; southlimit=-12.000000; westlimit=028.666667; units=degrees; projection=EPSG:4326" }
   let(:resource) do
     FactoryBot.build(:raster_resource,
                      title: "test title",
                      author: "test author",
                      creator: "test creator",
+                     coverage: coverage,
                      subject: "test subject",
                      identifier: "ark:/99999/fk4",
-                     holding_location: "https://bibdata.princeton.edu/locations/delivery_locations/14")
+                     holding_location: "https://bibdata.princeton.edu/locations/delivery_locations/14",
+                     imported_metadata: [{
+                       coverage: imported_coverage
+                     }])
   end
   it "exposes markup for rights statement" do
     expect(resource.decorate.rendered_rights_statement).not_to be_empty
@@ -21,6 +27,8 @@ RSpec.describe RasterResourceDecorator do
   end
   it "exposes markup for rendered coverage" do
     expect(resource.decorate.rendered_coverage).to match(/#{Regexp.escape('Toggle Map')}/)
+    expect(resource.decorate.rendered_coverage).to include(coverage)
+    expect(resource.decorate.rendered_coverage).not_to include(imported_coverage)
   end
   it "renders the identifier as an ark" do
     expect(resource.decorate.ark).to eq("http://arks.princeton.edu/ark:/99999/fk4")

--- a/spec/decorators/scanned_map_decorator_spec.rb
+++ b/spec/decorators/scanned_map_decorator_spec.rb
@@ -3,15 +3,20 @@ require "rails_helper"
 
 RSpec.describe ScannedMapDecorator do
   subject(:decorator) { described_class.new(resource) }
+  let(:imported_coverage) { "northlimit=07.033333; eastlimit=011.583333; southlimit=03.917778; westlimit=008.497222; units=degrees; projection=EPSG:4326" }
   let(:resource) do
     FactoryBot.build(:scanned_map,
                      title: "test title",
+                     coverage: [],
                      author: "test author",
                      creator: "test creator",
                      references: links.to_json,
                      subject: "test subject",
                      identifier: "ark:/99999/fk4",
-                     holding_location: "https://bibdata.princeton.edu/locations/delivery_locations/14")
+                     holding_location: "https://bibdata.princeton.edu/locations/delivery_locations/14",
+                     imported_metadata: [{
+                       coverage: imported_coverage
+                     }])
   end
   let(:links) do
     {
@@ -36,6 +41,7 @@ RSpec.describe ScannedMapDecorator do
   end
   it "exposes markup for rendered coverage" do
     expect(resource.decorate.rendered_coverage).to match(/#{Regexp.escape('Toggle Map')}/)
+    expect(resource.decorate.rendered_coverage).to include(imported_coverage)
   end
   it "exposes markup for rendered links" do
     expect(resource.decorate.rendered_links).to include(/www.jstor.org/)

--- a/spec/decorators/vector_resource_decorator_spec.rb
+++ b/spec/decorators/vector_resource_decorator_spec.rb
@@ -3,14 +3,19 @@ require "rails_helper"
 
 RSpec.describe VectorResourceDecorator do
   subject(:decorator) { described_class.new(resource) }
+  let(:imported_coverage) { "northlimit=07.033333; eastlimit=011.583333; southlimit=03.917778; westlimit=008.497222; units=degrees; projection=EPSG:4326" }
   let(:resource) do
     FactoryBot.build(:vector_resource,
                      title: "test title",
                      author: "test author",
                      creator: "test creator",
+                     coverage: [],
                      subject: "test subject",
                      identifier: "ark:/99999/fk4",
-                     holding_location: "https://bibdata.princeton.edu/locations/delivery_locations/14")
+                     holding_location: "https://bibdata.princeton.edu/locations/delivery_locations/14",
+                     imported_metadata: [{
+                       coverage: imported_coverage
+                     }])
   end
   it "exposes markup for rights statement" do
     expect(resource.decorate.rendered_rights_statement).not_to be_empty
@@ -21,6 +26,7 @@ RSpec.describe VectorResourceDecorator do
   end
   it "exposes markup for rendered coverage" do
     expect(resource.decorate.rendered_coverage).to match(/#{Regexp.escape('Toggle Map')}/)
+    expect(resource.decorate.rendered_coverage).to include(imported_coverage)
   end
   it "renders the identifier as an ark" do
     expect(resource.decorate.ark).to eq("http://arks.princeton.edu/ark:/99999/fk4")


### PR DESCRIPTION
Loading show page from Postgres changes the behavior of empty attributes. When loaded from Solr, an empty attribute on the document returns nil. When loaded from Postgres, an empty attribute on the document returns an empty array. The `rendered_coverage` method assumed a nil value.

Closes #1823 

