### PR TITLE
Add PDF Type to scanned map form

### DIFF
--- a/app/change_set_persisters/change_set_persister/cleanup_pdfs.rb
+++ b/app/change_set_persisters/change_set_persister/cleanup_pdfs.rb
@@ -10,7 +10,7 @@ class ChangeSetPersister
     end
 
     def run
-      return unless resource.is_a?(ScannedResource) && pdf_file
+      return unless clean_up?
 
       # Return if the only update is that file metadata is being updated
       if change_set.changed.except("file_metadata", "created_file_sets").empty?
@@ -24,6 +24,12 @@ class ChangeSetPersister
     end
 
     private
+
+      def clean_up?
+        return false unless resource.is_a?(ScannedResource) || resource.is_a?(ScannedMap)
+        return false unless pdf_file
+        true
+      end
 
       def pdf_file
         @pdf_file ||= resource.pdf_file

--- a/app/resources/scanned_maps/scanned_map_change_set.rb
+++ b/app/resources/scanned_maps/scanned_map_change_set.rb
@@ -17,6 +17,7 @@ class ScannedMapChangeSet < ScannedResourceChangeSet
       :gbl_suppressed_override,
       :rights_statement,
       :rights_note,
+      :pdf_type,
       :portion_note,
       :local_identifier,
       :holding_location,

--- a/spec/change_set_persisters/change_set_persister/cleanup_pdfs_spec.rb
+++ b/spec/change_set_persisters/change_set_persister/cleanup_pdfs_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ChangeSetPersister::CleanupPdfs do
   end
 
   describe "#run" do
-    context "with a resource that isn't a ScannedResource" do
+    context "with a resource that isn't a ScannedResource or a ScannedMap" do
       let(:resource) { FactoryBot.create(:draft_simple_resource) }
       it "does nothing" do
         change_set.prepopulate!
@@ -73,6 +73,17 @@ RSpec.describe ChangeSetPersister::CleanupPdfs do
     context "with a ScannedResource with a PDF attached and changes" do
       let(:resource) { FactoryBot.create(:scanned_resource, file_metadata: [pdf_file]) }
       it "deletes the PDF and removes it from the ScannedResource" do
+        change_set.prepopulate!
+        change_set.validate(title: "Updated resource")
+        hook.run
+
+        expect(CleanupFilesJob).to have_received(:perform_later).with(file_identifiers: ["asdf"])
+        expect(resource.file_metadata).to eq []
+      end
+    end
+    context "with a ScannedMap with a PDF attached and changes" do
+      let(:resource) { FactoryBot.create(:scanned_map, file_metadata: [pdf_file]) }
+      it "deletes the PDF and removes it from the ScannedMap" do
         change_set.prepopulate!
         change_set.validate(title: "Updated resource")
         hook.run

--- a/spec/resources/scanned_maps/scanned_map_feature_spec.rb
+++ b/spec/resources/scanned_maps/scanned_map_feature_spec.rb
@@ -15,6 +15,7 @@ RSpec.feature "ScannedMaps" do
     expect(page).to have_field "Source Metadata ID"
     expect(page).to have_css ".select[for='scanned_map_rights_statement']", text: "Rights Statement"
     expect(page).to have_field "Rights Note"
+    expect(page).to have_css ".select[for='scanned_map_pdf_type']", text: "PDF Type"
     expect(page).to have_field "Portion Note"
     expect(page).to have_field "Local identifier"
     expect(page).to have_css ".select[for='scanned_map_holding_location']", text: "Holding Location"
@@ -53,6 +54,7 @@ RSpec.feature "ScannedMaps" do
         rights_note: "test rights note",
         rights_statement: RightsStatements.copyright_not_evaluated.to_s,
         subject: "test value",
+        pdf_type: "color",
         portion_note: "test portion note",
         cartographic_scale: "test value",
         spatial: "test value",
@@ -81,6 +83,7 @@ RSpec.feature "ScannedMaps" do
       expect(page).to have_css ".attribute.local_identifier", text: "test ID"
       expect(page).to have_css ".attribute.rights_note", text: "test rights note"
       expect(page).to have_css ".attribute.rights_statement", text: RightsStatements.copyright_not_evaluated.to_s
+      expect(page).to have_css ".attribute.pdf_type", text: "color"
       expect(page).to have_css ".attribute.subject", text: "test value"
       expect(page).to have_css ".attribute.portion_note", text: "test portion note"
       expect(page).to have_css ".attribute.cartographic_scale", text: "test value"


### PR DESCRIPTION
- Adds PDF Type to scanned map
- Allows scanned map PDFs to be cleaned up

Closes #2694 