### PR TITLE
Fix reindexing memory problem

### DIFF
--- a/app/queries/memory_efficient_all_query.rb
+++ b/app/queries/memory_efficient_all_query.rb
@@ -15,9 +15,9 @@ class MemoryEfficientAllQuery
 
   def memory_efficient_all(except_models: [])
     connection.transaction(savepoint: true) do
-      relation = orm_class
+      relation = orm_class.use_cursor
       relation = relation.exclude(internal_resource: Array(except_models).map(&:to_s)) if except_models.present?
-      relation.stream.lazy.map do |object|
+      relation.lazy.map do |object|
         resource_factory.to_resource(object: object)
       end
     end

--- a/app/queries/memory_efficient_all_query.rb
+++ b/app/queries/memory_efficient_all_query.rb
@@ -17,7 +17,7 @@ class MemoryEfficientAllQuery
     connection.transaction(savepoint: true) do
       relation = orm_class
       relation = relation.exclude(internal_resource: Array(except_models).map(&:to_s)) if except_models.present?
-      relation.stream.map do |object|
+      relation.stream.lazy.map do |object|
         resource_factory.to_resource(object: object)
       end
     end

--- a/app/services/reindexer.rb
+++ b/app/services/reindexer.rb
@@ -1,20 +1,22 @@
 # frozen_string_literal: true
 class Reindexer
-  def self.reindex_all(logger: Logger.new(STDOUT), wipe: false)
+  def self.reindex_all(logger: Logger.new(STDOUT), wipe: false, batch_size: 1000)
     new(
       solr_adapter: Valkyrie::MetadataAdapter.find(:index_solr),
       query_service: Valkyrie::MetadataAdapter.find(:postgres).query_service,
       logger: logger,
-      wipe: wipe
+      wipe: wipe,
+      batch_size: batch_size
     ).reindex_all
   end
 
-  attr_reader :solr_adapter, :query_service, :logger, :wipe
-  def initialize(solr_adapter:, query_service:, logger:, wipe: false)
+  attr_reader :solr_adapter, :query_service, :logger, :wipe, :batch_size
+  def initialize(solr_adapter:, query_service:, logger:, wipe: false, batch_size: 1000)
     @solr_adapter = solr_adapter
     @query_service = query_service
     @logger = logger
     @wipe = wipe
+    @batch_size = batch_size
   end
 
   def reindex_all
@@ -23,7 +25,7 @@ class Reindexer
       solr_adapter.persister.wipe!
     end
     logger.info "Reindexing all records"
-    query_service.custom_queries.memory_efficient_all(except_models: blacklisted_models).each_slice(1000) do |records|
+    query_service.custom_queries.memory_efficient_all(except_models: blacklisted_models).each_slice(batch_size) do |records|
       logger.info "Indexing #{records.count} records"
       solr_adapter.persister.save_all(resources: records)
     end

--- a/spec/queries/memory_efficient_all_query_spec.rb
+++ b/spec/queries/memory_efficient_all_query_spec.rb
@@ -12,6 +12,14 @@ describe MemoryEfficientAllQuery do
         expect(query.memory_efficient_all.map(&:id).to_a).to eq [resource.id]
       end
     end
+
+    it "will only parse as many objects as is necessary" do
+      5.times { FactoryBot.create_for_repository(:scanned_resource) }
+      allow(query_service.resource_factory).to receive(:to_resource).and_call_original
+      expect(query.memory_efficient_all.first(2).length).to eq 2
+      expect(query_service.resource_factory).to have_received(:to_resource).exactly(2).times
+    end
+
     context "when given except_models argument" do
       it "finds everything that isn't one of those models" do
         resource = FactoryBot.create_for_repository(:scanned_resource)

--- a/spec/services/reindexer_spec.rb
+++ b/spec/services/reindexer_spec.rb
@@ -22,6 +22,14 @@ RSpec.describe Reindexer do
         expect { solr_adapter.query_service.find_by(id: output.id) }.not_to raise_error
       end
     end
+    it "reindexes multiple records" do
+      5.times do
+        postgres_adapter.persister.save(resource: FactoryBot.build(:scanned_resource))
+      end
+
+      described_class.reindex_all(logger: logger, wipe: true, batch_size: 2)
+      expect(solr_adapter.query_service.find_all.to_a.length).to eq 5
+    end
     context "when given ProcessedEvents" do
       it "doesn't index them" do
         resource = FactoryBot.build(:processed_event)


### PR DESCRIPTION
This uses cursors over streams to fix the reindexing issue. It appears that while using streams if we then saved to solr it would interrupt the stream and `each_slice` would stop working. Very odd.