### PR TITLE
Extends ApplyAuthToken to support the manual regeneration of authorization tokens for Playlists

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,6 +78,7 @@ Metrics/ClassLength:
     - 'app/jobs/ingest_archival_media_bag_job.rb'
     - 'app/services/manifest_builder/manifest_service_locator_v3.rb'
     - 'app/services/manifest_builder.rb'
+    - 'app/controllers/catalog_controller.rb'
 Metrics/CyclomaticComplexity:
   Exclude:
     - 'app/models/concerns/linked_data/linked_resource_factory.rb'

--- a/app/assets/stylesheets/components/show.scss
+++ b/app/assets/stylesheets/components/show.scss
@@ -10,12 +10,41 @@
 ul.tabular {
   list-style: none;
 }
-.attribute.visibility {
-  padding-left: 0;
+
+.attribute {
+  .visibility {
+    padding-left: 0;
+  }
+
+  .description {
+    white-space: pre-wrap;
+  }
 }
 
-.attribute.description {
-  white-space: pre-wrap;
+.auth-link {
+  form {
+    padding-top: 8px;
+    padding-bottom: 8px;
+    text-align: center;
+      @media (min-width: $bp-small) {
+        padding-top: inherit;
+	padding-bottom: inherit;
+      }
+
+      .submit {
+        @media (min-width: $bp-medium) {
+        float: right;
+      }
+    }
+  }
+
+  .summary {
+    float: right;
+    p {
+      color: #888888;
+      font-style: italic;
+    }
+  }
 }
 
 table.dataTable thead .sorting:after, table.dataTable thead .sorting_asc:after,

--- a/app/change_set_persisters/change_set_persister/apply_auth_token.rb
+++ b/app/change_set_persisters/change_set_persister/apply_auth_token.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 class ChangeSetPersister
-  # This either mints a new auth. token for a resource which has just been completed...
-  # ...or revokes it for a Resource which has been updated as incomplete
+  # Mints a new AuthToken for Resources which support token-authorized access which have the mint_auth_token ChangeSet flag, or which have reached the final state in their workflow
   class ApplyAuthToken
     attr_reader :change_set_persister, :change_set
     def initialize(change_set_persister:, change_set:)
@@ -14,13 +13,17 @@ class ChangeSetPersister
       return unless tokenized_access?
 
       # Mints a new token only if this resource is in it's final state
-      return unless change_set_final_state? && current_auth_token.blank?
+      return unless change_set_mint_auth_token? || (change_set_final_state? && current_auth_token.blank?)
 
       change_set.validate(auth_token: auth_token.token)
       change_set.sync
     end
 
     private
+
+      def change_set_mint_auth_token?
+        change_set.changed["mint_auth_token"] && change_set["mint_auth_token"].first
+      end
 
       def tokenized_access?
         change_set.resource.class.respond_to?(:tokenized_access?) && change_set.resource.class.tokenized_access?
@@ -45,6 +48,7 @@ class ChangeSetPersister
       end
 
       def auth_token
+        current_auth_token&.destroy
         AuthToken.create(label: auth_token_label, group: auth_token_groups)
       end
   end

--- a/app/change_set_persisters/change_set_persister/update_auth_token.rb
+++ b/app/change_set_persisters/change_set_persister/update_auth_token.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 class ChangeSetPersister
-  # This either mints a new auth. token for a resource which has just been completed...
-  # ...or revokes it for a Resource which has been updated as incomplete
+  # Updates any AuthTokens by storing the ID for the related Resource
   class UpdateAuthToken
     attr_reader :change_set_persister, :change_set
     def initialize(change_set_persister:, change_set:, post_save_resource:)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -54,6 +54,7 @@ class CatalogController < ApplicationController
     config.show.partials = config.show.partials.insert(1, :parent_breadcrumb)
     config.show.partials += [:universal_viewer]
     config.show.partials += [:resource_attributes]
+    config.show.partials += [:auth_link]
     config.show.partials += [:workflow_controls]
     config.show.partials += [:playlists]
     config.show.partials += [:vocabulary_nav]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -114,6 +114,10 @@ module ApplicationHelper
     @document.resource
   end
 
+  def build_authorized_link
+    link_to(request.base_url + solr_document_path(id: resource.id, auth_token: resource.auth_token), solr_document_path(id: resource.id, auth_token: resource.auth_token))
+  end
+
   # Renders an attribute value based on attribute name
   # @param attribute [Symbol] the attribute name
   # @param value [String] the value of the attribute

--- a/app/resources/playlists/playlist_change_set.rb
+++ b/app/resources/playlists/playlist_change_set.rb
@@ -12,6 +12,7 @@ class PlaylistChangeSet < ChangeSet
   property :auth_token, multiple: false, require: false
 
   property :file_set_ids, virtual: true, type: Valkyrie::Types::Array.of(Valkyrie::Types::ID)
+  property :mint_auth_token, virtual: true, multiple: false, type: Valkyrie::Types::Array.of(Valkyrie::Types::Bool), default: false
 
   validates_with MemberValidator
   validates_with StateValidator

--- a/app/resources/playlists/playlist_decorator.rb
+++ b/app/resources/playlists/playlist_decorator.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 class PlaylistDecorator < Valkyrie::ResourceDecorator
   display :title,
-          :visibility,
-          :authorized_link
+          :visibility
 
   display_in_manifest [:title]
 
@@ -22,12 +21,5 @@ class PlaylistDecorator < Valkyrie::ResourceDecorator
 
   def decorated_proxies
     members.map(&:decorate)
-  end
-
-  # Provide the authorization token to build the authorized link at the Controller layer
-  # @return [String]
-  def authorized_link
-    viewer_url = "#{h.root_url}viewer#?manifest=#{h.polymorphic_url([:manifest, object], auth_token: auth_token)}"
-    h.link_to viewer_url, viewer_url
   end
 end

--- a/app/views/catalog/_auth_link_default.html.erb
+++ b/app/views/catalog/_auth_link_default.html.erb
@@ -1,0 +1,27 @@
+<% if @change_set.respond_to?(:auth_token) && @change_set.resource.decorate.public_readable_state? %>
+  <div id="auth_link" class="panel panel-default auth-link">
+    <div class="panel-heading">
+      <h2 class="panel-title">Authorized Link</h2>
+    </div>
+    <div class="row panel-body">
+        <div class="col-sm-9">
+	  <%= build_authorized_link %>
+        </div>
+        <div class="col-sm-3">
+	  <% if can?(:edit, resource) %>
+	    <%= simple_form_for @change_set do |f| %>
+	      <%= f.input :mint_auth_token, as: :hidden, input_html: { value: "1" } %>
+	      <%= f.submit "Regenerate", class: ["submit", "btn", "btn-warning"] %>
+	    <% end %>
+	  <% end %>
+        </div>
+    </div>
+    <% if can?(:edit, resource) %>
+      <div class="row panel-body">
+        <div class="col-sm-6 summary">
+	  <p>Authorized links provide anonymous, public users with the ability to view playlists and play tracks.  Each link is unique, and one may generate only a single link for any given playlist.  Regeneration replaces the current link, rendering any previous links invalid.</p>
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/catalog/_authorized_link.html.erb
+++ b/app/views/catalog/_authorized_link.html.erb
@@ -1,0 +1,6 @@
+<%= value %><% if can?(:edit, resource) %>
+  <%= simple_form_for @change_set do |f| %>
+    <%= f.input :mint_auth_token, as: :hidden, input_html: { value: "1" } %>
+    <%= f.submit "Regenerate", class: ["submit", "btn", "btn-warning"] %>
+  <% end %>
+<% end %>

--- a/spec/resources/playlist/playlist_decorator_spec.rb
+++ b/spec/resources/playlist/playlist_decorator_spec.rb
@@ -49,28 +49,9 @@ RSpec.describe PlaylistDecorator do
     end
   end
 
-  describe "#authorized_link" do
-    let(:metadata_adapter) { Valkyrie.config.metadata_adapter }
-    let(:storage_adapter) { Valkyrie.config.storage_adapter }
-    let(:change_set_persister) { ChangeSetPersister.new(metadata_adapter: metadata_adapter, storage_adapter: storage_adapter) }
-    let(:playlist) do
-      res = Playlist.new
-      cs = PlaylistChangeSet.new(res)
-      cs.prepopulate!
-      cs.validate(label: ["my playlist"], state: "complete")
-      change_set_persister.save(change_set: cs)
-    end
-    it "accesses the authorization token" do
-      url = "http://test.host/viewer#?manifest=http://test.host/concern/playlists/#{playlist.id}/manifest?auth_token=#{decorator.auth_token}"
-      expect(decorator.authorized_link).to eq(
-        %(<a href="#{url}">#{url}</a>)
-      )
-    end
-  end
-
   describe "#displayed_attributes" do
     it "renders only the title, visibility, and authorized link" do
-      expect(decorator.displayed_attributes).to eq([:internal_resource, :created_at, :updated_at, :title, :visibility, :authorized_link])
+      expect(decorator.displayed_attributes).to eq([:internal_resource, :created_at, :updated_at, :title, :visibility])
     end
   end
 end


### PR DESCRIPTION
Also integrates a form on the catalog show view for regenerating the authorized links.  Resolves #2053 

As an authenticated user, the following is rendered:
<img width="1128" alt="figgy_issues_2053_screenshot_2" src="https://user-images.githubusercontent.com/1443986/48809612-4b56fc00-ecf3-11e8-8782-8c06bbb2bf3a.png">

As an anonymous user, only the link itself is rendered:
<img width="1133" alt="figgy_issues_2053_screenshot_3" src="https://user-images.githubusercontent.com/1443986/48809623-5742be00-ecf3-11e8-8753-50fb2290ed44.png">


