### PR TITLE
Raises an instance of ArgumentError within BulkIngestService#attach_each_dir and BulkIngestService#attach_dir when directory paths point towards non-existent or empty directories

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -81,6 +81,7 @@ Metrics/CyclomaticComplexity:
     - 'app/services/pdf_generator/canvas.rb'
     - 'app/jobs/ingest_intermediate_file_job.rb'
     - 'app/services/pul_metadata_services/bib_record.rb'
+    - 'app/services/bulk_ingest_service.rb'
 Metrics/MethodLength:
   Exclude:
     - 'db/migrate/**/*'
@@ -121,6 +122,7 @@ Metrics/PerceivedComplexity:
     - 'app/services/pdf_generator/canvas.rb'
     - 'app/jobs/ingest_intermediate_file_job.rb'
     - 'app/services/pul_metadata_services/bib_record.rb'
+    - 'app/services/bulk_ingest_service.rb'
 Rails/OutputSafety:
   Exclude:
     - 'app/decorators/**/*'

--- a/app/services/bulk_ingest_service.rb
+++ b/app/services/bulk_ingest_service.rb
@@ -15,7 +15,11 @@ class BulkIngestService
   # @param property [String, nil] the resource property (when attaching files to existing resources)
   # @param file_filter [String, nil] the filter used for matching against the filename extension
   def attach_each_dir(base_directory:, property: nil, file_filter: nil, **attributes)
-    Dir["#{base_directory}/*"].sort.each do |subdir|
+    raise ArgumentError, "#{self.class}: Directory does not exist: #{base_directory}" unless File.exist?(base_directory)
+
+    entries = Dir["#{base_directory}/*"]
+    raise ArgumentError, "#{self.class}: Directory is empty: #{base_directory}" if entries.empty?
+    entries.sort.each do |subdir|
       next unless File.directory?(subdir)
       logger.info "Attaching #{subdir}"
       attach_dir(base_directory: subdir, property: property, file_filter: file_filter, **attributes)
@@ -37,6 +41,10 @@ class BulkIngestService
   # @param property [String, nil] the resource property (when attaching files to existing resources)
   # @param file_filter [String, nil] the filter used for matching against the filename extension
   def attach_dir(base_directory:, property: nil, file_filter: nil, **attributes)
+    raise ArgumentError, "#{self.class}: Directory does not exist: #{base_directory}" unless File.exist?(base_directory)
+
+    entries = Dir["#{base_directory}/*"]
+    raise ArgumentError, "#{self.class}: Directory is empty: #{base_directory}" if entries.empty?
     directory_path = absolute_path(base_directory)
 
     base_name = File.basename(base_directory)

--- a/spec/services/bulk_ingest_service_spec.rb
+++ b/spec/services/bulk_ingest_service_spec.rb
@@ -38,6 +38,25 @@ RSpec.describe BulkIngestService do
         expect(reloaded2.member_ids.length).to eq 2
       end
     end
+
+    context "with a path to a non-existent directory" do
+      it "raises an error" do
+        expect { ingester.attach_each_dir(base_directory: "no/exist") }.to raise_error(ArgumentError, "BulkIngestService: Directory does not exist: no/exist")
+      end
+    end
+
+    context "with a path to an empty directory" do
+      let(:empty_dir) { Rails.root.join("spec", "fixtures", "empty") }
+      before do
+        Dir.mkdir(empty_dir)
+      end
+      after do
+        Dir.rmdir(empty_dir)
+      end
+      it "raises an error" do
+        expect { ingester.attach_each_dir(base_directory: empty_dir) }.to raise_error(ArgumentError, "BulkIngestService: Directory is empty: #{empty_dir}")
+      end
+    end
   end
 
   describe "#attach_dir" do
@@ -205,6 +224,25 @@ RSpec.describe BulkIngestService do
 
         expect(logger).to have_received(:warn).with("Failed to find the resource for noexist:ingest_single")
         expect(logger).to have_received(:info).with(/Created the resource/)
+      end
+    end
+
+    context "with a path to a non-existent directory" do
+      it "raises an error" do
+        expect { ingester.attach_each_dir(base_directory: "no/exist") }.to raise_error(ArgumentError, "BulkIngestService: Directory does not exist: no/exist")
+      end
+    end
+
+    context "with a path to an empty directory" do
+      let(:empty_dir) { Rails.root.join("spec", "fixtures", "empty") }
+      before do
+        Dir.mkdir(empty_dir)
+      end
+      after do
+        Dir.rmdir(empty_dir)
+      end
+      it "raises an error" do
+        expect { ingester.attach_each_dir(base_directory: empty_dir) }.to raise_error(ArgumentError, "BulkIngestService: Directory is empty: #{empty_dir}")
       end
     end
   end


### PR DESCRIPTION
Resolves #1679 