### PR TITLE
Add orangelight document builder for coins

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -217,6 +217,7 @@ RSpec/VerifiedDoubles:
     - 'spec/models/search_builder_spec.rb'
     - 'spec/validators/viewing_hint_validator_spec.rb'
     - 'spec/validators/viewing_direction_validator_spec.rb'
+    - 'spec/validators/year_validator_spec.rb'
     - 'spec/models/user_spec.rb'
     - 'spec/derivative_services/image_derivative_service_spec.rb'
     - 'spec/derivative_services/jp2_derivative_service_spec.rb'

--- a/app/controllers/concerns/orangelight_document_controller.rb
+++ b/app/controllers/concerns/orangelight_document_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module OrangelightDocumentController
+  extend ActiveSupport::Concern
+
+  included do
+    def orangelight
+      respond_to do |f|
+        f.json do
+          render json: orangelight_document
+        end
+      end
+    end
+  end
+
+  private
+
+    def orangelight_document
+      @resource = find_resource(params[:id])
+      @orangelight_document ||= OrangelightDocument.new(@resource)
+    end
+end

--- a/app/resources/coins/coins_controller.rb
+++ b/app/resources/coins/coins_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class CoinsController < BaseResourceController
+  include OrangelightDocumentController
+
   self.change_set_class = DynamicChangeSet
   self.resource_class = Coin
   self.change_set_persister = ::ChangeSetPersister.new(

--- a/app/resources/coins/orangelight_coin_builder.rb
+++ b/app/resources/coins/orangelight_coin_builder.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+class OrangelightCoinBuilder
+  attr_reader :decorator, :parent
+  def initialize(decorator)
+    @decorator = decorator
+    @parent = decorator.decorated_parent
+  end
+
+  def build
+    clean_document(document_hash)
+  end
+
+  private
+
+    def clean_document(hash)
+      hash.delete_if do |_k, v|
+        v.nil? || v.try(:empty?)
+      end
+    end
+
+    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/MethodLength
+    def document_hash
+      {
+        id: "coin-#{decorator.coin_number}",
+        title_display: "Coin: #{decorator.coin_number}",
+        access_facet: ["Online", "In the Library"],
+        location: decorator.holding_location,
+        format: ["Coin"],
+        advanced_location_s: ["num"],
+        counter_stamp_t: decorator.counter_stamp,
+        analysis_t: decorator.analysis,
+        notes_display: decorator.public_note,
+        find_place_t: decorator.find_place,
+        find_date_t: decorator.find_date,
+        find_feature_t: decorator.find_feature,
+        find_locus_t: decorator.find_locus,
+        find_number_t: decorator.find_number,
+        find_description_t: decorator.find_description,
+        die_axis_t: decorator.die_axis,
+        size_t: decorator.size,
+        technique: decorator.technique,
+        weight_t: decorator.weight,
+        pub_date_start_sort: parent.first_range&.start&.first.to_i,
+        pub_date_end_sort: parent.first_range&.end&.first.to_i,
+        issue_object_type_t: parent.object_type,
+        issue_denomination_t: parent.denomination,
+        issue_number_s: parent.issue_number.to_s,
+        issue_metal_t: parent.metal,
+        issue_shape_t: parent.shape,
+        issue_color_t: parent.color,
+        issue_edge_t: parent.edge,
+        issue_era_t: parent.era,
+        issue_ruler_t: parent.ruler,
+        issue_master_t: parent.master,
+        issue_workshop_t: parent.workshop,
+        issue_series_t: parent.series,
+        issue_place_t: parent.place,
+        issue_obverse_figure_t: parent.obverse_figure,
+        issue_obverse_symbol_t: parent.obverse_symbol,
+        issue_obverse_part_t: parent.obverse_part,
+        issue_obverse_orientation_t: parent.obverse_orientation,
+        issue_obverse_figure_description_t: parent.obverse_figure_description,
+        issue_obverse_figure_relationship_t: parent.obverse_figure_relationship,
+        issue_obverse_legend_t: parent.obverse_legend,
+        issue_obverse_attributes_t: parent.obverse_attributes,
+        issue_reverse_figure_t: parent.reverse_figure,
+        issue_reverse_symbol_t: parent.reverse_symbol,
+        issue_reverse_part_t: parent.reverse_part,
+        issue_reverse_orientation_t: parent.reverse_orientation,
+        issue_reverse_figure_description_t: parent.reverse_figure_description,
+        issue_reverse_figure_relationship_t: parent.reverse_figure_relationship,
+        issue_reverse_legend_t: parent.reverse_legend,
+        issue_reverse_attributes_t: parent.reverse_attributes,
+        issue_references_t: parent.citations
+      }
+    end
+  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/AbcSize
+end

--- a/app/resources/numismatic_issues/numismatic_issue.rb
+++ b/app/resources/numismatic_issues/numismatic_issue.rb
@@ -26,7 +26,7 @@ class NumismaticIssue < Resource
   attribute :obverse_figure
   attribute :obverse_figure_description
   attribute :obverse_figure_relationship
-  attribute :obverse_legend, Valkyrie::Types::SingleValuedString
+  attribute :obverse_legend
   attribute :obverse_orientation
   attribute :obverse_part
   attribute :obverse_symbol
@@ -35,7 +35,7 @@ class NumismaticIssue < Resource
   attribute :reverse_figure
   attribute :reverse_figure_description
   attribute :reverse_figure_relationship
-  attribute :reverse_legend, Valkyrie::Types::SingleValuedString
+  attribute :reverse_legend
   attribute :reverse_orientation
   attribute :reverse_part
   attribute :reverse_symbol
@@ -43,7 +43,7 @@ class NumismaticIssue < Resource
   attribute :series
   attribute :shape
   attribute :subject
-  attribute :workshop, Valkyrie::Types::SingleValuedString
+  attribute :workshop
 
   # adminstrative metadata
   attribute :depositor

--- a/app/services/geo_discovery/document_builder.rb
+++ b/app/services/geo_discovery/document_builder.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# frozen_string_literal: true
 module GeoDiscovery
   class DocumentBuilder
     class_attribute :services, :root_path_class

--- a/app/services/orangelight_document.rb
+++ b/app/services/orangelight_document.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+class OrangelightDocument
+  attr_reader :resource
+  delegate :to_json, to: :document
+
+  def initialize(resource)
+    @resource = resource
+  end
+
+  private
+
+    def document
+      builder_klass.new(resource.decorate).build
+    end
+
+    def builder_klass
+      "Orangelight#{resource.class}Builder".constantize
+    rescue
+      raise NotImplementedError, "Orangelight document builder for #{resource.class} not implemented."
+    end
+end

--- a/app/validators/year_validator.rb
+++ b/app/validators/year_validator.rb
@@ -2,7 +2,7 @@
 class YearValidator < ::ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return if value.blank?
-    return if value.length == 4 && value.to_i.to_s == value
+    return if value.delete("-").length <= 4 && value.to_i.to_s == value
     record.errors.add(attribute, "is not a valid year.")
   end
 end

--- a/app/views/records/edit_fields/_numismatic_monogram_ids.html.erb
+++ b/app/views/records/edit_fields/_numismatic_monogram_ids.html.erb
@@ -1,5 +1,5 @@
 <%= f.input :numismatic_monogram_ids,
-            collection: @numismatic_monograms.sort_by(&:title),
+            collection: @numismatic_monograms&.sort_by(&:title),
             label_method: :title,
             value_method: :id,
             input_html: { multiple: f.object.multiple?(key) },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -150,6 +150,7 @@ Rails.application.routes.draw do
         get :file_manager
         get :order_manager
         get :manifest, defaults: { format: :json }
+        get :orangelight, defaults: { format: :json }
         post :browse_everything_files
         get :discover_files
         post :auto_ingest

--- a/spec/resources/coins/coins_controller_spec.rb
+++ b/spec/resources/coins/coins_controller_spec.rb
@@ -123,4 +123,15 @@ RSpec.describe CoinsController, type: :controller do
       end
     end
   end
+  describe "GET /coins/:id/orangelight" do
+    let(:user) { FactoryBot.create(:admin) }
+
+    it "renders an orangelight document" do
+      coin = FactoryBot.create_for_repository(:coin)
+      FactoryBot.create_for_repository(:numismatic_issue, member_ids: [coin.id])
+      get :orangelight, params: { id: coin.id, format: :json }
+      doc = JSON.parse(response.body)
+      expect(doc["id"]).to eq "coin-#{coin.coin_number}"
+    end
+  end
 end

--- a/spec/services/orangelight_document_spec.rb
+++ b/spec/services/orangelight_document_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+require "rails_helper"
+include ActionDispatch::TestProcess
+
+describe OrangelightDocument do
+  describe "#to_json" do
+    context "when a resource does not have an associated builder class" do
+      subject(:builder) { described_class.new(scanned_resource) }
+      let(:scanned_resource) { ScannedResource.new }
+
+      it "raises a NotImplementedError" do
+        expect { builder.to_json }.to raise_error(NotImplementedError)
+      end
+    end
+
+    context "with an issue and a child coin" do
+      subject(:builder) { described_class.new(coin) }
+      let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }
+      let(:reference) { FactoryBot.create_for_repository(:numismatic_reference) }
+      let(:citation) { FactoryBot.create_for_repository(:numismatic_citation, numismatic_reference_id: reference.id) }
+      let(:date_range) { DateRange.new(start: "-91", end: "-41", approximate: true) }
+      let(:coin) do
+        FactoryBot.create_for_repository(:coin,
+                                         files: [file],
+                                         holding_location: "Firestone",
+                                         counter_stamp: "two small counter-stamps visible as small circles on reverse, without known parallel",
+                                         analysis: "holed at 12 o'clock, 16.73 grams",
+                                         public_note: ["Abraham Usher| John Field| Charles Meredith.", "Black and red ink.", "Visible flecks of mica."],
+                                         private_note: ["was in the same case as coin #8822"],
+                                         find_place: "Antioch, Syria",
+                                         find_date: "5/27/1939?",
+                                         find_feature: "Hill A?",
+                                         find_locus: "8-N 40",
+                                         find_number: "2237",
+                                         find_description: "at join of carcares and w. cavea surface",
+                                         die_axis: "6",
+                                         size: "27",
+                                         technique: "Cast",
+                                         weight: "8.26")
+      end
+      let(:issue) do
+        FactoryBot.create_for_repository(:numismatic_issue,
+                                         numismatic_citation_ids: [citation.id],
+                                         member_ids: [coin.id],
+                                         object_type: "coin",
+                                         date_range: date_range,
+                                         denomination: "1/2 Penny",
+                                         metal: "copper",
+                                         shape: "round",
+                                         color: "green",
+                                         edge: "GOTT MIT UNS",
+                                         era: "uncertain",
+                                         ruler: "George I",
+                                         master: "William Wood",
+                                         workshop: "Bristol",
+                                         series: "Hibernia",
+                                         place: "Great Britain",
+                                         obverse_figure: "bust",
+                                         obverse_symbol: "cornucopia",
+                                         obverse_part: "standing",
+                                         obverse_orientation: "right",
+                                         obverse_figure_description: "Harp at left side, 5 strings.",
+                                         obverse_figure_relationship: "Victory behind",
+                                         obverse_legend: "GEORGIUS•DEI•GRATIA•REX•",
+                                         obverse_attributes: ["to left and right", "around edge"],
+                                         reverse_figure: "Hibernia",
+                                         reverse_symbol: "goat head",
+                                         reverse_part: "seated",
+                                         reverse_orientation: "left",
+                                         reverse_figure_description: "Harp at right side, 11 strings. Right arm holding up a palm-branch",
+                                         reverse_figure_relationship: "corn-ear behind head",
+                                         reverse_legend: "•HIBERNIA•1723•",
+                                         reverse_attributes: ["above", "2 within Є"],
+                                         artist: ["André Galle"],
+                                         subject: ["unicorn"])
+      end
+
+      before do
+        stub_ezid(shoulder: "99999/fk4", blade: "123456")
+        coin
+        issue
+      end
+
+      it "returns an Orangelight document" do
+        output = MultiJson.load(builder.to_json, symbolize_keys: true)
+        expect(output[:id]).to eq "coin-#{coin.coin_number}"
+        expect(output[:title_display]).to eq "Coin: #{coin.coin_number}"
+        expect(output[:access_facet]).to eq ["Online", "In the Library"]
+        expect(output[:location]).to eq ["Firestone"]
+        expect(output[:format]).to eq ["Coin"]
+        expect(output[:advanced_location_s]).to eq ["num"]
+        expect(output[:counter_stamp_t]).to eq ["two small counter-stamps visible as small circles on reverse, without known parallel"]
+        expect(output[:analysis_t]).to eq ["holed at 12 o'clock, 16.73 grams"]
+        expect(output[:notes_display]).to eq ["Abraham Usher| John Field| Charles Meredith.", "Black and red ink.", "Visible flecks of mica."]
+        expect(output[:find_place_t]).to eq ["Antioch, Syria"]
+        expect(output[:find_date_t]).to eq ["5/27/1939?"]
+        expect(output[:find_feature_t]).to eq ["Hill A?"]
+        expect(output[:find_locus_t]).to eq ["8-N 40"]
+        expect(output[:find_number_t]).to eq ["2237"]
+        expect(output[:find_description_t]).to eq ["at join of carcares and w. cavea surface"]
+        expect(output[:die_axis_t]).to eq ["6"]
+        expect(output[:size_t]).to eq ["27"]
+        expect(output[:technique]).to eq ["Cast"]
+        expect(output[:weight_t]).to eq ["8.26"]
+        expect(output[:pub_date_start_sort]).to eq(-91)
+        expect(output[:pub_date_end_sort]).to eq(-41)
+        expect(output[:issue_object_type_t]).to eq ["coin"]
+        expect(output[:issue_denomination_t]).to eq ["1/2 Penny"]
+        expect(output[:issue_number_s]).to eq "1"
+        expect(output[:issue_metal_t]).to eq ["copper"]
+        expect(output[:issue_shape_t]).to eq ["round"]
+        expect(output[:issue_color_t]).to eq ["green"]
+        expect(output[:issue_edge_t]).to eq ["GOTT MIT UNS"]
+        expect(output[:issue_era_t]).to eq ["uncertain"]
+        expect(output[:issue_ruler_t]).to eq ["George I"]
+        expect(output[:issue_master_t]).to eq ["William Wood"]
+        expect(output[:issue_workshop_t]).to eq ["Bristol"]
+        expect(output[:issue_series_t]).to eq ["Hibernia"]
+        expect(output[:issue_place_t]).to eq ["Great Britain"]
+        expect(output[:issue_obverse_figure_t]).to eq ["bust"]
+        expect(output[:issue_obverse_symbol_t]).to eq ["cornucopia"]
+        expect(output[:issue_obverse_part_t]).to eq ["standing"]
+        expect(output[:issue_obverse_orientation_t]).to eq ["right"]
+        expect(output[:issue_obverse_figure_description_t]).to eq ["Harp at left side, 5 strings."]
+        expect(output[:issue_obverse_figure_relationship_t]).to eq ["Victory behind"]
+        expect(output[:issue_obverse_legend_t]).to eq ["GEORGIUS•DEI•GRATIA•REX•"]
+        expect(output[:issue_obverse_attributes_t]).to eq ["to left and right", "around edge"]
+        expect(output[:issue_reverse_figure_t]).to eq ["Hibernia"]
+        expect(output[:issue_reverse_symbol_t]).to eq ["goat head"]
+        expect(output[:issue_reverse_part_t]).to eq ["seated"]
+        expect(output[:issue_reverse_orientation_t]).to eq ["left"]
+        expect(output[:issue_reverse_figure_description_t]).to eq ["Harp at right side, 11 strings. Right arm holding up a palm-branch"]
+        expect(output[:issue_reverse_figure_relationship_t]).to eq ["corn-ear behind head"]
+        expect(output[:issue_reverse_legend_t]).to eq ["•HIBERNIA•1723•"]
+        expect(output[:issue_reverse_attributes_t]).to eq ["above", "2 within Є"]
+        expect(output[:issue_references_t]).to eq ["short-title citation part citation number"]
+      end
+    end
+  end
+end

