### PR TITLE
Don't load children to render OrderManager

### DIFF
--- a/app/controllers/concerns/resource_controller.rb
+++ b/app/controllers/concerns/resource_controller.rb
@@ -110,9 +110,6 @@ module ResourceController
   def order_manager
     @change_set = change_set_class.new(find_resource(params[:id])).prepopulate!
     authorize! :order_manager, @change_set.resource
-    @children = query_service.find_members(resource: @change_set).map do |x|
-      change_set_class.new(x).prepopulate!
-    end.to_a
   end
 
   def contextual_path(obj, change_set)


### PR DESCRIPTION
Children are pulled in dynamically as part of the JS, it's not necessary
to load them here and will just unnecessarily slow things down.