### PR TITLE
Reduce queries in GraphQL queries.

### DIFF
--- a/app/decorators/file_set_decorator.rb
+++ b/app/decorators/file_set_decorator.rb
@@ -27,7 +27,7 @@ class FileSetDecorator < Valkyrie::ResourceDecorator
 
   # TODO: Rename to decorated_parent
   def parent
-    wayfinder.decorated_parent
+    object.try(:loaded)&.[](:parents)&.first || wayfinder.decorated_parent
   rescue ArgumentError
     nil
   end

--- a/app/graphql/types/resource.rb
+++ b/app/graphql/types/resource.rb
@@ -19,6 +19,12 @@ module Types::Resource
   end
 
   def members
+    # This loads members using FindMembersWithInverseRelationship, which
+    # populates `loaded` on all members with the given property. In this case
+    # all returned members have `loaded[:parents] = [parent]`, which the
+    # decorator takes advantage of if it exists (FileSetDecorator#parent). This
+    # way the parent is pre-loaded and it won't run N+1 queries to determine the
+    # FileSet's parent type.
     @members ||= Wayfinder.for(object).members_with_parents
   end
 

--- a/app/graphql/types/resource.rb
+++ b/app/graphql/types/resource.rb
@@ -19,7 +19,7 @@ module Types::Resource
   end
 
   def members
-    @members ||= Wayfinder.for(object).members
+    @members ||= Wayfinder.for(object).members_with_parents
   end
 
   def manifest_url
@@ -55,7 +55,12 @@ module Types::Resource
   end
 
   def thumbnail_resource
-    @thumbnail_resource ||= query_service.find_by(id: object.try(:thumbnail_id).first)
+    @thumbnail_resource ||=
+      begin
+        members.find do |member|
+          member.id == object.try(:thumbnail_id).first
+        end || query_service.find_by(id: object.try(:thumbnail_id).first)
+      end
   rescue Valkyrie::Persistence::ObjectNotFoundError
     nil
   end

--- a/app/queries/find_members_with_inverse_relationship.rb
+++ b/app/queries/find_members_with_inverse_relationship.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+#
+# This is a custom query which finds all members of an object as well as
+# populates `loaded` with a hash of objects eager loaded from an inverse relationship.
+# For instance, if a member wants to pre-load all its parents and it's loaded
+# by this query, it will have a loaded value of
+#
+# ```ruby
+# {
+#   inverse_member_ids: [parent]
+# }
+# ```
+#
+# You can provide a `key` argument to control what the key in `loaded` will be
+# named.
+#
+# This can help in reducing N+1 queries.
+class FindMembersWithInverseRelationship
+  def self.queries
+    [:find_members_with_inverse_relationship]
+  end
+
+  attr_reader :query_service
+  delegate :resource_factory, to: :query_service
+  delegate :run_query, to: :query_service
+  def initialize(query_service:)
+    @query_service = query_service
+  end
+
+  def find_members_with_inverse_relationship(resource:, relationship:, key: nil)
+    key ||= :"inverse_#{relationship}"
+    members = query_service.find_members(resource: resource)
+    relationship_objects =
+      run_query(relationship_query, id: resource.id.to_s, relation: relationship.to_s, relation_query: { relationship => [{}] }.to_json)
+    populate_members(relationship, members, relationship_objects, key)
+  end
+
+  def populate_members(relationship, members, relationship_objects, key)
+    members.map do |member|
+      member.loaded[key] = relationship_objects.select do |relationship_object|
+        relationship_object.try(relationship)&.include?(member.id)
+      end
+      member
+    end
+  end
+
+  def relationship_query
+    <<-SQL
+        SELECT DISTINCT a.* FROM orm_resources a,
+        jsonb_array_elements(a.metadata->:relation) AS b(member)
+        WHERE (b.member->>'id')::uuid IN (
+          SELECT DISTINCT member.id FROM orm_resources a,
+          jsonb_array_elements(a.metadata->'member_ids') AS b(member),
+          orm_resources member WHERE (b.member->>'id')::uuid = member.id
+          AND a.id = :id
+        ) AND a.metadata @> :relation_query
+    SQL
+  end
+end

