### PR TITLE
Numismatic Issue form reorganization

### DIFF
--- a/app/resources/numismatic_issues/numismatic_issue.rb
+++ b/app/resources/numismatic_issues/numismatic_issue.rb
@@ -11,7 +11,6 @@ class NumismaticIssue < Resource
   # descriptive metadata
   attribute :artist
   attribute :color
-  attribute :date_object
   attribute :date_range
   attribute :denomination
   attribute :department
@@ -23,6 +22,7 @@ class NumismaticIssue < Resource
   attribute :master
   attribute :metal
   attribute :note
+  attribute :object_date
   attribute :object_type
   attribute :obverse_attributes
   attribute :obverse_figure

--- a/app/resources/numismatic_issues/numismatic_issue_change_set.rb
+++ b/app/resources/numismatic_issues/numismatic_issue_change_set.rb
@@ -70,47 +70,55 @@ class NumismaticIssueChangeSet < ChangeSet
   validates :visibility, presence: true
 
   def primary_terms
-    [
-      :rights_statement,
-      :rights_note,
-      :member_of_collection_ids,
-      :artist,
-      :color,
-      :date_object,
-      :date_range,
-      :denomination,
-      :department,
-      :description,
-      :edge,
-      :era,
-      :geographic_origin,
-      :issue_number,
-      :master,
-      :metal,
-      :note,
-      :object_type,
-      :obverse_attributes,
-      :obverse_figure,
-      :obverse_figure_description,
-      :obverse_figure_relationship,
-      :obverse_legend,
-      :obverse_orientation,
-      :obverse_part,
-      :obverse_symbol,
-      :place,
-      :reverse_attributes,
-      :reverse_figure,
-      :reverse_figure_description,
-      :reverse_figure_relationship,
-      :reverse_legend,
-      :reverse_orientation,
-      :reverse_part,
-      :reverse_symbol,
-      :ruler,
-      :series,
-      :shape,
-      :subject,
-      :workshop
-    ]
+    {
+      "" => [
+        :issue_number,
+        :department,
+        :object_type,
+        :denomination,
+        :metal,
+        :shape,
+        :color,
+        :edge,
+        :date_range,
+        :date_object,
+        :ruler,
+        :place,
+        :geographic_origin,
+        :artist,
+        :master,
+        :workshop,
+        :description,
+        :era,
+        :series,
+        :subject
+      ],
+      "Obverse" => [
+        :obverse_figure,
+        :obverse_symbol,
+        :obverse_part,
+        :obverse_orientation,
+        :obverse_figure_description,
+        :obverse_figure_relationship,
+        :obverse_legend,
+        :obverse_attributes
+      ],
+      "Reverse" => [
+        :reverse_figure,
+        :reverse_symbol,
+        :reverse_part,
+        :reverse_orientation,
+        :reverse_figure_description,
+        :reverse_figure_relationship,
+        :reverse_legend,
+        :reverse_attributes
+      ],
+      "Rights and Notes" => [
+        :note,
+        :member_of_collection_ids,
+        :rights_statement,
+        :rights_note
+      ]
+    }
   end
 end

--- a/app/resources/numismatic_issues/numismatic_issue_change_set.rb
+++ b/app/resources/numismatic_issues/numismatic_issue_change_set.rb
@@ -6,7 +6,6 @@ class NumismaticIssueChangeSet < ChangeSet
   include VisibilityProperty
   property :artist, multiple: true, required: false, default: []
   property :color, multiple: false, required: false
-  property :date_object, multiple: false, required: false
   property :date_range, multiple: false, required: false
   property :denomination, multiple: false, required: false
   property :department, multiple: false, required: false
@@ -18,6 +17,7 @@ class NumismaticIssueChangeSet < ChangeSet
   property :master, multiple: false, required: false
   property :metal, multiple: false, required: false
   property :note, multiple: true, required: false, default: []
+  property :object_date, multiple: false, required: false
   property :object_type, multiple: false, required: false
   property :obverse_attributes, multiple: true, required: false, default: []
   property :obverse_figure, multiple: false, required: false
