### PR TITLE
Ensuring that derivative FileMetadata is deleted from FileSets when IngestIntermediateFileJob appends an intermediate file for a resource

### DIFF
--- a/spec/change_sets/file_set_change_set_spec.rb
+++ b/spec/change_sets/file_set_change_set_spec.rb
@@ -2,7 +2,10 @@
 require "rails_helper"
 
 RSpec.describe FileSetChangeSet do
-  subject(:change_set) { described_class.new(FactoryBot.build(:file_set)) }
+  subject(:change_set) { described_class.new(file_set) }
+
+  let(:file_set) { FactoryBot.build(:file_set) }
+
   describe "#primary_terms" do
     it "is just the title" do
       expect(change_set.primary_terms).to eq [:title]

--- a/spec/jobs/ingest_intermediate_file_job_spec.rb
+++ b/spec/jobs/ingest_intermediate_file_job_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe IngestIntermediateFileJob do
     context "when the existing resource has FileSets" do
       let(:second_file) { double("File") }
       let(:cleanup_files_job) { class_double("CleanupFilesJob").as_stubbed_const(transfer_nested_constants: true) }
+      let(:resource) { FactoryBot.create_for_repository(:scanned_resource, files: [master_file]) }
 
       before do
         allow(second_file).to receive(:original_filename).and_return("example.tif")
@@ -59,6 +60,8 @@ RSpec.describe IngestIntermediateFileJob do
         described_class.perform_now(file_path: file_path, file_set_id: file_set.id)
 
         expect(cleanup_files_job).to have_received(:perform_now).with(file_identifiers: file_identifiers)
+        file_set_with_intermediates = metadata_adapter.query_service.find_by(id: file_set.id)
+        expect(file_set_with_intermediates.derivative_files.length).to eq(1)
       end
     end
 


### PR DESCRIPTION
When testing #1592, it was discovered that `FileMetadata` for the original derivatives of a Resource were not deleted once an intermediate file was appended by IngestIntermediateFileJob, and the derivatives were regenerated.