### PR TITLE
Ensures that cases where resources cannot be retrieved by ID for GraphQL queries are handled

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -16,6 +16,9 @@ class Types::QueryType < Types::BaseObject
     resource = query_service.find_by(id: id)
     return unless ability.can? :read, resource
     resource
+  rescue Valkyrie::Persistence::ObjectNotFoundError
+    Valkyrie.logger.error("Failed to retrieve the resource #{id} for a GraphQL query")
+    nil
   end
 
   def resources_by_bibid(bib_id:)

--- a/spec/graphql/types/query_type_spec.rb
+++ b/spec/graphql/types/query_type_spec.rb
@@ -74,4 +74,16 @@ RSpec.describe Types::QueryType do
       expect(type.resource(id: scanned_resource.id.to_s)).to be_nil
     end
   end
+
+  context "when the resource cannot be retrieved" do
+    before do
+      allow(Valkyrie.logger).to receive(:error)
+    end
+
+    it "returns nothing" do
+      type = described_class.new(nil, context)
+      expect(type.resource(id: "non-existent")).to be_nil
+      expect(Valkyrie.logger).to have_received(:error).with("Failed to retrieve the resource non-existent for a GraphQL query")
+    end
+  end
 end


### PR DESCRIPTION
Resolves #2356 