### PR TITLE
Remove unused `duplicate` field in MRRecording struct

### DIFF
--- a/app/services/music_import_service/recording_collector.rb
+++ b/app/services/music_import_service/recording_collector.rb
@@ -328,7 +328,6 @@ class MusicImportService::RecordingCollector
     :titles, # an array
     :bibs, # an array
     # id of Recording for which this is recording represents a playlist
-    :duplicate,
     :recommended_bib
   )
 end


### PR DESCRIPTION
NOTE: This will invalidate your cache