### PR TITLE
Add cocoon for nested forms

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,6 +56,7 @@ Metrics/BlockLength:
     - 'lib/tasks/export.rake'
 Metrics/ClassLength:
   Exclude:
+    - 'app/change_sets/change_set.rb'
     - 'app/change_set_persisters/change_set_persister.rb'
     - 'app/resources/ephemera_folders/ephemera_folder_change_set_base.rb'
     - 'app/resources/numismatic_issues/numismatic_issue_change_set.rb'

--- a/Gemfile
+++ b/Gemfile
@@ -120,4 +120,4 @@ gem "whenever", "~> 0.10"
 gem "blacklight_iiif_search", github: "boston-library/blacklight_iiif_search"
 gem "graphiql-rails", group: :development
 
-gem 'cocoon'
+gem "cocoon"

--- a/Gemfile
+++ b/Gemfile
@@ -119,3 +119,5 @@ gem "whenever", "~> 0.10"
 
 gem "blacklight_iiif_search", github: "boston-library/blacklight_iiif_search"
 gem "graphiql-rails", group: :development
+
+gem 'cocoon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,6 +245,7 @@ GEM
       archive-zip (~> 0.7.0)
       nokogiri (~> 1.6)
     chronic (0.10.2)
+    cocoon (1.2.12)
     coderay (1.1.1)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -842,6 +843,7 @@ DEPENDENCIES
   capistrano-rails-console
   capybara-screenshot
   chromedriver-helper
+  cocoon
   coffee-rails
   damerau-levenshtein
   database_cleaner

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -38,6 +38,7 @@
 //= require bootstrap/affix
 //= require babel/polyfill
 //= require hydra-editor/hydra-editor
