### PR TITLE
Adds a fallback of Arial to the UV theme.

### DIFF
--- a/public/uv/themes/uv-en-gb-theme/css/uv-seadragon-extension/theme.css
+++ b/public/uv/themes/uv-en-gb-theme/css/uv-seadragon-extension/theme.css
@@ -1411,7 +1411,7 @@
   padding: 0;
   height: 100%;
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-  font-family: sans-serif;
+  font-family: sans-serif, arial;
   font-size: 12px;
   line-height: 1.42857143;
   color: #ffffff;


### PR DESCRIPTION
I should probably create a custom theme instead of this, but I can't
figure it out and all the documentation is gone since V3.

Closes #928