### PR TITLE
Updates `PendingUpload#copied_file_name` to pass the auth. headers using another parameter key

### DIFF
--- a/app/models/pending_upload.rb
+++ b/app/models/pending_upload.rb
@@ -25,6 +25,6 @@ class PendingUpload < Valkyrie::Resource
     end
 
     def copied_file_name
-      @copied_file_name ||= BrowseEverything::Retriever.new.download("file_name" => file_name.first, "file_size" => file_size.first, "url" => url.first, "auth_header" => headers)
+      @copied_file_name ||= BrowseEverything::Retriever.new.download("file_name" => file_name.first, "file_size" => file_size.first, "url" => url.first, "headers" => headers)
     end
 end


### PR DESCRIPTION
Resolves #2837 (but this should be more properly resolved by ensuring that the legacy arguments are still handled on https://github.com/samvera/browse-everything)