### PR TITLE
WIP: Convert finding aids EAD XML to MARC records

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -115,6 +115,7 @@ gem "string_rtl"
 gem "tiny_tds"
 gem "valkyrie-sequel", github: "samvera-labs/valkyrie-sequel", branch: "valkyrie_1.5"
 gem "whenever", "~> 0.10"
+gem "zipline"
 
 gem "blacklight_iiif_search", github: "boston-library/blacklight_iiif_search"
 gem "graphiql-rails", group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -259,6 +259,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
+    curb (0.9.8)
     damerau-levenshtein (1.3.1)
     database_cleaner (1.6.1)
     ddtrace (0.16.0)
@@ -819,6 +820,11 @@ GEM
     xml-simple (1.1.5)
     xpath (2.1.0)
       nokogiri (~> 1.3)
+    zip_tricks (4.7.1)
+    zipline (1.1.0)
+      curb (>= 0.8.0, < 0.10)
+      rails (>= 3.2.1, < 6.1)
+      zip_tricks (>= 4.2.1, <= 5.0.0)
 
 PLATFORMS
   ruby
@@ -926,6 +932,7 @@ DEPENDENCIES
   webmock
   webpacker (>= 4.0.x)
   whenever (~> 0.10)
+  zipline
 
 BUNDLED WITH
    1.17.3

--- a/app/assets/xsl/ead-to-marc.xsl
+++ b/app/assets/xsl/ead-to-marc.xsl
@@ -1,0 +1,358 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- author: Don Thornbury <doncat@princeton.edu> -->
+<!-- December 26 2018 -->
+<xsl:stylesheet version="1.0"
+    xmlns:marc="https://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xpath-default-namespace="urn:isbn:1-931666-22-9">
+    <xsl:output indent="yes" method="xml"/>
+    <xsl:preserve-space elements="leader"/>
+    <xsl:preserve-space elements="controlfield"/>
+    <!-- Intent is DACS Single-level record, plus 650 and 655 and 7xx for access. The function of the MARC record is to serve as an advertisement for the finding aid.  -->
+    <xsl:template match="/">
+        <!-- marc:collection -->
+        <!--<collection xmlns:marc="http://www.loc.gov/MARC21/slim"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd">-->
+        <xsl:for-each select="//archdesc/did[1]">
+            <record>
+                <leader>
+                    <xsl:text>00000n</xsl:text>
+                    <!-- LDR/06 values based on title -->
+                    <xsl:choose>
+                        <xsl:when
+                            test="contains(lower-case(normalize-space(unittitle[1])), 'photograph') or contains(lower-case(normalize-space(unittitle[1])), 'negative') or contains(lower-case(normalize-space(unittitle)), 'film')">
+                            <xsl:text>k</xsl:text>
+                        </xsl:when>
+                        <xsl:when
+                            test="contains(lower-case(normalize-space(unittitle[1])), 'sound') or contains(lower-case(normalize-space(unittitle[1])), 'recording')">
+                            <xsl:text>i</xsl:text>
+                        </xsl:when>
+                        <xsl:when test="contains(repository/@id, 'book')">
+                            <xsl:text>a</xsl:text>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:text>p</xsl:text>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                    <xsl:text>caa2200000u  4500</xsl:text>
+                </leader>
+                <controlfield tag="008">
+                    <!-- This is what it's supposed to look like:  <controlfield tag="008">181217i16862010xx                      d</controlfield> -->
+                    <!-- positions 0-17, all LDR/06 -->
+                    <xsl:value-of select="'181218i'"/>
+                    <xsl:choose>
+                        <xsl:when test="unitdate[1]/@normal">  <xsl:value-of select="substring-before(unitdate[1]/@normal, '/')"/></xsl:when><xsl:otherwise><xsl:text>uuuu</xsl:text></xsl:otherwise>
+                    </xsl:choose>
+
+                    <xsl:choose>
+                        <xsl:when
+                            test="substring-before(unitdate[1]/@normal, '/') = substring-after(unitdate[1]/@normal, '/')">
+                            <xsl:text>    </xsl:text>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="substring-after(unitdate[1]/@normal, '/')"/>
+                            <xsl:if test="not(unitdate[1]/@normal)"><xsl:text>uuuu</xsl:text></xsl:if>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                    <xsl:text>xx </xsl:text>
+                    <!-- positions 18-34, related to LDR/06 -->
+                    <xsl:choose>
+                        <xsl:when
+                            test="contains(lower-case(normalize-space(unittitle[1])), 'photograph') or contains(lower-case(normalize-space(unittitle[1])), 'negative') or contains(lower-case(normalize-space(unittitle)), 'film')">
+                            <xsl:text>               ||</xsl:text>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:text>                 </xsl:text>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                    <!-- positions 35-37, language -->
+                    <xsl:value-of select="langmaterial[1]/language[1]/@langcode"/>
+                    <xsl:if test="not(langmaterial/language/@langcode)">
+                        <xsl:value-of select="'   '"/>
+                    </xsl:if>
+                    <!-- positions 38-39, all LDR/06 -->
+                    <xsl:text> d</xsl:text>
+                </controlfield>
+                <controlfield tag="001">
+                    <xsl:value-of select="//eadid"/>
+                </controlfield>
+                <!-- arbitrary value, just something for 035 -->
+                <controlfield tag="003">
+                    <xsl:value-of select="'PULFA'"/>
+                </controlfield>
+                <datafield ind1=" " ind2=" " tag="040">
+                    <subfield code="a">NjP</subfield>
+                    <subfield code="b">eng</subfield>
+                    <subfield code="e">dacs</subfield>
+                    <subfield code="c">NjP</subfield>
+                </datafield>
+                <!-- language codes  -->
+                <xsl:if test="count(langmaterial/language) > 1">
+                    <datafield ind1="0" ind2=" " tag="041">
+                        <xsl:for-each select="langmaterial/language">
+                            <subfield code="a">
+                                <xsl:value-of select="./@langcode"/>
+                            </subfield>
+                        </xsl:for-each>
+                    </datafield>
+                </xsl:if>
+                <!-- 1xx, including repository  -->
+                <xsl:for-each select="origination[1]/*[1]">
+                    <xsl:variable name="cleanname" select="normalize-space(replace(., '´', ''))"/>
+                    <datafield>
+                        <xsl:attribute name="tag">
+                            <xsl:choose>
+                                <xsl:when test="local-name(.) = 'persname'">
+                                    <xsl:text>100</xsl:text>
+                                </xsl:when>
+                                <xsl:when test="local-name(.) = 'corpname'">
+                                    <xsl:text>110</xsl:text>
+                                </xsl:when>
+                                <xsl:when test="local-name(.) = 'famname'">
+                                    <xsl:text>100</xsl:text>
+                                </xsl:when>
+                            </xsl:choose>
+                        </xsl:attribute>
+                        <xsl:attribute name="ind1">
+                            <xsl:choose>
+                                <xsl:when test="local-name(.) = 'persname'">
+                                    <xsl:text>1</xsl:text>
+                                </xsl:when>
+                                <xsl:when test="local-name(.) = 'corpname'">
+                                    <xsl:text>2</xsl:text>
+                                </xsl:when>
+                                <xsl:when test="local-name(.) = 'famname'">
+                                    <xsl:text>3</xsl:text>
+                                </xsl:when>
+                            </xsl:choose>
+                        </xsl:attribute>
+                        <xsl:attribute name="ind2">
+                            <xsl:choose>
+                                <xsl:when test="local-name(.) = 'persname'">
+                                    <xsl:text> </xsl:text>
+                                </xsl:when>
+                                <xsl:when test="local-name(.) = 'corpname'">
+                                    <xsl:text> </xsl:text>
+                                </xsl:when>
+                                <xsl:when test="local-name(.) = 'famname'">
+                                    <xsl:text> </xsl:text>
+                                </xsl:when>
+                            </xsl:choose>
+                        </xsl:attribute>
+                        <subfield code="a">
+                            <xsl:value-of select="$cleanname"/>
+                        </subfield>
+                    </datafield>
+                </xsl:for-each>
+                <!-- title and date  -->
+                <xsl:for-each select="unittitle[1]">
+                    <datafield ind1="0" tag="245">
+                        <xsl:attribute name="ind2">
+                            <xsl:choose>
+                                <xsl:when test="not(@altrender)">0</xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:value-of
+                                        select="string-length(substring-before(normalize-space(.), ' ')) + 1"
+                                    />
+                                </xsl:otherwise>
+                            </xsl:choose>
+                        </xsl:attribute>
+                        <subfield code="a">
+                            <xsl:value-of select="normalize-space(.)"/>
+                            <xsl:text>, </xsl:text>
+                        </subfield>
+                        <xsl:for-each select="../unitdate[not(@type = 'bulk')][1]">
+                            <subfield code="f">
+                                <xsl:value-of select="normalize-space(../unitdate[1])"/>
+                                <xsl:if test="not(../unitdate[@type = 'bulk'])">
+                                    <xsl:text>.</xsl:text>
+                                </xsl:if>
+                            </subfield>
+                        </xsl:for-each>
+                        <xsl:for-each select="../unitdate[@type = 'bulk'][1]">
+                            <subfield code="g">
+                                <xsl:text> (</xsl:text>
+                                <xsl:value-of select="normalize-space(../unitdate[1])"/>
+                                <xsl:text>)</xsl:text>
+                            </subfield>
+                        </xsl:for-each>
+                    </datafield>
+                </xsl:for-each>
+                <!-- extent  -->
+                <datafield ind1=" " ind2=" " tag="300">
+                    <subfield code="a">
+                        <xsl:for-each select="physdesc/extent">
+                            <xsl:if test="position() > 1">
+                                <xsl:text>, </xsl:text>
+                            </xsl:if>
+                            <xsl:value-of select="normalize-space(.)"/>
+                        </xsl:for-each>
+                    </subfield>
+                </datafield>
+                <!-- abstract, as scope and content  -->
+                <xsl:for-each select="//abstract[1]">
+                    <datafield ind1="2" ind2=" " tag="520">
+                        <subfield code="a">
+                            <xsl:value-of select="normalize-space(.)"/>
+                        </subfield>
+                    </datafield>
+                </xsl:for-each>
+                <!-- restrictions on access and use: general note to see the finding aid  -->
+                <datafield ind1="1" ind2=" " tag="506">
+                    <subfield code="a">
+                        <xsl:text>See finding aid for note on access and use.</xsl:text>
+                    </subfield>
+                </datafield>
+                <!-- 6xx -->
+                <xsl:for-each
+                    select="../controlaccess/(child::geogname | child::subject[not(@source = 'local')])">
+                    <datafield>
+                        <xsl:attribute name="tag">
+                            <xsl:choose>
+                                <xsl:when test="local-name(.) = 'geogname'">
+                                    <xsl:text>651</xsl:text>
+                                </xsl:when>
+                                <xsl:when test="local-name(.) = 'subject'">
+                                    <xsl:text>650</xsl:text>
+                                </xsl:when>
+                            </xsl:choose>
+                        </xsl:attribute>
+                        <xsl:attribute name="ind1">
+                            <xsl:text> </xsl:text>
+                        </xsl:attribute>
+                        <xsl:attribute name="ind2">
+                            <xsl:text>0</xsl:text>
+                        </xsl:attribute>
+                        <xsl:variable name="cleanterm" select="normalize-space(replace(., '´', ''))"/>
+                        <xsl:variable name="subtoken" select="tokenize($cleanterm, '--')"/>
+                        <xsl:for-each select="$subtoken">
+                            <xsl:if test="position() = 1">
+                                <subfield code="a">
+                                    <xsl:value-of select="normalize-space(.)"/>
+                                </subfield>
+                            </xsl:if>
+                            <xsl:if test="position() > 1">
+                                <subfield>
+                                    <xsl:attribute name="code">
+                                        <xsl:choose>
+                                            <xsl:when
+                                                test="matches(substring(normalize-space(.), 1, 2), '\d\d')">
+                                                <xsl:text>y</xsl:text>
+                                            </xsl:when>
+                                            <xsl:otherwise>
+                                                <xsl:text>x</xsl:text>
+                                            </xsl:otherwise>
+                                        </xsl:choose>
+                                    </xsl:attribute>
+                                    <xsl:value-of select="normalize-space(.)"/>
+                                </subfield>
+                            </xsl:if>
+                        </xsl:for-each>
+                    </datafield>
+                </xsl:for-each>
+                <xsl:for-each select="../controlaccess/genreform">
+                    <datafield ind1=" " ind2="7" tag="655">
+                        <xsl:variable name="gentoken" select="tokenize(normalize-space(.), '--')"/>
+                        <xsl:for-each select="$gentoken">
+                            <xsl:if test="position() = 1">
+                                <subfield code="a">
+                                    <xsl:value-of select="normalize-space(.)"/>
+                                </subfield>
+                            </xsl:if>
+                            <xsl:if test="position() > 1">
+                                <subfield>
+                                    <xsl:attribute name="code">
+                                        <xsl:choose>
+                                            <xsl:when
+                                                test="matches(substring(normalize-space(.), 1, 2), '\d\d')">
+                                                <xsl:text>y</xsl:text>
+                                            </xsl:when>
+                                            <xsl:otherwise>
+                                                <xsl:text>x</xsl:text>
+                                            </xsl:otherwise>
+                                        </xsl:choose>
+                                    </xsl:attribute>
+                                    <xsl:value-of select="normalize-space(.)"/>
+                                </subfield>
+                            </xsl:if>
+                        </xsl:for-each>
+                        <subfield code="2">
+                            <xsl:value-of select="@source"/>
+                        </subfield>
+                    </datafield>
+                </xsl:for-each>
+                <!-- 7xx  -->
+                <xsl:for-each
+                    select="child::origination[1]/child::*[position() > 1] | child::origination[position() > 1]/child::* | ../child::controlaccess/(child::persname | child::corpname | child::famname)[not(contains(., '--'))]">
+                    <xsl:variable name="cleanname" select="normalize-space(replace(., '´', ''))"/>
+                    <datafield>
+                        <xsl:attribute name="tag">
+                            <xsl:choose>
+                                <xsl:when test="local-name(.) = 'persname'">
+                                    <xsl:text>700</xsl:text>
+                                </xsl:when>
+                                <xsl:when test="local-name(.) = 'corpname'">
+                                    <xsl:text>710</xsl:text>
+                                </xsl:when>
+                                <xsl:when test="local-name(.) = 'famname'">
+                                    <xsl:text>700</xsl:text>
+                                </xsl:when>
+                            </xsl:choose>
+                        </xsl:attribute>
+                        <xsl:attribute name="ind1">
+                            <xsl:choose>
+                                <xsl:when test="local-name(.) = 'persname'">
+                                    <xsl:text>1</xsl:text>
+                                </xsl:when>
+                                <xsl:when test="local-name(.) = 'corpname'">
+                                    <xsl:text>2</xsl:text>
+                                </xsl:when>
+                                <xsl:when test="local-name(.) = 'famname'">
+                                    <xsl:text>3</xsl:text>
+                                </xsl:when>
+                            </xsl:choose>
+                        </xsl:attribute>
+                        <xsl:attribute name="ind2">
+                            <xsl:choose>
+                                <xsl:when test="local-name(.) = 'persname'">
+                                    <xsl:text> </xsl:text>
+                                </xsl:when>
+                                <xsl:when test="local-name(.) = 'corpname'">
+                                    <xsl:text> </xsl:text>
+                                </xsl:when>
+                                <xsl:when test="local-name(.) = 'famname'">
+                                    <xsl:text> </xsl:text>
+                                </xsl:when>
+                            </xsl:choose>
+                        </xsl:attribute>
+                        <subfield code="a">
+                            <xsl:value-of select="$cleanname"/>
+                        </subfield>
+                    </datafield>
+                </xsl:for-each>
+                <!-- ARK -->
+                <datafield ind1="4" ind2="2" tag="856">
+                    <subfield code="z">
+                        <xsl:text>Finding aid: </xsl:text>
+                    </subfield>
+                    <subfield code="u">
+                        <xsl:value-of select="//eadid/@url"/>
+                    </subfield>
+                </datafield>
+                <!-- holdings: location and call number -->
+                <xsl:for-each select="physloc[@type = 'code']">
+                    <datafield ind1="8" ind2=" " tag="852">
+                        <subfield code="b">
+                            <xsl:value-of select="normalize-space(.)"/>
+                        </subfield>
+                        <subfield code="h">
+                            <xsl:value-of select="//unitid[@type = 'collection'][1]"/>
+                        </subfield>
+                    </datafield>
+                </xsl:for-each>
+            </record>
+        </xsl:for-each>
+        <!--</collection>-->
+    </xsl:template>
+</xsl:stylesheet>

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class Report
   def self.all
