### PR TITLE
Implementing the FindManyByStringProperty custom query and GraphQL ResourcesByBibIds query

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -12,6 +12,11 @@ class Types::QueryType < Types::BaseObject
     argument :bib_id, String, required: true
   end
 
+  field :resources_by_bibids, [Types::Resource], null: true do
+    description "Find resources by BibIDs"
+    argument :bib_ids, [String], required: true
+  end
+
   def resource(id:)
     resource = query_service.find_by(id: id)
     return unless ability.can? :read, resource
@@ -24,6 +29,12 @@ class Types::QueryType < Types::BaseObject
   def resources_by_bibid(bib_id:)
     resources = query_service.custom_queries.find_by_string_property(property: :source_metadata_identifier, value: bib_id).select { |resource| ability.can? :read, resource }.to_a
     resources
+  end
+
+  def resources_by_bibids(bib_ids:)
+    resources = query_service.custom_queries.find_many_by_string_property(property: :source_metadata_identifier, values: bib_ids)
+    readable_resources = resources.select { |resource| ability.can? :read, resource }
+    readable_resources.to_a
   end
 
   def ability

--- a/app/graphql/types/scanned_map_type.rb
+++ b/app/graphql/types/scanned_map_type.rb
@@ -5,6 +5,7 @@ class Types::ScannedMapType < Types::BaseObject
   field :start_page, String, null: true
   field :viewing_direction, Types::ViewingDirectionEnum, null: true
   field :manifest_url, String, null: true
+  field :source_metadata_identifier, String, null: true
 
   def viewing_hint
     Array.wrap(super).first
@@ -21,5 +22,9 @@ class Types::ScannedMapType < Types::BaseObject
 
   def start_page
     Array.wrap(object.start_canvas).first
+  end
+
+  def source_metadata_identifier
+    Array.wrap(object.source_metadata_identifier).first
   end
 end

--- a/app/graphql/types/scanned_resource_type.rb
+++ b/app/graphql/types/scanned_resource_type.rb
@@ -5,6 +5,7 @@ class Types::ScannedResourceType < Types::BaseObject
   field :start_page, String, null: true
   field :viewing_direction, Types::ViewingDirectionEnum, null: true
   field :manifest_url, String, null: true
+  field :source_metadata_identifier, String, null: true
 
   def viewing_hint
     Array.wrap(super).first
@@ -20,5 +21,9 @@ class Types::ScannedResourceType < Types::BaseObject
 
   def start_page
     Array.wrap(object.start_canvas).first
+  end
+
+  def source_metadata_identifier
+    Array.wrap(object.source_metadata_identifier).first
   end
 end

--- a/app/queries/find_many_by_string_property.rb
+++ b/app/queries/find_many_by_string_property.rb
@@ -1,0 +1,37 @@
+
+# frozen_string_literal: true
+class FindManyByStringProperty
+  def self.queries
+    [:find_many_by_string_property]
+  end
+
+  attr_reader :query_service
+  delegate :resource_factory, to: :query_service
+  delegate :orm_class, to: :resource_factory
+  delegate :run_query, to: :query_service
+  def initialize(query_service:)
+    @query_service = query_service
+  end
+
+  def find_many_by_string_property(property:, values:)
+    query = build_query(property, values)
+    run_query(query)
+  end
+
+  private
+
+    def build_conditions(property, values)
+      conditions = values.map do |value|
+        "metadata @> '{\"#{property}\": [\"#{value}\"]}'"
+      end
+
+      conditions.join(" OR ")
+    end
+
+    def build_query(property, values)
+      conditions = build_conditions(property, values)
+      <<-SQL
+      select * FROM orm_resources WHERE #{conditions}
+      SQL
+    end
+end

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -276,6 +276,7 @@ Rails.application.config.to_prepare do
     FindByLocalIdentifier,
     FindByNumericProperty,
     FindByStringProperty,
+    FindManyByStringProperty,
     FindEphemeraTermByLabel,
     FindEphemeraVocabularyByLabel,
     MemoryEfficientAllQuery,

--- a/spec/graphql/types/scanned_map_type_spec.rb
+++ b/spec/graphql/types/scanned_map_type_spec.rb
@@ -9,14 +9,20 @@ RSpec.describe Types::ScannedMapType do
   end
 
   subject(:type) { described_class.new(scanned_map, {}) }
+  let(:bibid) { "5144620" }
   let(:scanned_map) do
     FactoryBot.create_for_repository(
       :scanned_map,
       viewing_hint: "individuals",
       title: ["I'm a map", "of null island"],
       viewing_direction: "left-to-right",
-      portion_note: "page 1"
+      portion_note: "page 1",
+      source_metadata_identifier: [bibid]
     )
