### PR TITLE
 Make child scanned maps optionally discoverable

### DIFF
--- a/app/models/schema/geo.rb
+++ b/app/models/schema/geo.rb
@@ -18,6 +18,9 @@ module Schema
       Geo.attributes.each do |field|
         attribute field
       end
+
+      # Can be used to override business logic about whether a record is discoverable in GeoBlacklight
+      attribute :gbl_suppressed_override, Valkyrie::Types::Bool
     end
   end
 end

--- a/app/resources/scanned_maps/scanned_map.rb
+++ b/app/resources/scanned_maps/scanned_map.rb
@@ -12,9 +12,6 @@ class ScannedMap < Resource
   attribute :file_metadata, Valkyrie::Types::Set.of(FileMetadata.optional)
   attribute :relation
 
-  # Can be used to override business logic about whether a record is discoverable in GeoBlacklight
-  attribute :gbl_suppressed_override, Valkyrie::Types::Bool
-
   def self.can_have_manifests?
     true
   end

--- a/app/resources/scanned_maps/scanned_map.rb
+++ b/app/resources/scanned_maps/scanned_map.rb
@@ -12,6 +12,9 @@ class ScannedMap < Resource
   attribute :file_metadata, Valkyrie::Types::Set.of(FileMetadata.optional)
   attribute :relation
 
+  # Can be used to override business logic about whether a record is discoverable in GeoBlacklight
+  attribute :gbl_suppressed_override, Valkyrie::Types::Bool
+
   def self.can_have_manifests?
     true
   end

--- a/app/resources/scanned_maps/scanned_map_change_set.rb
+++ b/app/resources/scanned_maps/scanned_map_change_set.rb
@@ -7,12 +7,14 @@ class ScannedMapChangeSet < ScannedResourceChangeSet
 
   property :relation, multiple: false, required: false
   property :references, multiple: false, required: false
+  property :gbl_suppressed_override, multiple: false, required: false
 
   # rubocop:disable Metrics/MethodLength
   def primary_terms
     [
       :title,
       :source_metadata_identifier,
+      :gbl_suppressed_override,
       :rights_statement,
       :rights_note,
       :portion_note,

--- a/app/resources/scanned_maps/scanned_map_decorator.rb
+++ b/app/resources/scanned_maps/scanned_map_decorator.rb
@@ -2,6 +2,7 @@
 class ScannedMapDecorator < Valkyrie::ResourceDecorator
   display Schema::Geo.attributes,
           :ark,
+          :gbl_suppressed_override,
           :rendered_holding_location,
           :rendered_coverage,
           :member_of_collections,
@@ -65,6 +66,10 @@ class ScannedMapDecorator < Valkyrie::ResourceDecorator
   # @return [Hash] a Hash of all of the resource attributes
   def display_attributes
     super.reject { |k, v| imported_attributes.fetch(k, nil) == v }
+  end
+
+  def gbl_suppressed_override
+    super ? "True" : "False"
   end
 
   def human_readable_type

--- a/app/services/geo_discovery/document_builder/relationship_builder.rb
+++ b/app/services/geo_discovery/document_builder/relationship_builder.rb
@@ -39,6 +39,7 @@ module GeoDiscovery
         # Documents with a parent work should be supressed.
         # @return [Boolean] should document be supressed?
         def suppressed
+          return if resource_decorator.model.gbl_suppressed_override
           return unless scanned_map? && parent?
           true
         end

--- a/app/views/records/edit_fields/_gbl_suppressed_override.html.erb
+++ b/app/views/records/edit_fields/_gbl_suppressed_override.html.erb
@@ -1,0 +1,3 @@
+<%= f.input :gbl_suppressed_override, 
+			label: 'Always show in Pulmap search results',
+			as: :boolean %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,8 @@ en:
         metadata: 'Metadata'
     show:
       attributes:
+        gbl_suppressed_override:
+          label: "Always show in Pulmap search results"
         internal_resource:
           label: "Model"
         created_at:

--- a/spec/resources/scanned_map/scanned_map_decorator_spec.rb
+++ b/spec/resources/scanned_map/scanned_map_decorator_spec.rb
@@ -148,4 +148,10 @@ RSpec.describe ScannedMapDecorator do
       expect(decorator.file_sets).to be_empty
     end
   end
+
+  describe "#gbl_suppressed_override" do
+    it "converts a bool to a string" do
+      expect(decorator.gbl_suppressed_override).to eq "False"
+    end
+  end
 end

--- a/spec/resources/scanned_map/scanned_map_feature_spec.rb
+++ b/spec/resources/scanned_map/scanned_map_feature_spec.rb
@@ -28,6 +28,7 @@ RSpec.feature "ScannedMaps" do
     expect(page).to have_field "Creator"
     expect(page).to have_field "Language"
     expect(page).to have_field "Cartographic scale"
+    expect(page).to have_field "Always show in Pulmap search results"
   end
 
   context "when a user creates a new scanned map" do
@@ -57,6 +58,7 @@ RSpec.feature "ScannedMaps" do
         spatial: "test value",
         temporal: "test value",
         issued: "test value",
+        gbl_suppressed_override: true,
         imported_metadata: [{
           extent: "test extent"
         }]
@@ -71,6 +73,7 @@ RSpec.feature "ScannedMaps" do
       visit solr_document_path scanned_map
 
       expect(page).to have_css ".attribute.visibility", text: "open"
+      expect(page).to have_css ".attribute.gbl_suppressed_override", text: "True"
       expect(page).to have_css ".attribute.title", text: "new scanned map"
       expect(page).to have_css ".attribute.creator", text: "test value"
       expect(page).to have_css ".attribute.description", text: "test value"

--- a/spec/services/geo_discovery/document_builder_spec.rb
+++ b/spec/services/geo_discovery/document_builder_spec.rb
@@ -229,7 +229,7 @@ describe GeoDiscovery::DocumentBuilder do
       change_set_persister.save(change_set: child_change_set)
     end
 
-    context "with a child resouce" do
+    context "when it is a child resouce" do
       subject(:document_builder) { described_class.new(query_service.find_by(id: child.id), document_class) }
       let(:child_change_set) { ScannedMapChangeSet.new(child, files: []) }
       it "returns a suppressed document with a source field" do
@@ -238,7 +238,16 @@ describe GeoDiscovery::DocumentBuilder do
       end
     end
 
-    context "with a parent resource" do
+    context "when it is a child resouce and gbl_suppressed_override is true" do
+      subject(:document_builder) { described_class.new(query_service.find_by(id: child.id), document_class) }
+      let(:child) { FactoryBot.create_for_repository(:scanned_map, coverage: coverage.to_s, visibility: visibility, gbl_suppressed_override: true) }
+      let(:child_change_set) { ScannedMapChangeSet.new(child, files: []) }
+      it "returns a non-suppressed document" do
+        expect(document["suppressed_b"]).to be_nil
+      end
+    end
+
+    context "when it is a parent resource" do
       let(:child_change_set) { ScannedMapChangeSet.new(child, files: [file]) }
       let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }
 


### PR DESCRIPTION
Scanned maps that are normally suppressed in a GeoBlacklight search can be made discoverable by setting the the gbl_suppressed_override property to true.

Closes #2393 