### PR TITLE
Overrides Blacklight::UrlHelperBehavior#link_back_to_catalog in order to generate search result links from Playlists

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,6 +32,7 @@ Metrics/AbcSize:
     - 'app/services/music_import_service.rb'
     - 'app/services/music_import_service/recording_collector.rb'
     - 'app/controllers/bulk_ingest_controller.rb'
+    - 'app/helpers/application_helper.rb'
 Metrics/BlockLength:
   Exclude:
     - 'app/controllers/catalog_controller.rb'
@@ -145,6 +146,7 @@ Metrics/MethodLength:
     - 'app/indexers/imported_metadata_indexer.rb'
     - 'app/controllers/concerns/resource_controller.rb'
     - 'app/models/search_builder.rb'
+    - 'app/helpers/application_helper.rb'
 Metrics/ModuleLength:
   Exclude:
     - 'app/models/schema/marc_relators.rb'
@@ -168,6 +170,7 @@ Metrics/PerceivedComplexity:
     - 'app/change_set_persisters/change_set_persister/apply_auth_token.rb'
     - 'config/initializers/sequel_active_support_notification.rb'
     - 'app/services/music_import_service.rb'
+    - 'app/helpers/application_helper.rb'
 Rails/OutputSafety:
   Exclude:
     - 'app/resources/**/*_decorator*'

--- a/app/javascript/components/document_adder.vue
+++ b/app/javascript/components/document_adder.vue
@@ -147,8 +147,11 @@ export default {
         return
       }
       let vm = this
-      // Get all recording titles and IDs from a catalog search (solr).
-      fetch(`/catalog.json?f[internal_resource_ssim][]=ScannedResource&f[change_set_ssim][]=recording&q=${this.recording_query}`)
+
+      // Get all recording titles and IDs from a catalog search (Solr).
+      // Ensure that this AJAX request does not trigger the caching of query
+      // parameters (this is the default behavior for Blacklight 6 Controllers)
+      fetch(`/catalog.json?f[internal_resource_ssim][]=ScannedResource&f[change_set_ssim][]=recording&q=${this.recording_query}&async=true`)
         .then(function (response) {
           return response.json()
         })

--- a/spec/features/playlist_spec.rb
+++ b/spec/features/playlist_spec.rb
@@ -52,6 +52,14 @@ RSpec.feature "PlaylistChangeSets" do
       playlist_members_element = playlist_members_elements.first
       expect(playlist_members_element.attributes[":members"].value).to eq json_fixture(resource.decorate.decorated_proxies.first, recording)
     end
+
+    scenario "returning to search results" do
+      persisted = adapter.query_service.find_by(id: resource.id)
+      visit "/?f[human_readable_type_ssim][]=Playlist&q="
+      visit solr_document_path persisted
+
+      expect(page).to have_css('a[href="/?f%5Bhuman_readable_type_ssim%5D%5B%5D=Playlist&q="]', text: "Back to Search")
+    end
   end
 
   def json_fixture(decorated_resource, recording)

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -71,4 +71,52 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe "#link_back_to_catalog" do
+    let(:search_session) do
+      {}
+    end
+    let(:search_state) { instance_double(Blacklight::SearchState) }
+    let(:current_search_session) { instance_double(Search) }
+
+    before do
+      # This is required to generate the path for the catalog actions
+      allow(helper).to receive(:search_action_path).and_return(search_catalog_path)
+
+      allow(helper).to receive(:search_session).and_return(search_session)
+      allow(search_state).to receive(:to_hash).and_return({})
+      allow(search_state).to receive(:reset).and_return(search_state)
+      allow(helper).to receive(:search_state).and_return(search_state)
+      allow(current_search_session).to receive(:query_params).and_return({})
+      allow(helper).to receive(:current_search_session).and_return(current_search_session)
+    end
+
+    it "generates the search URL from a record" do
+      expect(helper.link_back_to_catalog).to eq '<a href="/catalog">Back to Search</a>'
+    end
+
+    context "when the search session contained parameters for per-page result limits" do
+      # Scope objects are just anonymous objects
+      let(:scope) { double }
+      let(:blacklight_config) { Blacklight::Configuration.new }
+      let(:search_session) do
+        {
+          "per_page" => 10,
+          "counter" => 1,
+          "page" => 1
+        }
+      end
+
+      before do
+        allow(helper).to receive(:url_for)
+        allow(helper).to receive(:blacklight_config).and_return(blacklight_config)
+
+        helper.link_back_to_catalog
+      end
+
+      it "generates the search URL with query parameters" do
+        expect(helper).to have_received(:url_for).with(page: 1, q: "")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves #2502 by overriding `Blacklight::UrlHelperBehavior#link_back_to_catalog` to parse for cached query parameters stored from AJAX search requests and adding an `async` GET parameter to the DocumentAdder Vue Component.