### PR TITLE
Handles invalid change_set parameters for new ScannedResource forms

### DIFF
--- a/app/controllers/concerns/resource_controller.rb
+++ b/app/controllers/concerns/resource_controller.rb
@@ -11,6 +11,10 @@ module ResourceController
   def new
     @change_set = change_set_class.new(new_resource, append_id: params[:parent_id]).prepopulate!
     authorize! :create, resource_class
+  rescue NameError # This handles cases where the ChangeSet name cannot be resolved
+    Rails.logger.error("ScannedResources do not support #{params[:change_set]} as a ChangeSet.")
+    flash[:error] = "#{params[:change_set]} is not a valid resource type."
+    redirect_to new_scanned_resource_path
   end
 
   def new_resource

--- a/spec/resources/scanned_resources/scanned_resources_controller_spec.rb
+++ b/spec/resources/scanned_resources/scanned_resources_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ScannedResourcesController, type: :controller do
     let(:user) { FactoryBot.create(:admin) }
     render_views
 
-    context "when params change_set" do
+    context "when the params specify a change_set" do
       it "is simple, creates a new SimpleChangeSet" do
         get :new, params: { change_set: "simple" }
         expect(assigns(:change_set)).to be_a SimpleChangeSet
@@ -52,6 +52,18 @@ RSpec.describe ScannedResourcesController, type: :controller do
         expect(response.body).to have_field "Source Metadata ID"
         expect(response.body).to have_field "Title"
         expect(response.body).to have_selector "p.help-block", text: "Required if Source Metadata ID is blank"
+      end
+    end
+
+    context "when the params specify an invalid change_set" do
+      before do
+        allow(Rails.logger).to receive(:error)
+      end
+      it "creates a new ScannedResource and flashes a warning" do
+        get :new, params: { change_set: "invalid" }
+        expect(Rails.logger).to have_received(:error).with("ScannedResources do not support invalid as a ChangeSet.")
+        expect(response).to redirect_to new_scanned_resource_path
+        expect(flash[:error]).to eq("invalid is not a valid resource type.")
       end
     end
   end


### PR DESCRIPTION
Resolves #2724 by ensuring that, for cases where users try to create `ScannedResources` with invalid `ChangeSets`, the client is redirected to create a new `ScannedResource` and an error is flashed