### PR TITLE
Handles cases where the ChangeSetPersister::CleanupPdfs does not delete existing PDF metadata for resources when the files may have been deleted

### DIFF
--- a/app/controllers/scanned_resources_controller.rb
+++ b/app/controllers/scanned_resources_controller.rb
@@ -63,6 +63,7 @@ class ScannedResourcesController < BaseResourceController
     change_set = change_set_class.new(find_resource(params[:id])).prepopulate!
     authorize! :pdf, change_set.resource
     pdf_file = change_set.resource.pdf_file
+
     unless pdf_file && binary_exists_for?(pdf_file)
       pdf_file = PDFGenerator.new(resource: change_set.resource, storage_adapter: Valkyrie::StorageAdapter.find(:derivatives)).render
       change_set_persister.buffer_into_index do |buffered_changeset_persister|

--- a/spec/change_set_persisters/change_set_persister/cleanup_pdfs_spec.rb
+++ b/spec/change_set_persisters/change_set_persister/cleanup_pdfs_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe ChangeSetPersister::CleanupPdfs do
   let(:change_set_persister) { instance_double(ChangeSetPersister::Basic, query_service: query_service) }
   let(:change_set) { DynamicChangeSet.new(resource) }
   let(:query_service) { instance_double(Valkyrie::Persistence::Memory::QueryService) }
-  let(:pdf_file) { FileMetadata.new mime_type: "application/pdf", file_identifiers: [Valkyrie::ID.new("asdf")] }
+  let(:file_identifiers) { [Valkyrie::ID.new("asdf")] }
+  let(:pdf_file) { FileMetadata.new mime_type: "application/pdf", file_identifiers: file_identifiers }
 
   before do
     allow(CleanupFilesJob).to receive(:perform_later)
@@ -33,12 +34,40 @@ RSpec.describe ChangeSetPersister::CleanupPdfs do
     end
     context "with a ScannedResource with a PDF attached and no changes other than a PDF being attached" do
       let(:resource) { FactoryBot.create(:scanned_resource) }
-      it "does nothing" do
+      it "does not remove the files" do
         change_set.prepopulate!
         change_set.validate(file_metadata: [pdf_file])
         hook.run
 
         expect(CleanupFilesJob).not_to have_received(:perform_later)
+      end
+    end
+    context "with a ScannedResource with PDF metadata attached with missing files" do
+      let(:file_identifiers) { [] }
+      let(:resource) { FactoryBot.create(:scanned_resource, file_metadata: [pdf_file]) }
+      before do
+        allow(Valkyrie.logger).to receive(:error)
+      end
+      it "removes the metadata and does not attempt to delete the missing files" do
+        change_set.prepopulate!
+        change_set.validate(file_metadata: [pdf_file])
+        hook.run
+
+        expect(CleanupFilesJob).not_to have_received(:perform_later)
+        expect(resource.file_metadata).to eq []
+        expect(Valkyrie.logger).to have_received(:error).with(/Failed to locate the file for the PDF FileMetadata/)
+      end
+    end
+    context "with a ScannedResource with PDF metadata attached with existing files" do
+      let(:file_identifiers) { [Valkyrie::ID.new("disk://#{File.expand_path(__FILE__)}")] }
+      let(:resource) { FactoryBot.create(:scanned_resource, file_metadata: [pdf_file]) }
+      it "keeps the metadata and does not attempt to delete the missing files" do
+        change_set.prepopulate!
+        change_set.validate(file_metadata: [pdf_file])
+        hook.run
+
+        expect(CleanupFilesJob).not_to have_received(:perform_later)
+        expect(resource.file_metadata).to eq [pdf_file]
       end
     end
     context "with a ScannedResource with a PDF attached and changes" do


### PR DESCRIPTION
Resolves #2005 