### PR TITLE
Remove Coveralls from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,7 +140,7 @@ jobs:
       - run:
           name: Merge and check coverage
           command: |
-            bundle exec rake simplecov:report_coverage
+            RAILS_ENV=test bundle exec rake simplecov:report_coverage
       - store_artifacts:
           path: ~/figgy/coverage
           destination: coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,26 +105,45 @@ jobs:
           command: |
             mkdir /tmp/test-results
             bundle exec rspec $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
-      - run: echo $CIRCLE_BUILD_NUM > test-build-num
+      - run:
+          name: Stash Coverage Results
+          command: |
+            mkdir coverage_results
+            cp -R coverage/.resultset.json coverage_results/.resultset-${CIRCLE_NODE_INDEX}.json
       - persist_to_workspace:
           root: '~/figgy'
-          paths: 'test-build-num'
+          paths: 'coverage_results'
       # collect reports
       - store_test_results:
           path: /tmp/test-results
       - store_artifacts:
           path: /tmp/test-results
           destination: test-results
-  notify_coveralls:
+  coverage_report:
     working_directory: ~/figgy
     docker:
       - image: circleci/ruby:2.4.5-node-browsers
     steps:
       - attach_workspace:
           at: '~/figgy'
+      - run: sudo sh bin/ci_mediainfo_install.sh
+      - run: sudo apt-get update
+      - run: sudo apt-get install gdal-bin libgdal-dev libcairo2-dev libpango1.0-dev tesseract-ocr tesseract-ocr-ita tesseract-ocr-eng mediainfo ffmpeg postgresql-client
+      - run: sudo sh bin/ci_simple_tiles_install.sh
+      - run: sudo sh bin/ci_free_tds_install.sh
+      # Wait for DB
+      - run: sudo sh bin/ci_kakadu_install.sh
+      # Remove cached simpler-tiles - needs to be reinstalled every time.
+      - run: rm vendor/bundle/ruby/2.3.0/specifications/simpler-tiles-0.3.1.gemspec || true
+      # Bundle install dependencies
+      - run: bundle install --path vendor/bundle
       - run:
-          command: curl -k https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN -d "payload[build_num]=`cat test-build-num`&payload[status]=done"
-          name: "Notify Coveralls of Completion"
+          name: Merge and check coverage
+          command: |
+            bundle exec rake simplecov:report_coverage
+      - store_artifacts:
+          path: ~/figgy/coverage
+          destination: coverage
   rubocop:
     working_directory: ~/figgy
     docker:
@@ -159,7 +178,7 @@ workflows:
       - rubocop:
           requires:
             - build
-      - notify_coveralls:
+      - coverage_report:
           requires:
             - test
   nightly:
@@ -178,6 +197,6 @@ workflows:
       - rubocop:
           requires:
             - build
-      - notify_coveralls:
+      - coverage_report:
           requires:
             - test

--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,6 @@ group :development, :test do
   gem "awesome_print"
   gem "bixby"
   gem "bundler-audit", ">= 0.5.0", require: false
-  gem "coveralls"
   gem "dotenv-rails"
   gem "factory_bot_rails"
   gem "pdf-reader", github: "yob/pdf-reader"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,12 +244,6 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
-    coveralls (0.8.21)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.14.1)
-      term-ansicolor (~> 1.3)
-      thor (~> 0.19.4)
-      tins (~> 1.6)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
@@ -277,7 +271,7 @@ GEM
       declarative-option (< 0.2.0)
       representable (>= 2.4.0, <= 3.1.0)
       uber (< 0.2.0)
-    docile (1.1.5)
+    docile (1.3.1)
     docopt (0.5.0)
     dotenv (2.2.1)
     dotenv-rails (2.2.1)
@@ -701,11 +695,11 @@ GEM
     simple_form (3.5.0)
       actionpack (> 4, < 5.2)
       activemodel (> 4, < 5.2)
-    simplecov (0.14.1)
-      docile (~> 1.1.0)
+    simplecov (0.16.1)
+      docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.1)
+    simplecov-html (0.10.2)
     simpler-tiles (0.3.1)
     slop (3.6.0)
     solr_wrapper (1.1.0)
@@ -740,13 +734,10 @@ GEM
     string_rtl (0.1.0)
     sxp (1.0.0)
       rdf (~> 2.0)
-    term-ansicolor (1.6.0)
-      tins (~> 1.0)
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.8)
     timecop (0.9.1)
-    tins (1.15.0)
     tiny_tds (2.1.2)
     title (0.0.7)
       i18n
@@ -828,7 +819,6 @@ DEPENDENCIES
   capistrano-rails-console
   chromedriver-helper
   coffee-rails
-  coveralls
   damerau-levenshtein
   database_cleaner
   ddtrace

--- a/lib/tasks/simplecov_parallel.rake
+++ b/lib/tasks/simplecov_parallel.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# lib/tasks/simplecov_parallel.rake
+if Rails.env.test?
+  require_relative "../../spec/simplecov_helper"
+  namespace :simplecov do
+    desc "merge_results"
+    task :report_coverage do
+      SimpleCovHelper.report_coverage
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,14 +1,7 @@
 # frozen_string_literal: true
 ENV["RACK_ENV"] = "test"
 require "simplecov"
-require "coveralls"
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
-  [
-    SimpleCov::Formatter::HTMLFormatter,
-    Coveralls::SimpleCov::Formatter
-  ]
-)
 SimpleCov.start "rails"
 
 require File.expand_path("../../config/environment", __FILE__)

--- a/spec/simplecov_helper.rb
+++ b/spec/simplecov_helper.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# spec/simplecov_helper.rb
+require "active_support/inflector"
+require "simplecov"
+require "pry"
+
+class SimpleCovHelper
+  def self.report_coverage(base_dir: "./coverage_results")
+    SimpleCov.configure do
+      minimum_coverage(100)
+    end
+    new(base_dir: base_dir).merge_results
+  end
+
+  attr_reader :base_dir
+
+  def initialize(base_dir:)
+    @base_dir = base_dir
+  end
+
+  def all_results
+    Dir["#{base_dir}/.resultset*.json"]
+  end
+
+  def merge_results
+    results = all_results.map { |file| SimpleCov::Result.from_hash(JSON.parse(File.read(file))) }
+    results = SimpleCov::ResultMerger.merge_results(*results)
+    results.format!
+    covered_percent = results.covered_percent.round(2)
+    return unless covered_percent < SimpleCov.minimum_coverage
+    $stderr.printf("Coverage (%.2f%%) is below the expected minimum coverage (%.2f%%).\n", covered_percent, SimpleCov.minimum_coverage)
+    Kernel.exit SimpleCov::ExitCodes::MINIMUM_COVERAGE
+  end
+end


### PR DESCRIPTION
This adds a minute to the test suite, but we wouldn't have to wait for coverage. It's moderately complicated because we have to re-install all the dependencies to run the rake task which combines the coverage reports.

I'll fiddle with if I can extract this to a script rather than a rake task.