### PR TITLE
Cicognara MARC export improvements

### DIFF
--- a/app/services/cicognara_marc.rb
+++ b/app/services/cicognara_marc.rb
@@ -59,6 +59,7 @@ class CicognaraMarc
       bib_number = record["001"].value
       writer = MARC::XMLWriter.new(File.join(out_dir, "#{bib_number}_marc.xml"))
       writer.write(record)
+      writer.close
     end
 
     def wayfinder

--- a/app/services/marc_record_enhancer.rb
+++ b/app/services/marc_record_enhancer.rb
@@ -50,15 +50,17 @@ class MarcRecordEnhancer
 
     def add_024
       return unless resource.try(:local_identifier)&.present?
-      dcl = resource.local_identifier.first
-      dcl024 = existing_024s(dcl).first
-      if dcl024
-        dcl024.indicator1 = "8"
-        subfield2 = dcl024.subfields.select { |s| s.code == "2" }.first
-        dcl024.subfields.delete(subfield2) if subfield2
-      else
-        dcl024 = MARC::DataField.new("024", "8", " ", MARC::Subfield.new("a", dcl))
-        marc.append(dcl024)
+      dcl_numbers = resource.local_identifier.select { |s| s.start_with?("dcl:") }.uniq
+      dcl_numbers.each do |dcl|
+        dcl024 = existing_024s(dcl).first
+        if dcl024
+          dcl024.indicator1 = "8"
+          subfield2 = dcl024.subfields.select { |s| s.code == "2" }.first
+          dcl024.subfields.delete(subfield2) if subfield2
+        else
+          dcl024 = MARC::DataField.new("024", "8", " ", MARC::Subfield.new("a", dcl))
+          marc.append(dcl024)
+        end
       end
     end
 

--- a/app/services/marc_record_enhancer.rb
+++ b/app/services/marc_record_enhancer.rb
@@ -51,14 +51,13 @@ class MarcRecordEnhancer
     def add_024
       return unless resource.try(:local_identifier)&.present?
       dcl = resource.local_identifier.first
-      return if standard_identifiers.include? dcl
-      marc.append(
-        MARC::DataField.new(
-          "024", "7", " ",
-          MARC::Subfield.new("a", dcl),
-          MARC::Subfield.new("2", "dclib")
-        )
-      )
+      dcl024 = existing_024s(dcl).first
+      if dcl024
+        dcl024.indicator1 = "8"
+      else
+        dcl024 = MARC::DataField.new("024", "8", " ", MARC::Subfield.new("a", dcl))
+        marc.append(dcl024)
+      end
     end
 
     def add_510
@@ -86,9 +85,9 @@ class MarcRecordEnhancer
       end.first
     end
 
-    def standard_identifiers
-      marc.fields("024").map do |field|
-        field.subfields.select { |s| s.code == "a" }.map(&:value).first
+    def existing_024s(id)
+      marc.fields("024").select do |f|
+        f.subfields.select { |s| s.code == "a" }.first.value == id
       end
     end
 

--- a/app/services/marc_record_enhancer.rb
+++ b/app/services/marc_record_enhancer.rb
@@ -54,6 +54,8 @@ class MarcRecordEnhancer
       dcl024 = existing_024s(dcl).first
       if dcl024
         dcl024.indicator1 = "8"
+        subfield2 = dcl024.subfields.select { |s| s.code == "2" }.first
+        dcl024.subfields.delete(subfield2) if subfield2
       else
         dcl024 = MARC::DataField.new("024", "8", " ", MARC::Subfield.new("a", dcl))
         marc.append(dcl024)

--- a/spec/services/cicognara_marc_spec.rb
+++ b/spec/services/cicognara_marc_spec.rb
@@ -175,10 +175,14 @@ RSpec.describe CicognaraMarc do
         MARC::DataField.new("856", "4", "1", MARC::Subfield.new("u", "http://arks.princeton.edu/ark:/88435/#{blade2}"))
       end
       let(:manifest_856_1) do
-        MARC::DataField.new("856", "4", "1", MARC::Subfield.new("u", manifest_url_1))
+        f = MARC::DataField.new("856", "4", "1", MARC::Subfield.new("u", manifest_url_1))
+        f.append(MARC::Subfield.new("q", "JSON (IIIF Manifest)"))
+        f
       end
       let(:manifest_856_2) do
-        MARC::DataField.new("856", "4", "1", MARC::Subfield.new("u", manifest_url_2))
+        f = MARC::DataField.new("856", "4", "1", MARC::Subfield.new("u", manifest_url_2))
+        f.append(MARC::Subfield.new("q", "JSON (IIIF Manifest)"))
+        f
       end
       let(:manifest_url_1) { Rails.application.routes.url_helpers.polymorphic_url([:manifest, resource1]) }
       let(:manifest_url_2) { Rails.application.routes.url_helpers.polymorphic_url([:manifest, resource2]) }

--- a/spec/services/cicognara_marc_spec.rb
+++ b/spec/services/cicognara_marc_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe CicognaraMarc do
         allow(enhancer2).to receive(:enhance_cicognara).and_return(minimal_record2)
         allow(MARC::XMLWriter).to receive(:new).and_return(writer)
         allow(writer).to receive(:write)
+        allow(writer).to receive(:close)
       end
 
       it "puts a marc file per bibid in a specified directory" do
@@ -48,6 +49,7 @@ RSpec.describe CicognaraMarc do
         FactoryBot.create_for_repository(:complete_open_scanned_resource, member_of_collection_ids: collection.id, source_metadata_identifier: "8543429")
         allow(MARC::XMLWriter).to receive(:new).and_return(writer)
         allow(writer).to receive(:write)