+  end
+
+  before do
+    stub_bibdata(bib_id: bibid)
   end
 
   describe "class methods" do
@@ -28,6 +34,7 @@ RSpec.describe Types::ScannedMapType do
     it { is_expected.to have_field(:label).of_type(String) }
     it { is_expected.to have_field(:members) }
     it { is_expected.to have_field(:manifestUrl).of_type(String) }
+    it { is_expected.to have_field(:sourceMetadataIdentifier).of_type(String) }
   end
 
   describe "#viewing_hint" do
@@ -131,19 +138,8 @@ RSpec.describe Types::ScannedMapType do
   end
 
   describe "#source_metadata_identifier" do
-    let(:bibid) { "5144620" }
-    let(:scanned_map) do
-      FactoryBot.create_for_repository(
-        :scanned_map,
-        source_metadata_identifier: [bibid]
-      )
-    end
-    before do
-      stub_bibdata(bib_id: bibid)
-    end
-
-    it "returns bibids" do
-      expect(type.source_metadata_identifier).to eq [bibid]
+    it "returns the bib. ID" do
+      expect(type.source_metadata_identifier).to eq bibid
     end
   end
 

--- a/spec/graphql/types/scanned_resource_type_spec.rb
+++ b/spec/graphql/types/scanned_resource_type_spec.rb
@@ -9,13 +9,19 @@ RSpec.describe Types::ScannedResourceType do
   end
 
   subject(:type) { described_class.new(scanned_resource, {}) }
+  let(:bibid) { "123456" }
   let(:scanned_resource) do
     FactoryBot.create_for_repository(
       :scanned_resource,
       viewing_hint: "individuals",
       title: ["I'm a little teapot", "short and stout"],
-      viewing_direction: "left-to-right"
+      viewing_direction: "left-to-right",
+      source_metadata_identifier: [bibid]
     )
+  end
+
+  before do
+    stub_bibdata(bib_id: bibid)
   end
 
   describe "class methods" do
@@ -27,6 +33,7 @@ RSpec.describe Types::ScannedResourceType do
     it { is_expected.to have_field(:viewingDirection).of_type(Types::ViewingDirectionEnum) }
     it { is_expected.to have_field(:label).of_type(String) }
     it { is_expected.to have_field(:members) }
+    it { is_expected.to have_field(:sourceMetadataIdentifier).of_type(String) }
   end
 
   describe "#viewing_hint" do
@@ -130,19 +137,8 @@ RSpec.describe Types::ScannedResourceType do
   end
 
   describe "#source_metadata_identifier" do
-    let(:bibid) { "123456" }
-    let(:scanned_resource) do
-      FactoryBot.create_for_repository(
-        :scanned_resource,
-        source_metadata_identifier: [bibid]
-      )
-    end
-    before do
-      stub_bibdata(bib_id: bibid)
-    end
-
-    it "returns bibids" do
-      expect(type.source_metadata_identifier).to eq [bibid]
+    it "returns the bib. ID" do
+      expect(type.source_metadata_identifier).to eq bibid
     end
   end
 

--- a/spec/queries/find_many_by_string_property_spec.rb
+++ b/spec/queries/find_many_by_string_property_spec.rb
@@ -1,0 +1,27 @@
+
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe FindManyByStringProperty do
+  subject(:query) { described_class.new(query_service: query_service) }
+  let(:box) { FactoryBot.create_for_repository(:ephemera_folder, barcode: "1234567") }
+  let(:box2) { FactoryBot.create_for_repository(:ephemera_folder, barcode: "2345678") }
+  let(:query_service) { Valkyrie.config.metadata_adapter.query_service }
+
+  describe "#find_many_by_string_property" do
+    it "can find objects with strings in it by a property" do
+      output = query.find_many_by_string_property(property: :barcode, values: [box.barcode.first, box2.barcode.first])
+      expect(output.length).to eq 2
+      output_ids = output.map(&:id)
+      expect(output_ids).to include box.id
+      expect(output_ids).to include box2.id
+    end
+
+    context "when no objects have the string in that property" do
+      it "returns no results" do
+        output = query.find_many_by_string_property(property: :barcode, values: ["notabarcode"])
+        expect(output.to_a).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
This provides a GraphQL query for retrieving multiple resources for a set of bib. IDs (this will be necessary for resolving pulibrary/orangelight/issues/1534).  This ensures that only a single query must be made using GraphQL in order to retrieve a set of thumbnail IDs for a set of bib. IDs.