### PR TITLE
Updating Foreman config to run solr

### DIFF
--- a/.solr_wrapper
+++ b/.solr_wrapper
@@ -1,3 +1,9 @@
+version: 7.1.0
 url: https://archive.apache.org/dist/lucene/solr/7.1.0/solr-7.1.0.zip
 validate: false
 tmp_save_dir: tmp/solr
+instance_directory: tmp/figgy-core-dev
+collection:
+  persist: true
+  name: figgy-core-dev
+  dir: solr/config

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,4 @@
 # Procfile
 backend: bin/rails s -p 3000
 frontend: bin/webpack-dev-server
+solr: solr_wrapper


### PR DESCRIPTION
This allows running the application in development mode with only a single command, instead of having to run Solr in a separate window.