### PR TITLE
Fixing home page typo

### DIFF
--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -2,7 +2,7 @@
 <p>
   <%=t('product_name') %> is a secure application that enables
   <%=t('institution.name') %> to efficiently carry out varied
-  and complex workflows related to digitization while adhereing to standards
+  and complex workflows related to digitization while adhering to standards
   and best practices which ensure that our content will be preserved and
   accessible to our community and the world for generations.
 </p>


### PR DESCRIPTION
Reported by Dan Walker: "adhering" is misspelled as "adhereing" in the home page text.