### PR TITLE
Track file sets being created on ChangeSet

### DIFF
--- a/app/change_set_persisters/change_set_persister/characterize.rb
+++ b/app/change_set_persisters/change_set_persister/characterize.rb
@@ -1,12 +1,11 @@
 # frozen_string_literal: true
 class ChangeSetPersister
   class Characterize
-    attr_reader :change_set_persister, :change_set, :post_save_resource, :created_file_sets
+    attr_reader :change_set_persister, :change_set, :post_save_resource
     delegate :characterize?, to: :change_set_persister
-    def initialize(change_set_persister:, change_set:, created_file_sets:, post_save_resource: nil)
+    def initialize(change_set_persister:, change_set:, post_save_resource: nil)
       @change_set = change_set
       @change_set_persister = change_set_persister
-      @created_file_sets = created_file_sets
       @post_save_resource = post_save_resource
     end
 
@@ -16,6 +15,10 @@ class ChangeSetPersister
         next unless file_set.instance_of?(FileSet) && characterize?
         ::CharacterizationJob.set(queue: change_set_persister.queue).perform_later(file_set.id.to_s)
       end
+    end
+
+    def created_file_sets
+      change_set.try(:created_file_sets) || []
     end
   end
 end

--- a/app/change_set_persisters/change_set_persister/cleanup_pdfs.rb
+++ b/app/change_set_persisters/change_set_persister/cleanup_pdfs.rb
@@ -13,7 +13,7 @@ class ChangeSetPersister
       return unless resource.is_a?(ScannedResource) && pdf_file
 
       # Return if the only update is that file metadata is being updated
-      if change_set.changed.except("file_metadata").empty?
+      if change_set.changed.except("file_metadata", "created_file_sets").empty?
         # Delete the file metadata if the files cannot be located
         resource.file_metadata.delete(pdf_file) unless pdf_file_exists?
         return

--- a/app/change_set_persisters/change_set_persister/create_file.rb
+++ b/app/change_set_persisters/change_set_persister/create_file.rb
@@ -20,8 +20,10 @@ class ChangeSetPersister
     end
 
     def run
+      return unless change_set.respond_to?(:created_file_sets=)
       appender = file_appender.new(storage_adapter: storage_adapter, persister: persister, files: files)
-      change_set_persister.created_file_sets = appender.append_to(change_set.resource)
+      created_file_sets = appender.append_to(change_set.resource)
+      change_set.created_file_sets = created_file_sets
     end
 
     def files

--- a/app/change_set_persisters/change_set_persister/publish_message.rb
+++ b/app/change_set_persisters/change_set_persister/publish_message.rb
@@ -26,14 +26,15 @@ class ChangeSetPersister
   end
 
   class PublishCreatedMessage
-    attr_reader :change_set_persister, :change_set, :created_file_sets
-    def initialize(change_set_persister:, change_set: nil, created_file_sets: nil)
+    attr_reader :change_set_persister, :change_set
+    delegate :created_file_sets, to: :change_set
+    def initialize(change_set_persister:, change_set: nil)
       @change_set = change_set
       @change_set_persister = change_set_persister
-      @created_file_sets = created_file_sets
     end
 
     def run
+      return unless change_set.respond_to?(:created_file_sets)
       created_file_sets.each { |created_file_set| messenger.record_created(created_file_set) } unless created_file_sets.blank?
     end
 

--- a/app/change_sets/change_set.rb
+++ b/app/change_sets/change_set.rb
@@ -11,4 +11,10 @@ class ChangeSet < Valkyrie::ChangeSet
       @_changes = Disposable::Twin::Changed::Changes.new
     end
   end
+
+  # This property is set by ChangeSetPersister::CreateFile and is used to keep
+  # track of which FileSets were created by the ChangeSetPersister as part of
+  # saving this change_set. We may want to look into passing some sort of scope
+  # around with the change_set in ChangeSetPersister instead, at some point.
+  property :created_file_sets, virtual: true, multiple: true, required: false, default: []
 end

--- a/app/resources/collections/collection_change_set.rb
+++ b/app/resources/collections/collection_change_set.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CollectionChangeSet < Valkyrie::ChangeSet
+class CollectionChangeSet < ChangeSet
   delegate :human_readable_type, to: :model
   property :title, multiple: false, required: true
   property :slug, multiple: false, required: true

--- a/app/resources/file_sets/file_set_change_set.rb
+++ b/app/resources/file_sets/file_set_change_set.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class FileSetChangeSet < Valkyrie::ChangeSet
+class FileSetChangeSet < ChangeSet
   self.fields = [:title]
   property :files, virtual: true, multiple: true, required: false
   property :viewing_hint, multiple: false, required: false

--- a/app/resources/numismatic_monograms/numismatic_monogram_change_set.rb
+++ b/app/resources/numismatic_monograms/numismatic_monogram_change_set.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class NumismaticMonogramChangeSet < Valkyrie::ChangeSet
+class NumismaticMonogramChangeSet < ChangeSet
   delegate :human_readable_type, to: :model
 
   property :title, multiple: false, required: true

--- a/app/views/catalog/_workflow_controls_default.html.erb
+++ b/app/views/catalog/_workflow_controls_default.html.erb
@@ -1,4 +1,4 @@
-<% if can?(:edit, resource) && @change_set.respond_to?(:workflow_class) %>
+<% if can?(:edit, resource) && @change_set.respond_to?(:workflow_class) && @change_set.respond_to?(:state) %>
   <div id="workflow_controls"class="panel panel-default workflow-affix">
     <div class="panel-heading">
       <h2 class="panel-title">Review and Approval</h2>


### PR DESCRIPTION
The change_set_persister is re-used for multiple interactions with a
variety of ChangeSets. As such, tracking it there was leading to the
created_file_sets getting wiped, resulting in no characterization being
run.

Closes #2654