### PR TITLE
Don't pre-populate everywhere

### DIFF
--- a/app/change_set_persisters/change_set_persister/cleanup_structure.rb
+++ b/app/change_set_persisters/change_set_persister/cleanup_structure.rb
@@ -17,7 +17,6 @@ class ChangeSetPersister
       parents.each do |parent|
         parent_change_set = DynamicChangeSet.new(parent)
         next unless parent_change_set.respond_to? :logical_structure
-        parent_change_set.prepopulate!
         parent_change_set.logical_structure.each do |structure|
           recursive_delete(structure.nodes, @change_set.id)
         end

--- a/app/change_set_persisters/change_set_persister/cleanup_terms.rb
+++ b/app/change_set_persisters/change_set_persister/cleanup_terms.rb
@@ -16,7 +16,7 @@ class ChangeSetPersister
       return unless resource.is_a?(EphemeraTerm)
       resources = query_service.custom_queries.find_id_usage_by_model(id: resource.id, model: EphemeraFolder)
       change_sets = resources.map do |parent_resource, keys|
-        parent_change_set = DynamicChangeSet.new(parent_resource).prepopulate!
+        parent_change_set = DynamicChangeSet.new(parent_resource)
         keys.each do |key|
           parent_change_set.validate(key => (parent_resource[key] - [resource.id]))
         end

--- a/app/change_set_persisters/change_set_persister/propagate_visibility_and_state.rb
+++ b/app/change_set_persisters/change_set_persister/propagate_visibility_and_state.rb
@@ -19,7 +19,7 @@ class ChangeSetPersister
     def run
       return if new_collection_record
       members.each do |member|
-        resource_change_set = DynamicChangeSet.new(member).prepopulate!
+        resource_change_set = DynamicChangeSet.new(member)
         resource_change_set = propagate_visibility(resource_change_set)
         resource_change_set = propagate_state_for_related(resource_change_set)
         # we need to save these through the change set persister so the member

--- a/app/change_sets/change_set.rb
+++ b/app/change_sets/change_set.rb
@@ -6,15 +6,28 @@ class ChangeSet < Valkyrie::ChangeSet
     include(ChangeSetWorkflow)
   end
 
-  def prepopulate!
-    super.tap do
-      @_changes = Disposable::Twin::Changed::Changes.new
-    end
-  end
-
   # This property is set by ChangeSetPersister::CreateFile and is used to keep
   # track of which FileSets were created by the ChangeSetPersister as part of
   # saving this change_set. We may want to look into passing some sort of scope
   # around with the change_set in ChangeSetPersister instead, at some point.
   property :created_file_sets, virtual: true, multiple: true, required: false, default: []
+
+  def initialize(*args)
+    super.tap do
+      fix_multivalued_keys
+    end
+  end
+
+  # This is a temporary fix to deal with the fact that we have change sets which
+  # are set to be singular when the model is set to be multiple. REMOVE THIS as
+  # soon as the model has single-value fields in places where it makes sense.
+  #
+  # @todo: REMOVE THIS.
+  def fix_multivalued_keys
+    self.class.definitions.select { |_field, definition| definition[:multiple] == false }.each_key do |field|
+      value = Array.wrap(send(field.to_s)).first
+      send("#{field}=", value)
+    end
+    @_changes = Disposable::Twin::Changed::Changes.new
+  end
 end

--- a/app/controllers/base_resource_controller.rb
+++ b/app/controllers/base_resource_controller.rb
@@ -39,11 +39,11 @@ class BaseResourceController < ApplicationController
 
   # Attach a resource to a parent
   def attach_to_parent
-    @change_set = change_set_class.new(find_resource(params[:id])).prepopulate!
+    @change_set = change_set_class.new(find_resource(params[:id]))
     parent_resource = find_resource(parent_resource_params[:id])
     authorize! :update, parent_resource
 
-    parent_change_set = DynamicChangeSet.new(parent_resource).prepopulate!
+    parent_change_set = DynamicChangeSet.new(parent_resource)
     if parent_change_set.validate(parent_resource_params)
       current_member_ids = parent_resource.member_ids
       attached_member_ids = parent_change_set.member_ids
@@ -64,11 +64,11 @@ class BaseResourceController < ApplicationController
 
   # Remove a resource from a parent
   def remove_from_parent
-    @change_set = change_set_class.new(find_resource(params[:id])).prepopulate!
+    @change_set = change_set_class.new(find_resource(params[:id]))
     parent_resource = find_resource(parent_resource_params[:id])
     authorize! :update, parent_resource
 
-    parent_change_set = DynamicChangeSet.new(parent_resource).prepopulate!
+    parent_change_set = DynamicChangeSet.new(parent_resource)
     if parent_change_set.validate(parent_resource_params)
       current_member_ids = parent_resource.member_ids
       removed_member_ids = parent_change_set.member_ids

--- a/app/controllers/bulk_ingest_controller.rb
+++ b/app/controllers/bulk_ingest_controller.rb
@@ -128,7 +128,6 @@ class BulkIngestController < ApplicationController
 
     def build_change_set(attrs)
       change_set = DynamicChangeSet.new(build_resource)
-      change_set.prepopulate!
       change_set.validate(**attrs)
       change_set
     end

--- a/app/controllers/concerns/geo_resource_controller.rb
+++ b/app/controllers/concerns/geo_resource_controller.rb
@@ -3,7 +3,7 @@ module GeoResourceController
   extend ActiveSupport::Concern
   included do
     def extract_metadata
-      change_set = change_set_class.new(find_resource(params[:id])).prepopulate!
+      change_set = change_set_class.new(find_resource(params[:id]))
       authorize! :update, change_set.resource
       file_node = query_service.find_by(id: Valkyrie::ID.new(params[:file_set_id]))
       GeoMetadataExtractor.new(change_set: change_set, file_node: file_node, persister: change_set_persister).extract

--- a/app/controllers/concerns/resource_controller.rb
+++ b/app/controllers/concerns/resource_controller.rb
@@ -55,11 +55,11 @@ module ResourceController
     @change_set = change_set_class.new(find_resource(params[:id]))
     authorize! :update, @change_set.resource
     @change_set.prepopulate!
-    @change_set.validate({})
+    @change_set.valid? # Run validations to display errors on first load.
   end
 
   def update
-    @change_set = change_set_class.new(find_resource(params[:id])).prepopulate!
+    @change_set = change_set_class.new(find_resource(params[:id]))
     authorize! :update, @change_set.resource
     if @change_set.validate(resource_params)
       @change_set.sync

--- a/app/derivative_services/audio_derivative_service.rb
+++ b/app/derivative_services/audio_derivative_service.rb
@@ -36,7 +36,7 @@ class AudioDerivativeService
   end
 
   def change_set
-    @change_set ||= DynamicChangeSet.new(resource).prepopulate!
+    @change_set ||= DynamicChangeSet.new(resource)
   end
 
   def valid?
@@ -61,7 +61,7 @@ class AudioDerivativeService
     File.open(hls_file, "w") do |f|
       f.puts content
     end
-    change_set = DynamicChangeSet.new(output).prepopulate!
+    change_set = DynamicChangeSet.new(output)
     change_set.files = [build_file(hls_file, filename: "hls.m3u8")]
     change_set_persister.buffer_into_index do |buffered_persister|
       buffered_persister.save(change_set: change_set)

--- a/app/derivative_services/default_derivative_service.rb
+++ b/app/derivative_services/default_derivative_service.rb
@@ -27,7 +27,7 @@ class DefaultDerivativeService
   end
 
   def change_set
-    @change_set ||= DynamicChangeSet.new(resource).prepopulate!
+    @change_set ||= DynamicChangeSet.new(resource)
   end
 
   def valid?

--- a/app/derivative_services/hocr_derivative_service.rb
+++ b/app/derivative_services/hocr_derivative_service.rb
@@ -38,7 +38,7 @@ class HocrDerivativeService
     result = processor.run!
     change_set_persister.buffer_into_index do |buffered_persister|
       reloaded = buffered_persister.query_service.find_by(id: id)
-      reloaded_change_set = DynamicChangeSet.new(reloaded).prepopulate!
+      reloaded_change_set = DynamicChangeSet.new(reloaded)
       reloaded_change_set.hocr_content = result.hocr_content
       reloaded_change_set.ocr_content = result.ocr_content
       buffered_persister.save(change_set: reloaded_change_set)

--- a/app/derivative_services/image_derivative_service.rb
+++ b/app/derivative_services/image_derivative_service.rb
@@ -49,7 +49,7 @@ class ImageDerivativeService
   end
 
   def change_set
-    @change_set ||= DynamicChangeSet.new(resource).prepopulate!
+    @change_set ||= DynamicChangeSet.new(resource)
   end
 
   # If there are intermediate files with the supported format attached to the

--- a/app/derivative_services/jp2_derivative_service.rb
+++ b/app/derivative_services/jp2_derivative_service.rb
@@ -67,7 +67,7 @@ class Jp2DerivativeService
   end
 
   def change_set
-    @change_set ||= DynamicChangeSet.new(resource).prepopulate!
+    @change_set ||= DynamicChangeSet.new(resource)
   end
 
   def parent

--- a/app/derivative_services/raster_resource_derivative_service.rb
+++ b/app/derivative_services/raster_resource_derivative_service.rb
@@ -37,7 +37,7 @@ class RasterResourceDerivativeService
   end
 
   def change_set
-    @change_set ||= DynamicChangeSet.new(resource).prepopulate!
+    @change_set ||= DynamicChangeSet.new(resource)
   end
 
   def build_display_file

--- a/app/derivative_services/scanned_map_derivative_service.rb
+++ b/app/derivative_services/scanned_map_derivative_service.rb
@@ -27,7 +27,7 @@ class ScannedMapDerivativeService
   end
 
   def change_set
-    @change_set ||= DynamicChangeSet.new(resource).prepopulate!
+    @change_set ||= DynamicChangeSet.new(resource)
   end
 
   def valid?

--- a/app/derivative_services/vector_resource_derivative_service.rb
+++ b/app/derivative_services/vector_resource_derivative_service.rb
@@ -37,7 +37,7 @@ class VectorResourceDerivativeService
   end
 
   def change_set
-    @change_set ||= DynamicChangeSet.new(resource).prepopulate!
+    @change_set ||= DynamicChangeSet.new(resource)
   end
 
   def build_display_file

--- a/app/graphql/mutations/update_resource.rb
+++ b/app/graphql/mutations/update_resource.rb
@@ -33,7 +33,7 @@ class Mutations::UpdateResource < Mutations::BaseMutation
   end
 
   def update_resource(resource, attributes)
