### PR TITLE
Updates the BulkIngestController and BaseResourceController for directories selected with browse-everything

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -92,6 +92,7 @@ Metrics/ClassLength:
     - 'app/services/music_import_service/recording_collector.rb'
     - 'app/controllers/bulk_ingest_controller.rb'
     - 'app/controllers/application_controller.rb'
+    - 'app/controllers/base_resource_controller.rb'
 Metrics/CyclomaticComplexity:
   Exclude:
     - 'app/helpers/application_helper.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,6 @@ gem "rsolr", ">= 1.0"
 
 gem "aasm"
 gem "arabic-letter-connector"
-gem 'font-awesome-rails'
 gem "browse-everything", github: "jrgriffiniii/browse-everything", branch: "figgy-issues-1536-jrgriffiniii"
 gem "capistrano", "~> 3.7.1"
 gem "capistrano-passenger"

--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,8 @@ gem "rsolr", ">= 1.0"
 
 gem "aasm"
 gem "arabic-letter-connector"
-gem "browse-everything", github: "jrgriffiniii/browse-everything", branch: "figgy-issues-2465-jrgriffiniii"
+gem 'font-awesome-rails'
+gem "browse-everything", github: "jrgriffiniii/browse-everything", branch: "gdrive-paging-jrgriffiniii-rebased"
 gem "capistrano", "~> 3.7.1"
 gem "capistrano-passenger"
 gem "capistrano-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -83,7 +83,7 @@ gem "rsolr", ">= 1.0"
 gem "aasm"
 gem "arabic-letter-connector"
 gem 'font-awesome-rails'
-gem "browse-everything", github: "jrgriffiniii/browse-everything", branch: "gdrive-paging-jrgriffiniii-rebased"
+gem "browse-everything", github: "jrgriffiniii/browse-everything", branch: "figgy-issues-1536-jrgriffiniii"
 gem "capistrano", "~> 3.7.1"
 gem "capistrano-passenger"
 gem "capistrano-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: git://github.com/jrgriffiniii/browse-everything.git
-  revision: d564730eae3caf3e34afb791db2155f721230eb8
-  branch: gdrive-paging-jrgriffiniii-rebased
+  revision: 29f806e3807ea55ab21a300a3aff45b615c89eea
+  branch: figgy-issues-1536-jrgriffiniii
   specs:
-    browse-everything (1.0.0.rc2)
+    browse-everything (1.0.0)
       addressable (~> 2.5)
       aws-sdk-s3
       dropbox_api (>= 0.1.10)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,10 +9,10 @@ GIT
 
 GIT
   remote: git://github.com/jrgriffiniii/browse-everything.git
-  revision: 556400e206e8bd04bad60ad82364d7df4edeb0c3
-  branch: figgy-issues-2465-jrgriffiniii
+  revision: d564730eae3caf3e34afb791db2155f721230eb8
+  branch: gdrive-paging-jrgriffiniii-rebased
   specs:
-    browse-everything (1.0.0)
+    browse-everything (1.0.0.rc2)
       addressable (~> 2.5)
       aws-sdk-s3
       dropbox_api (>= 0.1.10)
@@ -158,17 +158,17 @@ GEM
     awesome_print (1.8.0)
     aws-eventstream (1.0.2)
     aws-partitions (1.144.0)
-    aws-sdk-core (3.47.0)
-      aws-eventstream (~> 1.0, >= 1.0.2)
+    aws-sdk-core (3.46.2)
+      aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)
       http-2 (~> 0.10)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.14.0)
