### PR TITLE
Introduces a work-around for Faraday HTTP proxy warnings using ENV['NO_PROXY']

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,3 +36,4 @@ RSpec.configure do |config|
 end
 
 WebMock.disable_net_connect!(allow_localhost: true)
+ENV["NO_PROXY"] = nil


### PR DESCRIPTION
Please see https://github.com/lostisland/faraday/blob/master/lib/faraday/connection.rb#L461