--- a/spec/validators/year_validator_spec.rb
+++ b/spec/validators/year_validator_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe YearValidator do
+  subject(:validator) { described_class.new(attributes: attributes) }
+
+  describe "#validate" do
+    let(:errors) { double("Errors") }
+    let(:attributes) { [:start] }
+
+    before do
+      allow(errors).to receive(:add)
+    end
+
+    context "with a postive four digit year" do
+      it "does not add errors" do
+        record = build_record(start: "1979")
+
+        validator.validate(record)
+
+        expect(errors).not_to have_received(:add)
+      end
+    end
+
+    context "with a negative one digit year" do
+      it "does not add errors" do
+        record = build_record(start: "-1")
+
+        validator.validate(record)
+
+        expect(errors).not_to have_received(:add)
+      end
+    end
+
+    context "with a five digit year" do
+      it "adds errors" do
+        record = build_record(start: "12345")
+
+        validator.validate(record)
+
+        expect(errors).to have_received(:add).with(:start, "is not a valid year.")
+      end
+    end
+
+    context "with a string that does not correspond to an integer" do
+      it "adds errors" do
+        record = build_record(start: "not an integer")
+
+        validator.validate(record)
+
+        expect(errors).to have_received(:add).with(:start, "is not a valid year.")
+      end
+    end
+  end
+
+  def build_record(start:)
+    record = instance_double DateRangeChangeSet
+    allow(record).to receive(:errors).and_return(errors)
+    allow(record).to receive(:start).and_return(start)
+    allow(record).to receive(:read_attribute_for_validation).with(:start).and_return(record.start)
+    record
+  end
+end


### PR DESCRIPTION
- Adds generic Orangelight document service and a builder for Coin resources.
- Fixes issue with nil values in numismatic monogram input.
- Increases flexibility of the year validator to accommodate BCE and years with less than four digits. 