### PR TITLE
Collection report improvements

### DIFF
--- a/app/views/collections_mailer/owner_report.html.erb
+++ b/app/views/collections_mailer/owner_report.html.erb
@@ -6,15 +6,18 @@
   <body>
     <h2>Weekly collection report for <%= @collection_title %></h2>
     <% @resources.each.group_by(&:state).each do |state, objects| %>
-    <p>Resources in workflow state "<%= Array.wrap(state).first %>"</p>
+    <p><%= objects.length %> Resource(s) in workflow state "<%= Array.wrap(state).first %>"</p>
     <ul>
-      <% objects.each do |resource| %>
+      <% objects[0, 10].each do |resource| %>
       <li>
         <%= link_to Array.wrap(resource.title).first,
           Rails.application.routes.url_helpers.solr_document_url(resource, host: Figgy.default_url_options[:host]) %>
       </li>
       <% end %>
     </ul>
+    <%= link_to "View All", Rails.application.routes.url_helpers.search_catalog_url(f: { member_of_collection_titles_ssim: [@collection_title], state_ssim: [Array.wrap(state).first] }, host: Figgy.default_url_options[:host]) %>
     <% end %>
+
+    <p>You received this email because you are a collection owner of <%= link_to @collection_title.html_safe, Rails.application.routes.url_helpers.solr_document_url(params[:collection], host: Figgy.default_url_options[:host]) %>
   </body>
 </html>

--- a/spec/resources/collections/collections_mailer_spec.rb
+++ b/spec/resources/collections/collections_mailer_spec.rb
@@ -24,9 +24,10 @@ RSpec.describe CollectionsMailer, type: :mailer do
       # the pending section is there, as are its two objects.
       # since they're not in the final review section they must be in the right place
       # thus the spec is less vulnerable to order fluctations
-      expect(email.body.to_s).to include "<p>Resources in workflow state \"pending\"</p>"
+      expect(email.body.to_s).to include "<p>2 Resource(s) in workflow state \"pending\"</p>"
       expect(email.body.to_s).to include expected_pending(resource: r1)
       expect(email.body.to_s).to include expected_pending(resource: r2)
+      expect(email.body.to_s).to include expected_collection(collection: collection)
       email.deliver
       expect(ActionMailer::Base.deliveries).not_to be_empty
     end
@@ -50,7 +51,7 @@ RSpec.describe CollectionsMailer, type: :mailer do
 
   def expected_final(id:)
     <<-FIXTURE
-    <p>Resources in workflow state "final review"</p>
+    <p>1 Resource(s) in workflow state "final review"</p>
     <ul>
       <li>
         <a href="http://www.example.com/catalog/#{id}">Pretty Resource</a>
@@ -65,5 +66,9 @@ FIXTURE
         <a href="http://www.example.com/catalog/#{resource.id}">#{resource.title.first}</a>
       </li>
 FIXTURE
+  end
+
+  def expected_collection(collection:)
+    "<p>You received this email because you are a collection owner of <a href=\"http://www.example.com/catalog/#{collection.id}\">#{collection.title.first}</a>"
   end
 end


### PR DESCRIPTION
* limiting collection report to 10 items per state (to avoid huge emails)
* adding links to view all items and the collection

Fixes #2348