-    change_set = DynamicChangeSet.new(resource).prepopulate!
+    change_set = DynamicChangeSet.new(resource)
     change_set.validate(attributes)
     if change_set.valid? && valid_member_ids?(change_set, attributes)
       {

--- a/app/graphql/types/scanned_map_type.rb
+++ b/app/graphql/types/scanned_map_type.rb
@@ -21,7 +21,7 @@ class Types::ScannedMapType < Types::BaseObject
   end
 
   def start_page
-    Array.wrap(object.start_canvas).first
+    Array.wrap(object.start_canvas).first.to_s
   end
 
   def source_metadata_identifier

--- a/app/graphql/types/scanned_resource_type.rb
+++ b/app/graphql/types/scanned_resource_type.rb
@@ -20,7 +20,7 @@ class Types::ScannedResourceType < Types::BaseObject
   end
 
   def start_page
-    Array.wrap(object.start_canvas).first
+    Array.wrap(object.start_canvas).first.to_s
   end
 
   def source_metadata_identifier

--- a/app/helpers/bounding_box_helper.rb
+++ b/app/helpers/bounding_box_helper.rb
@@ -5,7 +5,7 @@ module BoundingBoxHelper
   # rubocop:disable Rails/OutputSafety
   def bbox_input(property, change_set)
     markup = ""
-    markup << %(<div id='bbox' data-coverage='#{change_set.coverage}' data-input-id='#{bbox_input_id(property, change_set)}'></div>)
+    markup << %(<div id='bbox' data-coverage='#{change_set.resource.coverage}' data-input-id='#{bbox_input_id(property, change_set)}'></div>)
     markup << bbox_display_inputs
     markup.html_safe
   end

--- a/app/jobs/bulk_update_job.rb
+++ b/app/jobs/bulk_update_job.rb
@@ -4,7 +4,7 @@ class BulkUpdateJob < ApplicationJob
     change_set_persister.buffer_into_index do |buffered_change_set_persister|
       ids.each do |id|
         resource = query_service.find_by(id: id)
-        change_set = DynamicChangeSet.new(resource).prepopulate!
+        change_set = DynamicChangeSet.new(resource)
         attributes = {}.tap do |attrs|
           attrs[:state] = "complete" if args[:mark_complete] && !blacklisted_states.include?(resource.state.first)
         end

--- a/app/jobs/clean_deleted_subject_job.rb
+++ b/app/jobs/clean_deleted_subject_job.rb
@@ -6,7 +6,7 @@ class CleanDeletedSubjectJob < ApplicationJob
     folders = qs.find_inverse_references_by(property: :subject, id: subject_id)
     csp = ChangeSetPersister.new(metadata_adapter: adapter, storage_adapter: Valkyrie.config.storage_adapter)
     folders.each do |folder|
-      cs = DynamicChangeSet.new(folder).prepopulate!
+      cs = DynamicChangeSet.new(folder)
       subjects = cs.subject.reject { |id| id.to_s == subject_id }
       cs.validate(subject: subjects)
       if cs.valid?

--- a/app/jobs/ingest_intermediate_file_job.rb
+++ b/app/jobs/ingest_intermediate_file_job.rb
@@ -14,7 +14,6 @@ class IngestIntermediateFileJob < ApplicationJob
     @file_path = file_path
 
     change_set = FileSetChangeSet.new(file_set)
-    change_set.prepopulate!
 
     # Delete all existing derivatives
     derivative_file_ids = []

--- a/app/jobs/ingest_mets_job.rb
+++ b/app/jobs/ingest_mets_job.rb
@@ -92,7 +92,6 @@ class IngestMETSJob < ApplicationJob
     # @return [ScannedResource] the persisted resource with the logical structure assigned
     def assign_attributes(resource)
       new_change_set = DynamicChangeSet.new(resource)
-      new_change_set.prepopulate!
       return resource unless new_change_set.validate(mets.attributes)
       new_change_set.sync
       change_set_persister.save(change_set: new_change_set)

--- a/app/jobs/reprocess_mets_job.rb
+++ b/app/jobs/reprocess_mets_job.rb
@@ -11,7 +11,7 @@ class ReprocessMetsJob < ApplicationJob
         next unless mets_fileset
         mets_file = Valkyrie::StorageAdapter.find_by(id: mets_fileset.original_file.file_identifiers.first)
         mets_document = METSDocument::Factory.new(mets_file.disk_path).new
-        change_set = DynamicChangeSet.new(member).prepopulate!
+        change_set = DynamicChangeSet.new(member)
         change_set.validate(mets_document.attributes)
         buffered_adapter.save(change_set: change_set)
       end

--- a/app/jobs/voyager_update_job.rb
+++ b/app/jobs/voyager_update_job.rb
@@ -15,7 +15,6 @@ class VoyagerUpdateJob < ApplicationJob
           change_set = DynamicChangeSet.new(resource)
           next unless change_set.respond_to?(:apply_remote_metadata?) && change_set.respond_to?(:source_metadata_identifier)
 
-          change_set.prepopulate!
           change_set.validate(refresh_remote_metadata: "1")
 
           logger.info "Processing updates for Voyager record #{id} imported into resource #{resource.id}..."

--- a/app/resources/file_sets/file_sets_controller.rb
+++ b/app/resources/file_sets/file_sets_controller.rb
@@ -38,7 +38,7 @@ class FileSetsController < ApplicationController
   end
 
   def update
-    @change_set = change_set_class.new(find_resource(params[:id])).prepopulate!
+    @change_set = change_set_class.new(find_resource(params[:id]))
     authorize! :update, @change_set.resource
     if @change_set.validate(resource_params)
       obj = nil

--- a/app/resources/scanned_resources/scanned_resources_controller.rb
+++ b/app/resources/scanned_resources/scanned_resources_controller.rb
@@ -60,7 +60,7 @@ class ScannedResourcesController < BaseResourceController
   end
 
   def pdf
-    change_set = change_set_class.new(find_resource(params[:id])).prepopulate!
+    change_set = change_set_class.new(find_resource(params[:id]))
     authorize! :pdf, change_set.resource
     pdf_file = change_set.resource.pdf_file
 

--- a/app/services/bulk_edit_service.rb
+++ b/app/services/bulk_edit_service.rb
@@ -8,7 +8,6 @@ class BulkEditService
     c.decorate.members.each do |member|
       logger.info "Updating attributes for #{member}"
       change_set = DynamicChangeSet.new(member)
-      change_set.prepopulate!
       if change_set.validate(attributes)
         change_set_persister.save(change_set: change_set)
       else

--- a/app/services/bulk_ingest_service.rb
+++ b/app/services/bulk_ingest_service.rb
@@ -109,7 +109,6 @@ class BulkIngestService
       resource = klass.new
 
       change_set = change_set_class.new(resource)
-      change_set.prepopulate!
       return unless change_set.validate(**attributes)
       change_set.member_of_collection_ids = [collection.id] if collection.try(:id)
 

--- a/app/services/ingest_ephemera_service.rb
+++ b/app/services/ingest_ephemera_service.rb
@@ -94,7 +94,7 @@ class IngestEphemeraService
   end
 
   def change_set
-    @change_set ||= EphemeraFolderChangeSet.new(resource).tap(&:prepopulate!)
+    @change_set ||= EphemeraFolderChangeSet.new(resource)
   end
 
   def prov_metadata

--- a/app/services/music_import_service.rb
+++ b/app/services/music_import_service.rb
@@ -165,14 +165,14 @@ class MusicImportService
               query_service.custom_queries.find_by_property(property: :local_identifier, value: file.entry_id.to_s).first&.id => file.id
             }
           end.inject(&:merge).compact
-          change_set = DynamicChangeSet.new(playlist).prepopulate!
+          change_set = DynamicChangeSet.new(playlist)
           change_set.file_set_ids = file_set_ids.keys
           output = buffered_change_set_persister.save(change_set: change_set)
           # Fix labels
           members = Wayfinder.for(output).members
           possible_files = selection_files.group_by(&:id)
           members.each do |member|
-            change_set = DynamicChangeSet.new(member).prepopulate!
+            change_set = DynamicChangeSet.new(member)
             file = Array.wrap(possible_files[file_set_ids[member.proxied_file_id]]).first
             change_set.label = file.file_note
             change_set.local_identifier = file.id.to_s
@@ -256,7 +256,7 @@ class MusicImportService
         end
         ids = file_set_members.map(&:id)
         playlist = Playlist.new(title: selection_files.first.selection_title, local_identifier: selection_id.to_s, part_of: selections_to_courses[selection_id]&.first&.course_nums)
-        change_set = DynamicChangeSet.new(playlist).prepopulate!
+        change_set = DynamicChangeSet.new(playlist)
         change_set.file_set_ids = ids
         buffered_change_set_persister.save(change_set: change_set)
       end
@@ -275,7 +275,7 @@ class MusicImportService
     end
 
     def recording_change_set
-      @recording_change_set ||= RecordingChangeSet.new(resource).prepopulate!
+      @recording_change_set ||= RecordingChangeSet.new(resource)
     end
 
     def identifier

--- a/app/utils/data_seeder.rb
+++ b/app/utils/data_seeder.rb
@@ -160,7 +160,6 @@ class DataSeeder
 
     def add_child_resource(child:, parent_id:)
       change_set = DynamicChangeSet.new(child)
-      change_set.prepopulate!
       change_set.append_id = parent_id
       change_set_persister.save(change_set: change_set)
     end
@@ -216,14 +215,12 @@ class DataSeeder
     def add_file(resource:, file: nil)
       ingestable_file = file || IngestableFile.new(file_path: Rails.root.join("spec", "fixtures", "files", "example.tif"), mime_type: "image/tiff", original_filename: "example.tif")
       change_set = DynamicChangeSet.new(resource)
-      change_set.prepopulate!
       change_set.files = [ingestable_file]
       change_set_persister.save(change_set: change_set)
     end
 
     def add_member(parent:, member:)
       member_change_set = DynamicChangeSet.new(member)
-      member_change_set.prepopulate!
       member_change_set.append_id = parent.id
       change_set_persister.save(change_set: member_change_set)
       logger.info "Added #{member.class} #{member.id} to #{parent.class} #{parent.title || parent.box_number}"

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -15,7 +15,6 @@ namespace :migrate do
   task ephemera_folders: :environment do
     resources(model: EphemeraFolder).each do |resource|
       cs = DynamicChangeSet.new(resource)
-      cs.prepopulate!
       logger.info "Migrating folders within the box #{resource.id}..."
       change_set_persister.save(change_set: cs)
     end
@@ -34,7 +33,6 @@ namespace :migrate do
             logger.info "Migrating the collections for member resource #{child.id}..."
 
             child_change_set = DynamicChangeSet.new(child)
-            child_change_set.prepopulate!
             child_change_set.validate(member_of_collection_ids: [])
 
             buffered_change_set_persister.save(change_set: child_change_set)

--- a/spec/change_set_persisters/change_set_persister/cleanup_pdfs_spec.rb
+++ b/spec/change_set_persisters/change_set_persister/cleanup_pdfs_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe ChangeSetPersister::CleanupPdfs do
     context "with a resource that isn't a ScannedResource or a ScannedMap" do
       let(:resource) { FactoryBot.create(:draft_simple_resource) }
       it "does nothing" do
-        change_set.prepopulate!
         hook.run
 
         expect(CleanupFilesJob).not_to have_received(:perform_later)
@@ -26,7 +25,6 @@ RSpec.describe ChangeSetPersister::CleanupPdfs do
     context "with a ScannedResource without a PDF attached" do
       let(:resource) { FactoryBot.create(:scanned_resource) }
       it "does nothing" do
