### PR TITLE
Handle invalid remote identifier values during bulk ingest

### DIFF
--- a/app/services/bulk_ingest_service.rb
+++ b/app/services/bulk_ingest_service.rb
@@ -32,6 +32,8 @@ class BulkIngestService
   # @return [Boolean]
   def valid_remote_identifier?(value)
     RemoteRecord.retrieve(value).success?
+  rescue URI::InvalidURIError
+    false
   end
 
   # Attach files within a directory

--- a/spec/services/bulk_ingest_service_spec.rb
+++ b/spec/services/bulk_ingest_service_spec.rb
@@ -246,4 +246,14 @@ RSpec.describe BulkIngestService do
       end
     end
   end
+
+  describe "#valid_remote_identifier?" do
+    context "with a PULFA-like identifier that contains invalid characters" do
+      let(:value) { "June 31" }
+
+      it "returns false" do
+        expect(ingester.valid_remote_identifier?(value)).to be false
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes issue with spaces in folder names during bulk ingest of material from the maplab.

Closes #2288 


