### PR TITLE
Ensuring that PDFGenerator errors are logged with the URL used in the request

### DIFF
--- a/app/services/pdf_generator.rb
+++ b/app/services/pdf_generator.rb
@@ -24,7 +24,7 @@ class PDFGenerator
       begin
         prawn_document.image downloader.download, width: page_size.first, height: page_size.last, fit: page_size
       rescue OpenURI::HTTPError => uri_error
-        Valkyrie.logger.error "#{self.class}: Failed to download a PDF using the following URI as a base: #{downloader.canvas.url}: #{uri_error}"
+        Valkyrie.logger.error "#{self.class}: Failed to download a PDF using the following URI as a base: #{downloader.download_url}: #{uri_error}"
         download_attempts += 1
         retry unless download_attempts > 4
         raise Error

--- a/app/services/pdf_generator/canvas_downloader.rb
+++ b/app/services/pdf_generator/canvas_downloader.rb
@@ -11,7 +11,7 @@ class PDFGenerator
     # Download the PDF by opening the stream with OpenURI using the read-only and binary modes
     # @return [File]
     def download
-      open(canvas_url, "rb")
+      open(download_url, "rb")
     end
 
     def layout
@@ -31,11 +31,11 @@ class PDFGenerator
       canvas.width <= canvas.height
     end
 
-    private
+    def download_url
+      "#{canvas.url}/full/#{max_width},/0/#{quality}.#{format}"
+    end
 
-      def canvas_url
-        "#{canvas.url}/full/#{max_width},/0/#{quality}.#{format}"
-      end
+    private
 
       def format
         bitonal? ? "png" : "jpg"

--- a/spec/services/pdf_generator_spec.rb
+++ b/spec/services/pdf_generator_spec.rb
@@ -32,7 +32,9 @@ RSpec.describe PDFGenerator do
       end
       it "raises a PDFGeneratorError and logs an error for each attempted download" do
         expect { generator.render }.to raise_error(PDFGenerator::Error)
-        expect(Valkyrie.logger).to have_received(:error).exactly(5).times.with(/PDFGenerator\: Failed to download a PDF using the following URI as a base/)
+        # rubocop:disable Metrics/LineLength
+        expect(Valkyrie.logger).to have_received(:error).exactly(5).times.with("PDFGenerator: Failed to download a PDF using the following URI as a base: http://www.example.com/image-service/#{file_set.id}/full/200,/0/gray.jpg: 500 ")
+        # rubocop:enable Metrics/LineLength
       end
     end
 


### PR DESCRIPTION
This should assist with tracing the root of the cause for #2153 