-        change_set.prepopulate!
         hook.run
 
         expect(CleanupFilesJob).not_to have_received(:perform_later)
@@ -35,7 +33,6 @@ RSpec.describe ChangeSetPersister::CleanupPdfs do
     context "with a ScannedResource with a PDF attached and no changes other than a PDF being attached" do
       let(:resource) { FactoryBot.create(:scanned_resource) }
       it "does not remove the files" do
-        change_set.prepopulate!
         change_set.validate(file_metadata: [pdf_file])
         hook.run
 
@@ -49,7 +46,6 @@ RSpec.describe ChangeSetPersister::CleanupPdfs do
         allow(Valkyrie.logger).to receive(:error)
       end
       it "removes the metadata and does not attempt to delete the missing files" do
-        change_set.prepopulate!
         change_set.validate(file_metadata: [pdf_file])
         hook.run
 
@@ -62,7 +58,6 @@ RSpec.describe ChangeSetPersister::CleanupPdfs do
       let(:file_identifiers) { [Valkyrie::ID.new("disk://#{File.expand_path(__FILE__)}")] }
       let(:resource) { FactoryBot.create(:scanned_resource, file_metadata: [pdf_file]) }
       it "keeps the metadata and does not attempt to delete the missing files" do
-        change_set.prepopulate!
         change_set.validate(file_metadata: [pdf_file])
         hook.run
 
@@ -73,7 +68,6 @@ RSpec.describe ChangeSetPersister::CleanupPdfs do
     context "with a ScannedResource with a PDF attached and changes" do
       let(:resource) { FactoryBot.create(:scanned_resource, file_metadata: [pdf_file]) }
       it "deletes the PDF and removes it from the ScannedResource" do
-        change_set.prepopulate!
         change_set.validate(title: "Updated resource")
         hook.run
 
@@ -84,7 +78,6 @@ RSpec.describe ChangeSetPersister::CleanupPdfs do
     context "with a ScannedMap with a PDF attached and changes" do
       let(:resource) { FactoryBot.create(:scanned_map, file_metadata: [pdf_file]) }
       it "deletes the PDF and removes it from the ScannedMap" do
-        change_set.prepopulate!
         change_set.validate(title: "Updated resource")
         hook.run
 

--- a/spec/change_set_persisters/change_set_persister/mint_identifier_spec.rb
+++ b/spec/change_set_persisters/change_set_persister/mint_identifier_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe ChangeSetPersister::MintIdentifier do
     end
 
     it "mints a new ARK for published SimpleResources" do
-      change_set.prepopulate!
       change_set.validate(state: :complete)
 
       hook.run
@@ -32,7 +31,6 @@ RSpec.describe ChangeSetPersister::MintIdentifier do
       let(:existing_ark) { "ark:/#{shoulder}234567" }
       let(:simple_resource) { FactoryBot.create(:complete_simple_resource, identifier: existing_ark) }
       before do
-        change_set.prepopulate!
         change_set.validate(creator: "Johann Georg Faust")
       end
 
@@ -46,7 +44,6 @@ RSpec.describe ChangeSetPersister::MintIdentifier do
       let(:existing_ark) { "ark:/#{shoulder}234567" }
       let(:simple_resource) { FactoryBot.create(:complete_simple_resource, identifier: existing_ark) }
       before do
-        change_set.prepopulate!
         change_set.validate(title: "Doctor Faustens dreyfacher Höllenzwang")
       end
 
@@ -60,7 +57,6 @@ RSpec.describe ChangeSetPersister::MintIdentifier do
       let(:simple_resource) { FactoryBot.create(:complete_simple_resource, identifier: existing_ark) }
       let(:collection) { FactoryBot.create_for_repository(:collection) }
       before do
-        change_set.prepopulate!
         change_set.validate(member_of_collection_ids: [collection.id])
       end
       it "does not mint a new ARK" do
@@ -71,8 +67,6 @@ RSpec.describe ChangeSetPersister::MintIdentifier do
     context "when none of the relevant metadata has changed" do
       let(:simple_resource) { FactoryBot.create(:complete_simple_resource, identifier: new_ark) }
       it "does not run the hook" do
-        change_set.prepopulate!
-
         hook.run
 
         expect(hook.run).to be nil
@@ -81,8 +75,6 @@ RSpec.describe ChangeSetPersister::MintIdentifier do
     context "with an unpublished SimpleResource" do
       let(:simple_resource) { FactoryBot.create(:draft_simple_resource) }
       it "does not run the hook" do
-        change_set.prepopulate!
-
         hook.run
 
         expect(hook.run).to be nil
@@ -91,8 +83,6 @@ RSpec.describe ChangeSetPersister::MintIdentifier do
     context "with an Object of an unsupported Class" do
       let(:change_set) { EphemeraTermChangeSet.new(EphemeraTerm.new) }
       it "does not run the hook" do
-        change_set.prepopulate!
-
         expect(hook.run).to be nil
       end
     end

--- a/spec/change_set_persisters/change_set_persister_spec.rb
+++ b/spec/change_set_persisters/change_set_persister_spec.rb
@@ -111,7 +111,6 @@ RSpec.describe ChangeSetPersister do
     it "mints an ARK" do
       resource = FactoryBot.create(:scanned_resource, title: [], source_metadata_identifier: "123456", state: "final_review")
       change_set = change_set_class.new(resource)
-      change_set.prepopulate!
       change_set.validate(state: "complete")
       output = change_set_persister.save(change_set: change_set)
       expect(output.identifier.first).to eq "ark:/#{shoulder}#{blade}"
@@ -120,7 +119,6 @@ RSpec.describe ChangeSetPersister do
     it "mints an authorization token" do
       resource = FactoryBot.create(:playlist, title: ["test playlist"], state: "draft")
       change_set = PlaylistChangeSet.new(resource)
-      change_set.prepopulate!
       change_set.validate(state: "complete")
       output = change_set_persister.save(change_set: change_set)
 
@@ -137,7 +135,6 @@ RSpec.describe ChangeSetPersister do
     let(:change_set_class) { PlaylistChangeSet }
     let(:change_set) { change_set_class.new(resource) }
     let(:persisted) do
-      change_set.prepopulate!
       change_set.validate(state: "complete")
       change_set_persister.save(change_set: change_set)
     end
@@ -152,7 +149,6 @@ RSpec.describe ChangeSetPersister do
       expect(auth_token).not_to be nil
 
       cs = PlaylistChangeSet.new(persisted)
-      cs.prepopulate!
       cs.validate(mint_auth_token: true)
 
       updated = change_set_persister.save(change_set: cs)
@@ -174,7 +170,6 @@ RSpec.describe ChangeSetPersister do
       let(:change_set_class) { PlaylistChangeSet }
       let(:change_set) { change_set_class.new(resource) }
       let(:persisted) do
-        change_set.prepopulate!
         change_set.validate(state: "complete")
         change_set_persister.save(change_set: change_set)
       end
@@ -184,7 +179,6 @@ RSpec.describe ChangeSetPersister do
       it "clears the attribute on the model but preserves the token" do
         persisted_auth_token = persisted.auth_token
         takedown_change_set = change_set_class.new(persisted)
-        takedown_change_set.prepopulate!
         takedown_change_set.validate(state: "draft")
         change_set_persister.save(change_set: takedown_change_set)
 
@@ -205,7 +199,6 @@ RSpec.describe ChangeSetPersister do
     it "mints an ARK" do
       resource = FactoryBot.create(:draft_simple_resource)
       change_set = change_set_class.new(resource)
-      change_set.prepopulate!
       change_set.validate(state: "complete")
       output = change_set_persister.save(change_set: change_set)
       expect(output.identifier.first).to eq "ark:/#{shoulder}#{blade}"
@@ -216,19 +209,16 @@ RSpec.describe ChangeSetPersister do
       let(:change_set_class) { PlaylistChangeSet }
       let(:change_set) { change_set_class.new(resource) }
       let(:persisted) do
-        change_set.prepopulate!
         change_set.validate(state: "complete")
         change_set_persister.save(change_set: change_set)
       end
       let(:take_down) do
         takedown_change_set = change_set_class.new(persisted)
-        takedown_change_set.prepopulate!
         takedown_change_set.validate(state: "draft")
         change_set_persister.save(change_set: takedown_change_set)
       end
       let(:completed) do
         complete_change_set = change_set_class.new(take_down)
-        complete_change_set.prepopulate!
         complete_change_set.validate(state: "complete")
         change_set_persister.save(change_set: complete_change_set)
       end
@@ -434,20 +424,17 @@ RSpec.describe ChangeSetPersister do
     it "runs characterization for all files when added in sequence with the same persister", run_real_derivatives: true do
       resource = FactoryBot.create_for_repository(:scanned_resource)
       change_set = change_set_class.new(resource)
-      change_set.prepopulate!
       change_set.validate(files: [file])
       output = change_set_persister.save(change_set: change_set)
 
       change_set_persister.buffer_into_index do |buffered_change_set_persister|
         change_set = change_set_class.new(output)
-        change_set.prepopulate!
         change_set.validate(ocr_language: "eng")
         output = buffered_change_set_persister.save(change_set: change_set)
       end
 
       change_set_persister.buffer_into_index do |buffered_change_set_persister|
         change_set = change_set_class.new(output)
-        change_set.prepopulate!
         change_set.validate(files: [file])
         output = buffered_change_set_persister.save(change_set: change_set)
       end
@@ -896,7 +883,6 @@ RSpec.describe ChangeSetPersister do
     it "destroys any active authorization tokens" do
       resource = FactoryBot.create(:playlist)
       change_set = PlaylistChangeSet.new(resource)
-      change_set.prepopulate!
       change_set.validate(state: "complete")
       output = change_set_persister.save(change_set: change_set)
 
@@ -912,7 +898,6 @@ RSpec.describe ChangeSetPersister do
       let(:change_set_class) { PlaylistChangeSet }
       let(:change_set) { change_set_class.new(resource) }
       let(:completed) do
-        change_set.prepopulate!
         change_set.validate(state: "complete")
         change_set_persister.save(change_set: change_set)
       end
@@ -1058,12 +1043,12 @@ RSpec.describe ChangeSetPersister do
         child = FactoryBot.create_for_repository(:scanned_resource, read_groups: [])
         resource = FactoryBot.build(:scanned_resource, read_groups: [])
         resource.member_ids = [child.id]
-        change_set = DynamicChangeSet.new(resource).prepopulate!
+        change_set = DynamicChangeSet.new(resource)
         resource = change_set_persister.save(change_set: change_set)
         adapter = Valkyrie::MetadataAdapter.find(:indexing_persister)
         child = adapter.query_service.find_by(id: child.id)
 
-        change_set = change_set_class.new(resource).prepopulate!
+        change_set = change_set_class.new(resource)
         updated = change_set_persister.save(change_set: change_set)
 
         members = query_service.find_members(resource: updated)
@@ -1238,7 +1223,6 @@ RSpec.describe ChangeSetPersister do
         stub_bibdata(bib_id: "4609321")
         resource = FactoryBot.build(:pending_private_scanned_resource)
         change_set = change_set_class.new(resource)
