### PR TITLE
Use cached parents for File Manager.

### DIFF
--- a/app/controllers/concerns/resource_controller.rb
+++ b/app/controllers/concerns/resource_controller.rb
@@ -101,7 +101,7 @@ module ResourceController
   def file_manager
     @change_set = change_set_class.new(find_resource(params[:id])).prepopulate!
     authorize! :file_manager, @change_set.resource
-    file_set_children = query_service.find_members(resource: @change_set).select { |x| x.is_a?(FileSet) }
+    file_set_children = Wayfinder.for(@change_set.resource).members_with_parents.select { |x| x.is_a?(FileSet) }
     @children = file_set_children.map do |x|
       change_set_class.new(x).prepopulate!
     end.to_a

--- a/app/resources/raster_resources/raster_resource_wayfinder.rb
+++ b/app/resources/raster_resources/raster_resource_wayfinder.rb
@@ -28,4 +28,11 @@ class RasterResourceWayfinder < BaseWayfinder
         end
       end
   end
+
+  def members_with_parents
+    @members_with_parents ||= members.map do |member|
+      member.loaded[:parents] = [resource]
+      member
+    end
+  end
 end

--- a/app/resources/vector_resources/vector_resource_wayfinder.rb
+++ b/app/resources/vector_resources/vector_resource_wayfinder.rb
@@ -27,4 +27,11 @@ class VectorResourceWayfinder < BaseWayfinder
         end
       end
   end
+
+  def members_with_parents
+    @members_with_parents ||= members.map do |member|
+      member.loaded[:parents] = [resource]
+      member
+    end
+  end
 end

--- a/spec/features/file_manager_spec.rb
+++ b/spec/features/file_manager_spec.rb
@@ -103,5 +103,13 @@ RSpec.feature "File Manager" do
       expect(page).to have_selector("form[data-type='json']", count: 1)
       expect(page).not_to have_selector("form[data-type='json']", text: "Child Resource")
     end
+
+    it "uses cached parents for thumbnails" do
+      allow(adapter.query_service).to receive(:find_inverse_references_by).and_call_original
+
+      visit polymorphic_path [:file_manager, resource]
+
+      expect(adapter.query_service).to have_received(:find_inverse_references_by).exactly(1).times
+    end
   end
 end

--- a/spec/views/scanned_resources/file_manager.html.erb_spec.rb
+++ b/spec/views/scanned_resources/file_manager.html.erb_spec.rb
@@ -5,7 +5,7 @@ include ActionDispatch::TestProcess
 RSpec.describe "base/file_manager.html.erb", type: :view do
   let(:scanned_resource) { FactoryBot.create_for_repository(:scanned_resource, title: "Test Title", files: [file]) }
   let(:members) { [member] }
-  let(:member) { FileSetChangeSet.new(Valkyrie.config.metadata_adapter.query_service.find_by(id: scanned_resource.member_ids.first)) }
+  let(:member) { FileSetChangeSet.new(Wayfinder.for(scanned_resource).members_with_parents.first) }
   let(:parent) { ScannedResourceChangeSet.new(scanned_resource) }
   let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }
 


### PR DESCRIPTION
Speeds up rendering significantly by avoiding N+1 queries.