-      aws-sdk-core (~> 3, >= 3.47.0)
-      aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.32.0)
-      aws-sdk-core (~> 3, >= 3.47.0)
+    aws-sdk-kms (1.13.0)
+      aws-sdk-core (~> 3, >= 3.39.0)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-s3 (1.31.0)
+      aws-sdk-core (~> 3, >= 3.39.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
     aws-sigv4 (1.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 
 GIT
   remote: git://github.com/jrgriffiniii/browse-everything.git
-  revision: 29f806e3807ea55ab21a300a3aff45b615c89eea
+  revision: c8927010007f6f3483982a2451e1fb9272797ad9
   branch: figgy-issues-1536-jrgriffiniii
   specs:
     browse-everything (1.0.0)
@@ -157,18 +157,18 @@ GEM
       execjs
     awesome_print (1.8.0)
     aws-eventstream (1.0.2)
-    aws-partitions (1.144.0)
-    aws-sdk-core (3.46.2)
-      aws-eventstream (~> 1.0)
+    aws-partitions (1.147.0)
+    aws-sdk-core (3.48.3)
+      aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)
       http-2 (~> 0.10)
       jmespath (~> 1.0)
-    aws-sdk-kms (1.13.0)
-      aws-sdk-core (~> 3, >= 3.39.0)
-      aws-sigv4 (~> 1.0)
-    aws-sdk-s3 (1.31.0)
-      aws-sdk-core (~> 3, >= 3.39.0)
+    aws-sdk-kms (1.16.0)
+      aws-sdk-core (~> 3, >= 3.48.2)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.35.0)
+      aws-sdk-core (~> 3, >= 3.48.2)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
     aws-sigv4 (1.1.0)