-        change_set.prepopulate!
         change_set.validate(source_metadata_identifier: "4609321", set_visibility_by_date: "1")
 
         output = change_set_persister.save(change_set: change_set)
@@ -1253,7 +1237,6 @@ RSpec.describe ChangeSetPersister do
         stub_bibdata(bib_id: "123456")
         resource = FactoryBot.build(:pending_private_scanned_resource)
         change_set = change_set_class.new(resource)
-        change_set.prepopulate!
         change_set.validate(source_metadata_identifier: "123456", set_visibility_by_date: "1")
 
         output = change_set_persister.save(change_set: change_set)
@@ -1268,7 +1251,6 @@ RSpec.describe ChangeSetPersister do
         stub_bibdata(bib_id: "123456789")
         resource = FactoryBot.build(:pending_scanned_resource)
         change_set = change_set_class.new(resource)
-        change_set.prepopulate!
         change_set.validate(source_metadata_identifier: "123456789", set_visibility_by_date: "1")
 
         output = change_set_persister.save(change_set: change_set)
@@ -1283,7 +1265,6 @@ RSpec.describe ChangeSetPersister do
         stub_bibdata(bib_id: "123456")
         resource = FactoryBot.build(:pending_scanned_resource)
         change_set = change_set_class.new(resource)
-        change_set.prepopulate!
         change_set.validate(source_metadata_identifier: "123456")
 
         output = change_set_persister.save(change_set: change_set)
@@ -1303,7 +1284,6 @@ RSpec.describe ChangeSetPersister do
 
     before do
       stub_pulfa(pulfa_id: "C0652")
-      change_set.prepopulate!
       change_set.source_metadata_identifier = "C0652"
     end
 
@@ -1359,7 +1339,6 @@ RSpec.describe ChangeSetPersister do
       let(:resource) { Playlist.new }
       let(:change_set) do
         cs = PlaylistChangeSet.new(resource)
-        cs.prepopulate!
         cs.validate(title: ["test label"], file_set_ids: [file_set.id])
         cs
       end
@@ -1381,7 +1360,6 @@ RSpec.describe ChangeSetPersister do
       context "when deleting ProxyFileSet members of a Playlist" do
         before do
           cs = ProxyFileSetChangeSet.new(proxy)
-          cs.prepopulate!
           change_set_persister.delete(change_set: cs)
         end
         it "deletes the proxies and removes them as members of the Playlist" do
@@ -1402,13 +1380,11 @@ RSpec.describe ChangeSetPersister do
       let(:proxy_file_set) do
         proxy_file_set = ProxyFileSet.new
         cs = ProxyFileSetChangeSet.new(proxy_file_set)
-        cs.prepopulate!
         cs.validate(proxied_file_id: file_set.id)
         change_set_persister.save(change_set: cs)
       end
       let(:change_set) do
         cs = PlaylistChangeSet.new(resource)
-        cs.prepopulate!
         cs.validate(title: ["test label"], member_ids: [proxy_file_set.id])
         cs
       end
@@ -1445,7 +1421,6 @@ RSpec.describe ChangeSetPersister do
       resource = FactoryBot.create_for_repository(:scanned_resource, member_of_collection_ids: [collection.id])
 
       change_set = DynamicChangeSet.new(collection)
-      change_set.prepopulate!
       change_set.validate(title: "New Title")
 
       change_set_persister.save(change_set: change_set)
@@ -1460,7 +1435,6 @@ RSpec.describe ChangeSetPersister do
       project = FactoryBot.create_for_repository(:ephemera_project, member_ids: [box.id], title: "Old Title")
 
       change_set = DynamicChangeSet.new(project)
-      change_set.prepopulate!
       change_set.validate(title: "New Title")
 
       change_set_persister.save(change_set: change_set)
@@ -1480,7 +1454,6 @@ RSpec.describe ChangeSetPersister do
       file_set2 = FactoryBot.create_for_repository(:file_set)
 
       change_set = DynamicChangeSet.new(playlist)
-      change_set.prepopulate!
       change_set.validate(title: "Test Title", file_set_ids: [file_set2.id.to_s, file_set.id.to_s])
       expect(change_set.file_set_ids).to eq [file_set2.id, file_set.id]
 
@@ -1506,7 +1479,6 @@ RSpec.describe ChangeSetPersister do
       # `file_set_ids` on the ChangeSet. file_set1 is already attached through
       # `proxy`.
       change_set = DynamicChangeSet.new(playlist)
-      change_set.prepopulate!
       change_set.validate(title: "Test Title", file_set_ids: [file_set1.id.to_s, file_set2.id.to_s])
       output = change_set_persister.save(change_set: change_set)
       members = query_service.find_members(resource: output)

--- a/spec/change_sets/boxless_ephemera_folder_change_set_spec.rb
+++ b/spec/change_sets/boxless_ephemera_folder_change_set_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe BoxlessEphemeraFolderChangeSet do
     let(:valid_params) { { barcode: "", title: ["foo"], language: ["English"], page_count: [1], visibility: ["private"], rights_statement: RightsStatements.copyright_not_evaluated.to_s } }
 
     it "requires title, language, genre, page_count, visibility, and rights_statement" do
-      change_set.prepopulate!
       expect(change_set.validate(valid_params)).to eq true
     end
   end

--- a/spec/change_sets/concerns/date_range_property_spec.rb
+++ b/spec/change_sets/concerns/date_range_property_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe DateRangeProperty do
   let(:resource) { TestResource.new }
 
   it "can set date_range" do
-    change_set.prepopulate!
     change_set.validate(date_range_form_attributes: { start: "2017", end: "2018" })
     change_set.sync
     expect(change_set.model.date_range.first.end).to eq ["2018"]
@@ -28,7 +27,6 @@ RSpec.describe DateRangeProperty do
   end
 
   it "can set approximate date_range" do
-    change_set.prepopulate!
     change_set.validate(date_range_form_attributes: { start: "2017", end: "2018", approximate: true })
     change_set.sync
     expect(change_set.model.date_range.first.start).to eq ["2017"]
@@ -37,25 +35,21 @@ RSpec.describe DateRangeProperty do
   end
 
   it "validates" do
-    change_set.prepopulate!
     result = change_set.validate(date_range_form_attributes: { start: "abcd", end: "2018" })
     expect(result).to eq false
   end
 
   it "validates that the start is before the end" do
-    change_set.prepopulate!
     result = change_set.validate(date_range_form_attributes: { start: "2018", end: "2017" })
     expect(result).to eq false
   end
 
   it "is invalid if only start is given" do
-    change_set.prepopulate!
     result = change_set.validate(date_range_form_attributes: { start: "2018", end: "" })
     expect(result).to eq false
   end
 
   it "is invalid if only end is given" do
-    change_set.prepopulate!
     result = change_set.validate(date_range_form_attributes: { start: "", end: "2018" })
     expect(result).to eq false
   end

--- a/spec/change_sets/ephemera_box_change_set_spec.rb
+++ b/spec/change_sets/ephemera_box_change_set_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe EphemeraBoxChangeSet do
 
   describe "drive_barcode" do
     it "is invalid if the drive barcode is invalid" do
-      change_set.prepopulate!
       expect(change_set).to be_valid
 
       change_set.drive_barcode = ["11111111111111"]
@@ -24,7 +23,6 @@ RSpec.describe EphemeraBoxChangeSet do
     end
 
     it "is valid if the drive barcode is valid" do
-      change_set.prepopulate!
       expect(change_set).to be_valid
       change_set.drive_barcode = ["11111111111110"]
       expect(change_set).to be_valid
@@ -33,7 +31,6 @@ RSpec.describe EphemeraBoxChangeSet do
 
   describe "#state" do
     it "pre-populates" do
-      change_set.prepopulate!
       expect(change_set.state).to eq "new"
     end
 
@@ -45,9 +42,6 @@ RSpec.describe EphemeraBoxChangeSet do
       let(:storage_adapter) { Valkyrie.config.storage_adapter }
       let(:change_set_persister) { ChangeSetPersister.new(metadata_adapter: adapter, storage_adapter: storage_adapter) }
 
-      before do
-        change_set.prepopulate!
-      end
       it "propagates the state to member resources" do
         change_set.state = "all_in_production"
         persisted = change_set_persister.save(change_set: change_set)
@@ -61,14 +55,12 @@ RSpec.describe EphemeraBoxChangeSet do
   describe "validations" do
     context "when given a non-UUID for a member resource" do
       it "is not valid" do
-        change_set.prepopulate!
         change_set.validate(member_ids: ["not-valid"])
         expect(change_set).not_to be_valid
       end
     end
     context "when given a valid UUID for a member resource which does not exist" do
       it "is not valid" do
-        change_set.prepopulate!
         change_set.validate(member_ids: ["55a14e79-710d-42c1-86aa-3d8cdaa62930"])
         expect(change_set).not_to be_valid
       end

--- a/spec/change_sets/recording_change_set_spec.rb
+++ b/spec/change_sets/recording_change_set_spec.rb
@@ -9,9 +9,6 @@ RSpec.describe RecordingChangeSet do
   let(:form_resource) { scanned_resource }
 
   describe "validations" do
-    before do
-      change_set.prepopulate!
-    end
     it "is valid by default" do
       expect(change_set).to be_valid
     end
@@ -44,8 +41,6 @@ RSpec.describe RecordingChangeSet do
   describe "#rights_statement" do
     let(:form_resource) { ScannedResource.new(rights_statement: RDF::URI(rights_statement)) }
     it "is singular, required, and converts to an RDF::URI" do
-      change_set.prepopulate!
-
       expect(change_set.rights_statement).to eq RDF::URI(rights_statement)
       change_set.validate(rights_statement: "")
       expect(change_set).not_to be_valid
@@ -55,8 +50,6 @@ RSpec.describe RecordingChangeSet do
     context "when given a blank ScannedResource" do
       let(:form_resource) { ScannedResource.new }
       it "sets a default Rights Statement" do
-        change_set.prepopulate!
-
         expect(change_set.rights_statement).to eq RDF::URI(rights_statement)
       end
     end
@@ -64,7 +57,6 @@ RSpec.describe RecordingChangeSet do
 
   describe "#workflow" do
     it "has a workflow" do
-      change_set.prepopulate!
       expect(change_set.workflow).to be_a(DraftCompleteWorkflow)
       expect(change_set.workflow.draft?).to be true
     end
@@ -72,7 +64,6 @@ RSpec.describe RecordingChangeSet do
 
   describe "#change_set" do
     it "sets a recording default" do
-      change_set.prepopulate!
       expect(change_set.change_set).to eq "recording"
     end
   end
@@ -104,7 +95,6 @@ RSpec.describe RecordingChangeSet do
 
     describe "#valid?" do
       it "is a valid change set" do
-        change_set.prepopulate!
         expect(change_set).to be_valid
       end
     end

--- a/spec/change_sets/simple_change_set_spec.rb
+++ b/spec/change_sets/simple_change_set_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe SimpleChangeSet do
 
   describe "#workflow" do
     it "has a workflow" do
