### PR TITLE
Provides a route for dynamically generating Universal Viewer configuration settings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -150,6 +150,7 @@ Metrics/MethodLength:
     - 'app/helpers/application_helper.rb'
     - 'app/change_sets/change_set.rb'
     - 'app/resources/scanned_resources/scanned_resource_change_set.rb'
+    - 'app/values/viewer_configuration.rb'
 Metrics/ModuleLength:
   Exclude:
     - 'app/models/schema/marc_relators.rb'
@@ -223,6 +224,7 @@ RSpec/NestedGroups:
     - 'spec/controllers/bulk_ingest_controller_spec.rb'
     - 'spec/resources/numismatic_monograms/numismatic_monograms_controller_spec.rb'
     - 'spec/helpers/application_helper_spec.rb'
+    - 'spec/requests/viewer_config_spec.rb'
 RSpec/VerifiedDoubles:
   Exclude:
     - 'spec/models/search_builder_spec.rb'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -181,9 +181,7 @@ module ApplicationHelper
   # @param [Valkyrie::Resource]
   # @return [String]
   def universal_viewer_path(resource)
-    config_path = universal_viewer_config_path(resource)
-
-    "/uv/uv#?manifest=#{manifest_url(resource)}&config=#{root_url}/uv/#{config_path}"
+    "/uv/uv#?manifest=#{manifest_url(resource)}&config=#{viewer_config_url(resource.id)}"
   end
 
   def collection_present?
@@ -238,17 +236,5 @@ module ApplicationHelper
     # @return [Boolean]
     def current_query_async?
       current_query_params.fetch("async", nil) == "true"
-    end
-
-    # Generate the config. path for the Universal Viewer depending upon whether
-    # the resource should have downloads enabled for the user
-    # @param resource [Valkyrie::Resource] the resource being viewed
-    # @return [Boolean]
-    def universal_viewer_config_path(resource)
-      if resource.decorate.downloadable? || (!current_user.nil? && (current_user.staff? || current_user.admin?))
-        return "uv_config.json"
-      end
-
-      "uv_config_downloads_disabled.json"
     end
 end

--- a/app/values/viewer_configuration.rb
+++ b/app/values/viewer_configuration.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+# Class modeling configuration options for the Universal Viewer
+class ViewerConfiguration < ActiveSupport::HashWithIndifferentAccess
+  # Provides the default values for the viewer
+  # @return [Hash]
+  def self.default_values
+    {
+      "modules" =>
+      {
+        "pagingHeaderPanel" =>
+        {
+          "options" =>
+          {
+            "autoCompleteBoxEnabled" => false,
+            "imageSelectionBoxEnabled" => true
+          }
+        },
+        "contentLeftPanel" =>
+        {
+          "options" =>
+          {
+            "branchNodesSelectable" => true,
+            "defaultToTreeEnabled" => true
+          }
+        },
+        "footerPanel" =>
+        {
+          "options" =>
+          {
+            "shareEnabled" => false
+          }
+        }
+      }
+    }
+  end
+
+  # Constructor
+  # @param values [Hash] configuration options for the Universal Viewer
+  # @see https://github.com/UniversalViewer/universalviewer/wiki/Configuration
+  def initialize(values = {})
+    build_values = self.class.default_values.merge(values)
+
+    super(build_values)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -281,4 +281,6 @@ Rails.application.routes.draw do
   authenticate :user do
     mount Sidekiq::Web => "/sidekiq"
   end
+
+  get "/viewer/config/:id", to: "application#viewer_config", as: "viewer_config"
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -124,39 +124,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     let(:resource) { FactoryBot.create_for_repository(:complete_scanned_resource) }
 
     it "generates the path for the embedded UV partial" do
