### PR TITLE
Add citations to NumismaticIssue

### DIFF
--- a/app/resources/numismatic_issues/numismatic_issue.rb
+++ b/app/resources/numismatic_issues/numismatic_issue.rb
@@ -6,6 +6,7 @@ class NumismaticIssue < Resource
   include Valkyrie::Resource::AccessControls
   attribute :member_ids, Valkyrie::Types::Array
   attribute :member_of_collection_ids
+  attribute :numismatic_citation_ids, Valkyrie::Types::Array
 
   # descriptive metadata
   attribute :artist

--- a/app/resources/numismatic_issues/numismatic_issue_change_set.rb
+++ b/app/resources/numismatic_issues/numismatic_issue_change_set.rb
@@ -47,6 +47,7 @@ class NumismaticIssueChangeSet < ChangeSet
   property :depositor, multiple: false, required: false
   property :member_ids, multiple: true, required: false, type: Types::Strict::Array.of(Valkyrie::Types::ID)
   property :member_of_collection_ids, multiple: true, required: false, type: Types::Strict::Array.of(Valkyrie::Types::ID)
+  property :numismatic_citation_ids, multiple: true, required: false, type: Types::Strict::Array.of(Valkyrie::Types::ID)
   property :pending_uploads, multiple: true, required: false
 
   property :start_canvas, required: false

--- a/app/resources/numismatic_issues/numismatic_issue_decorator.rb
+++ b/app/resources/numismatic_issues/numismatic_issue_decorator.rb
@@ -49,10 +49,14 @@ class NumismaticIssueDecorator < Valkyrie::ResourceDecorator
                          :rendered_rights_statement,
                          :thumbnail_id
 
-  delegate :members, :decorated_file_sets, :decorated_coins, :coin_count, to: :wayfinder
+  delegate :members, :decorated_file_sets, :decorated_coins, :coin_count, :decorated_numismatic_citations, to: :wayfinder
 
   def attachable_objects
     [Coin]
+  end
+
+  def citations
+    decorated_numismatic_citations.map(&:title)
   end
 
   # Whether this box has a workflow state that grants access to its contents

--- a/app/resources/numismatic_issues/numismatic_issue_wayfinder.rb
+++ b/app/resources/numismatic_issues/numismatic_issue_wayfinder.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class NumismaticIssueWayfinder < BaseWayfinder
   relationship_by_property :members, property: :member_ids
+  relationship_by_property :numismatic_citations, property: :numismatic_citation_ids, singular: false
   relationship_by_property :file_sets, property: :member_ids, model: FileSet
   relationship_by_property :coins, property: :member_ids, model: Coin
   relationship_by_property :collections, property: :member_of_collection_ids

--- a/app/views/catalog/_members_numismatic_issue.html.erb
+++ b/app/views/catalog/_members_numismatic_issue.html.erb
@@ -1,5 +1,43 @@
   <div class="panel panel-default">
     <div class="panel-heading">
+      <h2 class="panel-title">Citations</h2>
+    </div>
+    <div class="row panel-body">
+      <table id="members" class="table table-striped">
+        <thead>
+          <tr>
+            <th>Title</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% unless decorated_resource.decorated_numismatic_citations.empty? %>
+            <% decorated_resource.decorated_numismatic_citations.each do |citation| %>
+              <% citation_url = solr_document_path("#{citation.id}") %>
+              <tr>
+                <td><%= citation.title %></td>
+                <td>
+                  <%= link_to 'View', citation_url, class: 'btn btn-default' %>
+                  <%= link_to 'Edit', main_app.polymorphic_path([:edit, citation]), class: 'btn btn-default' %>
+                  <%= link_to "Delete", main_app.polymorphic_path([citation]), class: 'btn btn-danger',
+                                        data: { confirm: "Delete this #{citation.human_readable_type}?" },
+                                        method: :delete %>
+                </td>
+              </tr>
+            <% end %>
+          <% end %>
+        </tbody>
+      </table>
+      <div class="col-sm-1">
+        <% if can?(:create, NumismaticCitation) %>
+          <%= link_to 'Add Citation', coin_add_numismatic_citation_path(resource, parent_id: resource.id), class: 'btn btn-primary' %>
+        <% end %>
+      </div>
+    </div>
+  </div>
+
+  <div class="panel panel-default">
+    <div class="panel-heading">
       <h2 class="panel-title">Coins</h2>
     </div>
     <div class="row panel-body">

--- a/spec/controllers/numismatic_citations_controller_spec.rb
+++ b/spec/controllers/numismatic_citations_controller_spec.rb
@@ -44,6 +44,18 @@ RSpec.describe NumismaticCitationsController do
         expect(response).to redirect_to("http://test.host/catalog/#{coin.id}")
       end
     end
+    context "adding to a parent numismatic issue" do
+      let(:user) { FactoryBot.create(:admin) }
+      let(:issue) { FactoryBot.create_for_repository(:numismatic_issue) }
+
+      it "adds the id to the coin's citation ids and redirects to parent coin" do
+        post :create, params: { numismatic_citation: valid_params.merge(citation_parent_id: issue.id) }
+
+        updated = Valkyrie.config.metadata_adapter.query_service.find_by(id: issue.id)
+        expect(updated.numismatic_citation_ids).not_to be_empty
+        expect(response).to redirect_to("http://test.host/catalog/#{issue.id}")
+      end
+    end
   end
   describe "destroy" do
     context "access control" do

--- a/spec/decorators/numismatic_issue_decorator_spec.rb
+++ b/spec/decorators/numismatic_issue_decorator_spec.rb
@@ -3,8 +3,10 @@ require "rails_helper"
 
 RSpec.describe NumismaticIssueDecorator do
   subject(:decorator) { described_class.new(issue) }
-  let(:issue) { FactoryBot.create_for_repository(:numismatic_issue, member_ids: [coin.id], state: "complete") }
+  let(:issue) { FactoryBot.create_for_repository(:numismatic_issue, member_ids: [coin.id], state: "complete", numismatic_citation_ids: [citation.id]) }
   let(:coin) { FactoryBot.create_for_repository(:coin) }
+  let(:citation) { FactoryBot.create_for_repository(:numismatic_citation, numismatic_reference_id: [reference.id]) }
+  let(:reference) { FactoryBot.create_for_repository(:numismatic_reference) }
 
   describe "#decorated_coins" do
     it "returns decorated member coins" do
@@ -18,6 +20,12 @@ RSpec.describe NumismaticIssueDecorator do
   describe "#attachable_objects" do
     it "allows attaching coins" do
       expect(decorator.attachable_objects).to eq([Coin])
+    end
+  end
+
+  describe "#citations" do
+    it "renders the linked citations" do
+      expect(decorator.citations).to eq(["short-title citation part citation number"])
     end
   end
 


### PR DESCRIPTION
Closes #2177 

- Adds ability to attach citations to Numismatic Issues.
- Improves styling on Citations panel.

<img width="1133" alt="screenshot 2018-11-15 14 59 10" src="https://user-images.githubusercontent.com/784196/48581391-4f47e000-e8e7-11e8-9ab6-c8b06c9b7340.png">