-      change_set.prepopulate!
       expect(change_set.workflow).to be_a(DraftCompleteWorkflow)
       expect(change_set.workflow.draft?).to be true
     end

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -92,7 +92,6 @@ RSpec.describe DownloadsController do
       let(:playlist) do
         playlist = Playlist.new
         cs = PlaylistChangeSet.new(playlist)
-        cs.prepopulate!
         cs.validate(file_set_ids: [file_set.id], state: ["complete"])
         change_set_persister.save(change_set: cs)
       end
@@ -114,7 +113,7 @@ RSpec.describe DownloadsController do
         change_set_persister = ScannedResourcesController.change_set_persister
         file_set = FactoryBot.create_for_repository(:file_set)
         file = fixture_file_upload("files/hls_playlist.m3u8", "application/x-mpegURL")
-        change_set = DynamicChangeSet.new(file_set).prepopulate!
+        change_set = DynamicChangeSet.new(file_set)
         change_set.files = [file]
         output = change_set_persister.save(change_set: change_set)
 
@@ -132,7 +131,7 @@ RSpec.describe DownloadsController do
         change_set_persister = ScannedResourcesController.change_set_persister
         file_set = FactoryBot.create_for_repository(:file_set)
         file = fixture_file_upload("files/hls_playlist.m3u8", "application/x-mpegURL")
-        change_set = DynamicChangeSet.new(file_set).prepopulate!
+        change_set = DynamicChangeSet.new(file_set)
         change_set.files = [file]
         output = change_set_persister.save(change_set: change_set)
 
@@ -148,14 +147,12 @@ RSpec.describe DownloadsController do
       let(:playlist) do
         playlist = Playlist.new
         cs = PlaylistChangeSet.new(playlist)
-        cs.prepopulate!
         cs.validate(file_set_ids: [file_set.id], state: ["complete"])
         change_set_persister.save(change_set: cs)
       end
       let(:playlist2) do
         playlist = Playlist.new
         cs = PlaylistChangeSet.new(playlist)
-        cs.prepopulate!
         cs.validate(file_set_ids: [file_set.id], state: ["complete"])
         change_set_persister.save(change_set: cs)
       end

--- a/spec/controllers/playlists_controller_spec.rb
+++ b/spec/controllers/playlists_controller_spec.rb
@@ -19,13 +19,11 @@ RSpec.describe PlaylistsController do
   let(:proxy1) do
     res = ProxyFileSet.new(proxied_file_id: file_set1.id, label: "Proxy Title")
     cs = ProxyFileSetChangeSet.new(res)
-    cs.prepopulate!
     change_set_persister.save(change_set: cs)
   end
   let(:proxy2) do
     res = ProxyFileSet.new(proxied_file_id: file_set2.id, label: "Proxy Title2")
     cs = ProxyFileSetChangeSet.new(res)
-    cs.prepopulate!
     change_set_persister.save(change_set: cs)
   end
   let(:resource) do
@@ -33,7 +31,6 @@ RSpec.describe PlaylistsController do
   end
   let(:persisted) do
     change_set = PlaylistChangeSet.new(resource)
-    change_set.prepopulate!
     change_set.validate(state: ["complete"])
     change_set_persister.save(change_set: change_set)
   end

--- a/spec/derivative_services/external_metadata_derivative_service_spec.rb
+++ b/spec/derivative_services/external_metadata_derivative_service_spec.rb
@@ -57,6 +57,6 @@ RSpec.describe ExternalMetadataDerivativeService do
     parent = query_service.find_by(id: parent_resource.id)
     expect(parent.title).to eq ["China census data by county, 2000-2010"]
     expect(parent.visibility).to eq ["open"]
-    expect(event_generator).to have_received(:record_updated).twice
+    expect(event_generator).to have_received(:record_updated).exactly(3).times
   end
 end

--- a/spec/factories/coin.rb
+++ b/spec/factories/coin.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
   factory :coin do
     read_groups "public"
     to_create do |instance|
-      Valkyrie.config.metadata_adapter.persister.save(resource: instance)
+      Valkyrie::MetadataAdapter.find(:indexing_persister).persister.save(resource: instance)
     end
     transient do
       files []
@@ -22,7 +22,6 @@ FactoryBot.define do
     after(:create) do |resource, evaluator|
       if evaluator.files.present?
         change_set = CoinChangeSet.new(resource, files: evaluator.files)
-        change_set.prepopulate!
         ::ChangeSetPersister.new(
           metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister),
           storage_adapter: Valkyrie.config.storage_adapter

--- a/spec/factories/ephemera_folder.rb
+++ b/spec/factories/ephemera_folder.rb
@@ -46,7 +46,6 @@ FactoryBot.define do
     after(:create) do |resource, evaluator|
       if evaluator.files.present?
         change_set = EphemeraFolderChangeSet.new(resource, files: evaluator.files)
-        change_set.prepopulate!
         ::ChangeSetPersister.new(
           metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister),
           storage_adapter: Valkyrie.config.storage_adapter

--- a/spec/factories/numismatic_monogram.rb
+++ b/spec/factories/numismatic_monogram.rb
@@ -11,7 +11,6 @@ FactoryBot.define do
     after(:create) do |resource, evaluator|
       if evaluator.files.present?
         change_set = NumismaticMonogramChangeSet.new(resource, files: evaluator.files)
-        change_set.prepopulate!
         ::ChangeSetPersister.new(
           metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister),
           storage_adapter: Valkyrie.config.storage_adapter

--- a/spec/factories/raster_resource.rb
+++ b/spec/factories/raster_resource.rb
@@ -29,7 +29,6 @@ FactoryBot.define do
       if evaluator.files.present? || evaluator.import_metadata
         import_metadata = "1" if evaluator.import_metadata
         change_set = RasterResourceChangeSet.new(resource, files: evaluator.files, refresh_remote_metadata: import_metadata)
-        change_set.prepopulate!
         ::ChangeSetPersister.new(
           metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister),
           storage_adapter: Valkyrie.config.storage_adapter

--- a/spec/factories/scanned_map.rb
+++ b/spec/factories/scanned_map.rb
@@ -29,7 +29,6 @@ FactoryBot.define do
       if evaluator.files.present? || evaluator.import_metadata
         import_metadata = "1" if evaluator.import_metadata
         change_set = ScannedMapChangeSet.new(resource, files: evaluator.files, refresh_remote_metadata: import_metadata)
-        change_set.prepopulate!
         ::ChangeSetPersister.new(
           metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister),
           storage_adapter: Valkyrie.config.storage_adapter

--- a/spec/factories/scanned_resource.rb
+++ b/spec/factories/scanned_resource.rb
@@ -29,7 +29,6 @@ FactoryBot.define do
       if evaluator.files.present? || evaluator.import_metadata
         import_metadata = "1" if evaluator.import_metadata
         change_set = ScannedResourceChangeSet.new(resource, files: evaluator.files, refresh_remote_metadata: import_metadata)
-        change_set.prepopulate!
         ::ChangeSetPersister.new(
           metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister),
           storage_adapter: Valkyrie.config.storage_adapter

--- a/spec/factories/vector_resource.rb
+++ b/spec/factories/vector_resource.rb
@@ -29,7 +29,6 @@ FactoryBot.define do
       if evaluator.files.present? || evaluator.import_metadata
         import_metadata = "1" if evaluator.import_metadata
         change_set = VectorResourceChangeSet.new(resource, files: evaluator.files, refresh_remote_metadata: import_metadata)
-        change_set.prepopulate!
         ::ChangeSetPersister.new(
           metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister),
           storage_adapter: Valkyrie.config.storage_adapter

--- a/spec/features/playlist_spec.rb
+++ b/spec/features/playlist_spec.rb
@@ -35,7 +35,6 @@ RSpec.feature "PlaylistChangeSets" do
     let(:file_set) { recording.decorate.members.first }
     let(:change_set) do
       cs = PlaylistChangeSet.new(resource)
-      cs.prepopulate!
       cs.validate(file_set_ids: [file_set.id])
       cs
     end

--- a/spec/jobs/ingest_intermediate_file_job_spec.rb
+++ b/spec/jobs/ingest_intermediate_file_job_spec.rb
@@ -50,7 +50,6 @@ RSpec.describe IngestIntermediateFileJob do
 
       it "deletes the existing derivatives" do
         change_set = FileSetChangeSet.new(file_set)
-        change_set.prepopulate!
         change_set.validate(files: [second_file])
         change_set.sync
         change_set_persister.save(change_set: change_set)

--- a/spec/jobs/missing_thumbnail_job_spec.rb
+++ b/spec/jobs/missing_thumbnail_job_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe MissingThumbnailJob do
       sr = FactoryBot.create_for_repository(:scanned_resource, files: [file])
       change_set = ScannedResourceChangeSet.new(sr)
       change_set.thumbnail_id = nil
-      change_set.prepopulate!
       change_set_persister.save(change_set: change_set)
     end
     let(:metadata_adapter) { Valkyrie.config.metadata_adapter }

--- a/spec/queries/find_invalid_thumbnail_resources_spec.rb
+++ b/spec/queries/find_invalid_thumbnail_resources_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe FindInvalidThumbnailResources do
     sr = FactoryBot.create_for_repository(:scanned_resource)
     change_set = ScannedResourceChangeSet.new(sr)
     change_set.thumbnail_id = "https://libimages1.princeton.edu/loris/figgy_prod/d7%2F44%2F84%2Fd74484d965664f95a9ac2634bd583775%2Fintermediate_file.jp2/full/!200,150/0/default.jpg"
-    change_set.prepopulate!
     change_set_persister.save(change_set: change_set)
   end
   let(:file) { fixture_file_upload("files/color-landscape.tif", "image/tiff") }

--- a/spec/queries/find_members_with_relationship_spec.rb
+++ b/spec/queries/find_members_with_relationship_spec.rb
@@ -7,16 +7,16 @@ RSpec.describe FindMembersWithRelationship do
 
   describe "#find_members_with_relationship" do
     it "returns members with `loaded_relationship` loaded" do
-      genre = FactoryBot.create_for_repository(:ephemera_term, label: "Genre")
-      genre2 = FactoryBot.create_for_repository(:ephemera_term, label: "Genre2")
-      folder = FactoryBot.create_for_repository(:ephemera_folder, genre: [genre.id, genre2.id])
-      folder2 = FactoryBot.create_for_repository(:ephemera_folder, genre: [genre.id])
+      genre = FactoryBot.create_for_repository(:ephemera_term, label: "Subject1")
+      genre2 = FactoryBot.create_for_repository(:ephemera_term, label: "Subject2")
+      folder = FactoryBot.create_for_repository(:ephemera_folder, geo_subject: [genre.id, genre2.id])
+      folder2 = FactoryBot.create_for_repository(:ephemera_folder, geo_subject: [genre.id])
       project = FactoryBot.create_for_repository(:ephemera_project, member_ids: [folder.id, folder2.id])
 
