### PR TITLE
Enables optimistic locking for FileSets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -114,7 +114,7 @@ gem "riiif"
 gem "sidekiq"
 gem "string_rtl"
 gem "tiny_tds"
-gem "valkyrie-sequel", github: "samvera-labs/valkyrie-sequel", branch: "valkyrie_1.5"
+gem "valkyrie-sequel", github: "samvera-labs/valkyrie-sequel"
 gem "whenever", "~> 0.10"
 
 gem "blacklight_iiif_search", github: "boston-library/blacklight_iiif_search"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,10 +44,9 @@ GIT
 
 GIT
   remote: git://github.com/samvera-labs/valkyrie-sequel.git
-  revision: 902577646f21365c70db446450c1e51572379ba4
-  branch: valkyrie_1.5
+  revision: 1cce3abbc6235b80b33224216942eda288f70043
   specs:
-    valkyrie-sequel (0.1.0)
+    valkyrie-sequel (1.0.0)
       oj
       sequel
       sequel_pg
@@ -540,7 +539,7 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    oj (3.7.8)
+    oj (3.7.12)
     omniauth (1.6.1)
       hashie (>= 3.4.6, < 3.6.0)
       rack (>= 1.6.2, < 3)
@@ -711,8 +710,8 @@ GEM
     selenium-webdriver (3.4.4)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
-    sequel (5.17.0)
-    sequel_pg (1.11.0)
+    sequel (5.19.0)
+    sequel_pg (1.12.0)
       pg (>= 0.18.0)
       sequel (>= 4.38.0)
     shrine (2.16.0)

--- a/app/adapters/bagit/persister.rb
+++ b/app/adapters/bagit/persister.rb
@@ -44,12 +44,12 @@ module Bagit
         return true if resource.id.blank?
         return true unless resource.optimistic_locking_enabled?
 
-        cached_resource = adapter.query_service.find_by(id: resource.id)
-        return true if cached_resource.blank?
-
         resource_lock_tokens = resource[Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK]
         resource_value = resource_lock_tokens.find { |lock_token| lock_token.adapter_id == adapter.id }
         return true if resource_value.blank?
+
+        cached_resource = adapter.query_service.find_by(id: resource.id)
+        return true if cached_resource.blank?
 
         cached_value = cached_resource[Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK].first
         cached_value == resource_value

--- a/app/characterization_services/external_metadata_characterization_service.rb
+++ b/app/characterization_services/external_metadata_characterization_service.rb
@@ -20,7 +20,7 @@ class ExternalMetadataCharacterizationService
   #   Valkyrie::Derivatives::FileCharacterizationService.for(file_set, persister).characterize(save: false)
   def characterize(save: true)
     original_file.mime_type = geo_mime_type
-    @persister.save(resource: @file_set) if save
+    @file_set = @persister.save(resource: @file_set) if save
     @file_set
   end
 

--- a/app/characterization_services/gdal_characterization_service.rb
+++ b/app/characterization_services/gdal_characterization_service.rb
@@ -21,7 +21,7 @@ class GdalCharacterizationService
     unzip_original_file if zip_file?
     new_file = original_file.new(file_characterization_attributes.to_h)
     @file_set.file_metadata = @file_set.file_metadata.select { |x| x.id != new_file.id } + [new_file]
-    @persister.save(resource: @file_set) if save
+    @file_set = @persister.save(resource: @file_set) if save
     clean_up_zip_directory if zip_file?
     @file_set
   end

--- a/app/characterization_services/geo_characterization_service.rb
+++ b/app/characterization_services/geo_characterization_service.rb
@@ -18,11 +18,11 @@ class GeoCharacterizationService
   # @example characterize a file and do not persist the changes
   #   Valkyrie::Derivatives::FileCharacterizationService.for(file_set, persister).characterize(save: false)
   def characterize(save: true)
-    TikaFileCharacterizationService.new(file_set: file_set, persister: persister).characterize
-    scanned_map_characterization_service.characterize if scanned_map_characterization_service.valid?
-    vector_characterization_service.characterize if vector_characterization_service.valid?
-    raster_characterization_service.characterize if raster_characterization_service.valid?
-    external_metadata_service.characterize if external_metadata_service.valid?
+    @file_set = TikaFileCharacterizationService.new(file_set: file_set, persister: persister).characterize
+    @file_set = scanned_map_characterization_service.characterize if scanned_map_characterization_service.valid?
+    @file_set = vector_characterization_service.characterize if vector_characterization_service.valid?
+    @file_set = raster_characterization_service.characterize if raster_characterization_service.valid?
+    @file_set = external_metadata_service.characterize if external_metadata_service.valid?
     @file_set
   end
 
@@ -35,18 +35,18 @@ class GeoCharacterizationService
   end
 
   def external_metadata_service
-    @external_metadata_service ||= ExternalMetadataCharacterizationService.new(file_set: file_set, persister: persister)
+    ExternalMetadataCharacterizationService.new(file_set: file_set, persister: persister)
   end
 
   def scanned_map_characterization_service
-    @scanned_map_characterization_service ||= ScannedMapCharacterizationService.new(file_set: file_set, persister: persister)
+    ScannedMapCharacterizationService.new(file_set: file_set, persister: persister)
   end
 
   def raster_characterization_service