+//= require cocoon
 //= require_tree .
 $(document).ready(function() {
   Initializer = require('figgy_boot')

--- a/app/assets/stylesheets/components/form.scss
+++ b/app/assets/stylesheets/components/form.scss
@@ -2,6 +2,15 @@
   .checkbox input[type='checkbox'] {
     margin-left: 0;
   }
+  .nested-fields {
+    border: 1px solid #ddd;
+    margin: 15px;
+    padding: 15px 5px;
+
+    .remove {
+      color: #d9534f;
+    }
+  }
   .required-tag {
     background-color: $dark-blue;
   }

--- a/app/change_sets/change_set.rb
+++ b/app/change_sets/change_set.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require "reform/form/active_model/form_builder_methods"
 class ChangeSet < Valkyrie::ChangeSet
+  def self.reflect_on_association(*_args); end
   include Reform::Form::ActiveModel
   include Reform::Form::ActiveModel::FormBuilderMethods
   class_attribute :workflow_class
@@ -82,14 +83,31 @@ class ChangeSet < Valkyrie::ChangeSet
   end
 
   # Defines the default populator for a nested single-valued changeset property
-  def populate_nested_property(fragment:, as:, **)
+  def populate_nested_property(fragment:, as:, collection: nil, index: nil, **)
     property_klass = model.class.schema[as.to_sym]
-    if fragment.values.select(&:present?).blank?
-      send(:"#{as}=", nil)
-      return skip!
+    if property_klass.respond_to?(:primitive) && property_klass.primitive == Array
+      item = collection.find { |x| x.id.to_s == fragment["id"] }
+      if item
+        if fragment["_destroy"] == "1" || fragment.values.select(&:present?).blank?
+          collection.delete_at(index)
+          return skip!
+        else
+          item
+        end
+      else
+        if fragment["_destroy"] == "1" || fragment.values.select(&:present?).blank?
+          skip!
+        else
+          collection.append(property_klass[[{id: SecureRandom.uuid}]].first)
+        end
+      end
+    else
+      if fragment.values.select(&:present?).blank?
+        send(:"#{as}=", nil)
+        return skip!
+      end
+      send("#{as.to_sym}=", property_klass.new(fragment))
     end
-
-    send("#{as.to_sym}=", property_klass.new(fragment))
   end
 
   # Override prepopulate method to correctly populate nested properties.
@@ -98,7 +116,12 @@ class ChangeSet < Valkyrie::ChangeSet
     schema.each(twin: true) do |property|
       property_name = property[:name]
       property_klass = model.class.schema[property_name.to_sym]
-      send(:"#{property_name}=", property_klass.new) unless send(property_name)
+      next if send(property_name).present?
+      if property_klass.respond_to?(:primitive) && property_klass.primitive == Array
+        send(:"#{property_name}=", property_klass[[{}]])
+      else
+        send(:"#{property_name}=", property_klass.new)
+      end
     end
 
     super

--- a/app/change_sets/change_set.rb
+++ b/app/change_sets/change_set.rb
@@ -82,20 +82,6 @@ class ChangeSet < Valkyrie::ChangeSet
     @_changes = Disposable::Twin::Changed::Changes.new
   end
 
-  # Defines the default populator for a nested single-valued changeset property
-  def populate_nested_property(fragment:, as:, collection: nil, index: nil, **)
-    property_klass = model.class.schema[as.to_sym]
-    if property_klass.respond_to?(:primitive) && property_klass.primitive == Array
-      populate_nested_collection(fragment: fragment, as: as, collection: collection, index: index)
-    else
-      if delete_fragment?(fragment)
-        send(:"#{as}=", nil)
-        return skip!
-      end
-      send("#{as.to_sym}=", property_klass.new(fragment))
-    end
-  end
-
   def populate_nested_collection(fragment:, as:, collection:, index:, **)
     property_klass = model.class.schema[as.to_sym]
     item = collection.find { |x| x.id.to_s == fragment["id"] }
@@ -126,8 +112,6 @@ class ChangeSet < Valkyrie::ChangeSet
       next if send(property_name).present?
       if property_klass.respond_to?(:primitive) && property_klass.primitive == Array
         send(:"#{property_name}=", property_klass[[{}]])
-      else
-        send(:"#{property_name}=", property_klass.new)
       end
     end
 

--- a/app/resources/coins/coin_decorator.rb
+++ b/app/resources/coins/coin_decorator.rb
@@ -37,7 +37,7 @@ class CoinDecorator < Valkyrie::ResourceDecorator
   end
 
   def pub_created_display
-    [decorated_parent.ruler&.first, decorated_parent.denomination&.first, decorated_parent.place&.city].compact.join(", ")
+    [decorated_parent.ruler&.first, decorated_parent.denomination&.first, decorated_parent.place&.first&.city].compact.join(", ")
   end
 
   def manageable_files?

--- a/app/resources/name_with_places/name_with_place_change_set.rb
+++ b/app/resources/name_with_places/name_with_place_change_set.rb
@@ -2,4 +2,13 @@
 class NameWithPlaceChangeSet < ChangeSet
   property :name
   property :place
+  property :_destroy, virtual: true
+
+  def new_record?
+    false
+  end
+
+  def marked_for_destruction?
+    false
+  end
 end

--- a/app/resources/numismatic_issues/numismatic_issue.rb
+++ b/app/resources/numismatic_issues/numismatic_issue.rb
@@ -30,7 +30,8 @@ class NumismaticIssue < Resource
   attribute :obverse_orientation
   attribute :obverse_part
   attribute :obverse_symbol
-  attribute :place, NumismaticPlace
+  attribute :place, Valkyrie::Types::Array.of(NumismaticPlace).meta(ordered: true)
+
   attribute :reverse_attributes
   attribute :reverse_figure
   attribute :reverse_figure_description

--- a/app/resources/numismatic_issues/numismatic_issue_change_set.rb
+++ b/app/resources/numismatic_issues/numismatic_issue_change_set.rb
@@ -23,7 +23,7 @@ class NumismaticIssueChangeSet < ChangeSet
   property :obverse_orientation, multiple: false, required: false
   property :obverse_part, multiple: false, required: false
   property :obverse_symbol, multiple: false, required: false
-  property :place, multiple: false, required: false, form: NumismaticPlaceChangeSet, populator: :populate_nested_property
+  collection :place, multiple: true, required: false, form: NumismaticPlaceChangeSet, populator: :populate_nested_collection, default: []
   property :replaces, multiple: true, required: false, default: []
   property :reverse_attributes, multiple: true, required: false, default: []
   property :reverse_figure, multiple: false, required: false

--- a/app/resources/numismatic_issues/numismatic_issue_decorator.rb
+++ b/app/resources/numismatic_issues/numismatic_issue_decorator.rb
@@ -84,8 +84,8 @@ class NumismaticIssueDecorator < Valkyrie::ResourceDecorator
   end
 
   def rendered_place
-    return unless place
-    place.decorate.rendered_place
+    return if place.empty?
+    place&.first&.decorate&.rendered_place
   end
 
   def rendered_rights_statement

--- a/app/resources/numismatic_place/numismatic_place_change_set.rb
+++ b/app/resources/numismatic_place/numismatic_place_change_set.rb
@@ -3,4 +3,13 @@ class NumismaticPlaceChangeSet < ChangeSet
   property :city
   property :state
   property :region
+  property :_destroy, virtual: true
+
+  def new_record?
+    false
+  end
+
+  def marked_for_destruction?
+    false
+  end
 end

--- a/app/resources/scanned_resources/letter_change_set.rb
+++ b/app/resources/scanned_resources/letter_change_set.rb
@@ -5,8 +5,8 @@ class LetterChangeSet < ChangeSet
   enable_order_manager
   enable_pdf_support
 
-  collection :sender, multiple: true, required: false, form: NameWithPlaceChangeSet, populator: :populate_nested_property, default: []
-  collection :recipient, multiple: true, required: false, form: NameWithPlaceChangeSet, populator: :populate_nested_property, default: []
+  collection :sender, multiple: true, required: false, form: NameWithPlaceChangeSet, populator: :populate_nested_collection, default: []
+  collection :recipient, multiple: true, required: false, form: NameWithPlaceChangeSet, populator: :populate_nested_collection, default: []
   self.feature_terms += [:member_of_collection_ids]
 
   def primary_terms

--- a/app/resources/scanned_resources/letter_change_set.rb
+++ b/app/resources/scanned_resources/letter_change_set.rb
@@ -6,17 +6,23 @@ class LetterChangeSet < ChangeSet
   enable_pdf_support
 
   collection :sender, multiple: true, required: false, form: NameWithPlaceChangeSet, populator: :populate_nested_property, default: []
-  property :recipient, multiple: false, required: false, form: NameWithPlaceChangeSet, populator: :populate_nested_property
+  collection :recipient, multiple: true, required: false, form: NameWithPlaceChangeSet, populator: :populate_nested_property, default: []
+  self.feature_terms += [:member_of_collection_ids]
 
   def primary_terms
-    feature_terms.dup.insert(
-      2,
-      [
-        :sender,
-        :recipient,
-        :member_of_collection_ids
+    {
+      "" => feature_terms,
+      "Sender" => [
+        :sender
+      ],
+      "Recipient" => [
+        :recipient
       ]
-    ).flatten
+    }
+  end
+
+  def build_recipient
+    schema["recipient"][:nested].new(model.class.schema[:recipient][[{}]].first)
   end
 
   def build_sender

--- a/app/resources/scanned_resources/letter_change_set.rb
+++ b/app/resources/scanned_resources/letter_change_set.rb
@@ -5,7 +5,7 @@ class LetterChangeSet < ChangeSet
   enable_order_manager
   enable_pdf_support
 
-  property :sender, multiple: false, required: false, form: NameWithPlaceChangeSet, populator: :populate_nested_property
+  collection :sender, multiple: true, required: false, form: NameWithPlaceChangeSet, populator: :populate_nested_property, default: []
   property :recipient, multiple: false, required: false, form: NameWithPlaceChangeSet, populator: :populate_nested_property
 
   def primary_terms
@@ -17,5 +17,9 @@ class LetterChangeSet < ChangeSet
         :member_of_collection_ids
       ]
     ).flatten
+  end
+
+  def build_sender
+    schema["sender"][:nested].new(model.class.schema[:sender][[{}]].first)
   end
 end

--- a/app/resources/scanned_resources/scanned_resource.rb
+++ b/app/resources/scanned_resources/scanned_resource.rb
@@ -14,7 +14,7 @@ class ScannedResource < Resource
   attribute :change_set, Valkyrie::Types::String
   attribute :archival_collection_code, Valkyrie::Types::String
   attribute :date_range
-  attribute :sender, NameWithPlace
+  attribute :sender, Valkyrie::Types::Array.of(NameWithPlace).meta(ordered: true)
   attribute :recipient, NameWithPlace
 
   def self.can_have_manifests?

--- a/app/resources/scanned_resources/scanned_resource.rb
+++ b/app/resources/scanned_resources/scanned_resource.rb
@@ -15,7 +15,7 @@ class ScannedResource < Resource
   attribute :archival_collection_code, Valkyrie::Types::String
   attribute :date_range
   attribute :sender, Valkyrie::Types::Array.of(NameWithPlace).meta(ordered: true)
-  attribute :recipient, NameWithPlace
+  attribute :recipient, Valkyrie::Types::Array.of(NameWithPlace).meta(ordered: true)
 
   def self.can_have_manifests?
     true

--- a/app/resources/scanned_resources/scanned_resource_decorator.rb
+++ b/app/resources/scanned_resources/scanned_resource_decorator.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 class ScannedResourceDecorator < Valkyrie::ResourceDecorator
   display Schema::Common.attributes,
+          :rendered_sender,
+          :rendered_recipient,
           :rendered_date_range,
           :rendered_ocr_language,
           :rendered_holding_location,
@@ -77,6 +79,18 @@ class ScannedResourceDecorator < Valkyrie::ResourceDecorator
     vocabulary = ControlledVocabulary.for(:ocr_language)
     ocr_language.map do |language|
       vocabulary.find(language).label
+    end
+  end
+
+  def rendered_sender
+    sender.collect do |s|
+      [s.name, s.place].compact.join("; ")
+    end
+  end
+
+  def rendered_recipient
+    recipient.collect do |r|
+      [r.name, r.place].compact.join("; ")
     end
   end
 

--- a/app/views/numismatic_issues/_place_fields.html.erb
+++ b/app/views/numismatic_issues/_place_fields.html.erb
@@ -1,0 +1,22 @@
+<div class='nested-fields'>
+  <div class="row">
+    <div class="col-md-6">
+      <%= f.input :city, required: f.object.required?(:city), label: "City" %>
+    </div>
+    <div class="col-md-6">
+      <%= f.input :state, required: f.object.required?(:state), label: "State" %>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-6">
+      <%= f.input :region, required: f.object.required?(:region), label: "Region" %>
+    </div>
+  </div>
+  <%= f.hidden_field :id %>
+  <%= link_to_remove_association f do %>
+    <button type="button" class="btn btn-link remove">
+      <span class="glyphicon glyphicon-remove"></span>
+      <span class="controls-remove-text">Remove</span>
+    </button>
+  <% end %>
+</div>

--- a/app/views/numismatic_issues/edit_fields/_place.html.erb
+++ b/app/views/numismatic_issues/edit_fields/_place.html.erb
@@ -1,13 +1,7 @@
 <div class="row">
-<%= f.simple_fields_for :place, wrapper: :inline_form do |g| %>
-  <div class="col-md-6">
-    <%= g.input :city, required: g.object.required?(:city), label: "City" %>
+  <div id="place">
+    <%= f.simple_fields_for :place, wrapper: :inline_form do |g| %>
+      <%= render 'place_fields', f: g %>
+    <% end %>
   </div>
-  <div class="col-md-6">
-    <%= g.input :state, required: g.object.required?(:state), label: "State" %>
-  </div>
-  <div class="col-md-6">
-    <%= g.input :region, required: g.object.required?(:region), label: "Region" %>
-  </div>
-<% end %>
 </div>

--- a/app/views/records/edit_fields/_recipient.html.erb
+++ b/app/views/records/edit_fields/_recipient.html.erb
@@ -1,10 +1,15 @@
 <div class="row">
-<%= f.simple_fields_for :recipient, wrapper: :inline_form do |g| %>
-  <div class="col-md-6">
-    <%= g.input :name, required: g.object.required?(:name), label: "Recipient Name" %>
+  <div id="recipient">
+    <%= f.simple_fields_for :recipient, wrapper: :inline_form do |g| %>
+      <%= render 'recipient_fields', f: g %>
+    <% end %>
   </div>
-  <div class="col-md-6">
-    <%= g.input :place, required: g.object.required?(:place), label: "Recipient Place" %>
+  <div class="links">
+    <%= link_to_add_association f, :recipient, partial: 'recipient_fields', force_non_association_create: true do %>
+      <button type="button" class="btn btn-link add">
+        <span class="glyphicon glyphicon-plus"></span>
+        <span class="controls-add-text">Add another Recipient</span>
+      </button>
+    <% end %>
   </div>
-<% end %>
 </div>

--- a/app/views/records/edit_fields/_sender.html.erb
+++ b/app/views/records/edit_fields/_sender.html.erb
@@ -6,7 +6,10 @@
   </div>
   <div class="links">
     <%= link_to_add_association f, :sender, partial: 'sender_fields', force_non_association_create: true do %>
-      Add
+      <button type="button" class="btn btn-link add">
+        <span class="glyphicon glyphicon-plus"></span>
+        <span class="controls-add-text">Add another Sender</span>
+      </button>
     <% end %>
   </div>
 </div>

--- a/app/views/records/edit_fields/_sender.html.erb
+++ b/app/views/records/edit_fields/_sender.html.erb
@@ -1,10 +1,12 @@
 <div class="row">
-<%= f.simple_fields_for :sender, wrapper: :inline_form do |g| %>
-  <div class="col-md-6">
-    <%= g.input :name, required: g.object.required?(:name), label: "Sender Name" %>
+  <div id="sender">
+    <%= f.simple_fields_for :sender, wrapper: :inline_form do |g| %>
+      <%= render 'sender_fields', f: g %>
+    <% end %>
   </div>
-  <div class="col-md-6">
-    <%= g.input :place, required: g.object.required?(:place), label: "Sender Place" %>
+  <div class="links">
+    <%= link_to_add_association f, :sender, partial: 'sender_fields', force_non_association_create: true do %>
+      Add
+    <% end %>
   </div>
-<% end %>
 </div>

--- a/app/views/scanned_resources/_recipient_fields.html.erb
+++ b/app/views/scanned_resources/_recipient_fields.html.erb
@@ -1,0 +1,15 @@
+<div class='nested-fields'>
+  <div class="col-md-6">
+    <%= f.input :name, required: f.object.required?(:name), label: "Recipient Name" %>
+  </div>
+  <div class="col-md-6">
+    <%= f.input :place, required: f.object.required?(:place), label: "Recipient Place" %>
+  </div>
+  <%= f.hidden_field :id %>
+  <%= link_to_remove_association f do %>
+    <button type="button" class="btn btn-link remove">
+      <span class="glyphicon glyphicon-remove"></span>
+      <span class="controls-remove-text">Remove</span>
+    </button>
+  <% end %>
+</div>

--- a/app/views/scanned_resources/_sender_fields.html.erb
+++ b/app/views/scanned_resources/_sender_fields.html.erb
@@ -6,5 +6,10 @@
     <%= f.input :place, required: f.object.required?(:place), label: "Sender Place" %>
   </div>
   <%= f.hidden_field :id %>
-  <%= link_to_remove_association "Remove Sender", f %>
+  <%= link_to_remove_association f do %>
+    <button type="button" class="btn btn-link remove">
+      <span class="glyphicon glyphicon-remove"></span>
+      <span class="controls-remove-text">Remove</span>
+    </button>
+  <% end %>
 </div>

--- a/app/views/scanned_resources/_sender_fields.html.erb
+++ b/app/views/scanned_resources/_sender_fields.html.erb
@@ -1,0 +1,10 @@
+<div class='nested-fields'>
+  <div class="col-md-6">
+    <%= f.input :name, required: f.object.required?(:name), label: "Sender Name" %>
+  </div>
+  <div class="col-md-6">
+    <%= f.input :place, required: f.object.required?(:place), label: "Sender Place" %>
+  </div>
+  <%= f.hidden_field :id %>
+  <%= link_to_remove_association "Remove Sender", f %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,10 +95,14 @@ en:
           label: "Holding Location"
         rendered_place:
           label: "Place"
-        rendered_subject:
-          label: "Subject"
+        rendered_recipient:
+          label: "Recipient"
         rendered_rights_statement:
           label: "Rights Statement"
+        rendered_sender:
+          label: "Sender"
+        rendered_subject:
+          label: "Subject"
         rendered_ocr_language:
           label: "OCR Language"
         rights_statement:

--- a/spec/factories/scanned_resource.rb
+++ b/spec/factories/scanned_resource.rb
@@ -35,6 +35,12 @@ FactoryBot.define do
         ).save(change_set: change_set)
       end
     end