--- a/app/values/browse_everything/resource.rb
+++ b/app/values/browse_everything/resource.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Class modeling resources selected for upload using browse-everything
+class BrowseEverything::Resource < ActiveSupport::HashWithIndifferentAccess
+  # Retrieve the path for the resource
+  # @return [String]
+  def path
+    return if url.nil?
+
+    _provider_key, uri = url.split(/:\/\//)
+    uri
+  end
+
+  # Determine whether or not this file is a cloud resource
+  # @return [Boolean]
+  def cloud_file?
+    return false if url.nil?
+
+    /^https?\:/ =~ url
+  end
+
+  private
+
+    # Retrieve the URL for the resource
+    # @return [String]
+    def url
+      fetch("url", nil)
+    end
+end

--- a/app/values/browse_everything_file_paths.rb
+++ b/app/values/browse_everything_file_paths.rb
@@ -64,8 +64,7 @@ class BrowseEverythingFilePaths
     # @return Array<Pathname>
     def file_paths
       @file_paths ||= begin
-        paths = @selected_files.values.map { |x| x["url"].gsub("file://", "") }
-        paths.map { |x| Pathname.new(x) }
+        @selected_files.map { |selected_file| Pathname.new(selected_file.path) }
       end
     end
 end

--- a/spec/controllers/bulk_ingest_controller_spec.rb
+++ b/spec/controllers/bulk_ingest_controller_spec.rb
@@ -77,7 +77,15 @@ RSpec.describe BulkIngestController do
       end
       let(:selected_files) do
         {
-          "0" => { "url" => "/base/resource1/1.tif", "file_name" => "1.tif", "file_size" => "100" }
+          browse_everything: {
+            selected_files: {
+              "0" => {
+                "url" => "file:///base/resource1/1.tif",
+                "file_name" => "1.tif",
+                "file_size" => "100"
+              }
+            }
+          }
         }
       end
 
@@ -114,8 +122,20 @@ RSpec.describe BulkIngestController do
       end
       let(:selected_files) do
         {
-          "0" => { "url" => "/base/resource1/1.tif", "file_name" => "1.tif", "file_size" => "100" },
-          "1" => { "url" => "/base/resource2/1.tif", "file_name" => "1.tif", "file_size" => "100" }
+          browse_everything: {
+            selected_files: {
+              "0" => {
+                "url" => "file:///base/resource1/1.tif",
+                "file_name" => "1.tif",
+                "file_size" => "100"
+              },
+              "1" => {
+                "url" => "file:///base/resource2/1.tif",
+                "file_name" => "1.tif",
+                "file_size" => "100"
+              }
+            }
+          }
         }
       end
 
@@ -128,8 +148,22 @@ RSpec.describe BulkIngestController do
     context "with files hosted on a cloud-storage provider" do
       let(:selected_files) do
         {
-          "0" => { "url" => "https://www.example.com/files/1.tif?alt=media", "file_name" => "1.tif", "file_size" => "100", "auth_header" => { "Authorization" => "Bearer secret" } },
-          "1" => { "url" => "https://www.example.com/files/2.tif?alt=media", "file_name" => "2.tif", "file_size" => "100", "auth_header" => { "Authorization" => "Bearer secret" } }
+          browse_everything: {
+            selected_files: {
+              "0" => {
+                "url" => "https://www.example.com/files/1.tif?alt=media",
+                "file_name" => "1.tif",
+                "file_size" => "100",
+                "auth_header" => { "Authorization" => "Bearer secret" }
+              },
+              "1" => {
+                "url" => "https://www.example.com/files/2.tif?alt=media",
+                "file_name" => "2.tif",
+                "file_size" => "100",
+                "auth_header" => { "Authorization" => "Bearer secret" }
+              }
+            }
+          }
         }
       end
 
@@ -152,6 +186,7 @@ RSpec.describe BulkIngestController do
 
       it "ingests the parent as two resources" do
         post :browse_everything_files, params: { resource_type: "scanned_resource", **attributes }
+
         expect(BrowseEverythingIngestJob).to have_received(:perform_later).with(resources.first.id.to_s, "BulkIngestController", [resources.first.pending_uploads.first.id.to_s])
         expect(BrowseEverythingIngestJob).to have_received(:perform_later).with(resources.last.id.to_s, "BulkIngestController", [resources.last.pending_uploads.first.id.to_s])
       end
@@ -200,8 +235,20 @@ RSpec.describe BulkIngestController do
       end
       let(:selected_files) do
         {
-          "0" => { "url" => "/base/resource1/vol1/1.tif", "file_name" => "1.tif", "file_size" => "100" },
-          "1" => { "url" => "/base/resource1/vol2/1.tif", "file_name" => "1.tif", "file_size" => "100" }
+          browse_everything: {
+            selected_files: {
+              "0" => {
+                "url" => "file:///base/resource1/vol1/1.tif",
+                "file_name" => "1.tif",
+                "file_size" => "100"
+              },
+              "1" => {
+                "url" => "file:///base/resource1/vol2/1.tif",
+                "file_name" => "1.tif",
+                "file_size" => "100"
+              }
+            }
+          }
         }
       end
 
@@ -222,10 +269,30 @@ RSpec.describe BulkIngestController do
       end
       let(:selected_files) do
         {
-          "0" => { "url" => "/base/resource1/vol1/1.tif", "file_name" => "1.tif", "file_size" => "100" },
-          "1" => { "url" => "/base/resource1/vol2/1.tif", "file_name" => "1.tif", "file_size" => "100" },
-          "2" => { "url" => "/base/resource2/vol1/1.tif", "file_name" => "1.tif", "file_size" => "100" },
-          "3" => { "url" => "/base/resource2/vol2/1.tif", "file_name" => "1.tif", "file_size" => "100" }
+          browse_everything: {
+            selected_files: {
+              "0" => {
+                "url" => "file:///base/resource1/vol1/1.tif",
+                "file_name" => "1.tif",
+                "file_size" => "100"
+              },
+              "1" => {
+                "url" => "file:///base/resource1/vol2/1.tif",
+                "file_name" => "1.tif",
+                "file_size" => "100"
+              },
+              "2" => {
+                "url" => "file:///base/resource2/vol3/1.tif",
+                "file_name" => "1.tif",
+                "file_size" => "100"
+              },
+              "3" => {
+                "url" => "file:///base/resource2/vol4/1.tif",
+                "file_name" => "1.tif",
+                "file_size" => "100"
+              }
+            }
+          }
         }
       end
 

--- a/spec/resources/scanned_resources/scanned_resources_controller_spec.rb
+++ b/spec/resources/scanned_resources/scanned_resources_controller_spec.rb
@@ -318,13 +318,20 @@ RSpec.describe ScannedResourcesController, type: :controller do
     #   Acts as a 'master spec' in this regard
     describe "POST /concern/scanned_resources/:id/browse_everything_files" do
       let(:file) { File.open(Rails.root.join("spec", "fixtures", "files", "example.tif")) }
+      let(:selected_files) do
+        {
+          "0" => {
+            "url" => "file://#{file.path}",
+            "file_name" => File.basename(file.path),
+            "file_size" => file.size
+          }
+        }
+      end
       let(:params) do
         {
           "selected_files" => {
-            "0" => {
-              "url" => "file://#{file.path}",
-              "file_name" => File.basename(file.path),
-              "file_size" => file.size
+            "browse_everything" => {
+              "selected_files" => selected_files
             }
           }
         }
@@ -343,15 +350,22 @@ RSpec.describe ScannedResourcesController, type: :controller do
 
       context "when a server-side error is encountered while downloading a file" do
         let(:expiry_time) { (Time.current + 3600).xmlschema }
+        let(:selected_files) do
+          {
+            "0" => {
+              "url" => "https://retrieve.cloud.example.com/some/dir/file.pdf",
+              "auth_header" => { "Authorization" => "Bearer ya29.kQCEAHj1bwFXr2AuGQJmSGRWQXpacmmYZs4kzCiXns3d6H1ZpIDWmdM8" },
+              "expires" => expiry_time,
+              "file_name" => "file.pdf",
+              "file_size" => "1874822"
+            }
+          }
+        end
         let(:params) do
           {
             "selected_files" => {
-              "0" => {
-                "url" => "https://retrieve.cloud.example.com/some/dir/file.pdf",
-                "auth_header" => { "Authorization" => "Bearer ya29.kQCEAHj1bwFXr2AuGQJmSGRWQXpacmmYZs4kzCiXns3d6H1ZpIDWmdM8" },
-                "expires" => expiry_time,
-                "file_name" => "file.pdf",
-                "file_size" => "1874822"
+              "browse_everything" => {
+                "selected_files" => selected_files
               }
             }
           }

--- a/spec/values/browse_everything_file_paths_spec.rb
+++ b/spec/values/browse_everything_file_paths_spec.rb
@@ -4,20 +4,25 @@ require "rails_helper"
 RSpec.describe BrowseEverythingFilePaths do
   subject { described_class.new(selected_files).parent_path }
   let(:single_dir) { Rails.root.join("spec", "fixtures", "ingest_single") }
+  let(:url) { "file://#{single_dir}" }
   describe "#parent_path" do
     context "with a path to a directory and a path to a file" do
       let(:selected_files) do
-        {
-          "0" => { "url" => single_dir.to_s, "file_name" => "color.tif", "file_size" => "100" },
-          "1" => { "url" => "#{single_dir}/gray.tif", "file_name" => "gray.tif", "file_size" => "100" }
-        }
+        [
+          BrowseEverything::Resource.new("url" => url.to_s,
+                                         "file_name" => "color.tif",
+                                         "file_size" => "100"),
+          BrowseEverything::Resource.new("url" => "#{url}/gray.tif",
+                                         "file_name" => "gray.tif",
+                                         "file_size" => "100")
+        ]
       end
 
       it { is_expected.to eq single_dir }
     end
     context "with no files selected" do
       let(:selected_files) do
-        {}
+        []
       end
 
       it { is_expected.to be nil }


### PR DESCRIPTION
This required some significant adjustments to the `browse-everything` branch which already integrated support for paginating Google Drive file entries: https://github.com/jrgriffiniii/browse-everything/compare/gdrive-paging-jrgriffiniii-rebased...jrgriffiniii:figgy-issues-1536-jrgriffiniii?expand=1

In order to retain backward compatibility with 1.x releases, this duplicates form fields and parameters passed in the `POST` request which disambiguate selected files from directories.  Additionally, this also provides a `BrowseEverything::Resource` class (which might be better suited for the `browse-everything` branch instead).  Resolves #1536 