### PR TITLE
Missing resources should redirect and error.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,6 +32,16 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  rescue_from Valkyrie::Persistence::ObjectNotFoundError, with: :resource_not_found
+  def resource_not_found(_exception)
+    respond_to do |format|
+      format.json { head :not_found }
+      format.html do
+        redirect_to root_url, alert: "The requested resource does not exist."
+      end
+    end
+  end
+
   # Figgy has no use cases for having unique shared searches, and this prevents
   # the user list from growing out of control.
   def guest_user

--- a/spec/resources/ephemera_box/ephemera_boxes_controller_spec.rb
+++ b/spec/resources/ephemera_box/ephemera_boxes_controller_spec.rb
@@ -154,7 +154,8 @@ RSpec.describe EphemeraBoxesController, type: :controller do
     end
     context "when a ephemera box doesn't exist" do
       it "raises an error" do
-        expect { get :edit, params: { id: "test" } }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+        get :edit, params: { id: "test" }
+        expect(response).to redirect_to_not_found
       end
     end
     context "when it does exist" do
@@ -193,7 +194,8 @@ RSpec.describe EphemeraBoxesController, type: :controller do
     end
     context "when a ephemera box doesn't exist" do
       it "raises an error" do
-        expect { patch :update, params: { id: "test" } }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+        patch :update, params: { id: "test" }
+        expect(response).to redirect_to_not_found
       end
     end
     it_behaves_like "a workflow controller", :ephemera_box

--- a/spec/resources/ephemera_field/ephemera_fields_controller_spec.rb
+++ b/spec/resources/ephemera_field/ephemera_fields_controller_spec.rb
@@ -111,7 +111,8 @@ RSpec.describe EphemeraFieldsController, type: :controller do
     end
     context "when a ephemera field doesn't exist" do
       it "raises an error" do
-        expect { get :edit, params: { id: "test" } }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+        get :edit, params: { id: "test" }
+        expect(response).to redirect_to_not_found
       end
     end
     context "when it does exist" do
@@ -151,7 +152,8 @@ RSpec.describe EphemeraFieldsController, type: :controller do
     end
     context "when a ephemera field doesn't exist" do
       it "raises an error" do
-        expect { patch :update, params: { id: "test" } }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+        patch :update, params: { id: "test" }
+        expect(response).to redirect_to_not_found
       end
     end
     context "when it does exist" do

--- a/spec/resources/ephemera_folder/ephemera_folders_controller_spec.rb
+++ b/spec/resources/ephemera_folder/ephemera_folders_controller_spec.rb
@@ -254,7 +254,8 @@ RSpec.describe EphemeraFoldersController, type: :controller do
     end
     context "when a ephemera folder doesn't exist" do
       it "raises an error" do
-        expect { get :edit, params: { id: "test" } }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+        get :edit, params: { id: "test" }
+        expect(response).to redirect_to_not_found
       end
     end
     context "when it does exist" do
@@ -382,7 +383,8 @@ RSpec.describe EphemeraFoldersController, type: :controller do
     end
     context "when a ephemera folder doesn't exist" do
       it "raises an error" do
-        expect { patch :update, params: { id: "test" } }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+        patch :update, params: { id: "test" }
+        expect(response).to redirect_to_not_found
       end
     end
     context "when it does exist" do

--- a/spec/resources/ephemera_project/ephemera_projects_controller_spec.rb
+++ b/spec/resources/ephemera_project/ephemera_projects_controller_spec.rb
@@ -148,7 +148,8 @@ RSpec.describe EphemeraProjectsController, type: :controller do
     end
     context "when a ephemera project doesn't exist" do
       it "raises an error" do
-        expect { get :edit, params: { id: "test" } }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+        get :edit, params: { id: "test" }
+        expect(response).to redirect_to_not_found
       end
     end
     context "when it does exist" do
@@ -184,7 +185,8 @@ RSpec.describe EphemeraProjectsController, type: :controller do
     end
     context "when a ephemera project doesn't exist" do
       it "raises an error" do
-        expect { patch :update, params: { id: "test" } }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+        patch :update, params: { id: "test" }
+        expect(response).to redirect_to_not_found
       end
     end
     context "when it does exist" do

--- a/spec/resources/ephemera_term/ephemera_terms_controller_spec.rb
+++ b/spec/resources/ephemera_term/ephemera_terms_controller_spec.rb
@@ -108,7 +108,8 @@ RSpec.describe EphemeraTermsController, type: :controller do
     end
     context "when a ephemera term doesn't exist" do
       it "raises an error" do
-        expect { get :edit, params: { id: "test" } }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+        get :edit, params: { id: "test" }
+        expect(response).to redirect_to_not_found
       end
     end
     context "when it does exist" do
@@ -132,7 +133,8 @@ RSpec.describe EphemeraTermsController, type: :controller do
     end
     context "when a ephemera term doesn't exist" do
       it "raises an error" do
-        expect { patch :update, params: { id: "test" } }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+        patch :update, params: { id: "test" }
+        expect(response).to redirect_to_not_found
       end
     end
     context "when it does exist" do

--- a/spec/resources/ephemera_vocabulary/ephemera_vocabularies_controller_spec.rb
+++ b/spec/resources/ephemera_vocabulary/ephemera_vocabularies_controller_spec.rb
@@ -125,7 +125,8 @@ RSpec.describe EphemeraVocabulariesController, type: :controller do
     end
     context "when a ephemera vocabulary doesn't exist" do
       it "raises an error" do