+    factory :letter do
+      change_set "letter"
+      factory :draft_letter do
+        state "draft"
+      end
+    end
     factory :simple_resource do
       change_set "simple"
       factory :draft_simple_resource do

--- a/spec/resources/numismatic_issues/numismatic_issue_change_set_spec.rb
+++ b/spec/resources/numismatic_issues/numismatic_issue_change_set_spec.rb
@@ -77,25 +77,27 @@ RSpec.describe NumismaticIssueChangeSet do
   end
 
   describe "#place" do
-    it "can be set with a ciy, state, and region" do
-      change_set.validate(place: { city: "City", state: "State", region: "Region" })
-      expect(change_set.place.city).to eq "City"
-      expect(change_set.place.state).to eq "State"
-      expect(change_set.place.region).to eq "Region"
+    it "can be set with a city, state, and region" do
+      change_set.validate(place: [{ city: "City", state: "State", region: "Region" }])
+      expect(change_set.place.first.city).to eq "City"
+      expect(change_set.place.first.state).to eq "State"
+      expect(change_set.place.first.region).to eq "Region"
       # Ensure form builder works.
-      change_set.validate("place_attributes" => { city: "City2", state: "State", region: "Region" })
-      expect(change_set.place.city).to eq "City2"
+      change_set.place = []
+      change_set.validate("place_attributes" => { "0" => { city: "City2", state: "State", region: "Region" } })
+      expect(change_set.place.first.city).to eq "City2"
       # Ensure it doesn't result in an empty object if nothing is set
