### PR TITLE
Turn off search history when in read-only mode

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -21,6 +21,12 @@ class CatalogController < ApplicationController
     }
   end
 
+  # turn off search history during read-only mode
+  def find_or_initialize_search_session_from_params(params)
+    return if Figgy.read_only_mode
+    super
+  end
+
   # enforce hydra access controls
   before_action :set_id, only: :iiif_search
   before_action :enforce_show_permissions, only: [:show, :iiif_search]

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -27,4 +27,21 @@ RSpec.feature "Scanned Resources" do
       expect(page).to have_content "New test work"
     end
   end
+
+  context "in read-only mode" do
+    let(:emsg) { "PG::InsufficientPrivilege: ERROR:  permission denied for relation searches" }
+    before do
+      allow(Figgy).to receive(:read_only_mode).and_return(true)
+      allow(Search).to receive(:create).and_raise ActiveRecord::StatementInvalid, emsg
+    end
+
+    scenario "users can search and view results" do
+      visit root_path
+      fill_in id: "catalog_search", with: "test123"
+      click_button id: "keyword-search-submit"
+      expect(page).to have_content "New test work"
+      click_link "New test work"
+      expect(page).to have_content "New test work"
+    end
+  end
 end


### PR DESCRIPTION
This allows people to search in read-only mode without getting errors
due to blacklight creating `Search` objects.

fixes #2875