### PR TITLE
Validate idle sequel connections

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GIT
 
 GIT
   remote: git://github.com/samvera-labs/valkyrie-sequel.git
-  revision: 8b27ab1ec883d1e79029ec1f614d1400371efb8b
+  revision: 7fee37642d7c9a26c25342631758e098b8b8f812
   specs:
     valkyrie-sequel (0.1.0)
       oj
@@ -513,7 +513,7 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    oj (3.6.10)
+    oj (3.6.11)
     omniauth (1.6.1)
       hashie (>= 3.4.6, < 3.6.0)
       rack (>= 1.6.2, < 3)


### PR DESCRIPTION
Closes #1928 
Integrates new patch in valkyrie-sequel: https://github.com/samvera-labs/valkyrie-sequel/commit/7fee37642d7c9a26c25342631758e098b8b8f812