### PR TITLE
Ensures that numismatic controllers handle cases where persisted NumismaticMonograms cannot be retrieved

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -209,6 +209,7 @@ RSpec/NestedGroups:
     - 'spec/change_set_persisters/change_set_persister_spec.rb'
     - 'spec/requests/scanned_resource_spec.rb'
     - 'spec/controllers/bulk_ingest_controller_spec.rb'
+    - 'spec/resources/numismatic_monograms/numismatic_monograms_controller_spec.rb'
 RSpec/VerifiedDoubles:
   Exclude:
     - 'spec/models/search_builder_spec.rb'

--- a/app/resources/numismatic_issues/numismatic_issues_controller.rb
+++ b/app/resources/numismatic_issues/numismatic_issues_controller.rb
@@ -11,6 +11,7 @@ class NumismaticIssuesController < BaseResourceController
 
   def load_monograms
     @numismatic_monograms = query_service.find_all_of_model(model: NumismaticMonogram).map(&:decorate)
+    return [] if @numismatic_monograms.to_a.blank?
   end
 
   def manifest

--- a/app/resources/numismatic_monograms/numismatic_monograms_controller.rb
+++ b/app/resources/numismatic_monograms/numismatic_monograms_controller.rb
@@ -28,5 +28,6 @@ class NumismaticMonogramsController < BaseResourceController
 
     def load_numismatic_monograms
       @numismatic_monograms = query_service.find_all_of_model(model: NumismaticMonogram).map(&:decorate)
+      return [] if @numismatic_monograms.to_a.blank?
     end
 end

--- a/spec/resources/numismatic_issues/numismatic_issues_controller_spec.rb
+++ b/spec/resources/numismatic_issues/numismatic_issues_controller_spec.rb
@@ -41,6 +41,22 @@ RSpec.describe NumismaticIssuesController, type: :controller do
       let(:factory) { :numismatic_issue }
       it_behaves_like "an access controlled edit request"
     end
+    let(:resource) { FactoryBot.create_for_repository(:numismatic_issue) }
+    it "retrieves all of the persisted numismatic monograms" do
+      monogram1 = FactoryBot.create_for_repository(:numismatic_monogram)
+      monogram2 = FactoryBot.create_for_repository(:numismatic_monogram)
+
+      get :edit, params: { id: resource.id.to_s }
+      numismatic_monograms = assigns(:numismatic_monograms)
+      expect(numismatic_monograms.map(&:id)).to include(monogram1.id)
+      expect(numismatic_monograms.map(&:id)).to include(monogram2.id)
+    end
+    context "when no numismatic monograms have been persisted" do
+      it "retrieves an empty array" do
+        get :edit, params: { id: resource.id.to_s }
+        expect(assigns(:numismatic_monograms)).to eq([])
+      end
+    end
   end
   describe "html update" do
     let(:user) { FactoryBot.create(:admin) }

--- a/spec/resources/numismatic_monograms/numismatic_monograms_controller_spec.rb
+++ b/spec/resources/numismatic_monograms/numismatic_monograms_controller_spec.rb
@@ -59,6 +59,21 @@ RSpec.describe NumismaticMonogramsController, type: :controller do
         get :index
         expect(response.body).to have_content "Test Monogram"
       end
+      it "retrieves all of the persisted numismatic monograms" do
+        monogram1 = FactoryBot.create_for_repository(:numismatic_monogram)
+        monogram2 = FactoryBot.create_for_repository(:numismatic_monogram)
+
+        get :index
+        numismatic_monograms = assigns(:numismatic_monograms)
+        expect(numismatic_monograms.map(&:id)).to include(monogram1.id)
+        expect(numismatic_monograms.map(&:id)).to include(monogram2.id)
+      end
+      context "when no numismatic monograms have been persisted" do
+        it "retrieves an empty array" do
+          get :index
+          expect(assigns(:numismatic_monograms)).to eq([])
+        end
+      end
     end
   end
   describe "manifest" do


### PR DESCRIPTION
Resolves #2573 