### PR TITLE
Add pub_created_display field to coin document

### DIFF
--- a/app/resources/coins/coin_decorator.rb
+++ b/app/resources/coins/coin_decorator.rb
@@ -26,15 +26,18 @@ class CoinDecorator < Valkyrie::ResourceDecorator
           :append_id
 
   delegate :members, :decorated_file_sets, :decorated_parent, :decorated_numismatic_citations, :accession, to: :wayfinder
+  delegate :id, :label, to: :accession, prefix: true
 
   def ark_mintable_state?
     false
   end
 
-  delegate :id, :label, to: :accession, prefix: true
-
   def citations
     decorated_numismatic_citations.map(&:title)
+  end
+
+  def pub_created_display
+    [decorated_parent.ruler&.first, decorated_parent.denomination&.first, decorated_parent.place&.city].compact.join(", ")
   end
 
   def manageable_files?

--- a/app/resources/coins/orangelight_coin_builder.rb
+++ b/app/resources/coins/orangelight_coin_builder.rb
@@ -25,6 +25,7 @@ class OrangelightCoinBuilder
       {
         id: decorator.orangelight_id,
         title_display: "Coin: #{decorator.coin_number}",
+        pub_created_display: decorator.pub_created_display,
         access_facet: ["Online", "In the Library"],
         location: decorator.holding_location,
         format: ["Coin"],

--- a/spec/services/orangelight_document_spec.rb
+++ b/spec/services/orangelight_document_spec.rb
@@ -87,6 +87,7 @@ describe OrangelightDocument do
         output = MultiJson.load(builder.to_json, symbolize_keys: true)
         expect(output[:id]).to eq coin.decorate.orangelight_id
         expect(output[:title_display]).to eq "Coin: #{coin.coin_number}"
+        expect(output[:pub_created_display]).to eq "George I, 1/2 Penny, City"
         expect(output[:access_facet]).to eq ["Online", "In the Library"]
         expect(output[:location]).to eq ["Firestone"]
         expect(output[:format]).to eq ["Coin"]


### PR DESCRIPTION
Generates a summary field for display in Orangelight search results.

Closes #2735
Closes pulibrary/orangelight#1606