@@ -72,7 +72,6 @@ class NumismaticIssueChangeSet < ChangeSet
   def primary_terms
     {
       "" => [
-        :issue_number,
         :department,
         :object_type,
         :denomination,
@@ -81,17 +80,14 @@ class NumismaticIssueChangeSet < ChangeSet
         :color,
         :edge,
         :date_range,
-        :date_object,
+        :object_date,
+        :era,
         :ruler,
-        :place,
-        :geographic_origin,
-        :artist,
         :master,
         :workshop,
-        :description,
-        :era,
         :series,
-        :subject
+        :place,
+        :geographic_origin
       ],
       "Obverse" => [
         :obverse_figure,
@@ -118,6 +114,11 @@ class NumismaticIssueChangeSet < ChangeSet
         :member_of_collection_ids,
         :rights_statement,
         :rights_note
+      ],
+      "Artists and Subjects" => [
+        :artist,
+        :subject,
+        :description
       ]
     }
   end

--- a/app/resources/numismatic_issues/numismatic_issue_decorator.rb
+++ b/app/resources/numismatic_issues/numismatic_issue_decorator.rb
@@ -2,7 +2,6 @@
 class NumismaticIssueDecorator < Valkyrie::ResourceDecorator
   display :artist,
           :color,
-          :date_object,
           :date_range,
           :denomination,
           :department,
@@ -13,6 +12,7 @@ class NumismaticIssueDecorator < Valkyrie::ResourceDecorator
           :master,
           :metal,
           :note,
+          :object_date,
           :object_type,
           :obverse_attributes,
           :obverse_figure,

--- a/app/views/base/_form.html.erb
+++ b/app/views/base/_form.html.erb
@@ -3,6 +3,7 @@
 <div class="row">
   <div class="col-xs-12 col-sm-8" role="main">
     <div class="form-panel-content">
+      <%= yield "metadata_tab".to_sym if content_for? "metadata_tab".to_sym %>
       <%= render "form_metadata", f: f %>
     </div>
   </div>

--- a/app/views/base/_form.html.erb
+++ b/app/views/base/_form.html.erb
@@ -2,23 +2,8 @@
 <%= simple_form_for @change_set do |f| %>
 <div class="row">
   <div class="col-xs-12 col-sm-8" role="main">
-    <!-- Nav tabs -->
-    <ul class="nav nav-tabs" role="tablist">
-      <li role="presentation" class="active">
-        <a href="#metadata" aria-controls="metadata" role="tab" data-toggle="tab">
-          <i class="fa icon-metadata"></i> <%= t("works.form.tab.metadata") %>
-      </a>
-      </li>
-    </ul>
-
-    <!-- Tab panes -->
-    <div class="tab-content">
-      <div role="tabpanel" class="tab-pane active" id="metadata">
-        <div class="form-tab-content">
-          <%= yield "metadata_tab".to_sym if content_for? "metadata_tab".to_sym %>
-          <%= render "form_metadata", f: f %>
-        </div>
-      </div>
+    <div class="form-panel-content">
+      <%= render "form_metadata", f: f %>
     </div>
   </div>
 

--- a/app/views/base/_form_metadata.html.erb
+++ b/app/views/base/_form_metadata.html.erb
@@ -1,14 +1,17 @@
-  <% if @change_set.primary_terms.is_a?(Array) %>
+<% if @change_set.primary_terms.is_a?(Array) %>
+  <div class="panel panel-default">
+    <div class="panel-heading">Metadata</div>
+    <%= render partial: 'form_metadata_inner', locals: { fields: @change_set.primary_terms, f: f } %>
+  </div>
+<% elsif @change_set.primary_terms.is_a?(Hash) %>
+  <% @change_set.primary_terms.each_pair do |label, fields| %>
     <div class="panel panel-default">
-      <%= render partial: 'form_metadata_inner', locals: { fields: @change_set.primary_terms, f: f } %>
+      <% unless label.empty? %>
+        <div class="panel-heading"><%= label %></div>
+      <% else %>
+        <div class="panel-heading">Metadata</div>
+      <% end %>
+      <%= render partial: 'form_metadata_inner', locals: { fields: fields, f: f } %>
     </div>
