### PR TITLE
Only include complete objects with BibIDs in the identifiers-to-reconcile report

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -20,7 +20,7 @@ class ReportsController < ApplicationController
 
   def identifiers_to_reconcile
     authorize! :show, Report
-    @resources = Valkyrie.config.metadata_adapter.query_service.custom_queries.find_identifiers_to_reconcile
+    @resources = find_identifiers_to_reconcile
     respond_to do |format|
       format.html
       format.csv do
@@ -31,6 +31,12 @@ class ReportsController < ApplicationController
   end
 
   private
+
+    def find_identifiers_to_reconcile
+      @identifiers_to_reconcile ||= query_service.custom_queries.find_identifiers_to_reconcile.select do |r|
+        PulMetadataServices::Client.bibdata?(r.source_metadata_identifier.first)
+      end
+    end
 
     def to_csv(records, fields:)
       CSV.generate(headers: true) do |csv|

--- a/app/queries/find_identifiers_to_reconcile.rb
+++ b/app/queries/find_identifiers_to_reconcile.rb
@@ -19,6 +19,7 @@ class FindIdentifiersToReconcile
     <<-SQL
       SELECT * FROM orm_resources
       WHERE internal_resource='ScannedResource'
+      AND orm_resources.metadata @> '{"state": ["complete"]}'
       AND orm_resources.metadata @> '{"identifier": []}'
       AND orm_resources.metadata @> '{"source_metadata_identifier": []}'
       AND NOT orm_resources.metadata @> '{"imported_metadata":[{"identifier": []}]}'

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe ReportsController, type: :controller do
 
   describe "GET #identifiers_to_reconcile" do
     let(:resource) { FactoryBot.build(:complete_scanned_resource, title: []) }
+    let(:resource2) { FactoryBot.build(:complete_scanned_resource, title: []) }
     let(:change_set_persister) { ChangeSetPersister.new(metadata_adapter: Valkyrie.config.metadata_adapter, storage_adapter: Valkyrie.config.storage_adapter) }
     let(:data) { "bibid,ark,title\n123456,ark:/99999/fk48675309,Earth rites : fertility rites in pre-industrial Britain\n" }
     before do
@@ -45,7 +46,12 @@ RSpec.describe ReportsController, type: :controller do
       stub_bibdata(bib_id: "123456")
       stub_ezid(shoulder: "99999/fk4", blade: "8675309")
       change_set = ScannedResourceChangeSet.new(resource)
-      change_set.validate(source_metadata_identifier: "123456")
+      change_set.validate(source_metadata_identifier: "123456", state: ["complete"])
+      change_set_persister.save(change_set: change_set)
+
+      stub_pulfa(pulfa_id: "MC016_c9616")
+      change_set = ScannedResourceChangeSet.new(resource2)
+      change_set.validate(source_metadata_identifier: "MC016_c9616")
       change_set_persister.save(change_set: change_set)
     end
 

--- a/spec/queries/find_identifiers_to_reconcile_spec.rb
+++ b/spec/queries/find_identifiers_to_reconcile_spec.rb
@@ -4,9 +4,9 @@ require "rails_helper"
 RSpec.describe FindIdentifiersToReconcile do
   subject(:query) { described_class.new(query_service: query_service) }
   let(:query_service) { Valkyrie.config.metadata_adapter.query_service }
-  let(:resource) { FactoryBot.build(:complete_scanned_resource, title: []) }
-  let(:resource2) { FactoryBot.create_for_repository(:scanned_resource, title: []) }
-  let(:resource3) { FactoryBot.create_for_repository(:scanned_resource, title: []) }
+  let(:complete_resource) { FactoryBot.build(:complete_scanned_resource, title: []) }
+  let(:basic_resource) { FactoryBot.create_for_repository(:scanned_resource, title: []) }
+  let(:incomplete_resource) { FactoryBot.create_for_repository(:scanned_resource, title: []) }
   let(:change_set_persister) { ChangeSetPersister.new(metadata_adapter: Valkyrie.config.metadata_adapter, storage_adapter: Valkyrie.config.storage_adapter) }
 
   before do
@@ -16,19 +16,23 @@ RSpec.describe FindIdentifiersToReconcile do
 
   describe "#find_identifiers_to_reconcile" do
     it "finds only resources with newly-minted identifiers" do
-      change_set = ScannedResourceChangeSet.new(resource)
+      # add remote metadata to a complete resource, which should be retrieved because its ARK won't be
+      # present in the remote metadata
+      change_set = ScannedResourceChangeSet.new(complete_resource)
       change_set.validate(source_metadata_identifier: "123456")
       saved_resource = change_set_persister.save(change_set: change_set)
 
-      change_set = ScannedResourceChangeSet.new(resource3)
+      # add remote metadata to an incomplete resource, which should not be retrieved because it won't have
+      # an ARK minted yet
+      change_set = ScannedResourceChangeSet.new(incomplete_resource)
       change_set.validate(source_metadata_identifier: "123456")
       change_set_persister.save(change_set: change_set)
 
       output = query.find_identifiers_to_reconcile
       ids = output.map(&:id)
       expect(ids).to include saved_resource.id
-      expect(ids).not_to include resource2.id
-      expect(ids).not_to include resource3.id
+      expect(ids).not_to include basic_resource.id
+      expect(ids).not_to include incomplete_resource.id
     end
   end
 end

--- a/spec/queries/find_identifiers_to_reconcile_spec.rb
+++ b/spec/queries/find_identifiers_to_reconcile_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe FindIdentifiersToReconcile do
   let(:query_service) { Valkyrie.config.metadata_adapter.query_service }
   let(:resource) { FactoryBot.build(:complete_scanned_resource, title: []) }
   let(:resource2) { FactoryBot.create_for_repository(:scanned_resource, title: []) }
+  let(:resource3) { FactoryBot.create_for_repository(:scanned_resource, title: []) }
   let(:change_set_persister) { ChangeSetPersister.new(metadata_adapter: Valkyrie.config.metadata_adapter, storage_adapter: Valkyrie.config.storage_adapter) }
 
   before do
@@ -19,10 +20,15 @@ RSpec.describe FindIdentifiersToReconcile do
       change_set.validate(source_metadata_identifier: "123456")
       saved_resource = change_set_persister.save(change_set: change_set)
 
+      change_set = ScannedResourceChangeSet.new(resource3)
+      change_set.validate(source_metadata_identifier: "123456")
+      change_set_persister.save(change_set: change_set)
+
       output = query.find_identifiers_to_reconcile
       ids = output.map(&:id)
       expect(ids).to include saved_resource.id
       expect(ids).not_to include resource2.id
+      expect(ids).not_to include resource3.id
     end
   end
 end


### PR DESCRIPTION
Fixes #850 