### PR TITLE
Don't display a filler thumbnail.

### DIFF
--- a/app/helpers/thumbnail_helper.rb
+++ b/app/helpers/thumbnail_helper.rb
@@ -8,7 +8,7 @@ module ThumbnailHelper
 
   def build_iiif_thumbnail_path(document, image_options = {})
     url = ManifestBuilder::ManifestHelper.new.manifest_image_thumbnail_path(document)
-    image_tag url, image_options.merge(onerror: default_icon_fallback) if url.present?
+    image_tag url, image_options.merge(onerror: "this.remove()") if url.present?
   rescue
     default_path
   end

--- a/spec/graphql/types/resource_spec.rb
+++ b/spec/graphql/types/resource_spec.rb
@@ -21,4 +21,12 @@ RSpec.describe Types::Resource do
       expect(described_class.resolve_type(FileSet.new, {})).to eq Types::FileSetType
     end
   end
+
+  describe ".helper" do
+    it "defines an overridden image_path to just return the given parameter back" do
+      type = Types::ScannedResourceType.new(ScannedResource.new, {})
+
+      expect(type.helper.image_path("test")).to eq "test"
+    end
+  end
 end


### PR DESCRIPTION
Instead of displaying a filler thumbnail, this just shows an empty space
if it can't resolve one.

Closes #2717