### PR TITLE
Import/Export Dependent Objects into Bags

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -203,6 +203,7 @@ RSpec/DescribeClass:
     - 'spec/inputs/**/*'
     - 'spec/requests/**/*'
     - 'spec/resources/**/*routes_spec.rb'
+    - 'spec/adapters/bagit/bag_roundtrip_spec.rb'
 RSpec/EmptyExampleGroup:
   Exclude:
     - 'spec/models/search_builder_spec.rb'

--- a/app/adapters/bagit/bag_exporter.rb
+++ b/app/adapters/bagit/bag_exporter.rb
@@ -60,7 +60,7 @@ module Bagit
       end
 
       def id_references
-        ids = resource.to_h.except(:id).values.flat_map { |x| x }.select { |value| value.is_a?(Valkyrie::ID) }
+        ids = resource.to_h.except(:id).values.flat_map { |x| x }.select { |value| value.is_a?(Valkyrie::ID) } - (resource.try(:member_ids) || [])
         query_service.find_many_by_ids(ids: ids)
       end
 

--- a/app/adapters/bagit/bag_exporter.rb
+++ b/app/adapters/bagit/bag_exporter.rb
@@ -51,7 +51,7 @@ module Bagit
       def export_references
         id_references.each do |reference|
           self.class.new(
-            metadata_adapter: metadata_adapter,
+            metadata_adapter: member_metadata_adapter,
             storage_adapter: storage_adapter,
             resource: reference,
             query_service: query_service

--- a/app/adapters/bagit/bag_importer.rb
+++ b/app/adapters/bagit/bag_importer.rb
@@ -41,6 +41,7 @@ module Bagit
         end
         resource = metadata_adapter.persister.save(resource: bag_resource)
         import_members!
+        import_references!
         resource
       end
 
@@ -60,6 +61,23 @@ module Bagit
             id: member_id
           ).import!
         end
+      end
+
+      def import_references!
+        id_references.each do |reference|
+          ResourceImporter.new(
+            bag_storage_adapter: bag_storage_adapter,
+            bag_metadata_adapter: bag_metadata_adapter,
+            metadata_adapter: metadata_adapter,
+            storage_adapter: storage_adapter,
+            id: reference.id
+          ).import!
+        end
+      end
+
+      def id_references
+        ids = bag_resource.to_h.except(:id).values.flat_map { |x| x }.select { |value| value.is_a?(Valkyrie::ID) }
+        bag_metadata_adapter.query_service.find_many_by_ids(ids: ids)
       end
 
       def member_ids

--- a/app/adapters/bagit/bag_importer.rb
+++ b/app/adapters/bagit/bag_importer.rb
@@ -65,6 +65,7 @@ module Bagit
 
       def import_references!
         id_references.each do |reference|