-      change_set.validate(place: { city: nil, state: nil, region: nil })
+      change_set.place = []
+      change_set.validate(place: [{ city: nil, state: nil, region: nil }])
       change_set.sync
-      expect(change_set.resource.place).to eq nil
+      expect(change_set.resource.place).to be_empty
     end
   end
 
   describe "#prepopulate!" do
     it "builds an empty numsimatic place" do
       change_set.prepopulate!
-      expect(change_set.place).to be_a NumismaticPlaceChangeSet
+      expect(change_set.place.first).to be_a NumismaticPlaceChangeSet
     end
   end
 end

--- a/spec/resources/scanned_resources/letter_change_set_spec.rb
+++ b/spec/resources/scanned_resources/letter_change_set_spec.rb
@@ -35,23 +35,25 @@ RSpec.describe LetterChangeSet do
   describe "#prepopulate!" do
     it "builds an empty sender/recipient" do
       change_set.prepopulate!
-      expect(change_set.sender).to be_a NameWithPlaceChangeSet
+      expect(change_set.sender.first).to be_a NameWithPlaceChangeSet
       expect(change_set.recipient).to be_a NameWithPlaceChangeSet
     end
   end
 
   describe "#sender" do
     it "can be set with a name and place" do
-      change_set.validate(sender: { name: "Test", place: "Place" })
-      expect(change_set.sender.name).to eq "Test"
-      expect(change_set.sender.place).to eq "Place"
+      change_set.validate(sender: [{ name: "Test", place: "Place" }])
+      expect(change_set.sender.first.name).to eq "Test"
+      expect(change_set.sender.first.place).to eq "Place"
       # Ensure form builder works.
