### PR TITLE
Don't re-query for filesets in ManifestBuilder

### DIFF
--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -352,7 +352,7 @@ class ManifestBuilder
     end
 
     def display_image_url
-      helper.manifest_image_medium_path(id)
+      helper.manifest_image_medium_path(resource)
     rescue
       ""
     end
@@ -451,16 +451,25 @@ class ManifestBuilder
 
     ##
     # Retrieve the URL path for an image served over the Riiif
-    # @param [String] id identifier for the image resource
+    # @param [String, Valkyrie::Resource] id_or_resource Either a Valkyrie::ID
+    #   for a resource to generate a thumbnail with, or the resource itself.
     # @return [String]
-    def manifest_image_thumbnail_path(id)
-      file_set = query_service.find_by(id: Valkyrie::ID.new(id))
+    def manifest_image_thumbnail_path(id_or_resource)
+      file_set = find_file_set(id_or_resource)
       "#{manifest_image_path(file_set)}/full/!200,150/0/default.jpg"
     end
 
-    def manifest_image_medium_path(id)
-      file_set = query_service.find_by(id: Valkyrie::ID.new(id))
+    def manifest_image_medium_path(id_or_resource)
+      file_set = find_file_set(id_or_resource)
       "#{manifest_image_path(file_set)}/full/!1000,/0/default.jpg"
+    end
+
+    def find_file_set(id_or_resource)
+      if id_or_resource.is_a?(Valkyrie::Resource)
+        id_or_resource
+      else
+        query_service.find_by(id: Valkyrie::ID.new(id_or_resource))
+      end
     end
 
     def query_service

--- a/app/services/manifest_builder/thumbnail_builder.rb
+++ b/app/services/manifest_builder/thumbnail_builder.rb
@@ -51,7 +51,7 @@ class ManifestBuilder
       # @return [Hash]
       def build_thumbnail_values(file_set)
         {
-          "@id" => helper.manifest_image_thumbnail_path(file_set.id),
+          "@id" => helper.manifest_image_thumbnail_path(file_set),
           "service" => {
             "@context" => "http://iiiif.io/api/image/2/context.json",
             "@id" => helper.manifest_image_path(file_set),

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -92,6 +92,16 @@ RSpec.describe ManifestBuilder do
       change_set_persister.save(change_set: change_set)
     end
 
+    it "only runs two find_by queries" do
+      manifest_builder # Cache the instance which has a `find_by` to instantiate
+      allow(query_service).to receive(:find_by).and_call_original
+
+      manifest_builder.build
+
+      # Two queries: One for thumbnail and one for start canvas
+      expect(query_service).to have_received(:find_by).exactly(2).times
+    end
+
     it "generates a IIIF document" do
       output = manifest_builder.build
       expect(output).to be_kind_of Hash


### PR DESCRIPTION
Should improve efficiency of manifest generation significantly.

Discovered via datadog: https://app.datadoghq.com/apm/resource/figgy/rack.request/68b3ff7466d9457a?start=1537461404405&end=1537465004405&paused=false&env=none&traceID=694789138216265633&spanID=6994033335916105774&graphType=span_list