-      expect(helper.universal_viewer_path(resource)).to eq "/uv/uv#?manifest=http://test.host/concern/scanned_resources/#{resource.id}/manifest&config=http://test.host//uv/uv_config.json"
-    end
-
-    context "when downloads are disabled" do
-      let(:resource) { FactoryBot.create_for_repository(:complete_scanned_resource, downloadable: ["none"]) }
-
-      it "generates the path for the embedded UV partial with downloads disabled" do
-        expect(helper.universal_viewer_path(resource)).to eq "/uv/uv#?manifest=http://test.host/concern/scanned_resources/#{resource.id}/manifest&config=http://test.host//uv/uv_config_downloads_disabled.json"
-      end
-
-      context "when authenticated as an admin. user" do
-        let(:admin) { FactoryBot.create(:admin) }
-
-        before do
-          sign_in(admin)
-        end
-
-        it "generates the path for the embedded UV partial with downloads enabled" do
-          expect(helper.universal_viewer_path(resource)).to eq "/uv/uv#?manifest=http://test.host/concern/scanned_resources/#{resource.id}/manifest&config=http://test.host//uv/uv_config.json"
-        end
-      end
-
-      context "when authenticated as a staff user" do
-        let(:staff) { FactoryBot.create(:staff) }
-
-        before do
-          sign_in(staff)
-        end
-
-        it "generates the path for the embedded UV partial with downloads enabled" do
-          expect(helper.universal_viewer_path(resource)).to eq "/uv/uv#?manifest=http://test.host/concern/scanned_resources/#{resource.id}/manifest&config=http://test.host//uv/uv_config.json"
-        end
-      end
+      expect(helper.universal_viewer_path(resource)).to eq "/uv/uv#?manifest=http://test.host/concern/scanned_resources/#{resource.id}/manifest&config=http://test.host/viewer/config/#{resource.id}"
     end
   end
 end

--- a/spec/requests/viewer_config_spec.rb
+++ b/spec/requests/viewer_config_spec.rb
@@ -1,0 +1,112 @@
+
+# frozen_string_literal: true
+require "rails_helper"
+include ActionDispatch::TestProcess
+
+RSpec.describe "ViewerConfiguration requests", type: :request do
+  let(:scanned_resource) { FactoryBot.create_for_repository(:complete_scanned_resource) }
+
+  describe "GET /viewer/config/:id" do
+    it "generates a Universal Viewer manifest for the resource" do
+      get "/viewer/config/#{scanned_resource.id}", params: { format: :json }
+
+      expect(response.status).to eq 200
+      expect(response.body).not_to be_empty
+      expect(response.content_length).to be > 0
+      expect(response.content_type).to eq "application/json"
+
+      response_values = JSON.parse(response.body)
+      expect(response_values).to include "modules"
+      expect(response_values["modules"]).to include "pagingHeaderPanel"
+      expect(response_values["modules"]).to include "contentLeftPanel"
+      expect(response_values["modules"]).to include "footerPanel"
+      expect(response_values["modules"]["pagingHeaderPanel"]).to include "options"
+      expect(response_values["modules"]["pagingHeaderPanel"]["options"]).to include(
+        "autoCompleteBoxEnabled" => false,
+        "imageSelectionBoxEnabled" => true
+      )
+      expect(response_values["modules"]["contentLeftPanel"]).to include "options"
+      expect(response_values["modules"]["contentLeftPanel"]["options"]).to include(
+        "branchNodesSelectable" => true,
+        "defaultToTreeEnabled" => true
+      )
+      expect(response_values["modules"]["footerPanel"]).to include "options"
+      expect(response_values["modules"]["footerPanel"]["options"]).to include(
+        "shareEnabled" => false
+      )
+    end
+
+    context "when the resource does not exist" do
+      it "responds with a 404 status code" do
+        get "/viewer/config/nonexistent", params: { format: :json }
+
+        expect(response.status).to eq 404
+      end
+    end
+
+    context "when the resource is not set to be downloadable" do
+      let(:scanned_resource) { FactoryBot.create_for_repository(:complete_scanned_resource, downloadable: ["none"]) }
+
+      it "responds with the configuration with downloads disabled" do
+        get "/viewer/config/#{scanned_resource.id}", params: { format: :json }
+
+        expect(response.status).to eq 200
+        expect(response.body).not_to be_empty
+        expect(response.content_length).to be > 0
+        expect(response.content_type).to eq "application/json"
+
+        response_values = JSON.parse(response.body)
+        expect(response_values).to include "modules"
+        expect(response_values["modules"]).to include "footerPanel"
+        expect(response_values["modules"]["footerPanel"]).to include "options"
+        expect(response_values["modules"]["footerPanel"]["options"]).to include "downloadEnabled" => false
+      end
+
+      context "when authenticated as an administrator" do
+        let(:admin) { FactoryBot.create(:admin) }
+
+        before do
+          sign_in(admin)
+        end
+
+        it "responds with the configuration with downloads disabled" do
+          get "/viewer/config/#{scanned_resource.id}", params: { format: :json }
+
+          expect(response.status).to eq 200
+          expect(response.body).not_to be_empty
+          expect(response.content_length).to be > 0
+          expect(response.content_type).to eq "application/json"
+
+          response_values = JSON.parse(response.body)
+          expect(response_values).to include "modules"
+          expect(response_values["modules"]).to include "footerPanel"
+          expect(response_values["modules"]["footerPanel"]).to include "options"
+          expect(response_values["modules"]["footerPanel"]["options"]).not_to include "downloadEnabled"
+        end
+      end
+
+      context "when authenticated as a staff member" do
+        let(:staff) { FactoryBot.create(:staff) }
+
+        before do
+          sign_in(staff)
+        end
+
+        it "responds with the configuration with downloads disabled" do
+          get "/viewer/config/#{scanned_resource.id}", params: { format: :json }
+
+          expect(response.status).to eq 200
+          expect(response.body).not_to be_empty
+          expect(response.content_length).to be > 0
+          expect(response.content_type).to eq "application/json"
+
+          response_values = JSON.parse(response.body)
+          expect(response_values).to include "modules"
+          expect(response_values["modules"]).to include "footerPanel"
+          expect(response_values["modules"]["footerPanel"]).to include "options"
+          expect(response_values["modules"]["footerPanel"]["options"]).not_to include "downloadEnabled"
+        end
+      end
+    end
+  end
+end