-    [:ephemera_data, :identifiers_to_reconcile, :pulfa_ark_report]
+    [:ead_to_marc, :ephemera_data, :identifiers_to_reconcile, :pulfa_ark_report]
   end
 end

--- a/app/services/finding_aids_updater.rb
+++ b/app/services/finding_aids_updater.rb
@@ -29,23 +29,6 @@ class FindingAidsUpdater
 
   private
 
-    class SvnParser
-      # @param [Date] date
-      def updated_collection_codes(date)
-        svn_config = Rails.application.config_for :svn
-        date = date.to_formatted_s(:iso8601)
-        stdout, status = Open3.capture2("svn diff --summarize -r {#{date}}:HEAD --username #{svn_config['user']} --password #{svn_config['pass']} #{File.join(svn_config['url'], 'pulfa/trunk/eads')}")
-        raise StandardError unless status.success?
-        parse_collection_ids(stdout)
-      end
-
-      def parse_collection_ids(svn_output)
-        svn_output.split("\n").map do |line|
-          line.rpartition("/").last.partition(".").first
-        end
-      end
-    end
-
     def query_service
       @query_service ||= Valkyrie.config.metadata_adapter.query_service
     end

--- a/app/services/svn_parser.rb
+++ b/app/services/svn_parser.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+class SvnParser
+  # List IDs of collections that have been modified since a given date
+  # @param [Date] date
+  def updated_collection_codes(date)
+    date = date.to_formatted_s(:iso8601)
+    parse_collection_ids(exec("diff --summarize -r {#{date}}:HEAD #{svn_root}"))
+  end
+
+  # List the paths of all collections
+  def all_collection_paths
+    parse_collection_paths(exec("list --recursive #{svn_root}"))
+  end
+
+  # Get the EAD XML for a collection
+  def get_collection(path)
+    exec("cat #{svn_root}/#{path}")
+  end
+
+  private
+
+    def exec(svn_cmd)
+      stdout, status = Open3.capture2("svn #{svn_auth} #{svn_cmd}")
+      raise StandardError unless status.success?
+      stdout
+    end
+
+    def parse_collection_ids(svn_output)
+      svn_output.split("\n").map do |line|
+        line.rpartition("/").last.partition(".").first
+      end
+    end
+
+    def parse_collection_paths(svn_output)
+      svn_output.split("\n").select { |s| s.end_with?(".EAD.xml") }
+    end
+
+    def svn_auth
+      "--username #{svn_config['user']} --password #{svn_config['pass']}"
+    end
+
+    def svn_config
+      @svn_config ||= Rails.application.config_for :svn
+    end
+
+    def svn_root
+      File.join(svn_config["url"], "pulfa/trunk/eads")
+    end
+end

--- a/app/views/reports/ead_to_marc.html.erb
+++ b/app/views/reports/ead_to_marc.html.erb
@@ -1,0 +1,8 @@
+<h2>EAD to MARC</h2>
+<ol class="breadcrumb">
+  <li>Download MARC records for collections updated since</li>
+</ol>
+<%= form_with(url: ead_to_marc_path, method: :get, local: true) do |f| %>
+  <%= f.text_field :since_date %>
+  <%= f.submit("View") %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -260,6 +260,7 @@ Rails.application.routes.draw do
   get "/iiif/lookup/:prefix/:naan/:arkid", to: "catalog#lookup_manifest", as: :lookup_manifest
 
   get "/reports/pulfa_ark_report/(:since_date)", to: "reports#pulfa_ark_report", as: :pulfa_ark_report
+  get "/reports/ead_to_marc/(:since_date)", to: "reports#ead_to_marc", as: :ead_to_marc
   get "/reports/ephemera_data/(:project_id)", to: "reports#ephemera_data", as: :ephemera_data
   get "/reports/identifiers_to_reconcile", to: "reports#identifiers_to_reconcile", as: :identifiers_to_reconcile
 

