### PR TITLE
fixes #1969 - Order Manager broken due to null thumbnail

### DIFF
--- a/app/javascript/store/vuex/actions.js
+++ b/app/javascript/store/vuex/actions.js
@@ -6,7 +6,7 @@ import gql from 'graphql-tag'
 const actions = {
   async loadImageCollectionGql (context, resource) {
       if (resource == null) {
-        context.commit('CHANGE_MANIFEST_LOAD_STATE', 'LOADING_ERROR')
+        context.commit('CHANGE_RESOURCE_LOAD_STATE', 'LOADING_ERROR')
         console.error('Failed to retrieve the resource')
         return
       }
@@ -58,7 +58,7 @@ const actions = {
         })
         context.commit('SET_RESOURCE', response.data.resource)
       } catch(err) {
-        context.commit('CHANGE_MANIFEST_LOAD_STATE', 'LOADING_ERROR')
+        context.commit('CHANGE_RESOURCE_LOAD_STATE', 'LOADING_ERROR')
         console.error(err)
       }
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "apollo-boost": "^0.1.10",
     "graphql": "^0.13.2",
     "graphql-tag": "^2.9.2",
-    "lux-design-system": "^0.0.25",
+    "lux-design-system": "^1.0.2",
     "npm": "^6.4.0",
     "openseadragon": "^2.3.1",
     "postcss-smart-import": "^0.7.6",


### PR DESCRIPTION
This bumps to LUX v1.0.2 which fixes this. Also tweaks some old action commits that have been changed since we moved off IIIF manifests.