### PR TITLE
Always queue fixity jobs as super_low priority

### DIFF
--- a/app/change_set_persisters/change_set_persister/check_fixity.rb
+++ b/app/change_set_persisters/change_set_persister/check_fixity.rb
@@ -14,7 +14,7 @@ class ChangeSetPersister
       # Don't run if a file has been updated; fixity will run after characterization on the new file
       new_file_scenarios = ["files", "pending_uploads"]
       return unless (change_set.changed.keys & new_file_scenarios).empty?
-      ::CheckFixityJob.set(queue: change_set_persister.queue).perform_later(change_set.resource.id.to_s)
+      ::CheckFixityJob.perform_later(change_set.resource.id.to_s)
     end
   end
 end

--- a/app/jobs/check_fixity_job.rb
+++ b/app/jobs/check_fixity_job.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 class CheckFixityJob < ApplicationJob
+  queue_as :super_low
   delegate :query_service, to: :metadata_adapter
 
   def perform(file_set_id)

--- a/app/jobs/check_fixity_recursive_job.rb
+++ b/app/jobs/check_fixity_recursive_job.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 class CheckFixityRecursiveJob < ApplicationJob
+  queue_as :super_low
   delegate :query_service, to: :metadata_adapter
 
   def perform
     CheckFixityJob.perform_now(next_file_set.id)
-    CheckFixityRecursiveJob.set(queue: :super_low).perform_later
+    CheckFixityRecursiveJob.perform_later
   end
 
   private

--- a/app/jobs/create_derivatives_job.rb
+++ b/app/jobs/create_derivatives_job.rb
@@ -7,7 +7,7 @@ class CreateDerivativesJob < ApplicationJob
     file_set = query_service.find_by(id: Valkyrie::ID.new(file_set_id))
     Valkyrie::Derivatives::DerivativeService.for(FileSetChangeSet.new(file_set)).create_derivatives
     messenger.derivatives_created(file_set)
-    CheckFixityJob.set(queue: queue_name).perform_later(file_set_id)
+    CheckFixityJob.perform_later(file_set_id)
   rescue Valkyrie::Persistence::ObjectNotFoundError => error
     Valkyrie.logger.warn "#{self.class}: #{error}: Failed to find the resource #{file_set_id}"
   end


### PR DESCRIPTION
* Always queue fixity jobs at the lowest level so they don't compete with ingest, derivatives processing, etc.