-        expect { get :edit, params: { id: "test" } }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+        get :edit, params: { id: "test" }
+        expect(response).to redirect_to_not_found
       end
     end
     context "when it does exist" do
@@ -149,7 +150,8 @@ RSpec.describe EphemeraVocabulariesController, type: :controller do
     end
     context "when a ephemera vocabulary doesn't exist" do
       it "raises an error" do
-        expect { patch :update, params: { id: "test" } }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+        patch :update, params: { id: "test" }
+        expect(response).to redirect_to_not_found
       end
     end
     context "when it does exist" do

--- a/spec/resources/file_set/file_sets_controller_spec.rb
+++ b/spec/resources/file_set/file_sets_controller_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe FileSetsController, type: :controller do
 
     context "with an invalid FileSet ID" do
       it "displays an error" do
-        expect { patch :update, params: { id: "no-exist", file_set: { title: ["Second"] } } }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+        patch :update, params: { id: "no-exist", file_set: { title: ["Second"] } }
+        expect(response).to redirect_to_not_found
       end
     end
 

--- a/spec/resources/raster_resource/raster_resources_controller_spec.rb
+++ b/spec/resources/raster_resource/raster_resources_controller_spec.rb
@@ -118,7 +118,8 @@ RSpec.describe RasterResourcesController, type: :controller do
     end
     context "when a raster resource doesn't exist" do
       it "raises an error" do
-        expect { get :edit, params: { id: "test" } }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+        get :edit, params: { id: "test" }
+        expect(response).to redirect_to_not_found
       end
     end
     context "when it does exist" do
@@ -156,7 +157,8 @@ RSpec.describe RasterResourcesController, type: :controller do
     end
     context "when a raster resource doesn't exist" do
       it "raises an error" do
-        expect { patch :update, params: { id: "test" } }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+        patch :update, params: { id: "test" }
+        expect(response).to redirect_to_not_found
       end
     end
     context "when it does exist" do

--- a/spec/resources/scanned_map/scanned_maps_controller_spec.rb
+++ b/spec/resources/scanned_map/scanned_maps_controller_spec.rb
@@ -177,7 +177,8 @@ RSpec.describe ScannedMapsController, type: :controller do
     end
     context "when a map image doesn't exist" do
       it "raises an error" do
-        expect { get :edit, params: { id: "test" } }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+        get :edit, params: { id: "test" }
+        expect(response).to redirect_to_not_found
       end
     end
     context "when it does exist" do
@@ -201,7 +202,8 @@ RSpec.describe ScannedMapsController, type: :controller do
     end
     context "when a map image doesn't exist" do
       it "raises an error" do
-        expect { patch :update, params: { id: "test" } }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+        patch :update, params: { id: "test" }
+        expect(response).to redirect_to_not_found
       end
     end
     context "when it does exist" do
@@ -239,7 +241,8 @@ RSpec.describe ScannedMapsController, type: :controller do
     end
     context "when a map image doesn't exist" do
       it "raises an error" do
-        expect { get :structure, params: { id: "banana" } }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+        get :structure, params: { id: "banana" }
+        expect(response).to redirect_to_not_found
       end
     end
     context "when it does exist" do

--- a/spec/resources/scanned_resource/scanned_resources_controller_spec.rb
+++ b/spec/resources/scanned_resource/scanned_resources_controller_spec.rb
@@ -203,7 +203,8 @@ RSpec.describe ScannedResourcesController, type: :controller do
     end
     context "when a scanned resource doesn't exist" do
       it "raises an error" do
-        expect { get :structure, params: { id: "banana" } }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+        get :structure, params: { id: "banana" }
+        expect(response).to redirect_to_not_found
       end
     end
     context "when it does exist" do

--- a/spec/resources/vector_resource/vector_resources_controller_spec.rb
+++ b/spec/resources/vector_resource/vector_resources_controller_spec.rb
@@ -118,7 +118,8 @@ RSpec.describe VectorResourcesController, type: :controller do
     end
     context "when a vector resource doesn't exist" do
       it "raises an error" do
-        expect { get :edit, params: { id: "test" } }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+        get :edit, params: { id: "test" }
+        expect(response).to redirect_to_not_found
       end
     end
     context "when it does exist" do
@@ -155,7 +156,8 @@ RSpec.describe VectorResourcesController, type: :controller do
     end
     context "when a vector resource doesn't exist" do
       it "raises an error" do
-        expect { patch :update, params: { id: "test" } }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+        patch :update, params: { id: "test" }
+        expect(response).to redirect_to_not_found
       end
     end
     context "when it does exist" do

--- a/spec/support/matchers/redirect_to_not_found.rb
+++ b/spec/support/matchers/redirect_to_not_found.rb
@@ -1,0 +1,6 @@
+RSpec::Matchers.define :redirect_to_not_found do
+  match do |actual|
+    expect(actual).to redirect_to '/'
+    expect(actual.flash["alert"]).to eq "The requested resource does not exist."
+  end
+end


### PR DESCRIPTION
This should prevent a whole suite of Honeybadger errors, and avoid
displaying 500 errors to users when they can't do anything about it.

Closes #2534