-      output = query.find_members_with_relationship(resource: project, relationship: :genre).to_a
-      expect(output.first.loaded[:genre][0].label).to eq ["Genre"]
-      expect(output.first.loaded[:genre][1].label).to eq ["Genre2"]
-      expect(output.last.loaded[:genre][0].label).to eq ["Genre"]
+      output = query.find_members_with_relationship(resource: project, relationship: :geo_subject).to_a
+      expect(output.first.loaded[:geo_subject][0].label).to eq ["Subject1"]
+      expect(output.first.loaded[:geo_subject][1].label).to eq ["Subject2"]
+      expect(output.last.loaded[:geo_subject][0].label).to eq ["Subject1"]
     end
   end
 end

--- a/spec/queries/find_missing_thumbnail_resources_spec.rb
+++ b/spec/queries/find_missing_thumbnail_resources_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe FindMissingThumbnailResources do
     sr = FactoryBot.create_for_repository(:scanned_resource)
     change_set = ScannedResourceChangeSet.new(sr)
     change_set.thumbnail_id = nil
-    change_set.prepopulate!
     change_set_persister.save(change_set: change_set)
   end
   let(:file) { fixture_file_upload("files/color-landscape.tif", "image/tiff") }

--- a/spec/requests/playlist_spec.rb
+++ b/spec/requests/playlist_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe "Playlist requests", type: :request do
   let(:playlist) do
     res = Playlist.new
     cs = PlaylistChangeSet.new(res)
-    cs.prepopulate!
     cs.validate(label: ["my playlist"], file_set_ids: [file_set.id], state: "complete")
     change_set_persister.save(change_set: cs)
   end

--- a/spec/resources/archival_media_collections/archival_media_collection_change_set_spec.rb
+++ b/spec/resources/archival_media_collections/archival_media_collection_change_set_spec.rb
@@ -6,10 +6,6 @@ RSpec.describe ArchivalMediaCollectionChangeSet do
   let(:collection) { FactoryBot.build(:archival_media_collection, state: "draft") }
   let(:form_resource) { collection }
 
-  before do
-    change_set.prepopulate!
-  end
-
   describe "#source_metadata_identifier" do
     it "is single-valued and required" do
       expect(change_set.multiple?(:source_metadata_identifier)).to eq false
@@ -138,7 +134,7 @@ RSpec.describe ArchivalMediaCollectionChangeSet do
         IngestArchivalMediaBagJob.perform_now(collection_component: collection_cid, bag_path: av_fixture_bag, user: nil)
         # retrieve the collection via the query service and put it in a change set with the bag
         collection = query_service.find_by(id: collection.id)
-        change_set = described_class.new(collection, bag_path: av_fixture_bag).prepopulate!
+        change_set = described_class.new(collection, bag_path: av_fixture_bag)
         expect(change_set).not_to be_valid
       end
     end
@@ -173,7 +169,7 @@ RSpec.describe ArchivalMediaCollectionChangeSet do
         IngestArchivalMediaBagJob.perform_now(collection_component: collection_cid, bag_path: av_fixture_bag, user: nil)
         # retrieve the collection via the query service and put it in a change set with the bag
         collection = query_service.find_by(id: collection.id)
-        change_set = described_class.new(collection, bag_path: av_fixture_bag).prepopulate!
+        change_set = described_class.new(collection, bag_path: av_fixture_bag)
         expect(change_set).not_to be_valid
       end
     end
@@ -187,7 +183,6 @@ RSpec.describe ArchivalMediaCollectionChangeSet do
 
   describe "#workflow" do
     it "has a workflow" do
-      change_set.prepopulate!
       expect(change_set.workflow).to be_a(DraftCompleteWorkflow)
       expect(change_set.workflow.draft?).to be true
     end

--- a/spec/resources/coins/coin_change_set_spec.rb
+++ b/spec/resources/coins/coin_change_set_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe CoinChangeSet do
     end
 
     it "pre-populates" do
-      change_set.prepopulate!
       expect(change_set.visibility).to eq "open"
     end
   end
@@ -30,21 +29,18 @@ RSpec.describe CoinChangeSet do
   describe "validations" do
     context "when given a non-UUID for a member resource" do
       it "is not valid" do
-        change_set.prepopulate!
         change_set.validate(member_ids: ["not-valid"])
         expect(change_set).not_to be_valid
       end
     end
     context "when given a valid UUID for a member resource which does not exist" do
       it "is not valid" do
-        change_set.prepopulate!
         change_set.validate(member_ids: ["55a14e79-710d-42c1-86aa-3d8cdaa62930"])
         expect(change_set).not_to be_valid
       end
     end
     context "when not given a coin number" do
       it "gives it a coin number" do
-        change_set.prepopulate!
         change_set.validate(coin_number: nil)
         expect(change_set).to be_valid
         expect(change_set.coin_number).to be_positive
@@ -52,7 +48,6 @@ RSpec.describe CoinChangeSet do
     end
     context "when given a coin number" do
       it "uses the given coin number" do
-        change_set.prepopulate!
         change_set.validate(coin_number: 5)
         expect(change_set).to be_valid
         expect(change_set.coin_number).to eq(5)

--- a/spec/resources/collections/collection_change_set_spec.rb
+++ b/spec/resources/collections/collection_change_set_spec.rb
@@ -4,9 +4,6 @@ require "rails_helper"
 RSpec.describe CollectionChangeSet do
   subject(:change_set) { described_class.new(collection) }
   let(:collection) { FactoryBot.build(:collection) }
-  before do
-    change_set.prepopulate!
-  end
   describe "#title" do
     it "is single-valued and required" do
       expect(change_set.multiple?(:title)).to eq false

--- a/spec/resources/ephemera_folders/ephemera_folder_change_set_spec.rb
+++ b/spec/resources/ephemera_folders/ephemera_folder_change_set_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe EphemeraFolderChangeSet do
 
   describe "#subject" do
     it "is required" do
-      change_set.prepopulate!
       expect(change_set.required?(:subject)).to eq true
       expect(change_set.validate(subject: nil)).to eq false
       expect(change_set.validate(subject: ["test"])).to eq true
@@ -36,7 +35,6 @@ RSpec.describe EphemeraFolderChangeSet do
   describe "#visibility" do
     let(:change_set) { described_class.new(FactoryBot.build(:ephemera_folder, visibility: nil)) }
     it "has a default of open" do
