### PR TITLE
Handes cases where the FileSet derivative cannot be retrieved for Playlists in the ManifestBuilder

### DIFF
--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -421,6 +421,7 @@ class ManifestBuilder
     end
 
     def download_url
+      return if derivative.nil?
       if helper.token_authorizable?(parent_node.resource)
         helper.download_url(resource.id, derivative.id, auth_token: parent_node.resource.auth_token)
       else

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -268,6 +268,25 @@ RSpec.describe ManifestBuilder do
             expect(first_annotation["body"]).to include("id" => "http://www.example.com/downloads/#{file_set1.id}/file/#{file_node1.id}?auth_token=#{persisted.auth_token}")
           end
         end
+
+        context "when the derivative cannot be retrieved for the FileSet" do
+          before do
+            allow_any_instance_of(FileSet).to receive(:derivative_file).and_return(nil)
+          end
+          it "generates the Canvases for the FileSets" do
+            expect(output).not_to be_empty
+
+            first_canvas = output["items"].first
+            first_annotation_page = first_canvas["items"].first
+            first_annotation = first_annotation_page["items"].first
+            expect(first_annotation["body"]["id"]).to be nil
+
+            last_canvas = output["items"].last
+            first_annotation_page = last_canvas["items"].first
+            first_annotation = first_annotation_page["items"].first
+            expect(first_annotation["body"]["id"]).to be nil
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Resolves #2497 