+          next unless metadata_adapter.query_service.find_many_by_ids(ids: [reference.id]).empty?
           ResourceImporter.new(
             bag_storage_adapter: bag_storage_adapter,
             bag_metadata_adapter: bag_metadata_adapter,

--- a/app/adapters/bagit/bag_importer.rb
+++ b/app/adapters/bagit/bag_importer.rb
@@ -77,7 +77,7 @@ module Bagit
       end
 
       def id_references
-        ids = bag_resource.to_h.except(:id).values.flat_map { |x| x }.select { |value| value.is_a?(Valkyrie::ID) }
+        ids = bag_resource.to_h.except(:id).values.flat_map { |x| x }.select { |value| value.is_a?(Valkyrie::ID) } - (bag_resource.try(:member_ids) || [])
         bag_metadata_adapter.query_service.find_many_by_ids(ids: ids)
       end
 

--- a/app/adapters/bagit/bag_importer.rb
+++ b/app/adapters/bagit/bag_importer.rb
@@ -68,7 +68,7 @@ module Bagit
           next unless metadata_adapter.query_service.find_many_by_ids(ids: [reference.id]).empty?
           ResourceImporter.new(
             bag_storage_adapter: bag_storage_adapter,
-            bag_metadata_adapter: bag_metadata_adapter,
+            bag_metadata_adapter: member_bag_metadata_adapter,
             metadata_adapter: metadata_adapter,
             storage_adapter: storage_adapter,
             id: reference.id
@@ -78,7 +78,7 @@ module Bagit
 
       def id_references
         ids = bag_resource.to_h.except(:id).values.flat_map { |x| x }.select { |value| value.is_a?(Valkyrie::ID) } - (bag_resource.try(:member_ids) || [])
-        bag_metadata_adapter.query_service.find_many_by_ids(ids: ids)
+        member_bag_metadata_adapter.query_service.find_many_by_ids(ids: ids)
       end
 
       def member_ids

--- a/spec/adapters/bagit/bag_roundtrip_spec.rb
+++ b/spec/adapters/bagit/bag_roundtrip_spec.rb
@@ -31,5 +31,22 @@ RSpec.describe "Bag Roundtripping" do
       expect(importer.metadata_adapter.query_service.find_all_of_model(model: EphemeraTerm).to_a.length).to eq 1
       expect(importer.metadata_adapter.query_service.find_all_of_model(model: EphemeraVocabulary).to_a.length).to eq 1
     end
+    it "doesn't import vocabularies that already exist" do
+      vocabulary = FactoryBot.create_for_repository(:ephemera_vocabulary)
+      term = FactoryBot.create_for_repository(:ephemera_term, member_of_vocabulary_id: vocabulary.id)
+      folder = FactoryBot.create_for_repository(:ephemera_folder, genre: term.id)
+      exporter.export(resource: folder)
+      importer.metadata_adapter.persister.wipe!
+      output = importer.metadata_adapter.persister.save(resource: vocabulary)
+
+      importer.import(id: folder.id)
+
+      expect(importer.metadata_adapter.query_service.find_all_of_model(model: EphemeraFolder).to_a.length).to eq 1
+      expect(importer.metadata_adapter.query_service.find_all_of_model(model: EphemeraTerm).to_a.length).to eq 1
+      expect(importer.metadata_adapter.query_service.find_all_of_model(model: EphemeraVocabulary).to_a.length).to eq 1
+
+      reloaded_vocabulary = importer.metadata_adapter.query_service.find_by(id: output.id)
+      expect(reloaded_vocabulary.created_at).to eq output.created_at
+    end
   end
 end

--- a/spec/adapters/bagit/bag_roundtrip_spec.rb
+++ b/spec/adapters/bagit/bag_roundtrip_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "Bag Roundtripping" do
+  let(:exporter) do
+    Bagit::BagExporter.new(
+      metadata_adapter: Valkyrie::MetadataAdapter.find(:bags),
+      storage_adapter: Valkyrie::StorageAdapter.find(:bags),
+      query_service: Valkyrie::MetadataAdapter.find(:indexing_persister).query_service
+    )
+  end
+  let(:importer) do
+    Bagit::BagImporter.new(
+      bag_metadata_adapter: Valkyrie::MetadataAdapter.find(:bags),
+      bag_storage_adapter: Valkyrie::StorageAdapter.find(:bags),
+      metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister),
+      storage_adapter: Valkyrie::StorageAdapter.find(:disk)
+    )
+  end
+  context "when given an EphemeraFolder" do
+    it "exports vocabularies if they need to be" do
+      vocabulary = FactoryBot.create_for_repository(:ephemera_vocabulary)
+      term = FactoryBot.create_for_repository(:ephemera_term, member_of_vocabulary_id: vocabulary.id)
+      folder = FactoryBot.create_for_repository(:ephemera_folder, genre: term.id)
+      exporter.export(resource: folder)
+      importer.metadata_adapter.persister.wipe!
+
+      importer.import(id: folder.id)
+
+      expect(importer.metadata_adapter.query_service.find_all_of_model(model: EphemeraFolder).to_a.length).to eq 1
+      expect(importer.metadata_adapter.query_service.find_all_of_model(model: EphemeraTerm).to_a.length).to eq 1
+      expect(importer.metadata_adapter.query_service.find_all_of_model(model: EphemeraVocabulary).to_a.length).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
This does a few things:

1. Adds a test for Ephemera with Vocabularies
2. Stores all referenced objects, recursing deep, into the bag of the parent on export. This bag is considered a preservation artifact, so the hope is that it's self-contained.
3. Don't overwrite objects on import if they already exist.