### PR TITLE
 Add graphql queries for coins and orangelight ids

### DIFF
--- a/app/queries/find_many_by_property.rb
+++ b/app/queries/find_many_by_property.rb
@@ -1,8 +1,7 @@
-
 # frozen_string_literal: true
-class FindManyByStringProperty
+class FindManyByProperty
   def self.queries
-    [:find_many_by_string_property]
+    [:find_many_by_property]
   end
 
   attr_reader :query_service
@@ -13,7 +12,7 @@ class FindManyByStringProperty
     @query_service = query_service
   end
 
-  def find_many_by_string_property(property:, values:)
+  def find_many_by_property(property:, values:)
     query = build_query(property, values)
     run_query(query)
   end
@@ -22,7 +21,8 @@ class FindManyByStringProperty
 
     def build_conditions(property, values)
       conditions = values.map do |value|
-        "metadata @> '{\"#{property}\": [\"#{value}\"]}'"
+        internal_array = { property => Array.wrap(value) }
+        "metadata @> '#{internal_array.to_json}'"
       end
 
       conditions.join(" OR ")

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -279,7 +279,7 @@ Rails.application.config.to_prepare do
   [
     FindByLocalIdentifier,
     FindByProperty,
-    FindManyByStringProperty,
+    FindManyByProperty,
     FindEphemeraTermByLabel,
     FindEphemeraVocabularyByLabel,
     MemoryEfficientAllQuery,

--- a/spec/graphql/types/query_type_spec.rb
+++ b/spec/graphql/types/query_type_spec.rb
@@ -23,11 +23,13 @@ RSpec.describe Types::QueryType do
     describe "resource field" do
       subject { described_class.fields["resource"] }
       it { is_expected.to accept_arguments(id: "ID!") }
+
       it "can return a resource by ID" do
         scanned_resource = FactoryBot.create_for_repository(:scanned_resource)
         type = described_class.new(nil, context)
         expect(type.resource(id: scanned_resource.id.to_s)).to be_a ScannedResource
       end
+
       it "can return a FileSet" do
         file_set = FactoryBot.create_for_repository(:file_set)
         type = described_class.new(nil, context)
@@ -97,10 +99,12 @@ RSpec.describe Types::QueryType do
   describe "#resources_by_bibids" do
     subject { described_class.fields["resourcesByBibids"] }
     it { is_expected.to accept_arguments(bibIds: "[String!]!") }
+
     context "when a user can read the resource" do
       before do
         allow(ability).to receive(:can?).with(:read, anything).and_return(true)
       end
+
       it "can return resources by its bibid" do
         stub_bibdata(bib_id: "7214786")
         stub_bibdata(bib_id: "8543429")
@@ -110,10 +114,12 @@ RSpec.describe Types::QueryType do
         expect(type.resources_by_bibids(bib_ids: ["7214786", "8543429"]).map(&:id)).to contain_exactly(scanned_resource.id, scanned_resource2.id)
       end
     end
+
     context "when the user can't read the resource" do
       before do
         allow(ability).to receive(:can?).with(:read, anything).and_return(false)
       end
+
       it "returns nothing" do
         stub_bibdata(bib_id: "7214786")
         stub_bibdata(bib_id: "8543429")
@@ -123,10 +129,12 @@ RSpec.describe Types::QueryType do
         expect(type.resources_by_bibids(bib_ids: ["7214786", "8543429"])).to eq []
       end
     end
+
     context "when one resource does not have a defined graphql type" do
       before do
         allow(ability).to receive(:can?).with(:read, anything).and_return(true)
       end
+
       it "returns the resource with the defined type only" do
         stub_bibdata(bib_id: "7214786")
         stub_bibdata(bib_id: "8543429")
@@ -139,7 +147,6 @@ RSpec.describe Types::QueryType do
   end
 
   describe "#resources_by_coin_number" do
-    subject { described_class.fields["resourcesByCoinNumber"] }
     context "when a user can read the resource" do
       before do
         allow(ability).to receive(:can?).with(:read, anything).and_return(true)
@@ -166,7 +173,6 @@ RSpec.describe Types::QueryType do
   end
 
   describe "#resources_by_coin_numbers" do
-    subject { described_class.fields["resourcesByCoinNumbers"] }
     context "when a user can read the resource" do
       before do
         allow(ability).to receive(:can?).with(:read, anything).and_return(true)
@@ -222,10 +228,12 @@ RSpec.describe Types::QueryType do
   describe "#resources_by_orangelight_ids" do
     subject { described_class.fields["resourcesByOrangelightIds"] }
     it { is_expected.to accept_arguments(ids: "[String!]!") }
+
     context "when a user can read the resource" do
       before do
         allow(ability).to receive(:can?).with(:read, anything).and_return(true)
       end
+
       it "can return resources by bibids" do
         stub_bibdata(bib_id: "7214786")
         stub_bibdata(bib_id: "8543429")
@@ -255,6 +263,7 @@ RSpec.describe Types::QueryType do
       before do
         allow(ability).to receive(:can?).with(:read, anything).and_return(false)
       end
+
       it "returns nothing" do
         stub_bibdata(bib_id: "7214786")
         stub_bibdata(bib_id: "8543429")

--- a/spec/queries/find_many_by_property_spec.rb
+++ b/spec/queries/find_many_by_property_spec.rb
@@ -2,15 +2,15 @@
 # frozen_string_literal: true
 require "rails_helper"
 
-RSpec.describe FindManyByStringProperty do
+RSpec.describe FindManyByProperty do
   subject(:query) { described_class.new(query_service: query_service) }
   let(:box) { FactoryBot.create_for_repository(:ephemera_folder, barcode: "1234567") }
   let(:box2) { FactoryBot.create_for_repository(:ephemera_folder, barcode: "2345678") }
   let(:query_service) { Valkyrie.config.metadata_adapter.query_service }
 
-  describe "#find_many_by_string_property" do
+  describe "#find_many_by_property" do
     it "can find objects with strings in it by a property" do
-      output = query.find_many_by_string_property(property: :barcode, values: [box.barcode.first, box2.barcode.first])
+      output = query.find_many_by_property(property: :barcode, values: [box.barcode.first, box2.barcode.first])
       expect(output.length).to eq 2
       output_ids = output.map(&:id)
       expect(output_ids).to include box.id
@@ -19,7 +19,7 @@ RSpec.describe FindManyByStringProperty do
 
     context "when no objects have the string in that property" do
       it "returns no results" do
-        output = query.find_many_by_string_property(property: :barcode, values: ["notabarcode"])
+        output = query.find_many_by_property(property: :barcode, values: ["notabarcode"])
         expect(output.to_a).to be_empty
       end
     end


### PR DESCRIPTION
Adds new queries for orangelight ids rather than just bib_ids.

Closes #2655