### PR TITLE
Handles cases where the resource passed to `loadImageCollectionGql` in the Order Manager is `null`

### DIFF
--- a/app/javascript/store/vuex/actions.js
+++ b/app/javascript/store/vuex/actions.js
@@ -5,6 +5,12 @@ import gql from 'graphql-tag'
 
 const actions = {
   async loadImageCollectionGql (context, resource) {
+      if (resource == null) {
+        context.commit('CHANGE_MANIFEST_LOAD_STATE', 'LOADING_ERROR')
+        console.error('Failed to retrieve the resource')
+        return
+      }
+
       let id = resource.id
       console.time(`getResourceById ${id}`)
 


### PR DESCRIPTION
I'm currently encountering the following issue when attempting to use the Order Manager within the staging environment:
```
TypeError: Cannot read property 'id' of null
    at c.SET_RESOURCE (system.js:7782)
    at vuex.esm.js:697
    at vuex.esm.js:389
    at Array.forEach (<anonymous>)
    at vuex.esm.js:388
    at c._withCommit (vuex.esm.js:495)
    at c.commit (vuex.esm.js:387)
    at Object.commit (vuex.esm.js:335)
    at c.<anonymous> (actions.js:53)
    at i (application-f6a645b52a30a87d8e5bd665521060a8656ca0a9b63626f1c9fdaafefd32d83c.js:29)
```
(please see https://figgy-staging.princeton.edu/concern/scanned_resources/e9f61f1b-8cd1-419d-bd53-49a7bce9e103/order_manager)