### PR TITLE
Ensuring that IngestIntermediateFileJob does not attempt to serialize Logger instances as arguments

### DIFF
--- a/app/services/bulk_ingest_intermediate_service.rb
+++ b/app/services/bulk_ingest_intermediate_service.rb
@@ -97,9 +97,9 @@ class BulkIngestIntermediateService
         end
 
         if background?
-          IngestIntermediateFileJob.set(queue: :low).perform_later(file_path: tiff_path, file_set_id: file_set.id.to_s, logger: @logger)
+          IngestIntermediateFileJob.set(queue: :low).perform_later(file_path: tiff_path, file_set_id: file_set.id.to_s)
         else
-          IngestIntermediateFileJob.perform_now(file_path: tiff_path, file_set_id: file_set.id.to_s, logger: @logger)
+          IngestIntermediateFileJob.perform_now(file_path: tiff_path, file_set_id: file_set.id.to_s)
         end
       end
     end

--- a/spec/services/bulk_ingest_intermediate_service_spec.rb
+++ b/spec/services/bulk_ingest_intermediate_service_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe BulkIngestIntermediateService do
       it "performs jobs for ingesting the intermediate file for each TIFF file in a directory" do
         service.ingest(base_directory)
 
-        expect(ingest_intermediate_file_job).to have_received(:perform_now).with(file_path: tiff_path, file_set_id: file_set.id.to_s, logger: logger)
+        expect(ingest_intermediate_file_job).to have_received(:perform_now).with(file_path: tiff_path, file_set_id: file_set.id.to_s)
       end
     end
 
@@ -74,7 +74,7 @@ RSpec.describe BulkIngestIntermediateService do
         service.ingest(base_directory)
 
         expect(ingest_intermediate_file_job).to have_received(:set).with(queue: :low)
-        expect(ingest_intermediate_file_job).to have_received(:perform_later).with(file_path: tiff_path, file_set_id: file_set.id.to_s, logger: logger)
+        expect(ingest_intermediate_file_job).to have_received(:perform_later).with(file_path: tiff_path, file_set_id: file_set.id.to_s)
       end
     end
 


### PR DESCRIPTION
This resolves an error I encountered when attempting to ingest intermediate files within the staging environment:
```
$ bundle exec rake bulk:ingest_intermediate_files DIR=/mnt/diglibdata/pudl/pudl0044/originals_no_watermark/ BACKGROUND=TRUE
I, [2018-09-27T13:43:20.868075 #16184]  INFO -- : ingesting files from: /mnt/diglibdata/pudl/pudl0044/originals_no_watermark/
E, [2018-09-27T13:43:22.062796 #16184] ERROR -- : Error: Unsupported argument type: Logger
E, [2018-09-27T13:43:22.062939 #16184] ERROR -- : ["/opt/figgy/shared/bundle/ruby/2.4.0/gems/activejob-5.1.6/lib/active_job/arguments.rb:71:in `serialize_argument'", "/opt/figgy/shared/bundle/ruby/2.4.0/gems/activejob-5.1.6/lib/active_job/arguments.rb:104:in `block in serialize_hash'"...
```