-      change_set.prepopulate!
       expect(change_set.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
     end
   end
@@ -56,28 +54,24 @@ RSpec.describe EphemeraFolderChangeSet do
   describe "validations" do
     context "when given a non-UUID for a collection" do
       it "is not valid" do
-        change_set.prepopulate!
         change_set.validate(member_of_collection_ids: ["not-valid"])
         expect(change_set).not_to be_valid
       end
     end
     context "when given a valid UUID for a collection which does not exist" do
       it "is not valid" do
-        change_set.prepopulate!
         change_set.validate(member_of_collection_ids: ["b8823acb-d42b-4e62-a5c9-de5f94cbd3f6"])
         expect(change_set).not_to be_valid
       end
     end
     context "when given a non-UUID for a member resource" do
       it "is not valid" do
-        change_set.prepopulate!
         change_set.validate(member_ids: ["not-valid"])
         expect(change_set).not_to be_valid
       end
     end
     context "when given a valid UUID for a member resource which does not exist" do
       it "is not valid" do
-        change_set.prepopulate!
         change_set.validate(member_ids: ["55a14e79-710d-42c1-86aa-3d8cdaa62930"])
         expect(change_set).not_to be_valid
       end

--- a/spec/resources/media_resources/media_resource_change_set_spec.rb
+++ b/spec/resources/media_resources/media_resource_change_set_spec.rb
@@ -15,9 +15,6 @@ RSpec.describe MediaResourceChangeSet do
     end
   end
   describe "validations" do
-    before do
-      change_set.prepopulate!
-    end
     it "is valid by default" do
       expect(change_set).to be_valid
     end
@@ -50,8 +47,6 @@ RSpec.describe MediaResourceChangeSet do
   describe "#rights_statement" do
     let(:form_resource) { MediaResource.new(rights_statement: RDF::URI(rights_statement)) }
     it "is singular, required, and converts to an RDF::URI" do
-      change_set.prepopulate!
-
       expect(change_set.rights_statement).to eq RDF::URI(rights_statement)
       change_set.validate(rights_statement: "")
       expect(change_set).not_to be_valid
@@ -61,8 +56,6 @@ RSpec.describe MediaResourceChangeSet do
     context "when given a blank MediaResource" do
       let(:form_resource) { MediaResource.new }
       it "sets a default Rights Statement" do
-        change_set.prepopulate!
-
         expect(change_set.rights_statement).to eq RDF::URI(rights_statement)
       end
     end
@@ -70,7 +63,6 @@ RSpec.describe MediaResourceChangeSet do
 
   describe "#workflow" do
     it "has a workflow" do
-      change_set.prepopulate!
       expect(change_set.workflow).to be_a(DraftCompleteWorkflow)
       expect(change_set.workflow.draft?).to be true
     end
@@ -100,7 +92,6 @@ RSpec.describe MediaResourceChangeSet do
 
     describe "#valid?" do
       it "is a valid change set" do
-        change_set.prepopulate!
         expect(change_set).to be_valid
       end
     end

--- a/spec/resources/numismatic_artists/numismatic_artist_wayfinder_spec.rb
+++ b/spec/resources/numismatic_artists/numismatic_artist_wayfinder_spec.rb
@@ -9,13 +9,11 @@ describe NumismaticArtistWayfinder do
   let(:numismatic_artist) do
     res = NumismaticArtist.new(title: "artist unknown")
     ch = NumismaticArtistChangeSet.new(res)
-    ch.prepopulate!
     change_set_persister.save(change_set: ch)
   end
   let(:coin) do
     res = Coin.new(title: "hercules", weight: 5, numismatic_artist_ids: [numismatic_artist.id])
     ch = CoinChangeSet.new(res)
-    ch.prepopulate!
     change_set_persister.save(change_set: ch)
   end
 

--- a/spec/resources/numismatic_citations/numismatic_citation_wayfinder_spec.rb
+++ b/spec/resources/numismatic_citations/numismatic_citation_wayfinder_spec.rb
@@ -9,13 +9,11 @@ describe NumismaticCitationWayfinder do
   let(:numismatic_citation) do
     res = NumismaticCitation.new(title: "athens")
     ch = NumismaticCitationChangeSet.new(res)
-    ch.prepopulate!
     change_set_persister.save(change_set: ch)
   end
   let(:coin) do
     res = Coin.new(title: "hercules", weight: 5, numismatic_citation_ids: [numismatic_citation.id])
     ch = CoinChangeSet.new(res)
-    ch.prepopulate!
     change_set_persister.save(change_set: ch)
   end
 

--- a/spec/resources/numismatic_issues/numismatic_issue_change_set_spec.rb
+++ b/spec/resources/numismatic_issues/numismatic_issue_change_set_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe NumismaticIssueChangeSet do
 
   describe "#state" do
     it "pre-populates" do
-      change_set.prepopulate!
       expect(change_set.state).to eq "draft"
     end
 
@@ -40,7 +39,6 @@ RSpec.describe NumismaticIssueChangeSet do
 
       before do
         stub_ezid(shoulder: "99999/fk4", blade: "123456")
-        change_set.prepopulate!
       end
       it "propagates the state to member resources" do
         change_set.state = "complete"
@@ -54,14 +52,12 @@ RSpec.describe NumismaticIssueChangeSet do
   describe "validations" do
     context "when given a non-UUID for a member resource" do
       it "is not valid" do
-        change_set.prepopulate!
         change_set.validate(member_ids: ["not-valid"])
         expect(change_set).not_to be_valid
       end
     end
     context "when given a valid UUID for a member resource which does not exist" do
       it "is not valid" do
-        change_set.prepopulate!
         change_set.validate(member_ids: ["55a14e79-710d-42c1-86aa-3d8cdaa62930"])
         expect(change_set).not_to be_valid
       end

--- a/spec/resources/playlists/playlist_change_set_spec.rb
+++ b/spec/resources/playlists/playlist_change_set_spec.rb
@@ -9,15 +9,11 @@ RSpec.describe PlaylistChangeSet do
 
   describe "#prepopulate!" do
     it "sets default private visibility" do
-      change_set.prepopulate!
       expect(change_set.visibility).to eq visibility
     end
   end
 
   describe "validations" do
-    before do
-      change_set.prepopulate!
-    end
     context "when given a non-UUID for a member resource" do
       it "is not valid" do
         change_set.validate(member_ids: ["not-valid"])

--- a/spec/resources/playlists/playlist_decorator_spec.rb
+++ b/spec/resources/playlists/playlist_decorator_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe PlaylistDecorator do
     let(:playlist) do
       res = Playlist.new
       cs = PlaylistChangeSet.new(res)
-      cs.prepopulate!
       cs.validate(file_set_ids: [file_set.id])
       change_set_persister.save(change_set: cs)
     end

--- a/spec/resources/playlists/playlist_wayfinder_spec.rb
+++ b/spec/resources/playlists/playlist_wayfinder_spec.rb
@@ -9,25 +9,21 @@ describe PlaylistWayfinder do
   let(:file_set1) do
     res = FileSet.new(title: "Symphony No. 14 in A major, K. 114")
     cs = FileSetChangeSet.new(res)
-    cs.prepopulate!
     change_set_persister.save(change_set: cs)
   end
   let(:file_set2) do
     res = FileSet.new(title: "Einleitung - I")
     cs = FileSetChangeSet.new(res)
-    cs.prepopulate!
     change_set_persister.save(change_set: cs)
   end
   let(:proxy1) do
     res = ProxyFileSet.new(proxied_file_id: file_set1.id)
     cs = ProxyFileSetChangeSet.new(res)
-    cs.prepopulate!
     change_set_persister.save(change_set: cs)
   end
   let(:proxy2) do
     res = ProxyFileSet.new(proxied_file_id: file_set2.id)
     cs = ProxyFileSetChangeSet.new(res)
-    cs.prepopulate!
     change_set_persister.save(change_set: cs)
   end
   let(:resource) do

--- a/spec/resources/playlists/playlists_controller_spec.rb
+++ b/spec/resources/playlists/playlists_controller_spec.rb
@@ -81,7 +81,6 @@ RSpec.describe PlaylistsController, type: :controller do
         let(:proxy_file_set) do
           proxy = ProxyFileSet.new
           cs = ProxyFileSetChangeSet.new(proxy)
-          cs.prepopulate!
           change_set_persister.save(change_set: cs)
         end
 
@@ -101,13 +100,11 @@ RSpec.describe PlaylistsController, type: :controller do
         let(:proxy_file_set) do
           proxy = ProxyFileSet.new
           cs = ProxyFileSetChangeSet.new(proxy)
-          cs.prepopulate!
           change_set_persister.save(change_set: cs)
         end
         let(:proxy_file_set2) do
           proxy = ProxyFileSet.new
           cs = ProxyFileSetChangeSet.new(proxy)
-          cs.prepopulate!
           change_set_persister.save(change_set: cs)
         end
         let(:resource) { FactoryBot.create_for_repository(:playlist, member_ids: [proxy_file_set.id]) }
@@ -157,13 +154,11 @@ RSpec.describe PlaylistsController, type: :controller do
         let(:proxy1) do
           res = ProxyFileSet.new(proxied_file_id: file_set1.id)
           cs = ProxyFileSetChangeSet.new(res)
-          cs.prepopulate!
           change_set_persister.save(change_set: cs)
         end
         let(:proxy2) do
           res = ProxyFileSet.new(proxied_file_id: file_set2.id)
           cs = ProxyFileSetChangeSet.new(res)
-          cs.prepopulate!
           change_set_persister.save(change_set: cs)
         end
         let(:resource) do

--- a/spec/resources/proxy_file_sets/proxy_file_set_change_set_spec.rb
+++ b/spec/resources/proxy_file_sets/proxy_file_set_change_set_spec.rb
@@ -9,16 +9,11 @@ RSpec.describe ProxyFileSetChangeSet do
 
   describe "#prepopulate!" do
     it "sets default private visibility" do
-      change_set.prepopulate!
       expect(change_set.visibility).to eq visibility
     end
   end
 
   describe "validations" do
-    before do
-      change_set.prepopulate!
-    end
-
     context "label" do
       let(:proxy_file_set) { ProxyFileSet.new }
       it "is required" do

--- a/spec/resources/raster_resources/raster_resource_change_set_spec.rb
+++ b/spec/resources/raster_resources/raster_resource_change_set_spec.rb
@@ -13,17 +13,12 @@ RSpec.describe RasterResourceChangeSet do
 
   describe "#workflow" do
     it "has a workflow" do
-      change_set.prepopulate!
       expect(change_set.workflow).to be_a(GeoWorkflow)
       expect(change_set.workflow.pending?).to be true
     end
   end
 
   describe "validations" do
-    before do
-      change_set.prepopulate!
-    end
-
     it "is valid by default" do
       expect(change_set).to be_valid
     end
@@ -96,7 +91,6 @@ RSpec.describe RasterResourceChangeSet do
 
   describe "#holding_location" do
     it "converts values to RDF::URIs" do
-      change_set.prepopulate!
       change_set.validate(holding_location: "http://test.com/")
       expect(change_set.holding_location).to be_instance_of RDF::URI
     end
@@ -105,8 +99,6 @@ RSpec.describe RasterResourceChangeSet do
   describe "#rights_statement" do
     let(:form_resource) { RasterResource.new(rights_statement: RDF::URI(rights_statement)) }
     it "is singular, required, and converts to an RDF::URI" do
-      change_set.prepopulate!
-
       expect(change_set.rights_statement).to eq RDF::URI(rights_statement)
       change_set.validate(rights_statement: "")
       expect(change_set).not_to be_valid
@@ -116,8 +108,6 @@ RSpec.describe RasterResourceChangeSet do
     context "when given a blank RasterResource" do
       let(:form_resource) { RasterResource.new }
       it "sets a default Rights Statement" do
-        change_set.prepopulate!
-
         expect(change_set.rights_statement).to eq RDF::URI(rights_statement)
       end
     end

--- a/spec/resources/scanned_maps/scanned_map_change_set_spec.rb
+++ b/spec/resources/scanned_maps/scanned_map_change_set_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe ScannedMapChangeSet do
 
   describe "#workflow" do
     it "has a workflow" do
-      change_set.prepopulate!
       expect(change_set.workflow).to be_a(GeoWorkflow)
       expect(change_set.workflow.pending?).to be true
     end

--- a/spec/resources/scanned_resources/scanned_resource_change_set_spec.rb
+++ b/spec/resources/scanned_resources/scanned_resource_change_set_spec.rb
@@ -18,20 +18,17 @@ RSpec.describe ScannedResourceChangeSet do
     context "when neither title or metadata identifier is set" do
       let(:form_resource) { scanned_resource.new(title: "", source_metadata_identifier: "") }
       it "is invalid" do
-        change_set.prepopulate!
         expect(change_set).not_to be_valid
       end
     end
     context "when only metadata_identifier is set" do
       let(:form_resource) { scanned_resource.new(title: "", source_metadata_identifier: "123456") }
       it "is valid" do
-        change_set.prepopulate!
         expect(change_set).to be_valid
       end
     end
     context "when given a valid state transition" do
       it "is valid" do
-        change_set.prepopulate!
         change_set.validate(state: "metadata_review")
         expect(change_set).to be_valid
       end
@@ -46,7 +43,6 @@ RSpec.describe ScannedResourceChangeSet do
 
   describe "#holding_location" do
     it "converts values to RDF::URIs" do
-      change_set.prepopulate!
       change_set.validate(holding_location: "http://test.com/")
       expect(change_set.holding_location).to be_instance_of RDF::URI
     end
@@ -54,7 +50,6 @@ RSpec.describe ScannedResourceChangeSet do
 
   describe "#workflow" do
     it "has a workflow" do
-      change_set.prepopulate!
       expect(change_set.workflow).to be_a(BookWorkflow)
       expect(change_set.workflow.pending?).to be true
     end
@@ -87,7 +82,6 @@ RSpec.describe ScannedResourceChangeSet do
     let(:resource1) { FactoryBot.create_for_repository(:file_set) }
     let(:resource2) { FactoryBot.create_for_repository(:file_set) }
     it "can set a whole structure all at once" do
-      change_set.prepopulate!
       expect(change_set.validate(logical_structure: [structure])).to eq true
 
       expect(change_set.logical_structure[0].label).to eq ["Top!"]
@@ -97,8 +91,6 @@ RSpec.describe ScannedResourceChangeSet do
       expect(change_set.logical_structure[0].nodes[1].nodes[0].proxy).to eq [resource2.id]
     end
     it "has a default label" do
-      change_set.prepopulate!
-
       expect(change_set.logical_structure[0].label).to eq ["Logical"]
     end
   end

--- a/spec/resources/vector_resources/vector_resource_change_set_spec.rb
+++ b/spec/resources/vector_resources/vector_resource_change_set_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe VectorResourceChangeSet do
 
   describe "#workflow" do
     it "has a workflow" do
-      change_set.prepopulate!
       expect(change_set.workflow).to be_a(GeoWorkflow)
       expect(change_set.workflow.pending?).to be true
     end
@@ -20,81 +19,69 @@ RSpec.describe VectorResourceChangeSet do
 
   describe "validations" do
     it "is valid by default" do
-      change_set.prepopulate!
       expect(change_set).to be_valid
     end
     context "when neither title or metadata identifier is set" do
       let(:form_resource) { vector_resource.new(title: "", source_metadata_identifier: "") }
       it "is invalid" do
-        change_set.prepopulate!
         expect(change_set).not_to be_valid
       end
     end
     context "when title is an empty array" do
       it "is invalid" do
-        change_set.prepopulate!
         expect(change_set.validate(title: [""])).to eq false
       end
     end
     context "when only metadata_identifier is set" do
       let(:form_resource) { vector_resource.new(title: "", source_metadata_identifier: "6592452") }
       it "is valid" do
-        change_set.prepopulate!
         expect(change_set).to be_valid
       end
     end
     context "when rights_statement isn't set" do
       let(:form_resource) { vector_resource.new(rights_statement: [""]) }
       it "is invalid" do
-        change_set.prepopulate!
         expect(change_set).not_to be_valid
       end
     end
     context "when visibility isn't set" do
       let(:form_resource) { vector_resource.new(visibility: [""]) }
       it "is invalid" do
-        change_set.prepopulate!
         expect(change_set).not_to be_valid
       end
     end
     context "when given a valid state transition" do
       it "is valid" do
-        change_set.prepopulate!
         change_set.validate(state: "final_review")
         expect(change_set).to be_valid
       end
     end
     context "when given an invalid state transition" do
       it "is invalid" do
-        change_set.prepopulate!
         change_set.validate(state: "complete")
         expect(change_set).not_to be_valid
       end
     end
     context "when given a non-UUID for a collection" do
       it "is not valid" do
-        change_set.prepopulate!
         change_set.validate(member_of_collection_ids: ["not-valid"])
         expect(change_set).not_to be_valid
       end
     end
     context "when given a valid UUID for a collection which does not exist" do
       it "is not valid" do
-        change_set.prepopulate!
         change_set.validate(member_of_collection_ids: ["b8823acb-d42b-4e62-a5c9-de5f94cbd3f6"])
         expect(change_set).not_to be_valid
       end
     end
     context "when given a non-UUID for a member resource" do
       it "is not valid" do
-        change_set.prepopulate!
         change_set.validate(member_ids: ["not-valid"])
         expect(change_set).not_to be_valid
       end
     end
     context "when given a valid UUID for a member resource which does not exist" do
       it "is not valid" do
-        change_set.prepopulate!
         change_set.validate(member_ids: ["55a14e79-710d-42c1-86aa-3d8cdaa62930"])
         expect(change_set).not_to be_valid
       end
@@ -103,7 +90,6 @@ RSpec.describe VectorResourceChangeSet do
 
   describe "#holding_location" do
     it "converts values to RDF::URIs" do
-      change_set.prepopulate!
       change_set.validate(holding_location: "http://test.com/")
       expect(change_set.holding_location).to be_instance_of RDF::URI
     end
@@ -112,8 +98,6 @@ RSpec.describe VectorResourceChangeSet do
   describe "#rights_statement" do
     let(:form_resource) { VectorResource.new(rights_statement: RightsStatements.no_known_copyright) }
     it "is singular, required, and converts to an RDF::URI" do
-      change_set.prepopulate!
-
       expect(change_set.rights_statement).to eq RightsStatements.no_known_copyright
       change_set.validate(rights_statement: "")
       expect(change_set).not_to be_valid
@@ -123,8 +107,6 @@ RSpec.describe VectorResourceChangeSet do
     context "when given a blank VectorResource" do
       let(:form_resource) { VectorResource.new }
       it "sets a default Rights Statement" do
-        change_set.prepopulate!
-
         expect(change_set.rights_statement).to eq RightsStatements.no_known_copyright
       end
     end

--- a/spec/services/manifest_builder/license_builder_spec.rb
+++ b/spec/services/manifest_builder/license_builder_spec.rb
@@ -20,21 +20,5 @@ RSpec.describe ManifestBuilder::LicenseBuilder do
         expect(manifest["license"]).to eq "https://creativecommons.org/licenses/by-nc/4.0/"
       end
     end
-
-    context "when viewing a new Scanned Resource with an invalid rights statement" do
-      let(:scanned_resource) do
-        FactoryBot.create_for_repository(:scanned_resource,
-                                         rights_statement: 1234)
-      end
-
-      before do
-        builder.apply(manifest)
-      end
-
-      it "appends the transformed metadata to the Manifest" do
-        expect(manifest["license"]).to be nil
-        expect(manifest).not_to have_key("license")
-      end
-    end
   end
 end

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -217,13 +217,11 @@ RSpec.describe ManifestBuilder do
         let(:proxy1) do
           res = ProxyFileSet.new(proxied_file_id: file_set1.id, label: "Proxy Title")
           cs = ProxyFileSetChangeSet.new(res)
-          cs.prepopulate!
           change_set_persister.save(change_set: cs)
         end
         let(:proxy2) do
           res = ProxyFileSet.new(proxied_file_id: file_set2.id, label: "Proxy Title2")
           cs = ProxyFileSetChangeSet.new(res)
-          cs.prepopulate!
           change_set_persister.save(change_set: cs)
         end
         let(:resource) do
@@ -284,7 +282,6 @@ RSpec.describe ManifestBuilder do
 
           let(:persisted) do
             change_set = PlaylistChangeSet.new(resource)
-            change_set.prepopulate!
             change_set.validate(state: ["complete"])
             change_set_persister.save(change_set: change_set)
           end

--- a/spec/services/marc_record_enhancer_spec.rb
+++ b/spec/services/marc_record_enhancer_spec.rb
@@ -286,7 +286,7 @@ RSpec.describe MarcRecordEnhancer do
     end
     let(:resource) do
       r = FactoryBot.build(:scanned_resource, source_metadata_identifier: "2085282")
-      change_set_persister.save(change_set: ScannedResourceChangeSet.new(r).prepopulate!)
+      change_set_persister.save(change_set: ScannedResourceChangeSet.new(r))
     end
     let(:marc_record) { MARC::Record.new }
     let(:enhancer) { described_class.new(marc: marc_record, resource: resource) }

--- a/spec/shared_specs/change_sets/change_set.rb
+++ b/spec/shared_specs/change_sets/change_set.rb
@@ -9,99 +9,86 @@ RSpec.shared_examples "a ChangeSet" do
       defined? resource_klass
   end
 
-  describe "#prepopulate!" do
-    it "doesn't make it look changed" do
+  describe "#validate!" do
+    it "doesn't make it look changed if passed an empty hash" do
       expect(change_set).not_to be_changed
-      change_set.prepopulate!
+      change_set.validate({})
       expect(change_set).not_to be_changed
     end
   end
 
   describe "validations" do
     it "is valid by default" do
-      change_set.prepopulate!
       expect(change_set).to be_valid
     end
 
     context "when title is an empty array" do
       it "is invalid" do
-        change_set.prepopulate!
         expect(change_set.validate(title: [])).to eq false
       end
     end
     context "when rights_statement isn't set" do
       let(:form_resource) { resource_klass.new(rights_statement: [""]) }
       it "is invalid" do
-        change_set.prepopulate!
         expect(change_set).not_to be_valid
       end
     end
     context "when visibility isn't set" do
       let(:form_resource) { resource_klass.new(visibility: [""]) }
       it "is invalid" do
-        change_set.prepopulate!
         expect(change_set).not_to be_valid
       end
     end
     context "when visibility hasn't been set" do
       let(:form_resource) { resource_klass.new(visibility: nil) }
       it "has a default of public" do
-        change_set.prepopulate!
         expect(change_set.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
       end
     end
     context "when given a bad viewing direction" do
       it "is invalid" do
-        change_set.prepopulate!
         change_set.validate(viewing_direction: "backwards-to-forwards")
         expect(change_set).not_to be_valid
       end
     end
     context "when given a good viewing direction" do
       it "is valid" do
-        change_set.prepopulate!
         change_set.validate(viewing_direction: "left-to-right")
         expect(change_set).to be_valid
       end
     end
     context "when given a bad viewing hint" do
       it "is invalid" do
-        change_set.prepopulate!
         change_set.validate(viewing_hint: "bananas")
         expect(change_set).not_to be_valid
       end
     end
     context "when given a good viewing direction" do
       it "is valid" do
-        change_set.prepopulate!
         change_set.validate(viewing_hint: "paged")
         expect(change_set).to be_valid
       end
     end
     context "when given a non-UUID for a collection" do
       it "is not valid" do
-        change_set.prepopulate!
         change_set.validate(member_of_collection_ids: ["not-valid"])
         expect(change_set).not_to be_valid
       end
     end
     context "when given a valid UUID for a collection which does not exist" do
       it "is not valid" do
-        change_set.prepopulate!
         change_set.validate(member_of_collection_ids: ["b8823acb-d42b-4e62-a5c9-de5f94cbd3f6"])
         expect(change_set).not_to be_valid
       end
     end
     context "when given a non-UUID for a member resource" do
       it "is not valid" do
-        change_set.prepopulate!
         change_set.validate(member_ids: ["not-valid"])
         expect(change_set).not_to be_valid
       end
     end
     context "when given a valid UUID for a member resource which does not exist" do
       it "is not valid" do
-        change_set.prepopulate!
         change_set.validate(member_ids: ["55a14e79-710d-42c1-86aa-3d8cdaa62930"])
         expect(change_set).not_to be_valid
       end
@@ -110,8 +97,6 @@ RSpec.shared_examples "a ChangeSet" do
     describe "#pdf_type" do
       let(:form_resource) { resource_klass.new }
       it "has a default of 'color'" do
-        change_set.prepopulate!
-
         expect(change_set.pdf_type).to eq "color"
       end
     end
@@ -119,8 +104,6 @@ RSpec.shared_examples "a ChangeSet" do
     describe "#rights_statement" do
       let(:form_resource) { resource_klass.new(rights_statement: RightsStatements.no_known_copyright) }
       it "is singular, required, and converts to an RDF::URI" do
-        change_set.prepopulate!
-
         expect(change_set.rights_statement).to eq RightsStatements.no_known_copyright
         change_set.validate(rights_statement: "")
         expect(change_set).not_to be_valid
@@ -130,8 +113,6 @@ RSpec.shared_examples "a ChangeSet" do
       context "when given a blank resource" do
         let(:form_resource) { resource_klass.new }
         it "sets a default Rights Statement" do
-          change_set.prepopulate!
-
           expect(change_set.rights_statement).to eq RightsStatements.no_known_copyright
         end
       end
@@ -140,7 +121,6 @@ RSpec.shared_examples "a ChangeSet" do
     describe "#viewing_hint" do
       it "is singular" do
         form_resource.viewing_hint = ["Test"]
-        change_set.prepopulate!
 
         expect(change_set.viewing_hint).to eq "Test"
       end
@@ -149,7 +129,6 @@ RSpec.shared_examples "a ChangeSet" do
     describe "#viewing_direction" do
       it "is singular" do
         form_resource.viewing_direction = ["Test"]
-        change_set.prepopulate!
 
         expect(change_set.viewing_direction).to eq "Test"
       end

--- a/spec/support/shared/ephemera_folder_change_set_specs.rb
+++ b/spec/support/shared/ephemera_folder_change_set_specs.rb
@@ -13,14 +13,12 @@ RSpec.shared_examples "an ephemera folder change set" do |change_set_class|
 
   describe "#state" do
     it "pre-populates" do
-      change_set.prepopulate!
       expect(change_set.state).to eq "needs_qa"
     end
   end
 
   describe "#provenance" do
     it "pre-populates as single-value" do
-      change_set.prepopulate!
       expect(change_set.provenance).to eq FactoryBot.build(:ephemera_folder).provenance.first
     end
   end


### PR DESCRIPTION
Reform pre-population is meant as a way to build up filler nested objects for display in an HTML form, not to transform values. This should make it easier to follow Reform documentation.