### PR TITLE
Add more descriptive labels for date range form fields

### DIFF
--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -47,6 +47,8 @@ en:
         member_of_collection_ids: "Collections"
         favorite_term_ids: "Favorite Terms"
         ocr_language: "OCR Language"
+        start: "Date start"
+        end: "Date end"
       numismatic_issue:
         numismatic_monogram_ids: "Monogram"
         object_date: "Date of object"


### PR DESCRIPTION
fixes #841
I didn't use parenthesis because the meaning seems clear without
them and I think fewer characters is better