-  <% elsif @change_set.primary_terms.is_a?(Hash) %>
-    <% @change_set.primary_terms.each_pair do |label, fields| %>
-      <div class="panel panel-default">
-        <% unless label.empty? %>
-          <div class="panel-heading"><%= label %></div>
-        <% end %>
-        <%= render partial: 'form_metadata_inner', locals: { fields: fields, f: f } %>
-      </div>
-    <% end %>
   <% end %>
+<% end %>

--- a/app/views/base/_form_metadata.html.erb
+++ b/app/views/base/_form_metadata.html.erb
@@ -1,3 +1,14 @@
-  <% (@change_set.primary_terms).each do |field| %>
-    <%= render_edit_field_partial(field, f: f) %>
+  <% if @change_set.primary_terms.is_a?(Array) %>
+    <div class="panel panel-default">
+      <%= render partial: 'form_metadata_inner', locals: { fields: @change_set.primary_terms, f: f } %>
+    </div>
+  <% elsif @change_set.primary_terms.is_a?(Hash) %>
+    <% @change_set.primary_terms.each_pair do |label, fields| %>
+      <div class="panel panel-default">
+        <% unless label.empty? %>
+          <div class="panel-heading"><%= label %></div>
+        <% end %>
+        <%= render partial: 'form_metadata_inner', locals: { fields: fields, f: f } %>
+      </div>
+    <% end %>
   <% end %>

--- a/app/views/base/_form_metadata_inner.html.erb
+++ b/app/views/base/_form_metadata_inner.html.erb
@@ -1,0 +1,5 @@
+    <div class="panel-body">
+      <% fields.each do |field| %>
+        <%= render_edit_field_partial(field, f: f) %>
+      <% end %>
+    </div>

--- a/app/views/templates/new.html.erb
+++ b/app/views/templates/new.html.erb
@@ -6,6 +6,7 @@
     <div class="row">
       <div class="col-xs-12 col-sm-8" role="main">
         <div class="form-panel-content">
+          <%= yield "metadata_tab".to_sym if content_for? "metadata_tab".to_sym %>
           <%= render "form_metadata", f: f %>
         </div>
       </div>

--- a/app/views/templates/new.html.erb
+++ b/app/views/templates/new.html.erb
@@ -5,23 +5,8 @@
     <% f.object = TemplateChangeSet::TemplateChangeSetDecorator.new(f.object) %>
     <div class="row">
       <div class="col-xs-12 col-sm-8" role="main">
-        <!-- Nav tabs -->
-        <ul class="nav nav-tabs" role="tablist">
-          <li role="presentation" class="active">
-            <a href="#metadata" aria-controls="metadata" role="tab" data-toggle="tab">
-              <i class="fa icon-metadata"></i> <%= t("works.form.tab.metadata") %>
-          </a>
-          </li>
-        </ul>
-
-        <!-- Tab panes -->
-        <div class="tab-content">
-          <div role="tabpanel" class="tab-pane active" id="metadata">
-            <div class="form-tab-content">
-              <%= yield "metadata_tab".to_sym if content_for? "metadata_tab".to_sym %>
-              <%= render "form_metadata", f: f %>
-            </div>
-          </div>
+        <div class="form-panel-content">
+          <%= render "form_metadata", f: f %>
         </div>
       </div>
 

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -47,6 +47,8 @@ en:
         member_of_collection_ids: "Collections"
         favorite_term_ids: "Favorite Terms"
         ocr_language: "OCR Language"
