### PR TITLE
Abort outdated request in Save & Ingest

### DIFF
--- a/app/assets/javascripts/save_and_ingest_handler.es6
+++ b/app/assets/javascripts/save_and_ingest_handler.es6
@@ -1,46 +1,47 @@
 export default class SaveAndIngestHandler {
-  constructor() {
-    this.button_element = $(this.button_selector)
-    this.field_element = $(this.field_element_selector)
-    this.info_element = $(this.info_element_selector)
-    this.reset_button()
+  constructor () {
+    this.button_element = $(this.buttonSelector)
+    this.field_element = $(this.fieldElementSelector)
+    this.info_element = $(this.infoElementSelector)
+    this.resetButton()
+    this.current_promise = null
     this.field_element.change((e) => {
-      this.reset_button()
+      this.resetButton()
       this.button_element.val('Searching...')
       // this will pass a value 'new' when  it's just a regular scanned resource,
       //   but code on the other side will ignore that.
       let qs = { 'change_set': window.location.pathname.split('/').pop() }
-      $.getJSON(`/concern/scanned_resources/save_and_ingest/${this.field_element.val()}`, qs)
+      if (this.current_promise) {
+        this.current_promise.abort()
+      }
+      this.current_promise = $.getJSON(`/concern/scanned_resources/save_and_ingest/${this.field_element.val()}`, qs)
         .done((data) => {
-          if(data.exists == true) {
-            this.reset_button()
+          if (data.exists === true) {
+            this.resetButton()
             this.button_element.prop('disabled', false)
-            if(data.file_count != 0)
-              this.info_element.text(`Ingest ${data.file_count} files from ${data.location}`)
-            else
-              this.info_element.text(`Ingest ${data.volume_count} volumes from ${data.location}`)
+            if (data.file_count != 0) { this.info_element.text(`Ingest ${data.file_count} files from ${data.location}`) } else { this.info_element.text(`Ingest ${data.volume_count} volumes from ${data.location}`) }
           } else {
-            this.reset_button()
+            this.resetButton()
           }
         })
     })
   }
 
-  reset_button() {
+  resetButton () {
     this.button_element.attr('disabled', true)
     this.button_element.val('Save and Ingest')
     this.info_element.text('')
   }
 
-  get button_selector() {
-    return "*[data-save-and-ingest]"
+  get buttonSelector () {
+    return '*[data-save-and-ingest]'
   }
 
-  get field_element_selector() {
+  get fieldElementSelector () {
     return "*[data-field='source_metadata_identifier_ssim']"
   }
 
-  get info_element_selector() {
-    return "#save-and-ingest-info"
+  get infoElementSelector () {
+    return '#save-and-ingest-info'
   }
 }


### PR DESCRIPTION
Stops requests from changing the field from auto-fill from running into
one another.