### PR TITLE
Ensures that cases where FileMetadata for derivative PDFs missing files trigger a regeneration in response to client requests in the ScannedResourcesController

### DIFF
--- a/app/controllers/scanned_resources_controller.rb
+++ b/app/controllers/scanned_resources_controller.rb
@@ -63,7 +63,7 @@ class ScannedResourcesController < BaseResourceController
     change_set = change_set_class.new(find_resource(params[:id])).prepopulate!
     authorize! :pdf, change_set.resource
     pdf_file = change_set.resource.pdf_file
-    unless pdf_file
+    unless pdf_file && binary_exists_for?(pdf_file)
       pdf_file = PDFGenerator.new(resource: change_set.resource, storage_adapter: Valkyrie::StorageAdapter.find(:derivatives)).render
       change_set_persister.buffer_into_index do |buffered_changeset_persister|
         change_set.validate(file_metadata: [pdf_file])
@@ -91,4 +91,18 @@ class ScannedResourcesController < BaseResourceController
       volume_count: locator.volume_count
     }
   end
+
+  private
+
+    def storage_adapter
+      Valkyrie.config.storage_adapter
+    end
+
+    def binary_exists_for?(file_desc)
+      pdf_file_binary = storage_adapter.find_by(id: file_desc.file_identifiers.first)
+      !pdf_file_binary.nil?
+    rescue Valkyrie::StorageAdapter::FileNotFound => error
+      Valkyrie.logger.error("Failed to locate the file for the PDF FileMetadata: #{file_desc.file_identifiers.first}: #{error}")
+      false
+    end
 end


### PR DESCRIPTION
Resolves #1994 and resolves #1997 