--- a/spec/fixtures/files/pulfa/svn/C0652.EAD.xml
+++ b/spec/fixtures/files/pulfa/svn/C0652.EAD.xml
@@ -1,0 +1,5181 @@
+<ead xmlns="urn:isbn:1-931666-22-9" xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="urn:isbn:1-931666-22-9 http://www.loc.gov/ead/ead.xsd" audience="external">
+   <eadheader countryencoding="iso3166-1" dateencoding="iso8601" langencoding="iso639-2b"
+      repositoryencoding="iso15511" scriptencoding="iso15924">
+      <eadid countrycode="US" mainagencycode="US-NjP"
+         url="http://arks.princeton.edu/ark:/88435/hd76s0088" urn="ark:/88435/hd76s0088"
+         >C0652</eadid>
+      <filedesc>
+         <titlestmt>
+            <titleproper>Emir Rodriguez Monegal Papers, <date normal="1941/1985" type="inclusive"
+                  >1941-1985</date> (bulk <date normal="1965/1968" type="bulk">1965-1968</date>):
+               Finding Aid</titleproper>
+         </titlestmt>
+         <publicationstmt id="rbscAddress">
+            <publisher>Princeton University Library. Department of Rare Books and Special
+               Collections.</publisher>
+            <address>
+               <addressline>Manuscripts Division</addressline>
+               <addressline>One Washington Road</addressline>
+               <addressline>Princeton, New Jersey 08544 USA</addressline>
+               <addressline>Phone: (609) 258-3184</addressline>
+               <addressline>Fax: (609) 258-2324</addressline>
+               <addressline>rbsc@princeton.edu</addressline>
+               <addressline>http://www.princeton.edu/~rbsc</addressline>
+            </address>
+            <date type="publication" normal="2002">2002</date>
+         </publicationstmt>
+      </filedesc>
+      <profiledesc>
+         <creation>Machine-readable finding aid encoded in EAD 2002 by Techbooks, Cristela
+            García-Spitz, and Amy E. Armstrong on <date normal="2007-05-11">May 11, 2007</date>.
+            Created from MARC record via MarcEdit and XSL stylesheets in 2007. </creation>
+         <langusage>
+            <language langcode="eng"/>
+         </langusage>
+         <descrules>Finding aid content adheres to that prescribed by <emph render="italic">
+               Describing Archives: A Content Standard. </emph>
+         </descrules>
+      </profiledesc>
+      <revisiondesc>
+         <change>
+            <date normal="2012-05-02">2012-05-02T14:07:16.205-04:00</date>
+            <item>Run through PULFA 2.0 normalization routines.</item>
+         </change>
+      </revisiondesc>
+   </eadheader>
+   <archdesc type="findingaid" level="collection" relatedencoding="marc21">
+      <did>
+         <unitid type="collection" countrycode="US" repositorycode="US-NjP">C0652</unitid>
+         <repository id="mss">
+            <corpname source="lcsh">Princeton University. Library. Dept. of Rare Books and Special
+               Collections</corpname>
+            <subarea>Manuscripts Division</subarea>
+            <address>
+               <addressline>One Washington Road</addressline>
+               <addressline>Princeton, New Jersey 08544 USA</addressline>
+            </address>
+         </repository>
+         <unittitle>Emir Rodriguez Monegal Papers</unittitle>
+         <unitdate normal="1941/1985" type="inclusive">1941-1985</unitdate>
+         <unitdate normal="1965/1968" type="bulk">1965-1968</unitdate>
+         <physdesc>
+            <extent>11 linear feet</extent>
+            <extent unit="boxes">24 archival boxes</extent>
+         </physdesc>
+         <origination>
+            <persname source="viaf" role="cre" authfilenumber="http://viaf.org/viaf/44304596"
+               >Rodriguez Monegal, Emir, 1921-1985.</persname>
+         </origination>
+         <langmaterial>
+            <language langcode="spa"/>
+            <language langcode="fre"/>
+            <language langcode="por"/>
+            <language langcode="eng"/>
+         </langmaterial>
+         <abstract>The Emir Rodriguez Monegal Papers consists of correspondence, manuscripts of
+            novels, short stories, verse, plays, and essays by others, mansucripts of essays and
+            criticism by Rodriguez Monegal, photographs, and printed and recorded
+            material.</abstract>
+         <physloc type="code">mss</physloc>
+      </did>
+      <bioghist>
+
+         <p>Emir Rodriguez Monegal, literary scholar and biographer, critic, and editor was born in
+            Melo, Uruguay on July 28, 1921, and died in New Haven, Conn. on November 14, 1985. At
+            the time of his death he was Professor of Latin American Literature and Director of the
+            Latin American Studies Council at Yale University. Rodriguez Monegal became in 1945
+            editor of the literary section of the weekly <emph render="italic">Marcha</emph>. In
+            1949 he founded the journal <emph render="italic">Número</emph>, which he co-edited with
+            Manuel Claps and Idea Vilariño until 1955. In 1966 he founded and edited the literary
+            and cultural journal <emph render="italic">Mundo Nuevo</emph> (published in Paris until
+            1969). He was the author of numerous books and articles many of which made important
+            contributions to the understanding of modern Latin American writing, notably among which
+            are <emph render="italic">El juicio de los parricidas: la nueva generación argentina y
+               sus maestros</emph> (1956), <emph render="italic">Literatura uruguaya del medio
+               siglo</emph> (1966), <emph render="italic">Narradores de esta América</emph> (1963;
+            1969), and <emph render="italic">El boom de la novela latinoamericana</emph> (1972).</p>
+         <p>Rodriguez Monegal was also know for his literary biographies of Andres Bello <emph
+               render="italic">(El otro Andrés Bello</emph> [1969]), of Horacio Quiroga ( <emph
+               render="italic">El desterrado: vida y obra de Horacio Quiroga</emph> [1968]), of
+            Pablo Neruda ( <emph render="italic">El viajero inmóvil: Introducción a Pablo
+               Neruda</emph> [1966] and <emph render="italic"> Neruda, el viajero inmóvil</emph>
+            [1977]), and of Jorge Luis Borges ( <emph render="italic">Jorge Luis Borges: A Literary
+               Biography</emph> [1978]). He also edited critical and literary collections, among
+            which are <emph render="italic">José Enrique Rodó, 1871-1917</emph> (1963, 1967), <emph
+               render="italic">El cuento uruguayo: de los orígenes al modernismo</emph> (1965),
+               <emph render="italic">Borges par lui-memê</emph> (1970, 1978, Spanish ed. 1983),
+               <emph render="italic">The Borzoi Anthology of Latin American Literature</emph> (with
+            Thomas Colchie, 1977), <emph render="italic">Pablo Neruda</emph> (1980), and <emph
+               render="italic">Borges, a Reader: A Selection from the Writings of Jorge Luis
+               Borges</emph> (with Alistair Reid, 1981).</p>
+      </bioghist>
+      <descgrp id="dacs3">
+         <scopecontent>
+            <p>The Emir Rodriguez Monegal Papers consists mainly of correspondence between Rodríguez
+               Monegal and a wide range of internationally prominent literary figures, scholars,
+               critics, publishers, and academic institutions(much of it relating to Rodriguez
+               Monegal's role as editor and literary critic of <emph render="italic">Marcha</emph>,
+               and <emph render="italic">Mundo Nuevo</emph>(covering mainly the period from 1965 to
+               1968. The collection includes notes and manuscript and typescript drafts with
+               holograph corrections of essays, lectures, and book reviews by Rodriguez Monegal.
+               Included also are manuscripts and typescripts of poetry, short stories, and novels of
+               authors such as Homero Aridjis, Cecilia Bustamante, Jose Donoso, Luisa Futoransky,
+               Salvador Garmendia, Pedro Salinas, and Severo Sarduy, some of which were submissions
+               by these writers to the aforementioned journals. There is also a large number of tape
+               recordings of interviews, readings, and lectures by Rodriguez Monegal and others.</p>
+            <p>Miscellaneous and printed material concerns <emph render="italic">Marcha</emph> and
+                  <emph render="italic">Mundo Nuevo</emph> (instructions to contributors, payments
+               to contributors, travel and entertainment expenses, etc.) and the International
+               P.E.N. meeting in Bled, Yugoslavia, in July, 1965. There are also copies of book
+               orders placed by Rodriguez Monegal, newspaper and magazine clippings, press releases,
+               and theater and movie programs.</p>
+         </scopecontent>
+
+      </descgrp>
+      <descgrp id="dacs4">
+         <accessrestrict type="open">
+            <p>Collection is open for research use.</p>
+            <p>Audiovisual Materials (Reading Room Access Only): Digital access copies are
+               accessible on a computer in RBSC's reading room. For preservation reasons, physical
+               access to original tapes is restricted.</p>
+         </accessrestrict>
+         <userestrict>
+            <p>Single photocopies may be made for research purposes. No further photoduplication of
+               copies of material in the collection can be made when Princeton University Library
+               does not own the original. Permission to publish material from the collection must be
+               requested from the Associate University Librarian for Rare Books and Special
+               Collections. The library has no information on the status of literary rights in the
+               collection and researchers are responsible for determining any questions of
+               copyright.</p>
+         </userestrict>
+      </descgrp>
+      <descgrp id="dacs5">
+         <acqinfo>
+            <p>The papers were purchased from Thomas Colchie and Associates, Inc., in 1986.</p>
+         </acqinfo>
+         <appraisal>
+            <p>Nothing was removed from the collection.</p>
+         </appraisal>
+      </descgrp>
+      <descgrp id="dacs7">
+         <prefercite>
+            <p>Identification of specific item; Date (if known); Emir Rodriguez Monegal Papers, Box
+               and Folder Number; Department of Rare Books and Special Collections, Princeton
+               University Library.</p>
+         </prefercite>
+         <processinfo id="processing">
+            <p>This collection was processed by <name role="processor">Rodolfo G. Aiello</name> in
+                  <date type="processed" normal="1995">1995</date>. Finding aid written by <name
+                  role="author">Rodolfo G. Aiello</name> in <date type="processed" normal="1995"
+                  >1995</date>.</p>
+         </processinfo>
+         <processinfo id="conservation">
+            <p>Audiovisual materials from this collection were digitized in <date normal="2017"
+                  type="processed">2017</date>.</p>
+         </processinfo>
+      </descgrp>
+      <dao xlink:title="Princeton University Manuscripts Division"
+         xlink:href="bioghist-images/msslogo.jpg" xlink:type="simple"/>
+      <controlaccess>
+
+         <persname source="lcnaf">Donoso, José, 1924- -- Este domingo.</persname>
+         <persname source="lcnaf">Donoso, José, 1924- -- Rie el eterno lacayo.</persname>
+         <subject source="lcsh" authfilenumber="http://id.loc.gov/authorities/subjects/sh2009128887"
+            >Latin American fiction -- 20th century.</subject>
+         <subject source="lcsh" authfilenumber="http://id.loc.gov/authorities/subjects/sh2009128892"
+            >Latin American poetry -- 20th century.</subject>
+         <subject source="lcsh" authfilenumber="http://id.loc.gov/authorities/subjects/sh85074926"
+            >Latin American literature -- 20th century.</subject>
+         <geogname source="lcsh">Latin America -- Intellectual life -- 20th century.</geogname>
+         <genreform source="aat">Correspondence.</genreform>
+         <genreform source="aat">Interviews.</genreform>
+         <genreform source="aat">Audiotapes.</genreform>
+         <genreform source="aat">Audiocassettes -- 20th century.</genreform>
+         <occupation source="lcsh">Critics -- Latin America -- 20th century.</occupation>
+         <occupation source="lcsh">Novelists, Latin American -- 20th century.</occupation>
+         <occupation source="lcsh">Poets, Latin American -- 20th century.</occupation>
+         <subject rules="local" source="local" encodinganalog="690" authfilenumber="t36">Latin
+            American literature</subject>
+      </controlaccess>
+      <dsc type="combined">
+         <c id="C0652_c0001" level="series">
+            <did>
+               <unittitle>Series 1: Correspondence</unittitle>
+               <unitdate>dates not examined</unitdate>
+               <physdesc>
+                  <extent type="computed" unit="boxes">16 boxes</extent>
+               </physdesc>
+            </did>
+            <scopecontent>
+               <p>The bulk of the correspondence comprises the period 1965-1968, and it is arranged
+                  alphabetically. Included are letters by Homero Aridjis, Miguel Angel Asturias, Max
+                  Aub, Mario Benedetti, Adolfo Bioy Casares, Guillermo Cabrera Infante, Julio
+                  Cortázar, José Donoso, Carlos Fuentes, Gabriel García Márquez, Juan Goytisolo,
+                  Jorge Guillen, Manuel Mujica Láinez, Nicanor Parra, Nelida Piñon, Octavio Paz,
+                  Manuel Puig, Ernesto Sábato, Severo Sarduy, Luisa Valenzuela, Mario Vargas Llosa,
+                  and others.</p>
+            </scopecontent>
+            <arrangement>
+               <p>Arranged alphabetically by correspondent.</p>
+            </arrangement>
+            <c level="file" id="C0652_c0002">
+               <did>
+
+                  <container type="folder" parent="C0652_i1">1</container>
+                  <unittitle>A (General)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0003">
+               <did>
+
+                  <container type="folder" parent="C0652_i1">2</container>
+                  <unittitle>Aguirre, Margarita</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0004">
+               <did>
+
+                  <container type="folder" parent="C0652_i1">3</container>
+                  <unittitle>Ainsa, Fernando</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0005">
+               <did>
+
+                  <container type="folder" parent="C0652_i1">4</container>
+                  <unittitle>Alatorre, Antonio</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0006">
+               <did>
+
+                  <container type="folder" parent="C0652_i1">5</container>
+                  <unittitle>Alegría, Fernando</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0007">
+               <did>
+
+                  <container type="folder" parent="C0652_i1">6</container>
+                  <unittitle>Alfred A. Knopf</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0008">
+               <did>
+
+                  <container type="folder" parent="C0652_i1">7</container>
+                  <unittitle>Alonso, Rodolfo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0009">
+               <did>
+
+                  <container type="folder" parent="C0652_i1">8-10</container>
+                  <unittitle>Alsina Thévenet, Homero</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">3 folders</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0010">
+               <did>
+
+                  <container type="folder" parent="C0652_i1">11</container>
+                  <unittitle>Alvarez, Manuel</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0011">
+               <did>
+
+                  <container type="folder" parent="C0652_i1">12</container>
+                  <unittitle>Amorim, Enrique</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0012">
+               <did>
+
+                  <container type="folder" parent="C0652_i1">13</container>
+                  <unittitle>Amorós, Andrés</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0013">
+               <did>
+
+                  <container type="folder" parent="C0652_i1">14</container>
+                  <unittitle>
+                     <emph render="italic">Análisis</emph>
+                  </unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0014">
+               <did>
+
+                  <container type="folder" parent="C0652_i1">15</container>
+                  <unittitle>Anderson-Imbert, Enrique</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0015">
+               <did>
+
+                  <container type="folder" parent="C0652_i1">16</container>
+                  <unittitle>Angelo, Ivan</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0016">
+               <did>
+
+                  <container type="folder" parent="C0652_i1">17</container>
+                  <unittitle>Arias, Augusto</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0017">
+               <did>
+
+                  <container type="folder" parent="C0652_i1">18</container>
+                  <unittitle>Aridjis, Homero</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0018">
+               <did>
+
+                  <container type="folder" parent="C0652_i1">19</container>
+                  <unittitle>Arteche, Miguel</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0019">
+               <did>
+
+                  <container type="folder" parent="C0652_i1">20</container>
+                  <unittitle>
+                     <emph render="italic">Asomante</emph>
+                  </unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0020">
+               <did>
+
+                  <container type="folder" parent="C0652_i1">21</container>
+                  <unittitle>Asturias, Miguel Angel</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0021">
+               <did>
+
+                  <container type="folder" parent="C0652_i1">22</container>
+                  <unittitle>Ateneo Ibero-Americano</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0022">
+               <did>
+
+                  <container type="folder" parent="C0652_i1">23</container>
+                  <unittitle>Aub, Max</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0023">
+               <did>
+
+                  <container type="folder" parent="C0652_i1">24</container>
+                  <unittitle>Ayala, Francisco</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0024">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">1</container>
+                  <unittitle>B (General)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0025">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">2</container>
+                  <unittitle>Baeza Flores, Alberto</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0026">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">3</container>
+                  <unittitle>Banks &amp; Miles</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0027">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">4</container>
+                  <unittitle>Barea, Arturo &amp; Ilsa</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0028">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">5</container>
+                  <unittitle>Bareiro Saguier, Rubén</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0029">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">6</container>
+                  <unittitle>Barthes, Roland</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0030">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">7</container>
+                  <unittitle>Bastos, María Luisa</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0031">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">8</container>
+                  <unittitle>Becco, Horacio Jorge</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0032">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">9</container>
+                  <unittitle>Behar, Lisa Block de</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0033">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">10</container>
+                  <unittitle>Belitt, Ben</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0034">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">11</container>
+                  <unittitle>Belli, Carlos German</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0035">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">12</container>
+                  <unittitle>Bellow, Saul</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0036">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">13</container>
+                  <unittitle>Benavides, Washington</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0037">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">14-15</container>
+                  <unittitle>Benedetti, Mario</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">2 folders</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0038">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">16</container>
+                  <unittitle>Benítez, Fernando</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0039">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">17</container>
+                  <unittitle>Bianciotti, Hector</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0040">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">18</container>
+                  <unittitle>Bianco, José</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0041">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">19</container>
+                  <unittitle>Bioy Casares, Adolfo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0042">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">20</container>
+                  <unittitle>Borges, Jorge Luis</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0043">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">21</container>
+                  <unittitle>Borges, Leonor Acevedo de</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0044">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">22</container>
+                  <unittitle>Bosch, Juan</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0045">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">23</container>
+                  <unittitle>Botsford, Keith</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0046">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">24</container>
+                  <unittitle>Boule, Annie</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0047">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">25</container>
+                  <unittitle>The British Council</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0048">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">26</container>
+                  <unittitle>Bromfield, Louis</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0049">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">27</container>
+                  <unittitle>Buitrago, Fanny</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0050">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">28</container>
+                  <unittitle>Buñuel, Luis</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0051">
+               <did>
+
+                  <container type="folder" parent="C0652_i2">29</container>
+                  <unittitle>Bustamante, Cecilia</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0052">
+               <did>
+
+                  <container type="folder" parent="C0652_i3">1-3</container>
+                  <unittitle>C (General)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">3 folders</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0053">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">1</container>
+                  <unittitle>Cabos, Pierre</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0054">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">2</container>
+                  <unittitle>Cabral, Manuel del</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0055">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">3-4</container>
+                  <unittitle>Cabrera Infante, Guillermo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">2 folders</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0056">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">5</container>
+                  <unittitle>Cabrera Pínon, Guarany</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0057">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">6</container>
+                  <unittitle>
+                     <emph render="italic">Cuadernos Brasileiros</emph>
+                  </unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0058">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">7</container>
+                  <unittitle>Cajino Vega, Mario</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0059">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">8</container>
+                  <unittitle>Campos, Haroldo de</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0060">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">9</container>
+                  <unittitle>Canning House</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0061">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">10</container>
+                  <unittitle>Carpentier, Alejo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0062">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">11</container>
+                  <unittitle>Carr, Raymond</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0063">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">12</container>
+                  <unittitle>Casalduero, Joaquín</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0064">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">13</container>
+                  <unittitle>Castellanos, Andrés</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0065">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">14</container>
+                  <unittitle>Castellet, José María</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0066">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">15</container>
+                  <unittitle>Castillo, Abelardo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0067">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">16</container>
+                  <unittitle>Castillo, Othón</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0068">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">17</container>
+                  <unittitle>Castro, Sergio de</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0069">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">18</container>
+                  <unittitle>CCF Publications</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0070">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">19</container>
+                  <unittitle>Cea, José Roberto</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0071">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">20</container>
+                  <unittitle>Center for Inter-American Relations</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0072">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">21</container>
+                  <unittitle>Chocron, Isaac</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0073">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">22</container>
+                  <unittitle>Christ, Ronald</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0074">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">23</container>
+                  <unittitle>Clemente, José Edmundo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0075">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">24</container>
+                  <unittitle>Cobo Borda, Juan G.</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0076">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">25</container>
+                  <unittitle>Cohen, J. M.</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0077">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">26</container>
+                  <unittitle>Combie, Elsie</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0078">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">27</container>
+                  <unittitle>
+                     <emph render="italic">Commentary</emph>
+                  </unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0079">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">28</container>
+                  <unittitle>Conti, Haroldo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0080">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">29</container>
+                  <unittitle>Cortázar, Julio</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0081">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">30</container>
+                  <unittitle>Cortázar, Mercedes</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0082">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">31</container>
+                  <unittitle>Cotelo, Rubén</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0083">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">32</container>
+                  <unittitle>Coulthard, G. R.</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0084">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">33</container>
+                  <unittitle>Coyné, André</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0085">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">34</container>
+                  <unittitle>Cozarinsky, Edgardo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0086">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">35</container>
+                  <unittitle>Cuevas, José Luis</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0087">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">36</container>
+                  <unittitle>Cúneo, Dardo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0088">
+               <did>
+
+                  <container type="folder" parent="C0652_i4">37</container>
+                  <unittitle>Cunha, Juan</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0089">
+               <did>
+
+                  <container type="folder" parent="C0652_i5">1</container>
+                  <unittitle>D (General)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0090">
+               <did>
+
+                  <container type="folder" parent="C0652_i5">2</container>
+                  <unittitle>
+                     <emph render="italic">Daedalus</emph>
+                  </unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0091">
+               <did>
+
+                  <container type="folder" parent="C0652_i5">3</container>
+                  <unittitle>Devoto, Daniel J.</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0092">
+               <did>
+
+                  <container type="folder" parent="C0652_i5">4</container>
+                  <unittitle>Di Giovanni, Norman T.</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0093">
+               <did>
+
+                  <container type="folder" parent="C0652_i5">5</container>
+                  <unittitle>Díaz, Jorge</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0094">
+               <did>
+
+                  <container type="folder" parent="C0652_i5">6-8</container>
+                  <unittitle>Donoso, José</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">3 folders</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0095">
+               <did>
+
+                  <container type="folder" parent="C0652_i5">9</container>
+                  <unittitle>Draper, Theodore</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0096">
+               <did>
+
+                  <container type="folder" parent="C0652_i6">1</container>
+                  <unittitle>E (General)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0097">
+               <did>
+
+                  <container type="folder" parent="C0652_i6">2</container>
+                  <unittitle>Echegoyen, Maruja</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0098">
+               <did>
+
+                  <container type="folder" parent="C0652_i6">3</container>
+                  <unittitle>Edwards, Jorge</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0099">
+               <did>
+
+                  <container type="folder" parent="C0652_i6">4</container>
+                  <unittitle>Editions Gallimard</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0100">
+               <did>
+
+                  <container type="folder" parent="C0652_i6">5</container>
+                  <unittitle>Editions Universitaires</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0101">
+               <did>
+
+                  <container type="folder" parent="C0652_i6">6</container>
+                  <unittitle>Editorial Aguilar</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0102">
+               <did>
+
+                  <container type="folder" parent="C0652_i6">7</container>
+                  <unittitle>Editorial Joaquín Mortiz</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0103">
+               <did>
+
+                  <container type="folder" parent="C0652_i6">8</container>
+                  <unittitle>Editorial Losada</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0104">
+               <did>
+
+                  <container type="folder" parent="C0652_i6">9</container>
+                  <unittitle>Editorial Lumen</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0105">
+               <did>
+
+                  <container type="folder" parent="C0652_i6">10</container>
+                  <unittitle>Editorial Seix Barral</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0106">
+               <did>
+
+                  <container type="folder" parent="C0652_i6">11</container>
+                  <unittitle>Editorial Siglo XXI</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0107">
+               <did>
+
+                  <container type="folder" parent="C0652_i6">12</container>
+                  <unittitle>Editorial Sudamericana</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0108">
+               <did>
+
+                  <container type="folder" parent="C0652_i6">13</container>
+                  <unittitle>Editorial Universitaria</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0109">
+               <did>
+
+                  <container type="folder" parent="C0652_i6">14</container>
+                  <unittitle>Educación Secundaria</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0110">
+               <did>
+
+                  <container type="folder" parent="C0652_i6">15</container>
+                  <unittitle>Ehrman, Hans</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0111">
+               <did>
+
+                  <container type="folder" parent="C0652_i6">16</container>
+                  <unittitle>
+                     <emph render="italic">Encounter</emph>
+                  </unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0112">
+               <did>
+
+                  <container type="folder" parent="C0652_i6">17</container>
+                  <unittitle>Espinosa, Mario</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0113">
+               <did>
+
+                  <container type="folder" parent="C0652_i6">18</container>
+                  <unittitle>Espinosa, Enrique</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0114">
+               <did>
+
+                  <container type="folder" parent="C0652_i6">19</container>
+                  <unittitle>Estenssoro, Hugo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0115">
+               <did>
+
+                  <container type="folder" parent="C0652_i6">20</container>
+                  <unittitle>Eudeba</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0116">
+               <did>
+
+                  <container type="folder" parent="C0652_i7">1</container>
+                  <unittitle>F (General)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0117">
+               <did>
+
+                  <container type="folder" parent="C0652_i7">2</container>
+                  <unittitle>Fell, Claude</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0118">
+               <did>
+
+                  <container type="folder" parent="C0652_i7">3</container>
+                  <unittitle>Fernández Molina, Antonio</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0119">
+               <did>
+
+                  <container type="folder" parent="C0652_i7">4-5</container>
+                  <unittitle>Fernández Moreno, Cesar</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">2 folders</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0120">
+               <did>
+
+                  <container type="folder" parent="C0652_i7">6</container>
+                  <unittitle>Fernández Retamar, R.</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0121">
+               <did>
+
+                  <container type="folder" parent="C0652_i7">7</container>
+                  <unittitle>Ford, Anibal</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0122">
+               <did>
+
+                  <container type="folder" parent="C0652_i7">8</container>
+                  <unittitle>Fraire, Isabel</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0123">
+               <did>
+
+                  <container type="folder" parent="C0652_i7">9</container>
+                  <unittitle>Franco, Jean</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0124">
+               <did>
+
+                  <container type="folder" parent="C0652_i7">10</container>
+                  <unittitle>Fuentes, Carlos</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0125">
+               <did>
+
+                  <container type="folder" parent="C0652_i7">11</container>
+                  <unittitle>G (General)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0126">
+               <did>
+
+                  <container type="folder" parent="C0652_i7">12</container>
+                  <unittitle>Garcia Márquez, Gabriel</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0127">
+               <did>
+
+                  <container type="folder" parent="C0652_i7">13</container>
+                  <unittitle>Ghiano, Juan Carlos</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0128">
+               <did>
+
+                  <container type="folder" parent="C0652_i7">14</container>
+                  <unittitle>Gombrich, Ernst H.</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0129">
+               <did>
+
+                  <container type="folder" parent="C0652_i7">15</container>
+                  <unittitle>Gombrowicz, Witold</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0130">
+               <did>
+
+                  <container type="folder" parent="C0652_i7">16</container>
+                  <unittitle>Goytisolo, Juan</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0131">
+               <did>
+
+                  <container type="folder" parent="C0652_i7">17</container>
+                  <unittitle>Goytisolo, Luís</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0132">
+               <did>
+
+                  <container type="folder" parent="C0652_i7">18</container>
+                  <unittitle>Grases, Pedro</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0133">
+               <did>
+
+                  <container type="folder" parent="C0652_i7">19</container>
+                  <unittitle>Guelbenzu, José María</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0134">
+               <did>
+
+                  <container type="folder" parent="C0652_i7">20</container>
+                  <unittitle>Guido, Beatriz</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0135">
+               <did>
+
+                  <container type="folder" parent="C0652_i7">21</container>
+                  <unittitle>Guillén, Jorge</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0136">
+               <did>
+
+                  <container type="folder" parent="C0652_i7">22</container>
+                  <unittitle>Gullón, Ricardo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0137">
+               <did>
+
+                  <container type="folder" parent="C0652_i8">1</container>
+                  <unittitle>H (General)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0138">
+               <did>
+
+                  <container type="folder" parent="C0652_i8">2</container>
+                  <unittitle>Hanke, Lewis</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0139">
+               <did>
+
+                  <container type="folder" parent="C0652_i8">3</container>
+                  <unittitle>Haslund, Ebba</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0140">
+               <did>
+
+                  <container type="folder" parent="C0652_i8">4</container>
+                  <unittitle>Harss, Luis</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0141">
+               <did>
+
+                  <container type="folder" parent="C0652_i8">5</container>
+                  <unittitle>Hernández, Juan José</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0142">
+               <did>
+
+                  <container type="folder" parent="C0652_i8">6</container>
+                  <unittitle>
+                     <emph render="italic">Hispania</emph>
+                  </unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0143">
+               <did>
+
+                  <container type="folder" parent="C0652_i8">7</container>
+                  <unittitle>Holder, Roy</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0144">
+               <did>
+
+                  <container type="folder" parent="C0652_i8">8</container>
+                  <unittitle>Huneeus, Christián</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0145">
+               <did>
+
+                  <container type="folder" parent="C0652_i8">9</container>
+                  <unittitle>I (General)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0146">
+               <did>
+
+                  <container type="folder" parent="C0652_i8">10</container>
+                  <unittitle>Instituto Latinoamericano de Relaciones Internacionales</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0147">
+               <did>
+
+                  <container type="folder" parent="C0652_i8">11</container>
+                  <unittitle>Instituto General Electric</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0148">
+               <did>
+
+                  <container type="folder" parent="C0652_i8">12</container>
+                  <unittitle>Instituto Nacional de Cultura</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0149">
+               <did>
+
+                  <container type="folder" parent="C0652_i8">13</container>
+                  <unittitle>Inter-American Foundation For The Arts</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0150">
+               <did>
+
+                  <container type="folder" parent="C0652_i8">14</container>
+                  <unittitle>Irbi, James E.</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0151">
+               <did>
+
+                  <container type="folder" parent="C0652_i8">15</container>
+                  <unittitle>J (General)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0152">
+               <did>
+
+                  <container type="folder" parent="C0652_i8">16</container>
+                  <unittitle>Jaramillo Levi, Enrique</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0153">
+               <did>
+
+                  <container type="folder" parent="C0652_i8">17</container>
+                  <unittitle>Jelenski, Constantin</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0154">
+               <did>
+
+                  <container type="folder" parent="C0652_i8">18</container>
+                  <unittitle>Jiménez, Juan Ramón</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0155">
+               <did>
+
+                  <container type="folder" parent="C0652_i8">19</container>
+                  <unittitle>Jitrik, Noé</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0156">
+               <did>
+
+                  <container type="folder" parent="C0652_i8">20</container>
+                  <unittitle>John Simon Guggenheim Memorial Foundation</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0157">
+               <did>
+
+                  <container type="folder" parent="C0652_i8">21</container>
+                  <unittitle>Jones, Ernest</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0158">
+               <did>
+
+                  <container type="folder" parent="C0652_i8">22</container>
+                  <unittitle>K (General)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0159">
+               <did>
+
+                  <container type="folder" parent="C0652_i9">1</container>
+                  <unittitle>L (General)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0160">
+               <did>
+
+                  <container type="folder" parent="C0652_i9">2</container>
+                  <unittitle>Lafourcade, Enrique</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0161">
+               <did>
+
+                  <container type="folder" parent="C0652_i9">3</container>
+                  <unittitle>Lago, Elda</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0162">
+               <did>
+
+                  <container type="folder" parent="C0652_i9">4</container>
+                  <unittitle>Laín Entralgo, Pedro</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0163">
+               <did>
+
+                  <container type="folder" parent="C0652_i9">5</container>
+                  <unittitle>Lastra, Pedro</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0164">
+               <did>
+
+                  <container type="folder" parent="C0652_i9">6</container>
+                  <unittitle>Laughlin, James</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0165">
+               <did>
+
+                  <container type="folder" parent="C0652_i9">7</container>
+                  <unittitle>Levine, Suzanne Jill</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0166">
+               <did>
+
+                  <container type="folder" parent="C0652_i9">8</container>
+                  <unittitle>Lewis, Oscar</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0167">
+               <did>
+
+                  <container type="folder" parent="C0652_i9">9</container>
+                  <unittitle>Librairie Pilote</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0168">
+               <did>
+
+                  <container type="folder" parent="C0652_i9">10</container>
+                  <unittitle>Lida, Raimundo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0169">
+               <did>
+
+                  <container type="folder" parent="C0652_i9">11</container>
+                  <unittitle>
+                     <emph render="italic">LIFE en Español</emph>
+                  </unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0170">
+               <did>
+
+                  <container type="folder" parent="C0652_i9">12</container>
+                  <unittitle>Lihn, Enrique</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0171">
+               <did>
+
+                  <container type="folder" parent="C0652_i9">13</container>
+                  <unittitle>Liscano, Juan</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0172">
+               <did>
+
+                  <container type="folder" parent="C0652_i9">14</container>
+                  <unittitle>López Chuhurra, Osvaldo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0173">
+               <did>
+
+                  <container type="folder" parent="C0652_i9">15</container>
+                  <unittitle>López Páez, Jorge</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0174">
+               <did>
+
+                  <container type="folder" parent="C0652_i9">16</container>
+                  <unittitle>Luchting, Wolfgang A.</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0175">
+               <did>
+
+                  <container type="folder" parent="C0652_i9">17</container>
+                  <unittitle>Lynch, Marta</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0176">
+               <did>
+
+                  <container type="folder" parent="C0652_i10">1-2</container>
+                  <unittitle>M (General)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">2 folders</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0177">
+               <did>
+
+                  <container type="folder" parent="C0652_i10">3</container>
+                  <unittitle>Mac Adam, Alfred J.</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0178">
+               <did>
+
+                  <container type="folder" parent="C0652_i10">4</container>
+                  <unittitle>Madrid, Juan</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0179">
+               <did>
+
+                  <container type="folder" parent="C0652_i10">5</container>
+                  <unittitle>Mafud, Julio</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0180">
+               <did>
+
+                  <container type="folder" parent="C0652_i10">6</container>
+                  <unittitle>Magis, Carlos</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0181">
+               <did>
+
+                  <container type="folder" parent="C0652_i10">7</container>
+                  <unittitle>Maldonado, Denis M.</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0182">
+               <did>
+
+                  <container type="folder" parent="C0652_i10">8</container>
+                  <unittitle>Mander, John</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0183">
+               <did>
+
+                  <container type="folder" parent="C0652_i10">9</container>
+                  <unittitle>
+                     <emph render="italic">Marcha</emph>
+                  </unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0184">
+               <did>
+
+                  <container type="folder" parent="C0652_i10">10</container>
+                  <unittitle>Marichal, Juan</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0185">
+               <did>
+
+                  <container type="folder" parent="C0652_i10">11</container>
+                  <unittitle>Martínez Estrada, Ezequiel</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0186">
+               <did>
+
+                  <container type="folder" parent="C0652_i10">12</container>
+                  <unittitle>Martínez Moreno, Carlos</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0187">
+               <did>
+
+                  <container type="folder" parent="C0652_i10">13</container>
+                  <unittitle>Mejía Sánchez, Ernesto</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0188">
+               <did>
+
+                  <container type="folder" parent="C0652_i10">14</container>
+                  <unittitle>Michaux, Henri</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0189">
+               <did>
+
+                  <container type="folder" parent="C0652_i10">15</container>
+                  <unittitle>Milla, Benito</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0190">
+               <did>
+
+                  <container type="folder" parent="C0652_i10">16</container>
+                  <unittitle>Moirano, Eduardo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0191">
+               <did>
+
+                  <container type="folder" parent="C0652_i10">17</container>
+                  <unittitle>Monegal de Rodríguez, H.</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0192">
+               <did>
+
+                  <container type="folder" parent="C0652_i10">18</container>
+                  <unittitle>Monsiváis, Carlos</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0193">
+               <did>
+
+                  <container type="folder" parent="C0652_i10">19</container>
+                  <unittitle>Moyano, Daniel</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0194">
+               <did>
+
+                  <container type="folder" parent="C0652_i10">20</container>
+                  <unittitle>Mujica Láinez, Manuel</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0195">
+               <did>
+
+                  <container type="folder" parent="C0652_i10">21</container>
+                  <unittitle>Muller, Mauricio</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0196">
+               <did>
+
+                  <container type="folder" parent="C0652_i10">22</container>
+                  <unittitle>Murena, Hector</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0197">
+               <did>
+
+                  <container type="folder" parent="C0652_i10">23</container>
+                  <unittitle>N (General)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0198">
+               <did>
+
+                  <container type="folder" parent="C0652_i10">24</container>
+                  <unittitle>Neruda, Pablo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0199">
+               <did>
+
+                  <container type="folder" parent="C0652_i11">1</container>
+                  <unittitle>O (General)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0200">
+               <did>
+
+                  <container type="folder" parent="C0652_i11">2</container>
+                  <unittitle>Oliva, Alberto</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0201">
+               <did>
+
+                  <container type="folder" parent="C0652_i11">3</container>
+                  <unittitle>Onetti, Juan Carlos</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0202">
+               <did>
+
+                  <container type="folder" parent="C0652_i11">4</container>
+                  <unittitle>Onis, Federico de</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0203">
+               <did>
+
+                  <container type="folder" parent="C0652_i11">5</container>
+                  <unittitle>Orgambide, Pedro</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0204">
+               <did>
+
+                  <container type="folder" parent="C0652_i11">6</container>
+                  <unittitle>Ortega, Julio</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0205">
+               <did>
+
+                  <container type="folder" parent="C0652_i11">7</container>
+                  <unittitle>Oviedo, José Miguel</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0206">
+               <did>
+
+                  <container type="folder" parent="C0652_i12">1-2</container>
+                  <unittitle>P (General)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">2 folders</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0207">
+               <did>
+
+                  <container type="folder" parent="C0652_i12">3</container>
+                  <unittitle>Padilla, Heberto</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0208">
+               <did>
+
+                  <container type="folder" parent="C0652_i12">4</container>
+                  <unittitle>The Pall Mall Press</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0209">
+               <did>
+
+                  <container type="folder" parent="C0652_i12">5</container>
+                  <unittitle>
+                     <emph render="italic">The Paris Review</emph>
+                  </unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0210">
+               <did>
+
+                  <container type="folder" parent="C0652_i12">6-7</container>
+                  <unittitle>Parra, Nicanor</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">2 folders</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0211">
+               <did>
+
+                  <container type="folder" parent="C0652_i12">8</container>
+                  <unittitle>Parrilla, José</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0212">
+               <did>
+
+                  <container type="folder" parent="C0652_i12">9</container>
+                  <unittitle>Pastori, Aurelio</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0213">
+               <did>
+
+                  <container type="folder" parent="C0652_i12">10</container>
+                  <unittitle>Pedreira, Hector</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0214">
+               <did>
+
+                  <container type="folder" parent="C0652_i12">11</container>
+                  <unittitle>Pendle, George</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0215">
+               <did>
+
+                  <container type="folder" parent="C0652_i12">12</container>
+                  <unittitle>Pereda, Fernando</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0216">
+               <did>
+
+                  <container type="folder" parent="C0652_i12">13</container>
+                  <unittitle>Piazza, Luis Guillermo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0217">
+               <did>
+
+                  <container type="folder" parent="C0652_i12">14</container>
+                  <unittitle>Pinillos, Manuel</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0218">
+               <did>
+
+                  <container type="folder" parent="C0652_i12">15</container>
+                  <unittitle>Piñon, Nelida</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0219">
+               <did>
+
+                  <container type="folder" parent="C0652_i12">16</container>
+                  <unittitle>Pizarnik, Alejandra</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0220">
+               <did>
+
+                  <container type="folder" parent="C0652_i12">17</container>
+                  <unittitle>
+                     <emph render="italic">Plural</emph>
+                  </unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0221">
+               <did>
+
+                  <container type="folder" parent="C0652_i12">18</container>
+                  <unittitle>
+                     <emph render="italic">Primera Plana</emph>
+                  </unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0222">
+               <did>
+
+                  <container type="folder" parent="C0652_i12">19</container>
+                  <unittitle>Puben, José</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0223">
+               <did>
+
+                  <container type="folder" parent="C0652_i12">20</container>
+                  <unittitle>Puig, Manuel</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0224">
+               <did>
+
+                  <container type="folder" parent="C0652_i12">21</container>
+                  <unittitle>Pupo-Walker, Enrique</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0225">
+               <did>
+
+                  <container type="folder" parent="C0652_i13">1</container>
+                  <unittitle>Paz, Octavio</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0226">
+               <did>
+
+                  <container type="folder" parent="C0652_i13">2</container>
+                  <unittitle>Paz, Octavio ( <emph render="italic">L'Herne</emph>)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0227">
+               <did>
+
+                  <container type="folder" parent="C0652_i14">1</container>
+                  <unittitle>Q (General)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0228">
+               <did>
+
+                  <container type="folder" parent="C0652_i14">2</container>
+                  <unittitle>Quijano, Carlos</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0229">
+               <did>
+
+                  <container type="folder" parent="C0652_i14">3-4</container>
+                  <unittitle>R (General)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">2 folders</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0230">
+               <did>
+
+                  <container type="folder" parent="C0652_i14">5</container>
+                  <unittitle>Real De Azúa, Carlos</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0231">
+               <did>
+
+                  <container type="folder" parent="C0652_i14">6</container>
+                  <unittitle>Recavarren, J. L.</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0232">
+               <did>
+
+                  <container type="folder" parent="C0652_i14">7</container>
+                  <unittitle>Reyes, Alfonso</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0233">
+               <did>
+
+                  <container type="folder" parent="C0652_i14">8</container>
+                  <unittitle>Ríos, Julian</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0234">
+               <did>
+
+                  <container type="folder" parent="C0652_i14">9</container>
+                  <unittitle>Rivero, Isel</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0235">
+               <did>
+
+                  <container type="folder" parent="C0652_i14">10</container>
+                  <unittitle>Roa Bastos, Augusto</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0236">
+               <did>
+
+                  <container type="folder" parent="C0652_i14">11</container>
+                  <unittitle>The Rockefeller Foundation</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0237">
+               <did>
+
+                  <container type="folder" parent="C0652_i14">12</container>
+                  <unittitle>Rodman, Selden</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0238">
+               <did>
+
+                  <container type="folder" parent="C0652_i14">13</container>
+                  <unittitle>Rodríguez Alfaro, Hugo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0239">
+               <did>
+
+                  <container type="folder" parent="C0652_i14">14</container>
+                  <unittitle>Rodríguez Gómez, A.</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0240">
+               <did>
+
+                  <container type="folder" parent="C0652_i14">15</container>
+                  <unittitle>Rodríguez Monegal Family</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0241">
+               <did>
+
+                  <container type="folder" parent="C0652_i14">16</container>
+                  <unittitle>Roggiano, Alfredo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0242">
+               <did>
+
+                  <container type="folder" parent="C0652_i14">17</container>
+                  <unittitle>Rojas, Gonzalo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0243">
+               <did>
+
+                  <container type="folder" parent="C0652_i14">18</container>
+                  <unittitle>Rosa, João Guimarães</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0244">
+               <did>
+
+                  <container type="folder" parent="C0652_i15">1-2</container>
+                  <unittitle>S (General)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">2 folders</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0245">
+               <did>
+
+                  <container type="folder" parent="C0652_i15">3</container>
+                  <unittitle>Sábato, Ernesto</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0246">
+               <did>
+
+                  <container type="folder" parent="C0652_i15">4</container>
+                  <unittitle>Saer, Juan José</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0247">
+               <did>
+
+                  <container type="folder" parent="C0652_i15">5</container>
+                  <unittitle>Sainz, Gustavo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0248">
+               <did>
+
+                  <container type="folder" parent="C0652_i15">6</container>
+                  <unittitle>Salvador, Tomás</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0249">
+               <did>
+
+                  <container type="folder" parent="C0652_i15">7</container>
+                  <unittitle>Sánchez, Luis Rafael</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0250">
+               <did>
+
+                  <container type="folder" parent="C0652_i15">8</container>
+                  <unittitle>Sánchez, Néstor</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0251">
+               <did>
+
+                  <container type="folder" parent="C0652_i15">9-10</container>
+                  <unittitle>Sarduy, Severo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">2 folders</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0252">
+               <did>
+
+                  <container type="folder" parent="C0652_i15">11</container>
+                  <unittitle>Segovia, Tomás</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0253">
+               <did>
+
+                  <container type="folder" parent="C0652_i15">12</container>
+                  <unittitle>Solari, Aldo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0254">
+               <did>
+
+                  <container type="folder" parent="C0652_i15">13</container>
+                  <unittitle>Sontag, Susan</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0255">
+               <did>
+
+                  <container type="folder" parent="C0652_i15">14</container>
+                  <unittitle>Strausfeld, Michi</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0256">
+               <did>
+
+                  <container type="folder" parent="C0652_i15">15</container>
+                  <unittitle>Street, John</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0257">
+               <did>
+
+                  <container type="folder" parent="C0652_i15">16</container>
+                  <unittitle>Sucre, Guillermo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0258">
+               <did>
+
+                  <container type="folder" parent="C0652_i15">17</container>
+                  <unittitle>Suescún, Nicolás</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0259">
+               <did>
+
+                  <container type="folder" parent="C0652_i15">18</container>
+                  <unittitle>
+                     <emph render="italic">Sur</emph>
+                  </unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0260">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">1</container>
+                  <unittitle>T (General)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0261">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">2</container>
+                  <unittitle>Timerman, Jacobo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0262">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">3</container>
+                  <unittitle>Todorov, Tzvetan</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0263">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">4</container>
+                  <unittitle>Torre, Guillermo de</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0264">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">5</container>
+                  <unittitle>Torre Nilsson, Leopoldo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0265">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">6</container>
+                  <unittitle>Torres Fierro, Danubio</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0266">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">7</container>
+                  <unittitle>Trajtenberg, Mario</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0267">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">8</container>
+                  <unittitle>U (General)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0268">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">9</container>
+                  <unittitle>Ulcia, Manuel</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0269">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">10</container>
+                  <unittitle>UNESCO</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0270">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">11</container>
+                  <unittitle>Uribe, Germán</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0271">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">12</container>
+                  <unittitle>Uruguay, Ministerio de Instruccion Publica</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0272">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">13</container>
+                  <unittitle>Uslar Pietri, Arturo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0273">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">14</container>
+                  <unittitle>V (General)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0274">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">15</container>
+                  <unittitle>Valente, José Angel</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0275">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">16</container>
+                  <unittitle>Valenzuela, Luisa</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0276">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">17</container>
+                  <unittitle>Vallejos, Roque</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0277">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">18</container>
+                  <unittitle>Vargas Llosa, Mario</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0278">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">19</container>
+                  <unittitle>Vera Ocampo, Raúl</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0279">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">20</container>
+                  <unittitle>Vilariño, Idea</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0280">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">21</container>
+                  <unittitle>Viñas, David</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0281">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">22</container>
+                  <unittitle>Vitier, Cintio</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0282">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">23</container>
+                  <unittitle>W (General)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0283">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">24</container>
+                  <unittitle>West, Anthony</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0284">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">25</container>
+                  <unittitle>Wey, Virginia &amp; Walter</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0285">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">26</container>
+                  <unittitle>White, Edmund</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0286">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">27</container>
+                  <unittitle>Wilcock, Juan Rodolfo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0287">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">28</container>
+                  <unittitle>Wilson, Edmund</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0288">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">29</container>
+                  <unittitle>X (General)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0289">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">30</container>
+                  <unittitle>Xirau, Ramón</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0290">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">31</container>
+                  <unittitle>Y (General)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0291">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">32</container>
+                  <unittitle>Yale University</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0292">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">33</container>
+                  <unittitle>Yglesias, José</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0293">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">34</container>
+                  <unittitle>Yopo, Boris</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0294">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">35</container>
+                  <unittitle>Yurkievich, Saúl</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0295">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">36</container>
+                  <unittitle>Z (General)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0296">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">37</container>
+                  <unittitle>Zagury, Eliane</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0297">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">38</container>
+                  <unittitle>Zani, Giselda</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0298">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">39</container>
+                  <unittitle>Zea, Leopoldo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0299">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">40</container>
+                  <unittitle>
+                     <emph render="italic">Zona Franca</emph>
+                  </unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0300">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">41</container>
+                  <unittitle>Zorrilla, Concepción</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0301">
+               <did>
+
+                  <container type="folder" parent="C0652_i16">42-43</container>
+                  <unittitle>Unidentified</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">2 folders</extent>
+                  </physdesc>
+               </did>
+            </c>
+         </c>
+         <c id="C0652_c0302" level="series">
+            <did>
+               <unittitle>Series 2: Articles, Reviews, Notes</unittitle>
+               <unitdate normal="1959-01-01/1960-12-31" type="inclusive">1959-1960</unitdate>
+               <physdesc>
+                  <extent type="computed" unit="folders">4 folders</extent>
+               </physdesc>
+            </did>
+            <scopecontent>
+               <p> Consists of manuscripts and typescripts for articles, reviews, and notes such as
+                  "Cuba: la escritura de su historia," "Isidoro Ducase, lector del barroco español,"
+                  and "Retratos y autorretratos: el hombre Freud y su biógrafo," as well as others.
+                  Also includes appointment books. </p>
+            </scopecontent>
+            <arrangement>
+               <p>Arranged alphabetically by title.</p>
+            </arrangement>
+            <c level="file" id="C0652_c0303">
+               <did>
+                  <unittitle>Articles, Reviews, Notes: A - G</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+               <c level="file" id="C0652_c0304">
+                  <did>
+
+                     <container type="folder" parent="C0652_i17">1</container>
+                     <unittitle>"Albert Camus," ANs with holograph corrections</unittitle>
+                     <physdesc>
+                        <extent unit="pages">9 pp.</extent>
+                     </physdesc>
+                     <unitdate>dates not examined</unitdate>
+                  </did>
+               </c>
+               <c level="file" id="C0652_c0305">
+                  <did>
+
+                     <container type="folder" parent="C0652_i17">1</container>
+                     <unittitle>"Carta abierta al Presidente Kennedy," TMs, pp. numbered
+                        [1]-4</unittitle>
+                     <unitdate>dates not examined</unitdate>
+                     <physdesc>
+                        <extent type="computed" unit="folders">portion of 1 folder</extent>
+                     </physdesc>
+                  </did>
+               </c>
+               <c level="file" id="C0652_c0306">
+                  <did>
+
+                     <container type="folder" parent="C0652_i17">1</container>
+                     <unittitle>"Carta del Uruguay," TMs with holograph corrections</unittitle>
+                     <physdesc>
+                        <extent unit="pages">3 pp.</extent>
+                     </physdesc>
+                     <unitdate>dates not examined</unitdate>
+                  </did>
+               </c>
+               <c level="file" id="C0652_c0307">
+                  <did>
+
+                     <container type="folder" parent="C0652_i17">1</container>
+                     <unittitle>"Cuba: la escritura de su historia," TMs with holograph
+                        corerections</unittitle>
+                     <physdesc>
+                        <extent unit="pages">11 pp.</extent>
+                     </physdesc>
+                     <unitdate>dates not examined</unitdate>
+                  </did>
+                  <scopecontent>
+                     <p>[on Guillermo Cabrera Infante, "Vista del amanecer en el trópico"]</p>
+                  </scopecontent>
+               </c>
+               <c level="file" id="C0652_c0308">
+                  <did>
+
+                     <container type="folder" parent="C0652_i17">1</container>
+                     <unittitle
+                        altrender="espectáculo más grotesco, ete. AMs with holograph corrections"
+                        >"El espectáculo más grotesco, ete." AMs with holograph
+                        corrections</unittitle>
+                     <physdesc>
+                        <extent unit="pages">15 pp.</extent>
+                     </physdesc>
+                     <unitdate>dates not examined</unitdate>
+                  </did>
+               </c>
+               <c level="file" id="C0652_c0309">
+                  <did>
+
+                     <container type="folder" parent="C0652_i17">1</container>
+                     <unittitle>"Gabriel García Márquez &amp; Mario Vargas Llosa: "La novela en
+                        América Latina: Diálogo," TMs</unittitle>
+                     <physdesc>
+                        <extent unit="pages">1 pp.</extent>
+                     </physdesc>
+                     <unitdate>dates not examined</unitdate>
+                  </did>
+               </c>
+               <c level="file" id="C0652_c0310">
+                  <did>
+
+                     <container type="folder" parent="C0652_i17">1</container>
+                     <unittitle>Spanish version TMs with holograph corrections</unittitle>
+                     <physdesc>
+                        <extent unit="pages">1 p.</extent>
+                     </physdesc>
+                     <unitdate>dates not examined</unitdate>
+                  </did>
+               </c>
+            </c>
+            <c level="file" id="C0652_c0311">
+               <did>
+                  <unittitle>Articles, Reviews, Notes: I</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+               <c level="file" id="C0652_c0312">
+                  <did>
+
+                     <container type="folder" parent="C0652_i17">2</container>
+                     <unittitle>Informe[s] sobre: ‘"De perfil," "Inventando el sueño," de José
+                        Agustín,' ‘"Extracción de la piedra de la locura," poemas de Alejandra
+                        Pizarnik,' ‘"Los días contados," novela de Fernando Alegría,' ‘"Siberia
+                        Blues," novela de Néstor Sánchez,' ‘"Jorge, un brasileiro," novela de
+                        Osvaldo França Jr.,' ‘"Los parientes," novela de Ricardo Prieto,'
+                        TMss</unittitle>
+                     <physdesc>
+                        <extent unit="pages">13 pp.</extent>
+                     </physdesc>
+                     <unitdate>dates not examined</unitdate>
+                  </did>
+               </c>
+               <c level="file" id="C0652_c0313">
+                  <did>
+
+                     <container type="folder" parent="C0652_i17">2</container>
+                     <unittitle>"Isidoro Ducase, lector del barroco español," TMs with holograph
+                        corrections, pp. numbered [1]-38</unittitle>
+                     <unitdate>dates not examined</unitdate>
+                     <physdesc>
+                        <extent type="computed" unit="folders">portion of 1 folder</extent>
+                     </physdesc>
+                  </did>
+               </c>
+            </c>
+            <c level="file" id="C0652_c0314">
+               <did>
+                  <unittitle>Articles, Reviews, Notes: J - Z</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+               <c level="file" id="C0652_c0315">
+                  <did>
+
+                     <container type="folder" parent="C0652_i17">3</container>
+                     <unittitle
+                        altrender="nueva literatura argentina, TMs with holograph corrections">"La
+                        nueva literatura argentina," TMs with holograph corrections</unittitle>
+                     <physdesc>
+                        <extent unit="pages">1 p.</extent>
+                     </physdesc>
+                     <unitdate>dates not examined</unitdate>
+                  </did>
+               </c>
+               <c level="file" id="C0652_c0316">
+                  <did>
+
+                     <container type="folder" parent="C0652_i17">3</container>
+                     <unittitle>"Personalidades: Alain Robbe-Grillet," TMs, pp. numbered 1-5, for El
+                        País (Madrid, September 19, 1962)</unittitle>
+                     <unitdate>dates not examined</unitdate>
+                     <physdesc>
+                        <extent type="computed" unit="folders">portion of 1 folder</extent>
+                     </physdesc>
+                  </did>
+               </c>
+               <c level="file" id="C0652_c0317">
+                  <did>
+
+                     <container type="folder" parent="C0652_i17">3</container>
+                     <unittitle>"Retratos y autorretratos: el hombre Freud y su biógrafo,"
+                        ANs</unittitle>
+                     <physdesc>
+                        <extent unit="pages">8 pp.</extent>
+                     </physdesc>
+                     <unitdate>dates not examined</unitdate>
+                  </did>
+               </c>
+               <c level="file" id="C0652_c0318">
+                  <did>
+
+                     <container type="folder" parent="C0652_i17">3</container>
+                     <unittitle>"Símbolos en la obra de Jorge Luis Borges, TMs with holograph
+                        corrections (Xerox), pp. numbered [1]-15</unittitle>
+                     <unitdate>dates not examined</unitdate>
+                     <physdesc>
+                        <extent type="computed" unit="folders">portion of 1 folder</extent>
+                     </physdesc>
+                  </did>
+               </c>
+               <c level="file" id="C0652_c0319">
+                  <did>
+
+                     <container type="folder" parent="C0652_i17">3</container>
+                     <unittitle>"Sobre una guía crítica de la literatura actual," TMs with holograph
+                        corrections, pp. numbered [1]-4</unittitle>
+                     <unitdate>dates not examined</unitdate>
+                     <physdesc>
+                        <extent type="computed" unit="folders">portion of 1 folder</extent>
+                     </physdesc>
+                  </did>
+               </c>
+               <c level="file" id="C0652_c0320">
+                  <did>
+
+                     <container type="folder" parent="C0652_i17">3</container>
+                     <unittitle>Reviews of "The Three Trials of Manirema," and "The Misplaced
+                        Machine and other stories," by Jose J. Veiga," two drafts, TMss with
+                        holograph corrections</unittitle>
+                     <physdesc>
+                        <extent unit="pages">4 pp.</extent>
+                     </physdesc>
+                     <unitdate>dates not examined</unitdate>
+                  </did>
+               </c>
+               <c level="file" id="C0652_c0321">
+                  <did>
+
+                     <container type="folder" parent="C0652_i17">3</container>
+                     <unittitle altrender="universo cataléptico de Samuel Beckett, ANs">"El universo
+                        cataléptico de Samuel Beckett," ANs</unittitle>
+                     <physdesc>
+                        <extent unit="pages">5 pp.</extent>
+                     </physdesc>
+                     <unitdate>dates not examined</unitdate>
+                  </did>
+               </c>
+               <c level="file" id="C0652_c0322">
+                  <did>
+
+                     <container type="folder" parent="C0652_i17">3</container>
+                     <unittitle>Untitled</unittitle>
+                     <unitdate>dates not examined</unitdate>
+                     <physdesc>
+                        <extent type="computed" unit="folders">portion of 1 folder</extent>
+                     </physdesc>
+                  </did>
+                  <scopecontent>
+                     <p>[answer to a letter concerning an article that Rodriguez Monegal wrote on
+                        the prologue of Carlos Real de Azúa to "Los motivos de Proteo."]</p>
+                  </scopecontent>
+               </c>
+            </c>
+            <c level="file" id="C0652_c0323">
+               <did>
+
+                  <container type="folder" parent="C0652_i17">4</container>
+                  <unittitle>Appointment Books</unittitle>
+                  <unitdate type="inclusive" normal="1959/1960">1959-1960</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+         </c>
+         <c id="C0652_c0324" level="series">
+            <did>
+               <unittitle>Series 3: Papers of Others</unittitle>
+               <unitdate>dates not examined</unitdate>
+               <physdesc>
+                  <extent type="computed" unit="boxes">2 boxes</extent>
+               </physdesc>
+            </did>
+            <scopecontent>
+               <p> Consists of the papers of others, such as Jorge Aguilar Mora, Carlos Delgado, and
+                  Juan Aguilar Mora, as well as others. </p>
+            </scopecontent>
+            <arrangement>
+               <p>Arranged alphabetically by author.</p>
+            </arrangement>
+            <c level="file" id="C0652_c0325">
+               <did>
+
+                  <container type="folder" parent="C0652_i18">1</container>
+                  <unittitle>Aguilar Mora, Jorge</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0326">
+               <did>
+
+                  <container type="folder" parent="C0652_i18">2</container>
+                  <unittitle>Aridjis, Homero</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0327">
+               <did>
+
+                  <container type="folder" parent="C0652_i18">3</container>
+                  <unittitle>"Aristarco"</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0328">
+               <did>
+
+                  <container type="folder" parent="C0652_i18">4</container>
+                  <unittitle>Avilés Fabila, René</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0329">
+               <did>
+
+                  <container type="folder" parent="C0652_i18">5</container>
+                  <unittitle>BBC (London)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0330">
+               <did>
+
+                  <container type="folder" parent="C0652_i18">6</container>
+                  <unittitle>Benarós, León</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0331">
+               <did>
+
+                  <container type="folder" parent="C0652_i18">7</container>
+                  <unittitle>Bendezú, Francisco</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0332">
+               <did>
+
+                  <container type="folder" parent="C0652_i18">8</container>
+                  <unittitle>Bloch-Michel, Jean</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0333">
+               <did>
+
+                  <container type="folder" parent="C0652_i18">9</container>
+                  <unittitle>Bustamante, Cecilia</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0334">
+               <did>
+
+                  <container type="folder" parent="C0652_i18">10</container>
+                  <unittitle>Cardenal, Ernesto</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0335">
+               <did>
+
+                  <container type="folder" parent="C0652_i18">11</container>
+                  <unittitle>Costa, Flávio Moreira Da</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0336">
+               <did>
+
+                  <container type="folder" parent="C0652_i18">12</container>
+                  <unittitle>Delgado, Carlos</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0337">
+               <did>
+
+                  <container type="folder" parent="C0652_i18">13-14</container>
+                  <unittitle>Donoso, José</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">2 folders</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0338">
+               <did>
+
+                  <container type="folder" parent="C0652_i18">15</container>
+                  <unittitle>Futoransky, Luisa</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0339">
+               <did>
+
+                  <container type="folder" parent="C0652_i18">16</container>
+                  <unittitle>Garcia Nieto, José</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0340">
+               <did>
+
+                  <container type="folder" parent="C0652_i18">17</container>
+                  <unittitle>Garmendia, Salvador</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0341">
+               <did>
+
+                  <container type="folder" parent="C0652_i18">18</container>
+                  <unittitle>Ibañez, Roberto</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0342">
+               <did>
+
+                  <container type="folder" parent="C0652_i18">19</container>
+                  <unittitle>Libertella, Héctor</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0343">
+               <did>
+
+                  <container type="folder" parent="C0652_i18">20</container>
+                  <unittitle>Lugo, Aniceto</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0344">
+               <did>
+
+                  <container type="folder" parent="C0652_i18">21</container>
+                  <unittitle>Marra, Nelson</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0345">
+               <did>
+
+                  <container type="folder" parent="C0652_i18">22</container>
+                  <unittitle>Monat, Olympia</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0346">
+               <did>
+
+                  <container type="folder" parent="C0652_i18">23</container>
+                  <unittitle>Nieto, Carlos</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0347">
+               <did>
+
+                  <container type="folder" parent="C0652_i18">24</container>
+                  <unittitle>Novás Calvo, Lino</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0348">
+               <did>
+
+                  <container type="folder" parent="C0652_i19">1</container>
+                  <unittitle>Payen-Appenzeller, P.</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0349">
+               <did>
+
+                  <container type="folder" parent="C0652_i19">2</container>
+                  <unittitle>Pendle, George</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0350">
+               <did>
+
+                  <container type="folder" parent="C0652_i19">3</container>
+                  <unittitle>Pico Estrada, Luis</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0351">
+               <did>
+
+                  <container type="folder" parent="C0652_i19">4</container>
+                  <unittitle>Salinas, Pedro</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0352">
+               <did>
+
+                  <container type="folder" parent="C0652_i19">5</container>
+                  <unittitle>Sánchez, Nestor</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0353">
+               <did>
+
+                  <container type="folder" parent="C0652_i19">6</container>
+                  <unittitle>Sánchez Peláez, Juan</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0354">
+               <did>
+
+                  <container type="folder" parent="C0652_i19">7-8</container>
+                  <unittitle>Sarduy, Severo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">2 folders</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0355">
+               <did>
+
+                  <container type="folder" parent="C0652_i19">9</container>
+                  <unittitle>Steiner, Carlo</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0356">
+               <did>
+
+                  <container type="folder" parent="C0652_i19">10</container>
+                  <unittitle>Trobo, Claudio</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0357">
+               <did>
+
+                  <container type="folder" parent="C0652_i19">11</container>
+                  <unittitle>Urbistondo, Vicente</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0358">
+               <did>
+
+                  <container type="folder" parent="C0652_i19">12</container>
+                  <unittitle>Wajda, Andrzej</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0359">
+               <did>
+
+                  <container type="folder" parent="C0652_i19">13</container>
+                  <unittitle>Zand, Nicole</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0360">
+               <did>
+
+                  <container type="folder" parent="C0652_i19">14</container>
+                  <unittitle>Unidentified</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+         </c>
+         <c id="C0652_c0361" level="series">
+            <did>
+               <unittitle>Series 4: Miscellaneous and Printed Material</unittitle>
+               <unitdate normal="1954-10-24/1965-12-31" type="inclusive">1954 October
+                  24-1965</unitdate>
+               <physdesc>
+                  <extent type="computed" unit="boxes">2 boxes</extent>
+               </physdesc>
+            </did>
+            <scopecontent>
+               <p> Consists of book orders, photographs, film reviews, press releases, and theater
+                  and movie programs, as well as other printed material. </p>
+            </scopecontent>
+            <arrangement>
+               <p>Arranged by genre of material.</p>
+            </arrangement>
+            <c level="file" id="C0652_c0362">
+               <did>
+
+                  <container type="folder" parent="C0652_i20">1</container>
+                  <unittitle>Book Orders</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0363">
+               <did>
+                  <unittitle>Revista <emph render="italic">Mundo Nuevo</emph>
+                  </unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">2 folders</extent>
+                  </physdesc>
+               </did>
+               <c level="file" id="C0652_c0364">
+                  <did>
+
+                     <container type="folder" parent="C0652_i20">2</container>
+                     <unittitle>Payments to Contributors</unittitle>
+                     <unitdate>dates not examined</unitdate>
+                     <physdesc>
+                        <extent type="computed" unit="folders">1 folder</extent>
+                     </physdesc>
+                  </did>
+               </c>
+               <c level="file" id="C0652_c0365">
+                  <did>
+
+                     <container type="folder" parent="C0652_i20">3</container>
+                     <unittitle>Travel &amp; Entertainment Expenses</unittitle>
+                     <unitdate>dates not examined</unitdate>
+                     <physdesc>
+                        <extent type="computed" unit="folders">1 folder</extent>
+                     </physdesc>
+                  </did>
+               </c>
+            </c>
+            <c level="file" id="C0652_c0366">
+               <did>
+
+                  <container type="folder" parent="C0652_i20">4</container>
+                  <unittitle>P. E. N. Club Meeting (Bled, Yugoslavia</unittitle>
+                  <unitdate normal="1965/1965">1965</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0367">
+               <did>
+
+                  <container type="folder" parent="C0652_i20">5</container>
+                  <unittitle>Photographs</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0368">
+               <did>
+
+                  <container type="folder" parent="C0652_i20">6</container>
+                  <unittitle>Film Reviews by Horacio Quiroga (photographs)</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0369">
+               <did>
+
+                  <container type="folder" parent="C0652_i21">1</container>
+                  <unittitle>
+                     <emph render="italic">Marcha</emph>, no. 743 (Número Fantasma)</unittitle>
+                  <unitdate normal="1954-10-24">1954 October 24</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0370">
+               <did>
+
+                  <container type="folder" parent="C0652_i21">2</container>
+                  <unittitle>Miscellaneous Printed Material</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0371">
+               <did>
+
+                  <container type="folder" parent="C0652_i21">3-5</container>
+                  <unittitle>Newspaper &amp; Magazine Clippings</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">3 folders</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0372">
+               <did>
+
+                  <container type="folder" parent="C0652_i21">6</container>
+                  <unittitle>Press Releases</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0373">
+               <did>
+
+                  <container type="folder" parent="C0652_i21">7</container>
+                  <unittitle>Publishers' Book Lists</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="file" id="C0652_c0374">
+               <did>
+
+                  <container type="folder" parent="C0652_i21">8</container>
+                  <unittitle>Theater &amp; Movie Programs</unittitle>
+                  <unitdate>dates not examined</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+            </c>
+         </c>
+         <c id="C0652_c0375" level="series">
+            <did>
+               <unittitle>Series 5: Audio Recordings</unittitle>
+               <unitdate normal="1956-01-01/1984-12-31" type="inclusive">1956-1984</unitdate>
+               <physdesc>
+                  <extent type="computed" unit="boxes">3 boxes</extent>
+               </physdesc>
+            </did>
+            <scopecontent>
+               <p> Consists of recordings originally on audiocassette and reel-to-reel featuring
+                  interviews Emir Rodriguez Monegal conducted with various Latin American writers as
+                  well as conference and seminar procedings. </p>
+            </scopecontent>
+            <arrangement>
+               <p>Arranged following the creator's order A1-A8 (interviews); B1-B3 (conferences);
+                  C1-C4 (lectures and interviews); D1-D2 (seminars and conferences); E1 (Latin
+                  American Novel program)</p>
+            </arrangement>
+            <c level="file" id="C0652_c0376">
+               <did>
+
+                  <container type="item" parent="C0652_i22">1</container>
+                  <unittitle>Interview: ERM / Maria Bonatti - About Borges (A1)</unittitle>
+                  <unitdate>undated</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+               <altformavail>
+                  <p>32101047382393_1_a.mp3</p>
+               </altformavail>
+               <scopecontent>
+                  <p>1 audiocassette; Side A written description on tape: Entrevista sobre a
+                     Biografía de Borges / Maria Bonatti. Side B written description on tape:
+                     [none].</p>
+                  <p>Side B is blank.</p>
+               </scopecontent>
+            </c>
+            <c level="file" id="C0652_c0377">
+               <did>
+                  <container type="item" parent="C0652_i22">2</container>
+                  <unittitle>Interview: ERM / Jose Donoso (A2)</unittitle>
+                  <unitdate normal="1970/1970">1970</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+               <altformavail>
+                  <p>32101047382401_1_a.mp3</p>
+                  <p>32101047382401_2_a.mp3</p>
+               </altformavail>
+               <scopecontent>
+                  <p>1 audiocassette; Side A written description on tape: Con't Donoso / ERM. Side B
+                     written description on tape: Entrevista José Donoso (Barcelona, Agosto 8,
+                     1970).</p>
+                  <p>From digitization transfer notes: Side A: Program in silence from approximately
+                     00:12 until 04:06, speed fluctuates throughout program on tape. Side B:
+                     Feedback heard throughout program on tape, gradual increase in speed throughout
+                     program on tape.</p>
+               </scopecontent>
+            </c>
+
+            <c level="file" id="C0652_c0378">
+               <did>
+
+                  <container type="item" parent="C0652_i22">3</container>
+                  <unittitle>Interview: ERM / Juan Carlos Onetti (A3), Tape 1-2</unittitle>
+                  <unitdate>undated</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+               <altformavail>
+                  <p>32101047382419_1_a.mp3</p>
+                  <p>32101047382419_2_a.mp3</p>
+                  <p>32101047382427_1_a.mp3</p>
+                  <p>32101047382427_2_a.mp3</p>
+               </altformavail>
+               <scopecontent>
+                  <p>2 audiocassettes; Tape 1, Side A written description on tape: Onetti / ERM Tape
+                     1 A3 1a Side B written description on tape: b A3. Tape 2, Side B written
+                     description on tape: Onetti / ERM Tape 2 A3 3a. Side B written description on
+                     tape: 3b A3</p>
+               </scopecontent>
+            </c>
+            <c level="file" id="C0652_c0379">
+               <did>
+
+                  <container type="item" parent="C0652_i22">4</container>
+                  <unittitle>Interview: ERM / Octavio Paz (A4)</unittitle>
+                  <unitdate normal="1979/1979">1979</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+               <altformavail>
+                  <p>32101047382435_1_a.mp3</p>
+                  <p>32101047382435_2_a.mp3</p>
+               </altformavail>
+               <scopecontent>
+                  <p>1 audiocassette; Tape 1, Side A written description on tape: Octavio Paz/Oct.
+                     25/1979 (NY) A4. Side B written description on tape: ERM / O. Paz</p>
+                  <p>From digitization transfer notes: The whole recording is faint, hard to hear
+                     anything; a hum can be heard throughout the tape.</p>
+               </scopecontent>
+            </c>
+            <c level="file" id="C0652_c0380">
+               <did>
+
+                  <container type="item" parent="C0652_i22">5</container>
+                  <unittitle>Interview: ERM / Manuel Puig (A5), Tape 1-2</unittitle>
+                  <unitdate normal="1969/1969">1969</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+               <altformavail>
+                  <p>32101047382443_1_a.mp3</p>
+                  <p>32101047382443_2_a.mp3</p>
+                  <p>32101047382450_1_a.mp3</p>
+                  <p>32101047382450_2_a.mp3</p>
+               </altformavail>
+               <scopecontent>
+                  <p>2 audiocassettes; Tape 1, Side A written description on tape: Manuel Puig /
+                     Entrevista 17 / VIII / 69 (Bs Aires). Side B written description on tape: A5.
+                     Tape 2, Side B written description on tape: ERM /Puig A5 Tape 2. Side B written
+                     description on tape: A5. </p>
+                  <p>From digitization transfer notes: Sound is hard to hear; pitch of speakers is
+                     very high; sped up in certain parts of recording.</p>
+               </scopecontent>
+            </c>
+            <c level="file" id="C0652_c0381">
+               <did>
+
+                  <container type="item" parent="C0652_i22">6</container>
+                  <unittitle>Interview: ERM / Severo Sarduy (A6)</unittitle>
+                  <unitdate normal="1969/1969">1969</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+               <altformavail>
+                  <p>32101047382468_1_a.mp3</p>
+                  <p>32101047382468_2_a.mp3</p>
+               </altformavail>
+               <scopecontent>
+                  <p>1 audiocassette; Tape 1, Side A written description on tape: Severo Sarduy
+                     Cobra (II) A6. Side B written description on tape: Severo Sarduy: Cobra (II) /
+                     Escrito sobre un cuerpo </p>
+                  <p>From digitization transfer notes: Very faint sound/bit of a hum starting at
+                     20:07 until 21:00. Date of interview: August 6, 1969.</p>
+               </scopecontent>
+            </c>
+            <c level="file" id="C0652_c0382">
+               <did>
+
+                  <container type="item" parent="C0652_i22">7</container>
+                  <unittitle>Interview: ERM / Mario Vargas Llosa (A7)</unittitle>
+                  <unitdate>undated</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+               <altformavail>
+                  <p>32101047382476_1_a.mp3</p>
+                  <p>32101047382476_2_a.mp3</p>
+               </altformavail>
+               <scopecontent>
+                  <p>1 audiocassette; Side A written description on tape: Vargas Llosa . ERM más
+                     inteligible A7. Side B written description on tape: [similar infomation as
+                     other side]. </p>
+               </scopecontent>
+            </c>
+            <c level="file" id="C0652_c0383">
+               <did>
+                  <container type="item" parent="C0652_i22">8</container>
+                  <unittitle>Interview: Fitas / ERM, Tape 1-2 (A8)</unittitle>
+                  <unitdate>undated</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+               <altformavail>
+                  <p>32101047382484_1_a.mp3</p>
+                  <p>32101047382484_2_a.mp3</p>
+                  <p>32101047382492_1_a.mp3</p>
+               </altformavail>
+               <scopecontent>
+                  <p>2 audiocassettes; Tape 1, Side A written description on tape: Fitas / Monegal
+                     Tape 1 A8. Tape 1, Side B written description on tape: Monegal "Borges" A8.
+                     Interview conducted in Portuguese, about Borges. Tape 2 written description on
+                     tape: [similar or same infomation as other side].</p>
+                  <p>Side B is blank.</p>
+               </scopecontent>
+            </c>
+            <c level="file" id="C0652_c0384">
+               <did>
+
+                  <container type="item" parent="C0652_i22">9</container>
+                  <unittitle>ERM: Conference (B1)</unittitle>
+                  <unitdate normal="1978/1978">1978</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+               <altformavail>
+                  <p>32101047382500_1_a.mp3</p>
+                  <p>32101047382500_2_a.mp3</p>
+               </altformavail>
+               <scopecontent>
+                  <p>1 audiocassette; Side A written description on tape: Conferencia do prof.
+                     Mongeal: A parodia e carnavalização na literatura moderna (B1). Side B written
+                     description on tape: [similar or same infomation as other side]. Written on
+                     case: Fae de letras Conferencia, junho 1978 UERT. Conference took place in
+                     Brazil, 1978.</p>
+               </scopecontent>
+            </c>
+            <c level="file" id="C0652_c0385">
+               <did>
+
+                  <container type="item" parent="C0652_i22">10</container>
+                  <unittitle>Conference: ERM: Conference #1-6 (B2)</unittitle>
+                  <unitdate normal="1982/1982">1982</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+               <altformavail>
+                  <p>32101047382518_1_a.mp3</p>
+                  <p>32101047382518_2_a.mp3</p>
+                  <p>32101047382526_1_a.mp3</p>
+                  <p>32101047382526_2_a.mp3</p>
+                  <p>32101047382534_1_a.mp3</p>
+                  <p>32101047382534_2_a.mp3</p>
+                  <p>32101047382542_1_a.mp3</p>
+                  <p>32101047382559_1_a.mp3</p>
+                  <p>32101047382559_2_a.mp3</p>
+                  <p>32101047382567_1_a.mp3</p>
+               </altformavail>
+               <scopecontent>
+                  <p>6 audiocassettes; Written description on case tapes: Prof. Emir Rodriguez
+                     Monegal Conferencia: "Tradução para Teatro". 25/08/82 Faculdade Ibero-Americana
+                     S. Paulo</p>
+                  <p>The following sides are blank: 32101047382542_2, 32101047382567_2</p>
+               </scopecontent>
+
+            </c>
+            <c level="file" id="C0652_c0386">
+               <did>
+
+                  <container type="item" parent="C0652_i23">1</container>
+                  <unittitle>Readings: ERM / José Lezama Lima (B3)</unittitle>
+                  <unitdate normal="1967/1967">1967</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+               <altformavail>
+                  <p>32101047382575_1_a.mp3</p>
+                  <p>32101047382575_2_a.mp3</p>
+               </altformavail>
+               <scopecontent>
+                  <p>1 audiocassette.</p>
+               </scopecontent>
+            </c>
+            <c level="file" id="C0652_c0387">
+               <did>
+
+                  <container type="item" parent="C0652_i23">2</container>
+                  <unittitle>Lecture: Blanco, Tape 1-2 (C1)</unittitle>
+                  <unitdate normal="1981/1981">1981</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+               <altformavail>
+                  <p>32101047382583_1_a.mp3</p>
+                  <p>32101047382583_2_a.mp3</p>
+                  <p>32101047382591_1_a.mp3</p>
+                  <p>32101047382591_2_a.mp3</p>
+               </altformavail>
+               <scopecontent>
+                  <p>2 audiocassettes; Lecture, Austin, 1981. Recording is in Spanish and
+                     Portuguese.</p>
+               </scopecontent>
+
+            </c>
+            <c level="file" id="C0652_c0388">
+               <did>
+
+                  <container type="item" parent="C0652_i23">3</container>
+                  <unittitle>Interview: Susana Haydn / Jorge Luis Borges (C2)</unittitle>
+                  <unitdate normal="1975/1975">1975</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+               <altformavail>
+                  <p>32101047382609_1_a.mp3</p>
+                  <p>32101047382609_2_a.mp3</p>
+               </altformavail>
+               <scopecontent>
+                  <p>1 audiocassette.</p>
+               </scopecontent>
+            </c>
+            <c level="file" id="C0652_c0389">
+               <did>
+
+                  <container type="item" parent="C0652_i23">4</container>
+                  <unittitle>Readings: Pablo Neruda III (C3)</unittitle>
+                  <unitdate>undated</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+               <altformavail>
+                  <p>32101047382617_1_a.mp3</p>
+                  <p>32101047382617_2_a.mp3</p>
+               </altformavail>
+               <scopecontent>
+                  <p>1 audiocassette; poetry readings with Pablo Neruda. Side B is disrupted by
+                     musical recording.</p>
+               </scopecontent>
+            </c>
+            <c level="file" id="C0652_c0390">
+               <did>
+
+                  <container type="item" parent="C0652_i23">5</container>
+                  <unittitle>Interview: Julia Kushsian / Severo Sarduy (C4)</unittitle>
+                  <unitdate normal="1982/1982">1982</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+               <altformavail>
+                  <p>32101047382625_1_a.mp3</p>
+                  <p>32101047382625_2_a.mp3</p>
+               </altformavail>
+               <scopecontent>
+                  <p>1 audiocassette; interview with Severo Sarduy, by Julia Kushsian.</p>
+               </scopecontent>
+            </c>
+            <c level="file" id="C0652_c0391">
+               <did>
+
+                  <container type="item" parent="C0652_i23">6</container>
+                  <unittitle>Conference? (About <emph render="italic">Aura</emph> by Carlos
+                     Fuentes)(D1)</unittitle>
+                  <unitdate>undated</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+               <altformavail>
+                  <p>32101047382633_1_a.mp3</p>
+                  <p>32101047382633_2_a.mp3</p>
+               </altformavail>
+               <scopecontent>
+                  <p>1 audiocassette; recording is in English.</p>
+               </scopecontent>
+            </c>
+            <c level="file" id="C0652_c0392">
+               <did>
+
+                  <container type="item" parent="C0652_i23">7</container>
+                  <unittitle>Seminar (About E.A. Poe, possibly by J.L. Borges), Tape 1-2
+                     (D2)</unittitle>
+                  <unitdate>undated</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+               <altformavail>
+                  <p>32101047382641_1_a.mp3</p>
+                  <p>32101047382641_2_a.mp3</p>
+                  <p>32101047382658_1_a.mp3</p>
+                  <p>32101047382658_2_a.mp3</p>
+               </altformavail>
+               <scopecontent>
+                  <p>2 audiocassettes; recording is in English.</p>
+               </scopecontent>
+            </c>
+            <c level="file" id="C0652_c0393">
+               <did>
+
+                  <container type="item" parent="C0652_i23">8</container>
+                  <unittitle>"Ideas on Magic and Revolution: The Latin American Novel." Four part
+                     series from Canadian radio, written and presented by Toronto Writers #1-4
+                     (E1-E2)</unittitle>
+                  <unitdate normal="1984/1984">1984</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+               <altformavail>
+                  <p>32101047382666_1_a.mp3</p>
+                  <p>32101047382666_2_a.mp3</p>
+                  <p>32101047382674_1_a.mp3</p>
+                  <p>32101047382674_2_a.mp3</p>
+                  <p>32101047382682_1_a.mp3</p>
+                  <p>32101047382682_2_a.mp3</p>
+                  <p>32101047382690_1_a.mp3</p>
+                  <p>32101047382690_2_a.mp3</p>
+                  <p>32101047382708_1_a.mp3</p>
+                  <p>32101047382708_2_a.mp3</p>
+               </altformavail>
+               <scopecontent>
+                  <p>5 audiocassettes (two copies of last volume); Four part series from Canadian
+                     radio, written and presented by Toronto Writers, conducted between February 9 -
+                     March 1, 1984. Includes comments and passages from novels and poetry by
+                     Asturias, Carpentier, García Márquez, Fuentes, Cortázar, Vargas Llosa, Infante.
+                     Recording is in English.</p>
+               </scopecontent>
+            </c>
+            <c level="file" id="C0652_c0394">
+               <did>
+
+                  <container type="item" parent="C0652_i23">9</container>
+                  <unittitle>"Memoria: Canciones en el Exilio". (Argentina)</unittitle>
+                  <unitdate>undated</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="folders">1 folder</extent>
+                  </physdesc>
+               </did>
+               <altformavail>
+                  <p>32101047382716_1_a.mp3</p>
+                  <p>32101047382716_2_a.mp3</p>
+               </altformavail>
+               <scopecontent>
+                  <p>1 audiocassette; recording is in Spanish.</p>
+               </scopecontent>
+            </c>
+            <c level="item" id="C0652_c0395">
+               <did>
+                     <container type="item" parent="C0652_i24">1</container>
+                  <unittitle>PEN Club - Versión Original / Versión Español 1-3</unittitle>
+                  <unitdate>undated</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="boxes">portion of 1 box</extent>
+                  </physdesc>
+               </did>
+               <altformavail>
+                  <p>32101047383474_1_a.mp3</p>
+                  <p>32101047383474_2_a.mp3</p>
+                  <p>32101047383482_1_a.mp3</p>
+                  <p>32101047383490_1_a.mp3</p>
+                  <p>32101047383508_1_a.mp3</p>
+               </altformavail>
+               <scopecontent>
+                  <p>4 audio reels; Side B of asset 32101047383482 is blank; Side B of asset
+                     32101047383490 is blank; Side B of asset 32101047383508 is blank.</p>
+               </scopecontent>
+            </c>
+            <c level="item" id="C0652_c0396">
+               <did>
+                     <container type="item" parent="C0652_i24">2</container>
+                  <unittitle>Spanish Lecture: Emir Rodriguez Monegal - Latin American Contemporary
+                     Novel</unittitle>
+                  <unitdate normal="1968/1968">1968</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="boxes">portion of 1 box</extent>
+                  </physdesc>
+               </did>
+               <altformavail>
+                  <p>32101047383516_1_a.mp3</p>
+                  <p>32101047383516_2_a.mp3</p>
+               </altformavail>
+               <scopecontent>
+                  <p>1 audio reel; recorded on December 5, 1968. Recording is in English.</p>
+               </scopecontent>
+            </c>
+            <c level="item" id="C0652_c0397">
+               <did>
+                  <container type="item" parent="C0652_i24">3</container>
+                  <unittitle>Leopoldo Torre Nilsson, Gustavo Sainz, Homero Aridjis</unittitle>
+                  <unitdate>undated</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="boxes">portion of 1 box</extent>
+                  </physdesc>
+               </did>
+               <altformavail>
+                  <p>32101047383524_1_a.mp3</p>
+                  <p>32101047383524_2_a.mp3</p>
+               </altformavail>
+               <scopecontent>
+                  <p>1 audio reel; recording is in Spanish.</p>
+               </scopecontent>
+            </c>
+            <c level="item" id="C0652_c0398">
+               <did>
+                  <container type="item" parent="C0652_i24">4</container>
+                  <unittitle>Juan Goytisolo, Severo Sarduy, Oscar Lewis, Carlos Fuentes, ERM, Silvia
+                     Rudni, Maurice Coindreau, Graciela Martinez, Leonor Fini, E. Souchere /
+                     Conference: ERM, Beatriz Guido, Leopoldo Torre Nilsson</unittitle>
+                  <unitdate>undated</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="boxes">portion of 1 box</extent>
+                  </physdesc>
+               </did>
+               <altformavail>
+                  <p>32101047383532_1_p1_a.mp3</p>
+                  <p>32101047383532_1_p2_a.mp3</p>
+                  <p>32101047383532_1_p3_a.mp3</p>
+                  <p>32101047383532_2_a.mp3</p>
+               </altformavail>
+               <scopecontent>
+                  <p>1 audio reel; Side A was split into three different parts during digitization;
+                     some distortion is present; recording is in Spanish, English, and French.</p>
+               </scopecontent>
+            </c>
+            <c level="item" id="C0652_c0399">
+               <did>
+                  <container type="item" parent="C0652_i24">5</container>
+                  <unittitle>Tercera Cinta del Archivo: ERM/Pettorutti, ERM/Torre Nilsson,
+                     ERM/Beatriz Guido, Cecilio Madanes, CFM/Pierre Kalfon</unittitle>
+                  <unitdate normal="1967/1967">1967</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="boxes">portion of 1 box</extent>
+                  </physdesc>
+               </did>
+               <altformavail>
+                  <p>32101047383540_1_p1_a.mp3</p>
+                  <p>32101047383540_1_p2_a.mp3</p>
+                  <p>32101047383540_2_a.mp3</p>
+               </altformavail>
+               <scopecontent>
+                  <p>1 audio reel; recorded on July 13, 1967. Side A was split into two different
+                     parts during digitization; some distortion is present in part 2 (37:36 - about
+                     41:00 and around 1:12:30- 1:12:58)</p>
+               </scopecontent>
+            </c>
+            <c level="item" id="C0652_c0400">
+               <did>
+                  <container type="item" parent="C0652_i24">6</container>
+                  <unittitle>Manuel Rabat Taylo Martines de Alcalá Madrid, España</unittitle>
+                  <unitdate normal="1967/1967">1967</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="boxes">portion of 1 box</extent>
+                  </physdesc>
+               </did>
+               <altformavail>
+                  <p>32101047383557_1_a.mp3</p>
+               </altformavail>
+               <scopecontent>
+                  <p>1 audio reel; interview took place - March 19, 1967 in Paris. Side B is
+                     blank.</p>
+               </scopecontent>
+            </c>
+            <c level="item" id="C0652_c0401">
+               <did>
+                  <container type="item" parent="C0652_i24">7</container>
+                  <unittitle>[Blank]</unittitle>
+                  <unitdate normal="1977/1977">1977</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="boxes">portion of 1 box</extent>
+                  </physdesc>
+               </did>
+               <altformavail>
+                  <p>32101047383565_1_p1_a.mp3</p>
+                  <p>32101047383565_1_p2_a.mp3</p>
+               </altformavail>
+               <scopecontent>
+                  <p>1 audio reel; recorded on June 12, 1977 in Spanish. Side A was split into two different
+                     parts during digitization. </p>
+               </scopecontent>
+            </c>
+            <c level="item" id="C0652_c0402">
+               <did>
+                  <container type="item" parent="C0652_i24">8</container>
+                  <unittitle>1 empty envelope</unittitle>
+                  <unitdate>undated</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="boxes">portion of 1 box</extent>
+                  </physdesc>
+               </did>
+            </c>
+            <c level="item" id="C0652_c0403">
+               <did>
+                  <container>
+                     <ptr target="C0652_i24"/>
+                  </container>
+                  <unittitle>Emir Rodriguez Monegal record (33 1/3 rpm): "La Nueva Literatura
+                     Uruguaya" ( 1956 Audición Biblioteca Nacional)</unittitle>
+                  <unitdate normal="1956/1956">1956</unitdate>
+                  <physdesc>
+                     <extent type="computed" unit="boxes">1 box</extent>
+                  </physdesc>
+               </did>
+            </c>
+         </c>
+      </dsc>
+      <dsc type="othertype" othertype="physicalholdings">
+         <c level="otherlevel" otherlevel="physicalitem" id="C0652_i1">
+            <did>
+               <container type="box">1</container>
+               <unitid type="barcode">32101037695150</unitid>
+               <physloc type="code">mss</physloc>
+
+            </did>
+         </c>
+         <c level="otherlevel" otherlevel="physicalitem" id="C0652_i2">
+            <did>
+               <container type="box">2</container>
+               <unitid type="barcode">32101037695168</unitid>
+               <physloc type="code">mss</physloc>
+
+            </did>
+         </c>
+         <c level="otherlevel" otherlevel="physicalitem" id="C0652_i3">
+            <did>
+               <container type="box">3</container>
+               <unitid type="barcode">32101037695176</unitid>
+               <physloc type="code">mss</physloc>
+
+            </did>
+         </c>
+         <c level="otherlevel" otherlevel="physicalitem" id="C0652_i4">
+            <did>
+               <container type="box">4</container>
+               <unitid type="barcode">32101037695184</unitid>
+               <physloc type="code">mss</physloc>
+
+            </did>
+         </c>
+         <c level="otherlevel" otherlevel="physicalitem" id="C0652_i5">
+            <did>
+               <container type="box">5</container>
+               <unitid type="barcode">32101037695192</unitid>
+               <physloc type="code">mss</physloc>
+
+            </did>
+         </c>
+         <c level="otherlevel" otherlevel="physicalitem" id="C0652_i6">
+            <did>
+               <container type="box">6</container>
+               <unitid type="barcode">32101037695200</unitid>
+               <physloc type="code">mss</physloc>
+
+            </did>
+         </c>
+         <c level="otherlevel" otherlevel="physicalitem" id="C0652_i7">
+            <did>
+               <container type="box">7</container>
+               <unitid type="barcode">32101037695218</unitid>
+               <physloc type="code">mss</physloc>
+
+            </did>
+         </c>
+         <c level="otherlevel" otherlevel="physicalitem" id="C0652_i8">
+            <did>
+               <container type="box">8</container>
+               <unitid type="barcode">32101037695226</unitid>
+               <physloc type="code">mss</physloc>
+
+            </did>
+         </c>
+         <c level="otherlevel" otherlevel="physicalitem" id="C0652_i9">
+            <did>
+               <container type="box">9</container>
+               <unitid type="barcode">32101037695234</unitid>
+               <physloc type="code">mss</physloc>
+
+            </did>
+         </c>
+         <c level="otherlevel" otherlevel="physicalitem" id="C0652_i10">
+            <did>
+               <container type="box">10</container>
+               <unitid type="barcode">32101037695242</unitid>
+               <physloc type="code">mss</physloc>
+
+            </did>
+         </c>
+         <c level="otherlevel" otherlevel="physicalitem" id="C0652_i11">
+            <did>
+               <container type="box">11</container>
+               <unitid type="barcode">32101037695259</unitid>
+               <physloc type="code">mss</physloc>
+
+            </did>
+         </c>
+         <c level="otherlevel" otherlevel="physicalitem" id="C0652_i12">
+            <did>
+               <container type="box">12</container>
+               <unitid type="barcode">32101037695267</unitid>
+               <physloc type="code">mss</physloc>
+
+            </did>
+         </c>
+         <c level="otherlevel" otherlevel="physicalitem" id="C0652_i13">
+            <did>
+               <container type="box">13</container>
+               <unitid type="barcode">32101037695275</unitid>
+               <physloc type="code">mss</physloc>
+
+            </did>
+         </c>
+         <c level="otherlevel" otherlevel="physicalitem" id="C0652_i14">
+            <did>
+               <container type="box">14</container>
+               <unitid type="barcode">32101037695283</unitid>
+               <physloc type="code">mss</physloc>
+
+            </did>
+         </c>
+         <c level="otherlevel" otherlevel="physicalitem" id="C0652_i15">
+            <did>
+               <container type="box">15</container>
+               <unitid type="barcode">32101037695291</unitid>
+               <physloc type="code">mss</physloc>
+
+            </did>
+         </c>
+         <c level="otherlevel" otherlevel="physicalitem" id="C0652_i16">
+            <did>
+               <container type="box">16</container>
+               <unitid type="barcode">32101037695309</unitid>
+               <physloc type="code">mss</physloc>
+
+            </did>
+         </c>
+         <c level="otherlevel" otherlevel="physicalitem" id="C0652_i17">
+            <did>
+               <container type="box">17</container>
+               <unitid type="barcode">32101037695317</unitid>
+               <physloc type="code">mss</physloc>
+
+            </did>
+         </c>
+         <c level="otherlevel" otherlevel="physicalitem" id="C0652_i18">
+            <did>
+               <container type="box">18</container>
+               <unitid type="barcode">32101037695325</unitid>
+               <physloc type="code">mss</physloc>
+
+            </did>
+         </c>
+         <c level="otherlevel" otherlevel="physicalitem" id="C0652_i19">
+            <did>
+               <container type="box">19</container>
+               <unitid type="barcode">32101037695333</unitid>
+               <physloc type="code">mss</physloc>
+
+            </did>
+         </c>
+         <c level="otherlevel" otherlevel="physicalitem" id="C0652_i20">
+            <did>
+               <container type="box">20</container>
+               <unitid type="barcode">32101037695341</unitid>
+               <physloc type="code">mss</physloc>
+
+            </did>
+         </c>
+         <c level="otherlevel" otherlevel="physicalitem" id="C0652_i21">
+            <did>
+               <container type="box">21</container>
+               <unitid type="barcode">32101037695358</unitid>
+               <physloc type="code">mss</physloc>
+
+            </did>
+         </c>
+         <c level="otherlevel" otherlevel="physicalitem" id="C0652_i22">
+            <did>
+               <container type="box">22</container>
+               <unitid type="barcode">32101047385362</unitid>
+               <physloc type="code">mss</physloc>
+
+            </did>
+         </c>
+         <c level="otherlevel" otherlevel="physicalitem" id="C0652_i23">
+            <did>
+               <container type="box">23</container>
+               <unitid type="barcode">32101047385354</unitid>
+               <physloc type="code">mss</physloc>
+
+            </did>
+         </c>
+         <c id="C0652_i24" level="otherlevel" otherlevel="physicalitem">
+            <did>
+               <container type="box">L-000025</container>
+               <unitid type="barcode">32101047385370</unitid>
+               <physloc type="code">mss</physloc>
+            </did>
+         </c>
+
+      </dsc>
+   </archdesc>
+</ead>

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -10,6 +10,6 @@ RSpec.describe Report do
   end
 
   it "has a list of available reports" do
-    expect(described_class.all).to eq [:ephemera_data, :identifiers_to_reconcile, :pulfa_ark_report]
+    expect(described_class.all).to eq [:ead_to_marc, :ephemera_data, :identifiers_to_reconcile, :pulfa_ark_report]
   end
 end

--- a/spec/services/finding_aids_updater_spec.rb
+++ b/spec/services/finding_aids_updater_spec.rb
@@ -67,7 +67,7 @@ describe FindingAidsUpdater do
     allow(Rails).to receive(:logger).and_return(logger)
     allow(success).to receive(:success?).and_return(true)
     allow(Open3).to receive(:capture2)
-      .with("svn diff --summarize -r {#{Time.zone.yesterday.to_formatted_s(:iso8601)}}:HEAD --username tester --password testing http://example.com/svn/pulfa/trunk/eads")
+      .with("svn --username tester --password testing diff --summarize -r {#{Time.zone.yesterday.to_formatted_s(:iso8601)}}:HEAD http://example.com/svn/pulfa/trunk/eads")
       .and_return([svn_fixture, success])
   end
 

--- a/spec/services/svn_parser_spec.rb
+++ b/spec/services/svn_parser_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe SvnParser do
+  subject(:svn) { described_class.new }
+  let(:success) { instance_double Process::Status }
+
+  before do
+    allow(success).to receive(:success?).and_return(true)
+  end
+
+  describe "#all_collection_paths" do
+    let(:svn_fixture) { "build.xml\ncotsen/\ncotsen/COTSEN1.EAD.xml\ncotsen/COTSEN2.EAD.xml\n" }
+    before do
+      allow(Open3).to receive(:capture2)
+        .with("svn --username tester --password testing list --recursive http://example.com/svn/pulfa/trunk/eads")
+        .and_return([svn_fixture, success])
+    end
+
+    it "lists collection paths" do
+      expect(svn.all_collection_paths).to eq(["cotsen/COTSEN1.EAD.xml", "cotsen/COTSEN2.EAD.xml"])
+    end
+  end
+
+  describe "#get_collection" do
+    let(:svn_fixture) { "<dummy_ead_xml/>\n" }
+    before do
+      allow(Open3).to receive(:capture2)
+        .with("svn --username tester --password testing cat http://example.com/svn/pulfa/trunk/eads/cotsen/COTSEN1.EAD.xml")
+        .and_return([svn_fixture, success])
+    end
+
+    it "retrieves collection EAD XML" do
+      expect(svn.get_collection("cotsen/COTSEN1.EAD.xml")).to eq(svn_fixture)
+    end
+  end
+end

--- a/spec/services/svn_parser_spec.rb
+++ b/spec/services/svn_parser_spec.rb
@@ -3,22 +3,24 @@ require "rails_helper"
 
 RSpec.describe SvnParser do
   subject(:svn) { described_class.new }
+  let(:logger) { instance_double Logger }
   let(:success) { instance_double Process::Status }
 
   before do
+    allow(logger).to receive(:info)
+    allow(Rails).to receive(:logger).and_return(logger)
     allow(success).to receive(:success?).and_return(true)
   end
 
-  describe "#all_collection_paths" do
-    let(:svn_fixture) { "build.xml\ncotsen/\ncotsen/COTSEN1.EAD.xml\ncotsen/COTSEN2.EAD.xml\n" }
+  describe "#updated_collection_paths" do
     before do
       allow(Open3).to receive(:capture2)
-        .with("svn --username tester --password testing list --recursive http://example.com/svn/pulfa/trunk/eads")
-        .and_return([svn_fixture, success])
+        .with("svn --username tester --password testing diff --summarize -r {#{Time.zone.yesterday.to_formatted_s(:iso8601)}}:HEAD http://example.com/svn/pulfa/trunk/eads")
+        .and_return([svn_diff_fixture, success])
     end
 
-    it "lists collection paths" do
-      expect(svn.all_collection_paths).to eq(["cotsen/COTSEN1.EAD.xml", "cotsen/COTSEN2.EAD.xml"])
+    it "lists updated collection paths" do
+      expect(svn.updated_collection_paths(Time.zone.yesterday)).to eq(["mss/C0652.EAD.xml", "mudd/publicpolicy/MC016.EAD.xml"])
     end
   end
 
@@ -27,11 +29,18 @@ RSpec.describe SvnParser do
     before do
       allow(Open3).to receive(:capture2)
         .with("svn --username tester --password testing cat http://example.com/svn/pulfa/trunk/eads/cotsen/COTSEN1.EAD.xml")
-        .and_return([svn_fixture, success])
+        .and_return(["<dummy/>", success])
     end
 
     it "retrieves collection EAD XML" do
-      expect(svn.get_collection("cotsen/COTSEN1.EAD.xml")).to eq(svn_fixture)
+      expect(svn.get_collection("cotsen/COTSEN1.EAD.xml")).to eq("<dummy/>")
     end
+  end
+
+  def svn_diff_fixture
+    <<~HEREDOC
+      M       http://example.com/svn/pulfa/trunk/eads/mss/C0652.EAD.xml
+      M       http://example.com/svn/pulfa/trunk/eads/mudd/publicpolicy/MC016.EAD.xml
+    HEREDOC
   end
 end


### PR DESCRIPTION
* Allows discovery of finding aids in the catalog, by syncing changes from finding aids to MARC records
* Based on `ead-to-marc.xsl` from Don Thornbury
* refactoring SvnParser for access

Fixes #2019 