### PR TITLE
Add bulk complete UI

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -29,6 +29,7 @@
 @import 'components/alert_inline';
 @import 'components/batch_upload';
 @import 'components/bulk_ingest';
+@import 'components/bulk_edit';
 @import 'components/bounding_box';
 @import 'components/breadcrumb';
 @import 'components/datepicker';

--- a/app/assets/stylesheets/components/bulk_edit.scss
+++ b/app/assets/stylesheets/components/bulk_edit.scss
@@ -1,3 +1,7 @@
 .bulk-edit-button {
   margin-right: 5px;
 }
+
+#content .checkbox input[type="checkbox"] {
+	margin-left: 0;
+}

--- a/app/assets/stylesheets/components/bulk_edit.scss
+++ b/app/assets/stylesheets/components/bulk_edit.scss
@@ -1,0 +1,3 @@
+.bulk-edit-button {
+  margin-right: 5px;
+}

--- a/app/controllers/bulk_edit_controller.rb
+++ b/app/controllers/bulk_edit_controller.rb
@@ -8,34 +8,32 @@ class BulkEditController < ApplicationController
   end
 
   def resources_update
-    batch_size = params["batch_size"] || 50
     args = {}.tap do |hash|
       hash[:mark_complete] = (params["mark_complete"] == "1")
     end
-    builder_params = { q: params["search_params"]["q"], f: params["search_params"]["f"] }
-    builder = search_builder.with(builder_params)
-    builder.rows = batch_size
-    resources_count = spawn_update_jobs(builder, args)
+    batches = prepare_batches
+    batches.each do |ids|
+      BulkUpdateJob.perform_later(ids: ids, args: args)
+    end
+    resources_count = batches.map(&:count).reduce(:+)
     flash[:notice] = "#{resources_count} resources were queued for bulk update."
     redirect_to root_url
   end
 
   private
 
-    # collects batches of ids then enqueues jobs
-    def spawn_update_jobs(builder, args)
-      batches = []
-      num_results = 0
-      loop do
-        response = repository.search(builder)
-        num_results = response["response"]["numFound"]
-        batches << response.documents.map(&:id)
-        break if (builder.page * builder.rows) >= num_results
-        builder.page += 1
+    # Prepare / execute the search and process into id arrays
+    def prepare_batches
+      builder_params = { q: params["search_params"]["q"], f: params["search_params"]["f"] }
+      builder = search_builder.with(builder_params)
+      builder.rows = params["batch_size"] || 50
+      [].tap do |batches|
+        loop do
+          response = repository.search(builder)
+          batches << response.documents.map(&:id)
+          break if (builder.page * builder.rows) >= response["response"]["numFound"]
+          builder.page += 1
+        end
       end
-      batches.each do |ids|
-        BulkUpdateJob.perform_later(ids: ids, args: args)
-      end
-      num_results
     end
 end

--- a/app/controllers/bulk_edit_controller.rb
+++ b/app/controllers/bulk_edit_controller.rb
@@ -32,6 +32,7 @@ class BulkEditController < ApplicationController
           response = repository.search(builder)
           batches << response.documents.map(&:id)
           break if (builder.page * builder.rows) >= response["response"]["numFound"]
+          builder.start = builder.rows * builder.page
           builder.page += 1
         end
       end

--- a/app/controllers/bulk_edit_controller.rb
+++ b/app/controllers/bulk_edit_controller.rb
@@ -3,18 +3,31 @@ class BulkEditController < ApplicationController
   include Blacklight::SearchHelper
 
   def resources_edit
-    (@solr_response, @document_list) = search_results(q: params["q"], f: params["f"])
+    (solr_response, _document_list) = search_results(q: params["q"], f: params["f"])
+    @resources_count = solr_response["response"]["numFound"]
   end
 
   def resources_update
-    (_, document_list) = search_results(q: params["search_params"]["q"], f: params["search_params"]["f"])
-    ids = document_list.map(&:id)
+    batch_size = params["batch_size"] || 50
     args = {}.tap do |hash|
       hash[:mark_complete] = (params["mark_complete"] == "1")
     end