+      numismatic_issue:
+        object_date: "Date of object"
     required:
       html: '<span class="label label-info required-tag">required</span>'
   helpers:

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -729,7 +729,6 @@ RSpec.describe CatalogController do
       {
         artist: "issue-artist",
         color: "issue-color",
-        date_object: "issue-date-object",
         date_range: "issue-date",
         denomination: "issue-denomination",
         department: "issue-department",
@@ -742,6 +741,7 @@ RSpec.describe CatalogController do
         master: "issue-master",
         metal: "issue-metal",
         note: "issue-note",
+        object_date: "issue-object-date",
         object_type: "issue-type",
         obverse_attributes: "issue-obv-attributes",
         obverse_figure: "issue-obverse-figure",

--- a/spec/resources/numismatic_issue/numismatic_issue_change_set_spec.rb
+++ b/spec/resources/numismatic_issue/numismatic_issue_change_set_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NumismaticIssueChangeSet do
   describe "#primary_terms" do
     it "includes displayed fields" do
       expect(change_set.primary_terms).to be_a(Hash)
-      expect(change_set.primary_terms.keys).to eq(["", "Obverse", "Reverse", "Rights and Notes"])
+      expect(change_set.primary_terms.keys).to eq(["", "Obverse", "Reverse", "Rights and Notes", "Artists and Subjects"])
       expect(change_set.primary_terms[""]).to include(:object_type, :denomination, :metal, :workshop)
     end
   end

--- a/spec/resources/numismatic_issue/numismatic_issue_change_set_spec.rb
+++ b/spec/resources/numismatic_issue/numismatic_issue_change_set_spec.rb
@@ -7,7 +7,9 @@ RSpec.describe NumismaticIssueChangeSet do
 
   describe "#primary_terms" do
     it "includes displayed fields" do
-      expect(change_set.primary_terms).to include(:object_type, :denomination, :metal, :workshop)
+      expect(change_set.primary_terms).to be_a(Hash)
+      expect(change_set.primary_terms.keys).to eq(["", "Obverse", "Reverse", "Rights and Notes"])
+      expect(change_set.primary_terms[""]).to include(:object_type, :denomination, :metal, :workshop)
     end
   end
 

--- a/spec/resources/numismatic_issue/numismatic_issues_feature_spec.rb
+++ b/spec/resources/numismatic_issue/numismatic_issues_feature_spec.rb
@@ -31,7 +31,7 @@ RSpec.feature "NumismaticIssues" do
     expect(page).to have_css '.select[for="numismatic_issue_member_of_collection_ids"]', text: "Collections"
     expect(page).to have_field "Artist"
     expect(page).to have_field "Color"
-    expect(page).to have_field "Date object"
+    expect(page).to have_field "Date of object"
     expect(page).to have_field "Date range"
     expect(page).to have_field "Denomination"
     expect(page).to have_field "Department"
@@ -81,7 +81,6 @@ RSpec.feature "NumismaticIssues" do
         member_of_collection_ids: [collection.id],
         artist: "test value",
         color: "test value",
-        date_object: "test value",
         date_range: "test value",
         denomination: "test value",
         department: "test value",
@@ -92,6 +91,7 @@ RSpec.feature "NumismaticIssues" do
         master: "test value",
         metal: "test value",
         note: "test value",
+        object_date: "test value",
         object_type: "test value",
         obverse_attributes: "test value",
         obverse_figure: "test value",
@@ -127,7 +127,6 @@ RSpec.feature "NumismaticIssues" do
       expect(page).to have_css ".attribute.member_of_collections", text: "Title"
       expect(page).to have_css ".attribute.artist", text: "test value"
       expect(page).to have_css ".attribute.color", text: "test value"
-      expect(page).to have_css ".attribute.date_object", text: "test value"
       expect(page).to have_css ".attribute.date_range", text: "test value"
       expect(page).to have_css ".attribute.denomination", text: "test value"
       expect(page).to have_css ".attribute.department", text: "test value"
@@ -138,6 +137,7 @@ RSpec.feature "NumismaticIssues" do
       expect(page).to have_css ".attribute.master", text: "test value"
       expect(page).to have_css ".attribute.metal", text: "test value"
       expect(page).to have_css ".attribute.note", text: "test value"
+      expect(page).to have_css ".attribute.object_date", text: "test value"
       expect(page).to have_css ".attribute.object_type", text: "test value"
       expect(page).to have_css ".attribute.obverse_attributes", text: "test value"
       expect(page).to have_css ".attribute.obverse_figure", text: "test value"


### PR DESCRIPTION
* Updates metadata views to support either an Array or a Hash for `primary_terms` — a Hash creates a section with the key as the label, and the values as field names.
* Updates the Numismatic Issue to use a `primary_terms` Hash to group fields in a similar order to the existing application

Fixes #2174 , Fixes #2129 