### PR TITLE
allows lux design tokens to be used as variables in figgy asset pipeline

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,7 @@
 @import 'variables/colors';
 @import 'variables/typography';
 @import 'variables/visibility_widget';
+@import "../../../node_modules/lux-design-system/dist/system/system.utils.scss";
 
 @import "bootstrap-sprockets";
 @import "bootstrap";


### PR DESCRIPTION
Simple tweak that allows any [LUX Design Tokens](https://pulibrary.github.io/lux/docs/#/Design%20Tokens)(color, font size, spacing, etc) to be used as variables in the Rails asset pipeline.