-    ids.each_slice(50) do |batch|
-      BulkUpdateJob.perform_later(batch, args)
-    end
+    builder_params = { q: params["search_params"]["q"], f: params["search_params"]["f"] }
+    builder = search_builder.with(builder_params)
+    builder.rows = batch_size
+    spawn_update_jobs(builder, args)
     redirect_to root_url
   end
+
+  private
+
+    def spawn_update_jobs(builder, args)
+      loop do
+        response = repository.search(builder)
+        ids = response.documents.map(&:id)
+        BulkUpdateJob.perform_later(ids, args)
+        break if (builder.page * builder.rows) >= response["response"]["numFound"]
+        builder.page += 1
+      end
+    end
 end

--- a/app/controllers/bulk_edit_controller.rb
+++ b/app/controllers/bulk_edit_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+class BulkEditController < ApplicationController
+  include Blacklight::SearchHelper
+
+  def resources_edit
+    (@solr_response, @document_list) = search_results(q: params["q"], f: params["f"])
+  end
+
+  def resources_update
+    (_, document_list) = search_results(q: params["search_params"]["q"], f: params["search_params"]["f"])
+    ids = document_list.map(&:id)
+    args = {}.tap do |hash|
+      hash[:mark_complete] = (params["mark_complete"] == "1")
+    end
+    ids.each_slice(50) do |batch|
+      BulkUpdateJob.perform_later(batch, args)
+    end
+    redirect_to root_url
+  end
+end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -3,6 +3,7 @@ class CatalogController < ApplicationController
   include ::Hydra::Catalog
   include TokenAuth
   layout "application"
