### PR TITLE
Ensures that the PlaylistDecorator does not display the members attribute

### DIFF
--- a/app/resources/playlists/playlist_decorator.rb
+++ b/app/resources/playlists/playlist_decorator.rb
@@ -2,7 +2,6 @@
 class PlaylistDecorator < Valkyrie::ResourceDecorator
   display :title,
           :visibility,
-          :members,
           :authorized_link
 
   display_in_manifest [:title]

--- a/spec/decorators/playlist_decorator_spec.rb
+++ b/spec/decorators/playlist_decorator_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe PlaylistDecorator do
+  subject(:decorator) { described_class.new(resource) }
+  let(:resource) { FactoryBot.build(:playlist) }
+  describe "decoration" do
+    it "decorates a Playlist" do
+      expect(resource.decorate).to be_a described_class
+    end
+  end
+
+  describe "#displayed_attributes" do
+    it "renders only the title, visibility, and authorized link" do
+      expect(resource.decorate.displayed_attributes).to eq([:internal_resource, :created_at, :updated_at, :title, :visibility, :authorized_link])
+    end
+  end
+end


### PR DESCRIPTION
Resolves #2203 