### PR TITLE
Extends the GraphQL Types::Resource in order to ensure that invalid IIIF manifest URLs are handled

### DIFF
--- a/app/graphql/types/resource.rb
+++ b/app/graphql/types/resource.rb
@@ -66,11 +66,21 @@ module Types::Resource
   end
 
   def thumbnail
-    return if object.try(:thumbnail_id).blank? || thumbnail_resource.blank? || helper.figgy_thumbnail_path(thumbnail_resource).blank?
+    return if object.try(:thumbnail_id).blank? || thumbnail_resource.blank?
+
+    figgy_thumbnail_path = helper.figgy_thumbnail_path(thumbnail_resource)
+    return if figgy_thumbnail_path.nil?
+
+    # Explicitly set this nil if the service URL cannot be parsed
+    iiif_service_url = nil
+    service_substr = "/full/!200,150/0/default.jpg"
+    if figgy_thumbnail_path.include?(service_substr)
+      iiif_service_url = figgy_thumbnail_path.gsub(service_substr, "")
+    end
     {
       id: thumbnail_resource.id.to_s,
-      thumbnail_url: helper.figgy_thumbnail_path(thumbnail_resource),
-      iiif_service_url: helper.figgy_thumbnail_path(thumbnail_resource).gsub("/full/!200,150/0/default.jpg", "")
+      thumbnail_url: figgy_thumbnail_path,
+      iiif_service_url: iiif_service_url
     }
   end
 

--- a/spec/graphql/types/scanned_resource_type_spec.rb
+++ b/spec/graphql/types/scanned_resource_type_spec.rb
@@ -78,6 +78,14 @@ RSpec.describe Types::ScannedResourceType do
         allow(type.helper).to receive(:figgy_thumbnail_path).and_return(nil)
         expect(type.thumbnail).to be_nil
       end
+      it "returns nil for the iiif_service_url if the URL cannot be parsed" do
+        allow(type.helper).to receive(:figgy_thumbnail_path).and_return("https://images.institution.edu/invalid")
+        expect(type.thumbnail).to eq(
+          iiif_service_url: nil,
+          thumbnail_url: "https://images.institution.edu/invalid",
+          id: file_set.id.to_s
+        )
+      end
     end
     context "when a bad thumbnail is set" do
       let(:scanned_resource) do


### PR DESCRIPTION
Resolved #2374 