### PR TITLE
Add capybara-screenshot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,7 @@ group :development, :staging do
 end
 
 group :test do
+  gem "capybara-screenshot"
   gem "chromedriver-helper"
   gem "database_cleaner"
   gem "formulaic"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-screenshot (1.0.22)
+      capybara (>= 1.0, < 4)
+      launchy
     childprocess (0.7.1)
       ffi (~> 1.0, >= 1.0.11)
     chromedriver-helper (1.1.0)
@@ -446,6 +449,8 @@ GEM
       activerecord
       kaminari-core (= 1.0.1)
     kaminari-core (1.0.1)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     lcsort (0.9.1)
     ldp (0.7.0)
       deprecation
@@ -817,6 +822,7 @@ DEPENDENCIES
   capistrano-passenger
   capistrano-rails
   capistrano-rails-console
+  capybara-screenshot
   chromedriver-helper
   coffee-rails
   damerau-levenshtein

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'capybara/rails'
 require 'capybara/rspec'
+require 'capybara-screenshot/rspec'
 RSpec.configure do |config|
   config.include Capybara::RSpecMatchers, type: :request
 end

--- a/spec/support/capybara_selenium.rb
+++ b/spec/support/capybara_selenium.rb
@@ -2,7 +2,9 @@
 require 'capybara/rspec'
 require 'selenium-webdriver'
 
-Capybara.register_driver(:headless_chrome) do |app|
+# there's a bug in capybara-screenshot that requires us to name
+#   the driver ":selenium" so we changed it from :headless_chrome"
+Capybara.register_driver(:selenium) do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     chromeOptions: { args: %w(headless disable-gpu disable-setuid-sandbox window-size=7680,4320) }
   )
@@ -16,5 +18,5 @@ Capybara.register_driver(:headless_chrome) do |app|
                                  http_client: http_client)
 end
 
-Capybara.javascript_driver = :headless_chrome
+Capybara.javascript_driver = :selenium
 Capybara.default_max_wait_time = 15


### PR DESCRIPTION
This gem automatically takes a screenshot whenever a javascript-enabled
feature test fails. Occasionally very helpful for debugging.