### PR TITLE
Don't check members twice in ManifestBuilder.

### DIFF
--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -172,6 +172,20 @@ class ManifestBuilder
       ]
     end
 
+    ##
+    # Retrieve the child members for the subject resource of the Manifest
+    # @return [Resource]
+    def members
+      @members ||= decorate.members.to_a
+    end
+
+    ##
+    # Retrieve the leaf nodes for the Manifest
+    # @return [FileSet]
+    def leaf_nodes
+      @leaf_nodes ||= members.select { |x| x.instance_of?(FileSet) && leaf_node_mime_type?(x.mime_type) }
+    end
+
     private
 
       ##
@@ -179,20 +193,6 @@ class ManifestBuilder
       # @return [ManifestHelper]
       def helper
         @helper ||= ManifestHelper.new
-      end
-
-      ##
-      # Retrieve the child members for the subject resource of the Manifest
-      # @return [Resource]
-      def members
-        @members ||= decorate.members.to_a
-      end
-
-      ##
-      # Retrieve the leaf nodes for the Manifest
-      # @return [FileSet]
-      def leaf_nodes
-        @leaf_nodes ||= members.select { |x| x.instance_of?(FileSet) && leaf_node_mime_type?(x.mime_type) }
       end
 
       ##
@@ -578,7 +578,7 @@ class ManifestBuilder
     def manifest
       @manifest ||= begin
         # note this assumes audio resources use flat modeling
-        if audio_files(Wayfinder.for(@resource.to_model).try(:file_sets)).empty?
+        if audio_files(resource.try(:leaf_nodes)).empty?
           IIIFManifest::ManifestFactory.new(@resource, manifest_service_locator: ManifestServiceLocator).to_h
         else
           IIIFManifest::V3::ManifestFactory.new(@resource, manifest_service_locator: ManifestServiceLocatorV3).to_h

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -102,6 +102,15 @@ RSpec.describe ManifestBuilder do
       expect(query_service).to have_received(:find_by).exactly(2).times
     end
 
+    it "only runs one find_members query" do
+      manifest_builder
+      allow(query_service).to receive(:find_members).and_call_original
+
+      manifest_builder.build
+
+      expect(query_service).to have_received(:find_members).exactly(1).times
+    end
+
     it "generates a IIIF document" do
       output = manifest_builder.build
       expect(output).to be_kind_of Hash


### PR DESCRIPTION
Should halve our manifest build times, bringing them back to where they
were before playlists.