### PR TITLE
Add image id to manifests

### DIFF
--- a/app/services/manifest_builder/image_builder.rb
+++ b/app/services/manifest_builder/image_builder.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+class ManifestBuilder
+  class ImageBuilder < IIIFManifest::ManifestBuilder::ImageBuilder
+    # Add an id. the only data we have is what we pull out of the canvas and other hashes.
+    #   Use the canvas id since we know it references the fileset.
+    def apply(canvas)
+      annotation["@id"] = canvas["@id"].sub(/(.*)canvas/, '\1image')
+      super
+    end
+  end
+end

--- a/app/services/manifest_builder/manifest_service_locator.rb
+++ b/app/services/manifest_builder/manifest_service_locator.rb
@@ -123,6 +123,14 @@ class ManifestBuilder
         )
       end
 
+      def image_builder
+        IIIFManifest::ManifestServiceLocator::InjectedFactory.new(
+          ::ManifestBuilder::ImageBuilder,
+          iiif_annotation_factory: iiif_annotation_factory,
+          resource_builder_factory: resource_builder_factory
+        )
+      end
+
       ##
       # Override sequence builder to support adding viewingHint.
       def sequence_builder

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -122,6 +122,7 @@ RSpec.describe ManifestBuilder do
       expect(output["sequences"][0]["canvases"][0]["width"]).to be_a Integer
       first_image = output["sequences"][0]["canvases"][0]["images"][0]
 
+      expect(first_image["@id"]).to eq "http://www.example.com/concern/scanned_resources/#{scanned_resource.id}/manifest/image/#{scanned_resource.member_ids.first}"
       expect(first_image["resource"]["@id"]).to eq "http://www.example.com/image-service/#{scanned_resource.member_ids.first}/full/!1000,/0/default.jpg"
       expect(output["sequences"][0]["canvases"][0]["local_identifier"]).to eq "p79409x97p"
 


### PR DESCRIPTION
I'm not sure whether this will fix dpul altogether or if widget will have to be re-assembled after this fix. but they're pretty broken already so I think that's okay we'll just have to check and adjust them if needed (see pulibrary/pomegranate#441)
closes #2246