--- a/app/wayfinders/file_set_wayfinder.rb
+++ b/app/wayfinders/file_set_wayfinder.rb
@@ -10,4 +10,5 @@ class FileSetWayfinder < BaseWayfinder
     []
   end
   alias decorated_members members
+  alias members_with_parents members
 end

--- a/app/wayfinders/scanned_map_wayfinder.rb
+++ b/app/wayfinders/scanned_map_wayfinder.rb
@@ -27,4 +27,8 @@ class ScannedMapWayfinder < BaseWayfinder
         end
       end
   end
+
+  def members_with_parents
+    @members_with_parents ||= query_service.custom_queries.find_members_with_inverse_relationship(resource: resource, relationship: :member_ids, key: :parents)
+  end
 end

--- a/app/wayfinders/scanned_resource_wayfinder.rb
+++ b/app/wayfinders/scanned_resource_wayfinder.rb
@@ -10,4 +10,8 @@ class ScannedResourceWayfinder < BaseWayfinder
   def scanned_resources_count
     @scanned_resources_count ||= query_service.custom_queries.count_members(resource: resource, model: ScannedResource)
   end
+
+  def members_with_parents
+    @members_with_parents ||= query_service.custom_queries.find_members_with_inverse_relationship(resource: resource, relationship: :member_ids, key: :parents)
+  end
 end

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -261,7 +261,8 @@ Rails.application.config.to_prepare do
     FindFixityFailures,
     CountMembers,
     FindSavedIds,
-    FindMembersWithRelationship
+    FindMembersWithRelationship,
+    FindMembersWithInverseRelationship
   ].each do |query_handler|
     Valkyrie.config.metadata_adapter.query_service.custom_queries.register_query_handler(query_handler)
   end

--- a/spec/queries/find_members_with_inverse_relationship_spec.rb
+++ b/spec/queries/find_members_with_inverse_relationship_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe FindMembersWithInverseRelationship do
+  subject(:query) { described_class.new(query_service: query_service) }
+  let(:query_service) { Valkyrie.config.metadata_adapter.query_service }
+
+  describe "#find_members_with_inverse_relationship" do
+    it "returns members with `loaded_relationship` loaded" do
+      file_set = FactoryBot.create_for_repository(:file_set)
+      file_set2 = FactoryBot.create_for_repository(:file_set)
+      FactoryBot.create_for_repository(:file_set)
+      parent = FactoryBot.create_for_repository(:scanned_resource, member_ids: [file_set.id, file_set2.id])
+      parent2 = FactoryBot.create_for_repository(:scanned_resource, member_ids: [file_set2.id])
+
+      output = query.find_members_with_inverse_relationship(resource: parent, relationship: :member_ids, key: :parents)
+
+      expect(output.map(&:id)).to eq [file_set.id, file_set2.id]
+      expect(output.first.loaded[:parents].map(&:id)).to eq [parent.id]
+      expect(output.last.loaded[:parents].map(&:id)).to contain_exactly parent.id, parent2.id
+    end
+  end
+end

--- a/spec/wayfinders/wayfinder_spec.rb
+++ b/spec/wayfinders/wayfinder_spec.rb
@@ -15,6 +15,20 @@ RSpec.describe Wayfinder do
       end
     end
 
+    describe "#members_with_parents" do
+      it "returns undecorated members with parents pre-loaded" do
+        member = FactoryBot.create_for_repository(:scanned_resource)
+        resource = FactoryBot.create_for_repository(:scanned_resource, member_ids: member.id)
+        FactoryBot.create_for_repository(:scanned_resource)
+
+        wayfinder = described_class.for(resource)
+
+        expect(wayfinder.members_with_parents.map(&:id)).to eq [member.id]
+        found_member = wayfinder.members_with_parents.first
+        expect(found_member.loaded[:parents].map(&:id)).to eq [resource.id]
+      end
+    end
+
     describe "#scanned_resources_count" do
       it "returns the count of scanned resource members" do
         member = FactoryBot.create_for_repository(:scanned_resource)


### PR DESCRIPTION
By pre-loading parents for FileSets in GraphQL queries it avoids running
an inverse query for every page to determine if something is a Geo
FileSet.