### PR TITLE
Implements a route for providing Universal Viewer configurations for digital exhibit platforms

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -89,6 +89,7 @@ Metrics/ClassLength:
     - 'app/services/music_import_service.rb'
     - 'app/services/music_import_service/recording_collector.rb'
     - 'app/controllers/bulk_ingest_controller.rb'
+    - 'app/controllers/application_controller.rb'
 Metrics/CyclomaticComplexity:
   Exclude:
     - 'app/helpers/application_helper.rb'

--- a/app/values/exhibit_viewer_configuration.rb
+++ b/app/values/exhibit_viewer_configuration.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+# Class modeling configuration options for the Universal Viewer used in digital
+# exhibits
+class ExhibitViewerConfiguration < ViewerConfiguration
+  # Provides the default values for the viewer
+  # @return [Hash]
+  def self.default_values
+    {
+      "modules" =>
+      {
+        "pagingHeaderPanel" =>
+        {
+          "options" =>
+          {
+            "autoCompleteBoxEnabled" => false,
+            "imageSelectionBoxEnabled" => true
+          }
+        }
+      }
+    }
+  end
+end

--- a/app/values/viewer_configuration.rb
+++ b/app/values/viewer_configuration.rb
@@ -38,7 +38,7 @@ class ViewerConfiguration < ActiveSupport::HashWithIndifferentAccess
   # @param values [Hash] configuration options for the Universal Viewer
   # @see https://github.com/UniversalViewer/universalviewer/wiki/Configuration
   def initialize(values = {})
-    build_values = self.class.default_values.merge(values)
+    build_values = self.class.default_values.deep_merge(values.with_indifferent_access)
 
     super(build_values)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -283,4 +283,5 @@ Rails.application.routes.draw do
   end
 
   get "/viewer/config/:id", to: "application#viewer_config", as: "viewer_config"
+  get "/viewer/exhibit/config", to: "application#viewer_exhibit_config", as: "viewer_exhibit_config"
 end

--- a/spec/requests/viewer_exhibit_config_spec.rb
+++ b/spec/requests/viewer_exhibit_config_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+require "rails_helper"
+include ActionDispatch::TestProcess
+
+RSpec.describe "ExhibitViewerConfiguration requests", type: :request do
+  let(:scanned_resource) { FactoryBot.create_for_repository(:complete_scanned_resource) }
+
+  describe "GET /viewer/exhibit/config" do
+    let(:manifest_url) { manifest_scanned_resource_url(scanned_resource) }
+
+    it "generates a Universal Viewer configuration for the exhibit resource" do
+      get "/viewer/exhibit/config?manifest=#{CGI.escape(manifest_url)}", params: { format: :json }
+
+      expect(response.status).to eq 200
+      expect(response.body).not_to be_empty
+      expect(response.content_length).to be > 0
+      expect(response.content_type).to eq "application/json"
+
+      response_values = JSON.parse(response.body)
+      expect(response_values).to include "modules"
+      expect(response_values["modules"]).to include "pagingHeaderPanel"
+      expect(response_values["modules"]["pagingHeaderPanel"]).to include "options"
+      expect(response_values["modules"]["pagingHeaderPanel"]["options"]).to include(
+        "autoCompleteBoxEnabled" => false,
+        "imageSelectionBoxEnabled" => true
+      )
+    end
+
+    context "with a request for hypertext content" do
+      it "generates a Universal Viewer configuration for the exhibit resource" do
+        get "/viewer/exhibit/config?manifest=#{CGI.escape(manifest_url)}", params: { format: :html }
+
+        expect(response.status).to eq 200
+        expect(response.body).not_to be_empty
+        expect(response.content_length).to be > 0
+        expect(response.content_type).to eq "text/html"
+
+        response_values = JSON.parse(response.body)
+        expect(response_values).to include "modules"
+        expect(response_values["modules"]).to include "pagingHeaderPanel"
+        expect(response_values["modules"]["pagingHeaderPanel"]).to include "options"
+        expect(response_values["modules"]["pagingHeaderPanel"]["options"]).to include(
+          "autoCompleteBoxEnabled" => false,
+          "imageSelectionBoxEnabled" => true
+        )
+      end
+    end
+
+    context "without a manifest parameter" do
+      it "responds with a 400 status code" do
+        get "/viewer/exhibit/config", params: { format: :json }
+
+        expect(response.status).to eq 400
+      end
+    end
+
+    context "when the resource is not set to be downloadable" do
+      let(:scanned_resource) { FactoryBot.create_for_repository(:complete_scanned_resource, downloadable: ["none"]) }
+
+      it "responds with the configuration with downloads disabled" do
+        get "/viewer/exhibit/config?manifest=#{CGI.escape(manifest_url)}", params: { format: :json }
+
+        expect(response.status).to eq 200
+        expect(response.body).not_to be_empty
+        expect(response.content_length).to be > 0
+        expect(response.content_type).to eq "application/json"
+
+        response_values = JSON.parse(response.body)
+        expect(response_values).to include "modules"
+        expect(response_values["modules"]).to include "footerPanel"
+        expect(response_values["modules"]["footerPanel"]).to include "options"
+        expect(response_values["modules"]["footerPanel"]["options"]).to include "downloadEnabled" => false
+      end
+    end
+  end
+end

--- a/spec/routing/viewer_exhibit_config_routes_spec.rb
+++ b/spec/routing/viewer_exhibit_config_routes_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "Exhibit Viewer Configuration Routes" do
+  it "routes requests for viewer configurations for digital exhibits with a manifest URL" do
+    expect(get("/viewer/exhibit/config?manifest=https://manifest-url")).to route_to("application#viewer_exhibit_config", manifest: "https://manifest-url")
+  end
+end

--- a/spec/values/exhibit_viewer_configuration_spec.rb
+++ b/spec/values/exhibit_viewer_configuration_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe ExhibitViewerConfiguration do
+  subject(:viewer_configuration) { described_class.new(foo: "bar") }
+
+  describe ".default_values" do
+    it "generates the default configuration options" do
+      expect(described_class.default_values).to include "modules"
+      expect(described_class.default_values["modules"]).to include "pagingHeaderPanel"
+      expect(described_class.default_values["modules"]["pagingHeaderPanel"]).to include "options"
+      expect(described_class.default_values["modules"]["pagingHeaderPanel"]["options"]).to include(
+        "autoCompleteBoxEnabled" => false,
+        "imageSelectionBoxEnabled" => true
+      )
+    end
+  end
+
+  describe ".new" do
+    it "constructs an object with custom properties" do
+      expect(viewer_configuration).to include "foo"
+      expect(viewer_configuration["foo"]).to eq "bar"
+    end
+  end
+end


### PR DESCRIPTION
Implements a route and ApplicationController functionality for providing configurations to Universal Viewer installations which are embedded in digital exhibit platforms (this is necessary for https://github.com/pulibrary/pomegranate/issues/562)