+
   def self.search_config
     {
       "qf" => %w[identifier_tesim

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -182,4 +182,8 @@ module ApplicationHelper
   def universal_viewer_path(resource)
     "/uv/uv#?manifest=#{manifest_url(resource)}&config=#{root_url}/uv/uv_config.json"
   end
+
+  def collection_present?
+    params[:f] && params[:f]["member_of_collection_titles_ssim"].present?
+  end
 end

--- a/app/jobs/bulk_update_job.rb
+++ b/app/jobs/bulk_update_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class BulkUpdateJob < ApplicationJob
-  def perform(ids, args)
+  def perform(ids:, args:)
     return unless args[:mark_complete]
     change_set_persister.buffer_into_index do |buffered_change_set_persister|
       ids.each do |id|

--- a/app/jobs/bulk_update_job.rb
+++ b/app/jobs/bulk_update_job.rb
@@ -9,7 +9,10 @@ class BulkUpdateJob < ApplicationJob
           attrs[:state] = "complete" if args[:mark_complete] && !resource.state.include?("complete")
         end
         change_set.validate(attributes)
-        buffered_change_set_persister.save(change_set: change_set) if change_set.changed?
+        if change_set.changed?
+          raise "Bulk update failed for batch #{ids} with args #{args} due to invalid change set on resource #{id}" unless change_set.valid?
+          buffered_change_set_persister.save(change_set: change_set)
+        end
       end
     end
   end

--- a/app/jobs/bulk_update_job.rb
+++ b/app/jobs/bulk_update_job.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+class BulkUpdateJob < ApplicationJob
+  def perform(ids, args)
+    return unless args[:mark_complete]
+    change_set_persister.buffer_into_index do |buffered_change_set_persister|
+      ids.each do |id|
+        resource = query_service.find_by(id: id)
+        change_set = DynamicChangeSet.new(resource)
+        change_set.validate(state: "complete") unless resource.state.include?("complete")
+        buffered_change_set_persister.save(change_set: change_set) if change_set.changed?
+      end
+    end
+  end
+
+  private
+
+    def query_service
+      metadata_adapter.query_service
+    end
+
+    def metadata_adapter
+      Valkyrie::MetadataAdapter.find(:indexing_persister)
+    end
+
+    def storage_adapter
+      Valkyrie::StorageAdapter.find(:disk_via_copy)
+    end
+
+    def change_set_persister
+      @change_set_persister ||= ChangeSetPersister.new(
+        metadata_adapter: metadata_adapter,
+        storage_adapter: storage_adapter
+      )
+    end
+end

--- a/app/jobs/bulk_update_job.rb
+++ b/app/jobs/bulk_update_job.rb
@@ -5,7 +5,7 @@ class BulkUpdateJob < ApplicationJob
     change_set_persister.buffer_into_index do |buffered_change_set_persister|
       ids.each do |id|
         resource = query_service.find_by(id: id)
-        change_set = DynamicChangeSet.new(resource)
+        change_set = DynamicChangeSet.new(resource).prepopulate!
         change_set.validate(state: "complete") unless resource.state.include?("complete")
         buffered_change_set_persister.save(change_set: change_set) if change_set.changed?
       end

--- a/app/views/bulk_edit/resources_edit.html.erb
+++ b/app/views/bulk_edit/resources_edit.html.erb
@@ -1,15 +1,24 @@
-<h2>Bulk edit <%= @resources_count %> resources</h2>
-<%= form_tag bulk_edit_resources_update_url(search_params: search_state.params_for_search) do %>
-
-  <h3>Workflow State</h3>
-  <%= check_box_tag "mark_complete" %>
-  <%= label_tag "mark_complete", "Mark all complete" %>
-
-  <div>
-    <%= submit_tag "Apply Edits",
-      id: 'bulk-edit-submit',
-      class: 'btn btn-primary',
-      data: {confirm: "Are you sure you want to bulk edit #{@resources_count} resources?"}
-    %>
+<div id="content" class="col-sm-12">
+  <div id="bulk-edit-constraints">
+    <%= render partial: "catalog/constraints" %>
   </div>
-<% end %>
+  <div class="panel panel-default">
+    <div class="panel-heading">Bulk edit <%= @resources_count %> resources</div>
+    <div class="panel-body">
+      <%= form_tag bulk_edit_resources_update_url(search_params: search_state.params_for_search), id: "bulk-edit-form", class: "form-group" do %>
+        <label>Workflow State</label>
+        <div class="checkbox">
+          <%= check_box_tag "mark_complete" %>
+          <%= label_tag "mark_complete", "Mark all complete" %>
+        </div>
+        <div class="panel-footer panel-save-controls pull-right">
+          <%= submit_tag "Apply Edits",
+            id: 'bulk-edit-submit',
+            class: 'btn btn-primary',
+            data: {confirm: "Are you sure you want to bulk edit #{@resources_count} resources?"}
+          %>
+        </div>
+      <% end %>
+    </div>  
+  </div>
+</div>

--- a/app/views/bulk_edit/resources_edit.html.erb
+++ b/app/views/bulk_edit/resources_edit.html.erb
@@ -1,4 +1,4 @@
-<h2>Bulk edit <%= @document_list.count %> resources</h2>
+<h2>Bulk edit <%= @resources_count %> resources</h2>
 <%= form_tag bulk_edit_resources_update_url(search_params: search_state.params_for_search) do %>
 
   <h3>Workflow State</h3>
@@ -9,7 +9,7 @@
     <%= submit_tag "Apply Edits",
       id: 'bulk-edit-submit',
       class: 'btn btn-primary',
-      data: {confirm: "Are you sure you want to bulk edit #{@document_list.count} resources?"}
+      data: {confirm: "Are you sure you want to bulk edit #{@resources_count} resources?"}
     %>
   </div>
 <% end %>

--- a/app/views/bulk_edit/resources_edit.html.erb
+++ b/app/views/bulk_edit/resources_edit.html.erb
@@ -1,0 +1,15 @@
+<h2>Bulk edit <%= @document_list.count %> resources</h2>
+<%= form_tag bulk_edit_resources_update_url(search_params: search_state.params_for_search) do %>
+
+  <h3>Workflow State</h3>
+  <%= check_box_tag "mark_complete" %>
+  <%= label_tag "mark_complete", "Mark all complete" %>
+
+  <div>
+    <%= submit_tag "Apply Edits",
+      id: 'bulk-edit-submit',
+      class: 'btn btn-primary',
+      data: {confirm: "Are you sure you want to bulk edit #{@document_list.count} resources?"}
+    %>
+  </div>
+<% end %>

--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -1,0 +1,6 @@
+<div id="sortAndPerPage" class="clearfix">
+  <%= render :partial => "paginate_compact", :object => @response if show_pagination? %>
+  <%= render_results_collection_tools wrapping_class: "search-widgets pull-right" %>
+  <%# local edit to add our bulk edit button here %>
+  <%= render partial: "collections/bulk_edit_button" %>
+</div>

--- a/app/views/collections/_bulk_edit_button.html.erb
+++ b/app/views/collections/_bulk_edit_button.html.erb
@@ -1,0 +1,3 @@
+<% if collection_present? %>
+  <%= link_to "Bulk Edit", bulk_edit_resources_edit_url(search_state.params_for_search), id: "bulk-edit", class: 'btn btn-primary pull-right bulk-edit-button' %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -259,6 +259,9 @@ Rails.application.routes.draw do
   get "bulk_ingest/:resource_type", to: "bulk_ingest#show", as: "bulk_ingest_show"
   post "bulk_ingest/:resource_type/browse_everything_files", to: "bulk_ingest#browse_everything_files", as: "browse_everything_files_bulk_ingest"
 
+  get "bulk_edit", to: "bulk_edit#resources_edit", as: "bulk_edit_resources_edit"
+  post "bulk_edit", to: "bulk_edit#resources_update", as: "bulk_edit_resources_update"
+
   mount BrowseEverything::Engine => "/browse"
 
   if Rails.env.development? || Rails.env.test?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -260,7 +260,7 @@ Rails.application.routes.draw do
   post "bulk_ingest/:resource_type/browse_everything_files", to: "bulk_ingest#browse_everything_files", as: "browse_everything_files_bulk_ingest"
 
   get "bulk_edit", to: "bulk_edit#resources_edit", as: "bulk_edit_resources_edit"
-  post "bulk_edit", to: "bulk_edit#resources_update", as: "bulk_edit_resources_update"
+  post "bulk_edit(/:batch_size)", to: "bulk_edit#resources_update", as: "bulk_edit_resources_update"
 
   mount BrowseEverything::Engine => "/browse"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -261,6 +261,7 @@ Rails.application.routes.draw do
 
   get "bulk_edit", to: "bulk_edit#resources_edit", as: "bulk_edit_resources_edit"
   post "bulk_edit(/:batch_size)", to: "bulk_edit#resources_update", as: "bulk_edit_resources_update"
+  get "bulk_edit", to: "bulk_edit#index"
 
   mount BrowseEverything::Engine => "/browse"
 

--- a/spec/controllers/bulk_edit_controller_spec.rb
+++ b/spec/controllers/bulk_edit_controller_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe BulkEditController, type: :controller do
+  let(:user) { FactoryBot.create(:admin) }
+  let(:metadata_adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
+  let(:storage_adapter) { Valkyrie.config.storage_adapter }
+  let(:change_set_persister) { ChangeSetPersister.new(metadata_adapter: metadata_adapter, storage_adapter: storage_adapter) }
+  let(:query_service) { metadata_adapter.query_service }
+  let(:collection) { FactoryBot.create_for_repository(:collection, title: ["The Important Person's Things"]) }
+  let(:collection_title) { ["The Important Person's Things"] }
+  let(:resource1) { FactoryBot.create_for_repository(:scanned_resource, member_of_collection_ids: collection.id, title: "Resource 1 - Significant") }
+  let(:resource2) { FactoryBot.create_for_repository(:scanned_resource, member_of_collection_ids: collection.id, title: "Resource 2 - Significant") }
+  let(:resource3) { FactoryBot.create_for_repository(:scanned_resource, member_of_collection_ids: collection.id, title: "Resource 3") }
+  let(:state) { ["pending"] }
+  let(:params) { { f: { member_of_collection_titles_ssim: collection_title, state_ssim: state }, q: "significant" } }
+  before do
+    sign_in user
+    change_set_persister.save(change_set: DynamicChangeSet.new(collection))
+    change_set_persister.save(change_set: DynamicChangeSet.new(resource1))
+    change_set_persister.save(change_set: DynamicChangeSet.new(resource2))
+  end
+  describe "GET /bulk_edit" do
+    render_views
+    it "renders the selected " do
+      get :resources_edit, params: params
+      puts request.original_url
+      expect(response.body).to have_content("Bulk edit 2 resources")
+      expect(response.body).to have_field("mark_complete")
+    end
+  end
+
+  describe "POST /bulk_edit" do
+    let(:params) { { mark_complete: "1", search_params: { f: { member_of_collection_titles_ssim: collection_title, state_ssim: state }, q: "significant" } } }
+    before do
+      stub_ezid(shoulder: "99999/fk4", blade: "123456")
+    end
+    it "updates the resources" do
+      expect { post :resources_update, params: params }.to have_enqueued_job(BulkUpdateJob).with([resource2.id.to_s, resource1.id.to_s], mark_complete: true)
+      expect(response.body).to redirect_to root_path
+    end
+  end
+end

--- a/spec/controllers/bulk_edit_controller_spec.rb
+++ b/spec/controllers/bulk_edit_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe BulkEditController, type: :controller do
       stub_ezid(shoulder: "99999/fk4", blade: "123456")
     end
     it "updates the resources" do
-      expect { post :resources_update, params: params }.to have_enqueued_job(BulkUpdateJob).with([resource2.id.to_s, resource1.id.to_s], mark_complete: true)
+      expect { post :resources_update, params: params }.to have_enqueued_job(BulkUpdateJob).with(ids: [resource2.id.to_s, resource1.id.to_s], args: { mark_complete: true })
       expect(response.body).to redirect_to root_path
       expect(flash[:notice]).to eq "2 resources were queued for bulk update."
     end

--- a/spec/controllers/bulk_edit_controller_spec.rb
+++ b/spec/controllers/bulk_edit_controller_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe BulkEditController, type: :controller do
     it "updates the resources" do
       expect { post :resources_update, params: params }.to have_enqueued_job(BulkUpdateJob).with([resource2.id.to_s, resource1.id.to_s], mark_complete: true)
       expect(response.body).to redirect_to root_path
+      expect(flash[:notice]).to eq "2 resources were queued for bulk update."
     end
 
     context "when there are multiple pages of results" do

--- a/spec/features/bulk_edit_spec.rb
+++ b/spec/features/bulk_edit_spec.rb
@@ -61,6 +61,7 @@ RSpec.feature "Bulk edit", js: true do
         click_button("Apply Edits")
       end
       expect(current_path).to eq root_path
+      expect(page).to have_content "1 resources were queued for bulk update."
       expect(adapter.query_service.find_by(id: member_scanned_resource.id).state).to eq ["complete"]
     end
   end

--- a/spec/features/bulk_edit_spec.rb
+++ b/spec/features/bulk_edit_spec.rb
@@ -56,6 +56,7 @@ RSpec.feature "Bulk edit", js: true do
     end
     it "updates the object" do
       visit bulk_edit_resources_edit_path("q" => "", "f[member_of_collection_titles_ssim][]" => "My Collection")
+      expect(page).to have_content "You searched for"
       page.check("mark_complete")
       accept_alert do
         click_button("Apply Edits")

--- a/spec/features/bulk_edit_spec.rb
+++ b/spec/features/bulk_edit_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "Bulk edit", js: true do
+  let(:user) { FactoryBot.create(:admin) }
+  let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
+  let(:collection_title) { "My Collection" }
+  let(:collection) { FactoryBot.create_for_repository(:collection, title: collection_title) }
+  let(:member_scanned_resource) do
+    FactoryBot.create_for_repository(:scanned_resource, title: ["Member Resource"], member_of_collection_ids: [collection.id])
+  end
+  let(:nonmember_scanned_resource) do
+    FactoryBot.create_for_repository(:scanned_resource, title: ["Nonmember Resource"])
+  end
+  let(:change_set_persister) do
+    ChangeSetPersister.new(metadata_adapter: adapter, storage_adapter: Valkyrie.config.storage_adapter)
+  end
+
+  before do
+    [collection, member_scanned_resource, nonmember_scanned_resource].each do |resource|
+      change_set = DynamicChangeSet.new(resource)
+      change_set_persister.save(change_set: change_set)
+    end
+    sign_in user
+  end
+
+  context "the bulk edit button" do
+    it "will not display in an empty search" do
+      visit root_path(q: "")
+
+      expect(page).not_to have_css("#bulk-edit")
+      expect(page).to have_content("My Collection")
+      expect(page).to have_content("Member Resource")
+      expect(page).to have_content("Nonmember Resource")
+    end
+
+    it "will display when a collection is selected" do
+      visit root_path("q" => "", "f[member_of_collection_titles_ssim][]" => "My Collection")
+
+      expect(page).to have_content("Member Resource")
+      expect(page).not_to have_content("Nonmember Resource")
+      expect(page).to have_css("#bulk-edit")
+      # We can't test the whole href because it is constructed
+      #   from path not as an absolute url
+      link = page.find_link("Bulk Edit")
+      uri = URI(link["href"])
+      expect(uri.query).to eq "f%5Bmember_of_collection_titles_ssim%5D%5B%5D=My+Collection&q="
+      expect(uri.path).to eq "/bulk_edit"
+    end
+  end
+
+  context "submit form" do
+    with_queue_adapter :inline
+    before do
+      stub_ezid(shoulder: "99999/fk4", blade: "4609321")
+    end
+    it "updates the object" do
+      visit bulk_edit_resources_edit_path("q" => "", "f[member_of_collection_titles_ssim][]" => "My Collection")
+      page.check("mark_complete")
+      accept_alert do
+        click_button("Apply Edits")
+      end
+      expect(current_path).to eq root_path
+      expect(adapter.query_service.find_by(id: member_scanned_resource.id).state).to eq ["complete"]
+    end
+  end
+end

--- a/spec/jobs/bulk_update_job_spec.rb
+++ b/spec/jobs/bulk_update_job_spec.rb
@@ -15,7 +15,7 @@ describe BulkUpdateJob do
       resource1
       resource2
       stub_ezid(shoulder: "99999/fk4", blade: "123456")
-      described_class.perform_now(ids, args)
+      described_class.perform_now(ids: ids, args: args)
     end
 
     it "updates the resource state" do

--- a/spec/jobs/bulk_update_job_spec.rb
+++ b/spec/jobs/bulk_update_job_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe BulkUpdateJob do
+  with_queue_adapter :inline
+  let(:metadata_adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
+  let(:query_service) { metadata_adapter.query_service }
+
+  let(:resource1) { FactoryBot.create_for_repository(:scanned_resource, state: "pending") }
+  let(:resource2) { FactoryBot.create_for_repository(:scanned_resource, state: "pending") }
+  let(:ids) { [resource1.id, resource2.id] }
+  let(:args) { { mark_complete: true } }
+  describe "#perform" do
+    before do
+      resource1
+      resource2
+      stub_ezid(shoulder: "99999/fk4", blade: "123456")
+      described_class.perform_now(ids, args)
+    end
+
+    it "updates the resource state" do
+      r1 = query_service.find_by(id: resource1.id)
+      r2 = query_service.find_by(id: resource2.id)
+      expect(r1.state).to eq ["complete"]
+      expect(r2.state).to eq ["complete"]
+    end
+
+    context "one of the resources was already complete" do
+      let(:resource2) do
+        Timecop.freeze(Time.now.utc - 1.day) do
+          FactoryBot.create_for_repository(:scanned_resource, state: "complete")
+        end
+      end
+      it "doesn't persist the one that was already complete" do
+        r2 = query_service.find_by(id: resource2.id)
+        expect(r2.updated_at.to_date).to be < Time.current.to_date
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Bulk edit button displays on search results page when a collection facet
is selected.
- search params are passed around so we can retrieve the same results
set
- Bulk edit controller queues 1 update job per 50 resources

Closes #1860 
Closes #2494 
Closes #697 
Other functionality moved to #2586 