-    @raster_characterization_service ||= GdalCharacterizationService::Raster.new(file_set: file_set, persister: persister)
+    GdalCharacterizationService::Raster.new(file_set: file_set, persister: persister)
   end
 
   def vector_characterization_service
-    @vector_characterization_service ||= GdalCharacterizationService::Vector.new(file_set: file_set, persister: persister)
+    GdalCharacterizationService::Vector.new(file_set: file_set, persister: persister)
   end
 end

--- a/app/characterization_services/imagemagick_characterization_service.rb
+++ b/app/characterization_services/imagemagick_characterization_service.rb
@@ -39,7 +39,7 @@ class ImagemagickCharacterizationService
     }
     new_file = original_file.new(@file_characterization_attributes.to_h)
     @file_set.file_metadata = @file_set.file_metadata.select { |x| x.id != new_file.id } + [new_file]
-    @persister.save(resource: @file_set) if save
+    @file_set = @persister.save(resource: @file_set) if save
     @file_set
   end
 

--- a/app/characterization_services/mediainfo_characterization_service.rb
+++ b/app/characterization_services/mediainfo_characterization_service.rb
@@ -35,7 +35,7 @@ class MediainfoCharacterizationService
     }
     new_file = preservation_file.new(@file_characterization_attributes.to_h)
     @file_set.file_metadata = @file_set.file_metadata.select { |x| x.id != new_file.id } + [new_file]
-    @persister.save(resource: @file_set) if save
+    @file_set = @persister.save(resource: @file_set) if save
     @file_set
   end
 

--- a/app/characterization_services/scanned_map_characterization_service.rb
+++ b/app/characterization_services/scanned_map_characterization_service.rb
@@ -23,7 +23,7 @@ class ScannedMapCharacterizationService
     }
     new_file = original_file.new(@file_characterization_attributes.to_h)
     @file_set.file_metadata = @file_set.file_metadata.select { |x| x.id != new_file.id } + [new_file]
-    @persister.save(resource: @file_set) if save
+    @file_set = @persister.save(resource: @file_set) if save
     @file_set
   end
 

--- a/app/characterization_services/tika_file_characterization_service.rb
+++ b/app/characterization_services/tika_file_characterization_service.rb
@@ -21,7 +21,7 @@ class TikaFileCharacterizationService
   def characterize(save: true)
     new_file = original_file.new(file_characterization_attributes.to_h)
     @file_set.file_metadata = @file_set.file_metadata.select { |x| x.id != new_file.id } + [new_file]
-    @persister.save(resource: @file_set) if save
+    @file_set = @persister.save(resource: @file_set) if save
     @file_set
   end
 

--- a/app/resources/file_sets/file_set.rb
+++ b/app/resources/file_sets/file_set.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 class FileSet < Resource
+  enable_optimistic_locking
   include Valkyrie::Resource::AccessControls
   attribute :title, Valkyrie::Types::Set
   attribute :file_metadata, Valkyrie::Types::Set.of(FileMetadata.optional)

--- a/app/resources/file_sets/file_set_change_set.rb
+++ b/app/resources/file_sets/file_set_change_set.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 class FileSetChangeSet < ChangeSet
   self.fields = [:title]
+  property :optimistic_lock_token,
+           multiple: true,
+           required: true,
+           type: Valkyrie::Types::Set.of(Valkyrie::Types::OptimisticLockToken)
   property :files, virtual: true, multiple: true, required: false
   property :viewing_hint, multiple: false, required: false
   property :hocr_content, multiple: false, required: false

--- a/app/resources/file_sets/file_sets_controller.rb
+++ b/app/resources/file_sets/file_sets_controller.rb
@@ -45,7 +45,7 @@ class FileSetsController < ApplicationController
       change_set_persister.buffer_into_index do |persist|
         obj = persist.save(change_set: @change_set)
       end
-      update_derivatives unless derivative_resource_params.empty?
+      update_derivatives(obj) unless derivative_resource_params.empty?
 
       after_update_success(obj, @change_set)
     end
@@ -68,7 +68,8 @@ class FileSetsController < ApplicationController
       @derivative_resource_params ||= filtered_file_params(file_filter: "derivative_files")
     end
 
-    def update_derivatives
+    def update_derivatives(obj)
+      @change_set = DynamicChangeSet.new(obj)
       return unless @change_set.validate(derivative_resource_params)
       derivative_change_set_persister.buffer_into_index do |persist|
         persist.save(change_set: @change_set)

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -9,6 +9,11 @@ RSpec.describe FileSet do
     stub_ezid(shoulder: shoulder, blade: blade)
   end
 
+  describe "optimistic locking" do
+    it "is enabled" do
+      expect(described_class.optimistic_locking_enabled?).to eq true
+    end
+  end
   describe ".run_fixity" do
     let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }
     let(:resource) { FactoryBot.build(:scanned_resource) }


### PR DESCRIPTION
This should prevent all race conditions overriding things like derivatives happening in background jobs. It could theoretically cause an error for users too, but we'll have to see if that happens in reality - it should be pretty hard to trigger, since the form doesn't include the lock token.

Tested and made sure this fixes the issue with #2657 and #2877.

Closes #2657 
Closes #2877