+        allow(writer).to receive(:close)
         stub_bibdata(bib_id: "8543429", content_type: BibdataStubbing::CONTENT_TYPE_MARC_XML)
       end
 
@@ -71,6 +73,7 @@ RSpec.describe CicognaraMarc do
         allow(enhancer).to receive(:enhance_cicognara).and_return(minimal_record)
         allow(MARC::XMLWriter).to receive(:new).and_return(writer)
         allow(writer).to receive(:write)
+        allow(writer).to receive(:close)
       end
 
       it "writes just one marc record" do
@@ -97,6 +100,7 @@ RSpec.describe CicognaraMarc do
         allow(enhancer2).to receive(:enhance_cicognara).and_return(minimal_record2)
         allow(MARC::XMLWriter).to receive(:new).and_return(writer)
         allow(writer).to receive(:write)
+        allow(writer).to receive(:close)
       end
 
       it "writes just one marc record" do
@@ -123,6 +127,7 @@ RSpec.describe CicognaraMarc do
         allow(enhancer2).to receive(:enhance_cicognara).and_return(minimal_record2)
         allow(MARC::XMLWriter).to receive(:new).and_return(writer)
         allow(writer).to receive(:write)
+        allow(writer).to receive(:close)
       end
 
       it "writes just one marc record" do

--- a/spec/services/cicognara_marc_spec.rb
+++ b/spec/services/cicognara_marc_spec.rb
@@ -192,8 +192,8 @@ RSpec.describe CicognaraMarc do
       let(:manifest_url_1) { Rails.application.routes.url_helpers.polymorphic_url([:manifest, resource1]) }
       let(:manifest_url_2) { Rails.application.routes.url_helpers.polymorphic_url([:manifest, resource2]) }
       let(:metadata_mock) { double }
-      let(:li1) { "dlc:li1" }
-      let(:li2) { "dlc:li2" }
+      let(:li1) { "dcl:li1" }
+      let(:li2) { "dcl:li2" }
       let(:ref1) { "123" }
       let(:ref2) { "456" }
       let(:blade1) { "jm214s442" }

--- a/spec/services/marc_record_enhancer_spec.rb
+++ b/spec/services/marc_record_enhancer_spec.rb
@@ -153,17 +153,15 @@ RSpec.describe MarcRecordEnhancer do
       end
       let(:dcl_024) do
         MARC::DataField.new(
-          "024", "7", " ",
-          MARC::Subfield.new("a", "dcl:xjt"),
-          MARC::Subfield.new("2", "dclib")
+          "024", "8", " ",
+          MARC::Subfield.new("a", "dcl:xjt")
         )
       end
       it "leaves that 024" do
         std_ids = enhancer.enhance_cicognara.fields("024").select do |field|
-          field.indicator1 == "7" &&
+          field.indicator1 == "8" &&
             field.indicator2 == " " &&
-            field.subfields.select { |subfield| subfield.code == "a" }.count == 1 &&
-            field.subfields.select { |subfield| subfield.code == "2" }.first.value == "dclib"
+            field.subfields.select { |subfield| subfield.code == "a" }.count == 1
         end
         expect(std_ids.count).to eq 1
         subfield_a = std_ids.first.subfields.select { |s| s.code == "a" }.first
@@ -186,14 +184,13 @@ RSpec.describe MarcRecordEnhancer do
       it "adds another 024 with our dcl #" do
         expect(enhancer.enhance_cicognara.fields("024").count).to eq 2
         std_ids = enhancer.marc.fields("024").select do |field|
-          field.indicator1 == "7" &&
+          field.indicator1 == "8" &&
             field.indicator2 == " " &&
-            field.subfields.select { |subfield| subfield.code == "a" }.count == 1 &&
-            field.subfields.select { |subfield| subfield.code == "2" }.first&.value == "dclib"
+            field.subfields.select { |subfield| subfield.code == "a" }.count == 1
         end
-        expect(std_ids.count).to eq 1
-        subfield_a = std_ids.first.subfields.select { |s| s.code == "a" }.first
-        expect(subfield_a.value).to eq "dcl:xjt"
+        expect(std_ids.count).to eq 2
+        id_values = std_ids.flat_map(&:subfields).select { |s| s.code == "a" }
+        expect(id_values.map(&:value)).to contain_exactly("dcl:xjt", "rando id")
       end
     end
 
@@ -201,10 +198,9 @@ RSpec.describe MarcRecordEnhancer do
       let(:marc_record) { MARC::Record.new }
       it "adds an 024 with our dcl #" do
         std_ids = enhancer.enhance_cicognara.fields("024").select do |field|
-          field.indicator1 == "7" &&
+          field.indicator1 == "8" &&
             field.indicator2 == " " &&
-            field.subfields.select { |subfield| subfield.code == "a" }.count == 1 &&
-            field.subfields.select { |subfield| subfield.code == "2" }.first.value == "dclib"
+            field.subfields.select { |subfield| subfield.code == "a" }.count == 1
         end
         expect(std_ids.count).to eq 1
         subfield_a = std_ids.first.subfields.select { |s| s.code == "a" }.first

--- a/spec/services/marc_record_enhancer_spec.rb
+++ b/spec/services/marc_record_enhancer_spec.rb
@@ -96,6 +96,7 @@ RSpec.describe MarcRecordEnhancer do
           "http://arks.princeton.edu/ark:/88435/jm214s442",
           manifest_url
         )
+        expect(urls.flat_map(&:subfields).select { |s| s.code == "q" }.map(&:value)).to eq(["JSON (IIIF Manifest)"])
       end
     end
 


### PR DESCRIPTION
* Manifest 856 should include a subfield q declaring it to be JSON/IIIF
* Close XML write to ensure valid XML
* DCL Number 024 should have "8" for first indicator

Fixes #2684 