### PR TITLE
Ensures that cases where PULFA ARK updates raise errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -105,6 +105,7 @@ Metrics/LineLength:
     - 'spec/views/scanned_resources/order_manager.html.erb_spec.rb'
     - 'lib/tasks/music_reserves.rake'
     - 'spec/features/playlist_spec.rb'
+    - 'spec/resources/scanned_resources/scanned_resources_controller_spec.rb'
 Metrics/MethodLength:
   Exclude:
     - 'db/migrate/**/*'
@@ -140,6 +141,7 @@ Metrics/MethodLength:
     - 'config/initializers/sequel_active_support_notification.rb'
     - 'app/services/manifest_builder.rb'
     - 'app/indexers/imported_metadata_indexer.rb'
+    - 'app/controllers/concerns/resource_controller.rb'
 Metrics/ModuleLength:
   Exclude:
     - 'app/models/schema/marc_relators.rb'

--- a/app/change_set_persisters/change_set_persister/mint_identifier.rb
+++ b/app/change_set_persisters/change_set_persister/mint_identifier.rb
@@ -22,9 +22,34 @@ class ChangeSetPersister
         identifier_service.mint_or_update(resource: change_set.model)
       end
 
+      # Determine whether or not the changes being persisted include the
+      # resource being published
+      # @param change_set [ChangeSet]
+      # @return [Boolean]
+      def published?(change_set)
+        change_set.changed?(:state) && change_set.resource.decorate.public_readable_state?
+      end
+
+      # Determine whether or not the changes being persisted include an updated
+      # title for an already published resource
+      # @param change_set [ChangeSet]
+      # @return [Boolean]
+      def published_with_new_title?(change_set)
+        change_set.resource.decorate.public_readable_state? && change_set.changed?(:title)
+      end
+
+      # Determine whether or not the changes being persisted necessitate the
+      # minting of a new identifier for the resource (or, the updating of ARK
+      # metadata for the resource [e. g. the ARK target or title of the resource])
+      # @param change_set [ChangeSet]
+      # @return [Boolean]
       def needs_updating?(change_set)
+        # Always mint/update the ARK unless the resource already has an identifier
         return true unless change_set.resource.try(:identifier)
-        change_set.state_changed? || change_set.changed?(:title) || change_set.changed?(:source_metadata_identifier)
+        # Only update under the following conditions:
+        # - The resource has been published with a new identifier
+        # - The source metadata identifier has changed
+        published?(change_set) || published_with_new_title?(change_set) || change_set.changed?(:source_metadata_identifier)
       end
 
       def identifier_service

--- a/app/controllers/concerns/resource_controller.rb
+++ b/app/controllers/concerns/resource_controller.rb
@@ -71,6 +71,9 @@ module ResourceController
     else
       after_update_failure
     end
+  rescue IdentifierService::RestrictedArkError => ark_error
+    flash[:alert] = ark_error.message
+    after_update_failure
   rescue Valkyrie::Persistence::ObjectNotFoundError => e
     after_update_error e
   end

--- a/spec/change_set_persisters/change_set_persister/mint_identifier_spec.rb
+++ b/spec/change_set_persisters/change_set_persister/mint_identifier_spec.rb
@@ -27,6 +27,35 @@ RSpec.describe ChangeSetPersister::MintIdentifier do
       expect(change_set.model.identifier).not_to be_empty
       expect(change_set.model.identifier).to include new_ark
     end
+
+    context "when an already published SimpleResource is updated" do
+      let(:existing_ark) { "ark:/#{shoulder}234567" }
+      let(:simple_resource) { FactoryBot.create(:complete_simple_resource, identifier: existing_ark) }
+      before do
+        change_set.prepopulate!
+        change_set.validate(creator: "Johann Georg Faust")
+      end
+
+      it "does not mint a new ARK" do
+        expect(hook.run).to be nil
+        expect(change_set.model.identifier).to eq [existing_ark]
+      end
+    end
+
+    context "when an already published SimpleResource has its title updated" do
+      let(:existing_ark) { "ark:/#{shoulder}234567" }
+      let(:simple_resource) { FactoryBot.create(:complete_simple_resource, identifier: existing_ark) }
+      before do
+        change_set.prepopulate!
+        change_set.validate(title: "Doctor Faustens dreyfacher Höllenzwang")
+      end
+
+      it "updates the existing ARK" do
+        expect(hook.run).to be_a SimpleResourceChangeSet
+        expect(change_set.model.identifier).to eq [existing_ark]
+      end
+    end
+
     context "when none of the relevant metadata has changed" do
       let(:simple_resource) { FactoryBot.create(:complete_simple_resource, identifier: new_ark) }
       it "does not run the hook" do

--- a/spec/change_set_persisters/change_set_persister/mint_identifier_spec.rb
+++ b/spec/change_set_persisters/change_set_persister/mint_identifier_spec.rb
@@ -55,7 +55,19 @@ RSpec.describe ChangeSetPersister::MintIdentifier do
         expect(change_set.model.identifier).to eq [existing_ark]
       end
     end
-
+    context "when an already published SimpleResource is added to a collection" do
+      let(:existing_ark) { "ark:/#{shoulder}234567" }
+      let(:simple_resource) { FactoryBot.create(:complete_simple_resource, identifier: existing_ark) }
+      let(:collection) { FactoryBot.create_for_repository(:collection) }
+      before do
+        change_set.prepopulate!
+        change_set.validate(member_of_collection_ids: [collection.id])
+      end
+      it "does not mint a new ARK" do
+        expect(hook.run).to be nil
+        expect(change_set.model.identifier).to eq [existing_ark]
+      end
+    end
     context "when none of the relevant metadata has changed" do
       let(:simple_resource) { FactoryBot.create(:complete_simple_resource, identifier: new_ark) }
       it "does not run the hook" do


### PR DESCRIPTION
Resolves #2577 by addressing the following:

- Modifies `IdentifierService` to only mint/update ARKs for resources with updated titles when they have already been published
- Ensures that cases where PULFA ARK updates raise errors are handled by flashing an alert to clients and redirecting them to the edit form