### PR TITLE
Ensuring that the ScannedResourcesController test suite expects both the original file and MP3 derivative for audio reserve resources

### DIFF
--- a/spec/controllers/scanned_resources_controller_spec.rb
+++ b/spec/controllers/scanned_resources_controller_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe ScannedResourcesController do
 
           expect(resource.member_ids.length).to eq 1
           file_set = find_resource(resource.member_ids.first)
-          expect(file_set.file_metadata.length).to eq 1
+          expect(file_set.file_metadata.length).to eq 2
           expect(file_set.original_file).not_to be nil
           expect(file_set.original_file.label).to eq ["1791261_0701.wav"]
           expect(file_set.original_file.mime_type).to eq ["audio/x-wav"]


### PR DESCRIPTION
ScannedResources with audio files attached to their FileSets now have MP3 derivatives generated.  This accounts for those derivatives.