### PR TITLE
Ensures that ResourceDecorator#downloadable? handles cases where the "downloadable" attribute is nil

### DIFF
--- a/app/decorators/valkyrie/resource_decorator.rb
+++ b/app/decorators/valkyrie/resource_decorator.rb
@@ -87,10 +87,19 @@ class Valkyrie::ResourceDecorator < ApplicationDecorator
     false
   end
 
+  # Determine whether or not a resource is publicly visible
+  # @return [Boolean]
+  def visible?
+    model.respond_to?(:visibility) && model.visibility.include?(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
+  end
+
   # Determine whether or not a resource can be downloaded
   # @return [Boolean]
   def downloadable?
-    respond_to?(:downloadable) && downloadable&.include?("public")
+    return false unless respond_to?(:downloadable)
+    return visible? && public_readable_state? if downloadable.nil?
+
+    downloadable&.include?("public")
   end
 
   def attachable_objects

--- a/spec/decorators/valkyrie/resource_decorator_spec.rb
+++ b/spec/decorators/valkyrie/resource_decorator_spec.rb
@@ -263,9 +263,38 @@ RSpec.describe Valkyrie::ResourceDecorator do
       expect(decorator.visibility_badge.first).not_to have_selector("div.alert")
     end
   end
+  describe "#visible?" do
+    it "determines whether or not a resource is visible" do
+      expect(decorator.visible?).to be true
+    end
+
+    context "when a resource is set to private" do
+      let(:resource) { FactoryBot.build(:complete_private_scanned_resource) }
+
+      it "is not visible" do
+        expect(decorator.visible?).to be false
+      end
+    end
+  end
   describe "#downloadable?" do
     it "determines whether or not a decorated resource can be downloaded" do
       expect(decorator.downloadable?).to be true
+    end
+
+    context "when the resource has the downloadable attribute set to none" do
+      let(:resource) { FactoryBot.build(:complete_scanned_resource, downloadable: ["none"]) }
+
+      it "does not allow downloads" do
+        expect(decorator.downloadable?).to be false
+      end
+    end
+
+    context "when the resource has a nil downloadable attribute" do
+      let(:resource) { FactoryBot.build(:complete_scanned_resource, downloadable: nil) }
+
+      it "delegates to whether unauthenicated users can access the resource" do
+        expect(decorator.downloadable?).to eq(decorator.visible? && decorator.public_readable_state?)
+      end
     end
   end
 end


### PR DESCRIPTION
When the downloadable attribute is a nil value, `ResourceDecorator` will then delegate to the visibility and workflow state of the resource.