### PR TITLE
Update link text for members of a collection

### DIFF
--- a/app/views/catalog/_members_archival_media_collection.html.erb
+++ b/app/views/catalog/_members_archival_media_collection.html.erb
@@ -1,2 +1,2 @@
-<%= link_to "View Members List", facet_search_url(field: "member_of_collection_titles_ssim", value: decorated_resource.title), class: "btn btn-default" %>
+<%= link_to "View all #{decorated_resource.members.count} items in this collection", facet_search_url(field: "member_of_collection_titles_ssim", value: decorated_resource.title), class: "btn btn-default" %>
 <%= link_to "View ARK / Component ID report", archival_media_collections_ark_report_path, class: 'btn btn-default' %>

--- a/app/views/catalog/_members_collection.html.erb
+++ b/app/views/catalog/_members_collection.html.erb
@@ -1,1 +1,1 @@
-<%= link_to "View Members List", facet_search_url(field: "member_of_collection_titles_ssim", value: decorated_resource.title), class: "btn btn-default" %>
+<%= link_to "View all #{decorated_resource.members.count} items in this collection", facet_search_url(field: "member_of_collection_titles_ssim", value: decorated_resource.title), class: "btn btn-default" %>

--- a/spec/features/archival_media_collection_spec.rb
+++ b/spec/features/archival_media_collection_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Refresh" do
       collection = persister.save(resource: FactoryBot.build(:archival_media_collection))
       persister.save(resource: FactoryBot.build(:complete_media_resource, member_of_collection_ids: [collection.id]))
       visit "catalog/#{collection.id}"
-      expect(page).to have_link "View Members List"
+      expect(page).to have_link "View all 1 items in this collection"
       expect(page).to have_link "View ARK / Component ID report"
       expect(page).to have_link "Edit This Archival Media Collection", href: edit_archival_media_collection_path(collection)
       expect(page).to have_link "Delete This Archival Media Collection", href: archival_media_collection_path(collection)

--- a/spec/features/collections_spec.rb
+++ b/spec/features/collections_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "Refresh" do
       persister.save(resource: FactoryBot.build(:scanned_resource, member_of_collection_ids: [collection.id]))
 
       visit "catalog/#{collection.id}"
-      expect(page).to have_link "View Members List"
+      expect(page).to have_link "View all 1 items in this collection"
       expect(page).to have_link "Edit This Collection", href: edit_collection_path(collection)
       expect(page).to have_link "Delete This Collection", href: collection_path(collection)
       expect(page).not_to have_link "File Manager"


### PR DESCRIPTION
gives number of members,
uses word "items" instead of "members", which was confusing
fixes #1781