-      change_set.validate("sender_attributes" => { name: "Test2", place: "Place" })
-      expect(change_set.sender.name).to eq "Test2"
+      change_set.sender = []
+      change_set.validate("sender_attributes" => { "0" => { name: "Test2", place: "Place" } })
+      expect(change_set.sender.first.name).to eq "Test2"
       # Ensure it doesn't result in an empty object if nothing is set
-      change_set.validate(sender: { name: "", place: "" })
+      change_set.sender = []
+      change_set.validate(sender: [{ name: "", place: "" }])
       change_set.sync
-      expect(change_set.resource.sender).to eq nil
+      expect(change_set.resource.sender).to be_empty
     end
   end
 
@@ -66,7 +68,7 @@ RSpec.describe LetterChangeSet do
       # Ensure it doesn't result in an empty object if nothing is set
       change_set.validate(recipient: { name: "", place: "" })
       change_set.sync
-      expect(change_set.resource.recipient).to eq nil
+      expect(change_set.resource.recipient).to be_nil
     end
   end
 end

--- a/spec/resources/scanned_resources/letter_change_set_spec.rb
+++ b/spec/resources/scanned_resources/letter_change_set_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe LetterChangeSet do
 
   describe "#primary_terms" do
     it "has necessary terms" do
-      expect(change_set.primary_terms).to contain_exactly(
+      expect(change_set.primary_terms.keys).to eq(["", "Sender", "Recipient"])
+      expect(change_set.primary_terms.values.flatten).to include(
         :title,
         :rights_statement,
         :rights_note,
@@ -36,7 +37,7 @@ RSpec.describe LetterChangeSet do
     it "builds an empty sender/recipient" do
       change_set.prepopulate!
       expect(change_set.sender.first).to be_a NameWithPlaceChangeSet
-      expect(change_set.recipient).to be_a NameWithPlaceChangeSet
+      expect(change_set.recipient.first).to be_a NameWithPlaceChangeSet
     end
   end
 
@@ -59,16 +60,18 @@ RSpec.describe LetterChangeSet do
 
   describe "#recipient" do
     it "can be set with a name and place" do
-      change_set.validate(recipient: { name: "Test", place: "Place" })
-      expect(change_set.recipient.name).to eq "Test"
-      expect(change_set.recipient.place).to eq "Place"
+      change_set.validate(recipient: [{ name: "Test", place: "Place" }])
+      expect(change_set.recipient.first.name).to eq "Test"
+      expect(change_set.recipient.first.place).to eq "Place"
       # Ensure form builder works.
-      change_set.validate("recipient_attributes" => { name: "Test2", place: "Place" })
-      expect(change_set.recipient.name).to eq "Test2"
+      change_set.recipient = []
+      change_set.validate("recipient_attributes" => { "0" => { name: "Test2", place: "Place" } })
+      expect(change_set.recipient.first.name).to eq "Test2"
       # Ensure it doesn't result in an empty object if nothing is set
-      change_set.validate(recipient: { name: "", place: "" })
+      change_set.recipient = []
+      change_set.validate(recipient: [{ name: "", place: "" }])
       change_set.sync
-      expect(change_set.resource.recipient).to be_nil
+      expect(change_set.resource.recipient).to be_empty
     end
   end
 end

--- a/spec/resources/scanned_resources/letter_feature_spec.rb
+++ b/spec/resources/scanned_resources/letter_feature_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "Letter" do
+  let(:user) { FactoryBot.create(:admin) }
+  let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
+  let(:persister) { adapter.persister }
+  let(:letter) do
+    res = FactoryBot.create_for_repository(:letter)
+    persister.save(resource: res)
+  end
+  let(:change_set) do
+    LetterChangeSet.new(letter)
+  end
+  let(:change_set_persister) do
+    ChangeSetPersister.new(metadata_adapter: adapter, storage_adapter: Valkyrie.config.storage_adapter)
+  end
+
+  before do
+    change_set_persister.save(change_set: change_set)
+    sign_in user
+  end
+
+  scenario "creating a new resource" do
+    visit new_letter_scanned_resources_path
+
+    expect(page).to have_css '.select[for="scanned_resource_rights_statement"]', text: "Rights Statement"
+    expect(page).to have_css '.select[for="scanned_resource_member_of_collection_ids"]', text: "Collections"
+    expect(page).to have_field "Title"
+    expect(page).to have_field "Sender Name"
+    expect(page).to have_field "Sender Place"
+    expect(page).to have_field "Recipient Name"
+    expect(page).to have_field "Recipient Place"
+
+    fill_in "Title", with: "a letter"
+    click_button "Save"
+
+    expect(page).to have_content "a letter"
+  end
+
+  context "when a user creates a new numismatic issue" do
+    let(:collection) { FactoryBot.create_for_repository(:collection) }
+    let(:sender1) { NameWithPlace.new(name: "Sender Name 1", place: "Sender Place 1") }
+    let(:sender2) { NameWithPlace.new(name: "Sender Name 2", place: "Sender Place 2") }
+    let(:recipient) { NameWithPlace.new(name: "Recipient Name", place: "Recipient Place") }
+    let(:letter) do
+      FactoryBot.create_for_repository(
+        :letter,
+        title: "a letter",
+        rights_statement: RightsStatements.copyright_not_evaluated.to_s,
+        member_of_collection_ids: [collection.id],
+        sender: [sender1, sender2],
+        recipient: recipient
+      )
+    end
+
+    scenario "viewing a resource" do
+      visit solr_document_path letter
+
+      expect(page).to have_css ".attribute.rendered_rights_statement", text: "Copyright Not Evaluated"
+      expect(page).to have_css ".attribute.visibility", text: "open"
+      expect(page).to have_css ".attribute.member_of_collections", text: "Title"
+      expect(page).to have_css ".attribute.title", text: "a letter"
+      expect(page).to have_css ".attribute.rendered_sender", text: "Sender Name 1; Sender Place 1"
+      expect(page).to have_css ".attribute.rendered_sender", text: "Sender Name 2; Sender Place 2"
+      expect(page).to have_css ".attribute.rendered_recipient", text: "Recipient Name; Recipient Place"
+    end
+
+    scenario "user can edit a letter and remove a nested sender", js: true do
+      visit edit_scanned_resource_path letter
+
+      within "#sender" do
+        find(".remove_fields", match: :first).click
+      end
+
+      click_button "Save"
+
+      visit solr_document_path letter
+
+      expect(page).not_to have_css ".attribute.rendered_sender", text: "Sender Name 1; Sender Place 1"
+      expect(page).to have_css ".attribute.rendered_sender", text: "Sender Name 2; Sender Place 2"
+    end
+  end
+end

--- a/spec/resources/scanned_resources/letter_feature_spec.rb
+++ b/spec/resources/scanned_resources/letter_feature_spec.rb
@@ -42,15 +42,13 @@ RSpec.feature "Letter" do
     let(:collection) { FactoryBot.create_for_repository(:collection) }
     let(:sender1) { NameWithPlace.new(name: "Sender Name 1", place: "Sender Place 1") }
     let(:sender2) { NameWithPlace.new(name: "Sender Name 2", place: "Sender Place 2") }
-    let(:recipient) { NameWithPlace.new(name: "Recipient Name", place: "Recipient Place") }
     let(:letter) do
       FactoryBot.create_for_repository(
         :letter,
         title: "a letter",
         rights_statement: RightsStatements.copyright_not_evaluated.to_s,
         member_of_collection_ids: [collection.id],
-        sender: [sender1, sender2],
-        recipient: recipient
+        sender: [sender1, sender2]
       )
     end
 
@@ -63,15 +61,17 @@ RSpec.feature "Letter" do
       expect(page).to have_css ".attribute.title", text: "a letter"
       expect(page).to have_css ".attribute.rendered_sender", text: "Sender Name 1; Sender Place 1"
       expect(page).to have_css ".attribute.rendered_sender", text: "Sender Name 2; Sender Place 2"
-      expect(page).to have_css ".attribute.rendered_recipient", text: "Recipient Name; Recipient Place"
     end
 
-    scenario "user can edit a letter and remove a nested sender", js: true do
+    scenario "user can edit a letter to update sender and recipient", js: true do
       visit edit_scanned_resource_path letter
 
       within "#sender" do
         find(".remove_fields", match: :first).click
       end
+
+      fill_in "Recipient Name", with: "Recipient Name 1"
+      fill_in "Recipient Place", with: "Recipient Place 1"
 
       click_button "Save"
 
@@ -79,6 +79,7 @@ RSpec.feature "Letter" do
 
       expect(page).not_to have_css ".attribute.rendered_sender", text: "Sender Name 1; Sender Place 1"
       expect(page).to have_css ".attribute.rendered_sender", text: "Sender Name 2; Sender Place 2"
+      expect(page).to have_css ".attribute.rendered_recipient", text: "Recipient Name 1; Recipient Place 1"
     end
   end
 end


### PR DESCRIPTION
- Adds Cocoon gem for nested forms.
- Adjust styling to mimic hydra-editor multivalued fields.
- Makes all nested resource forms a collection. 
  - This is a departure from the existing nested form implementation. This fixes an issue with deleting a nested resource and improves the UI. 
  - The `place` property on numismatic issue is an example of a nested form where users can only add a single set of values. https://github.com/pulibrary/figgy/blob/5a8ac11b673e209ae91fcb50cb412fea5583e554/app/views/numismatic_issues/edit_fields/_place.html.erb
  - This could also be enforced with a validator.