--- a/spec/routing/viewer_config_routes_spec.rb
+++ b/spec/routing/viewer_config_routes_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "Viewer Configuration Routes" do
+  it "routes requests for viewer configurations with a resource ID" do
+    expect(get("/viewer/config/resource-id")).to route_to("application#viewer_config", id: "resource-id")
+  end
+end

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
-require_relative 'request_spec_helper'
+require_relative "request_spec_helper"
 RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :view
   config.include Devise::Test::ControllerHelpers, type: :controller
-  config.include Devise::Test::ControllerHelpers, type: :helper
   config.include RequestSpecHelper, type: :request
 end

--- a/spec/values/viewer_configuration_spec.rb
+++ b/spec/values/viewer_configuration_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe ViewerConfiguration do
+  subject(:viewer_configuration) { described_class.new(foo: "bar") }
+
+  describe ".default_values" do
+    it "generates the default configuration options" do
+      expect(described_class.default_values).to include "modules"
+      expect(described_class.default_values["modules"]).to include "pagingHeaderPanel"
+      expect(described_class.default_values["modules"]).to include "contentLeftPanel"
+      expect(described_class.default_values["modules"]).to include "footerPanel"
+      expect(described_class.default_values["modules"]["pagingHeaderPanel"]).to include "options"
+      expect(described_class.default_values["modules"]["pagingHeaderPanel"]["options"]).to include(
+        "autoCompleteBoxEnabled" => false,
+        "imageSelectionBoxEnabled" => true
+      )
+      expect(described_class.default_values["modules"]["contentLeftPanel"]).to include "options"
+      expect(described_class.default_values["modules"]["contentLeftPanel"]["options"]).to include(
+        "branchNodesSelectable" => true,
+        "defaultToTreeEnabled" => true
+      )
+      expect(described_class.default_values["modules"]["footerPanel"]).to include "options"
+      expect(described_class.default_values["modules"]["footerPanel"]["options"]).to include(
+        "shareEnabled" => false
+      )
+    end
+  end
+
+  describe ".new" do
+    it "constructs an object with custom properties" do
+      expect(viewer_configuration).to include "foo"
+      expect(viewer_configuration["foo"]).to eq "bar"
+    end
+  end
+end


### PR DESCRIPTION
Provides a proper solution for #2628 (which will ensure that external services, such as dpul.princeton.edu, can access the viewer with downloads disabled for Figgy resources)