### PR TITLE
Handles errors in retrieving file nodes for the DownloadsController

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -160,6 +160,7 @@ RSpec/NestedGroups:
     - 'spec/controllers/scanned_resources_controller_spec.rb'
     - 'spec/controllers/catalog_controller_spec.rb'
     - 'spec/controllers/simple_resources_controller_spec.rb'
+    - 'spec/controllers/downloads_controller_spec.rb'
 RSpec/VerifiedDoubles:
   Exclude:
     - 'spec/models/search_builder_spec.rb'

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -39,7 +39,11 @@ class DownloadsController < ApplicationController
 
   def binary_file
     return unless file_desc
+    # binding.pry
     @binary_file ||= storage_adapter.find_by(id: file_desc.file_identifiers.first)
+  rescue Valkyrie::StorageAdapter::FileNotFound => not_found_error
+    Valkyrie.logger.error "Failed to retrieve the binary file when requesting to download #{params[:id]}: #{not_found_error}"
+    return nil
   end
 
   class FileWithMetadata < Dry::Struct


### PR DESCRIPTION
Ensures that cases where file nodes with metadata cannot be retrieved within the `DownloadsController` return a 404 response for requests and only log an error

Works towards resolving #1994 and resolves #1687