### PR TITLE
Revert "Lazy map resources in MemoryEfficientAllQuery"

### DIFF
--- a/app/queries/memory_efficient_all_query.rb
+++ b/app/queries/memory_efficient_all_query.rb
@@ -17,7 +17,7 @@ class MemoryEfficientAllQuery
     connection.transaction(savepoint: true) do
       relation = orm_class
       relation = relation.exclude(internal_resource: Array(except_models).map(&:to_s)) if except_models.present?
-      relation.stream.lazy.map do |object|
+      relation.stream.map do |object|
         resource_factory.to_resource(object: object)
       end
     end

--- a/spec/queries/memory_efficient_all_query_spec.rb
+++ b/spec/queries/memory_efficient_all_query_spec.rb
@@ -11,13 +11,6 @@ describe MemoryEfficientAllQuery do
         resource = FactoryBot.create_for_repository(:scanned_resource)
         expect(query.memory_efficient_all.map(&:id).to_a).to eq [resource.id]
       end
-      it "will only parse as many objects as is necessary" do
-        5.times { FactoryBot.create_for_repository(:scanned_resource) }
-        allow(query_service.resource_factory).to receive(:to_resource).and_call_original
-
-        expect(query.memory_efficient_all.first(2).length).to eq 2
-        expect(query_service.resource_factory).to have_received(:to_resource).exactly(2).times
-      end
     end
     context "when given except_models argument" do
       it "finds everything that isn't one of those models" do


### PR DESCRIPTION
This reverts commit d34d45afa838844420158ae20efa2175a7fe1127.

On staging, that commit resulted in only one batch of records reindexing.

```
I, [2018-11-12T10:32:13.258438 #6424]  INFO -- : Clearing Solr
I, [2018-11-12T10:32:13.299740 #6424]  INFO -- : Reindexing all records
I, [2018-11-12T10:32:15.326994 #6424]  INFO -- : Indexing 1000 records
I, [2018-11-12T10:32:22.463393 #6424]  INFO -- : Done
```

Reverting the commit on staging allows the full set of records to index