### PR TITLE
updates voyager updater tasks to process refactored bibdata dump format

### DIFF
--- a/app/services/voyager_updater/dump.rb
+++ b/app/services/voyager_updater/dump.rb
@@ -12,13 +12,7 @@ module VoyagerUpdater
     # Retrieve the bib. IDs from the Voyager data dump marked as updated
     # @return [Array<String>]
     def update_ids
-      parsed_json["ids"]["update_ids"].map { |x| x["id"] }
-    end
-
-    # Retrieve the bib. IDs from the Voyager data dump marked as created
-    # @return [Array<String>]
-    def create_ids
-      parsed_json["ids"]["create_ids"].map { |x| x["id"] }
+      parsed_json["ids"]["update_ids"]
     end
 
     # Retrieve the resource IDs for those resources marked for update
@@ -37,7 +31,7 @@ module VoyagerUpdater
       # Retrieve the bib. IDs used for the resource updates
       # @return [Array<String>]
       def relevant_ids
-        update_ids + create_ids
+        update_ids
       end
 
       # Retrieve the JSON from Voyager and parse the values into a Hash

--- a/spec/services/voyager_updater/dump_spec.rb
+++ b/spec/services/voyager_updater/dump_spec.rb
@@ -7,12 +7,7 @@ describe VoyagerUpdater::Dump do
   let(:data) do
     {
       "ids" => {
-        "update_ids" => [
-          { "id" => "123456" }
-        ],
-        "create_ids" => [
-          { "id" => "4609321" }
-        ]
+        "update_ids" => ["123456", "4609321"]
       }
     }
   end
@@ -30,13 +25,7 @@ describe VoyagerUpdater::Dump do
 
   describe "#update_ids" do
     it "retrieves the bib. IDs for records which Voyager marked as updated" do
-      expect(dump.update_ids).to eq(["123456"])
-    end
-  end
-
-  describe "#create_ids" do
-    it "retrieves the bib. IDs for records which Voyager marked as created" do
-      expect(dump.create_ids).to eq(["4609321"])
+      expect(dump.update_ids).to eq(["123456", "4609321"])
     end
   end
 

--- a/spec/services/voyager_updater/event_spec.rb
+++ b/spec/services/voyager_updater/event_spec.rb
@@ -17,12 +17,7 @@ describe VoyagerUpdater::Event do
   let(:dump_data) do
     {
       "ids" => {
-        "update_ids" => [
-          { "id" => "123456" }
-        ],
-        "create_ids" => [
-          { "id" => "4609321" }
-        ]
+        "update_ids" => ["123456", "4609321"]
       }
     }
   end


### PR DESCRIPTION
Closes #2042. Because of the refactored Voyager Dump jobs, we have combined create_ids and update_ids into a single array of bib ids in update_ids. The job has been failing since the refactored bibdata events were deployed on Friday. Looking at the code it seems like the rake task is set up to process all of the Bibdata events and process them unless they have been previously processed. I think the failed jobs will be captured in the next nightly update after this branch is deployed