### PR TITLE
Skip CSRF protection for GraphQL

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -5,6 +5,7 @@ class GraphqlController < ApplicationController
     metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister),
     storage_adapter: Valkyrie.config.storage_adapter
   )
+  skip_before_action :verify_authenticity_token
   protect_from_forgery with: :null_session
   def execute
     authorize! :read, :graphql


### PR DESCRIPTION
It's not useful, and right now it's just throwing a log message since
the session is a null session.