### PR TITLE
Fixes for NumismaticPerson

### DIFF
--- a/app/resources/numismatic_people/numismatic_person_change_set.rb
+++ b/app/resources/numismatic_people/numismatic_person_change_set.rb
@@ -11,6 +11,7 @@ class NumismaticPersonChangeSet < ChangeSet
   property :class_of, multiple: false, required: false
   property :years_active_start, multiple: false, required: false
   property :years_active_end, multiple: false, required: false
+  property :replaces, multiple: true, required: false, default: []
 
   def primary_terms
     [

--- a/app/resources/numismatic_people/numismatic_person_decorator.rb
+++ b/app/resources/numismatic_people/numismatic_person_decorator.rb
@@ -29,7 +29,7 @@ class NumismaticPersonDecorator < Valkyrie::ResourceDecorator
   private
 
     def date_range
-      return "(#{born.first} - #{died.first})" unless born.blank? && died.blank?
-      return "(#{years_active_start.first} - #{years_active_end.first})" unless years_active_start.blank? || years_active_end.blank?
+      return "(#{born&.first} - #{died&.first})" unless born.blank? && died.blank?
+      return "(#{years_active_start&.first} - #{years_active_end&.first})" unless years_active_start.blank? && years_active_end.blank?
     end
 end

--- a/spec/resources/numismatic_people/numismatic_person_decorator_spec.rb
+++ b/spec/resources/numismatic_people/numismatic_person_decorator_spec.rb
@@ -20,17 +20,31 @@ RSpec.describe NumismaticPersonDecorator do
       end
     end
 
-    context "with only years_active start and end dates" do
+    context "with only a died date" do
+      let(:numismatic_person) do
+        FactoryBot.create_for_repository(:numismatic_person,
+                                         born: nil,
+                                         died: "1963",
+                                         years_active_start: nil,
+                                         years_active_end: nil)
+      end
+
+      it "generates a title" do
+        expect(decorator.title).to eq("name1 name2 epithet ( - 1963)")
+      end
+    end
+
+    context "with only a years_active_start date" do
       let(:numismatic_person) do
         FactoryBot.create_for_repository(:numismatic_person,
                                          born: nil,
                                          died: nil,
                                          years_active_start: "1894",
-                                         years_active_end: "1961")
+                                         years_active_end: nil)
       end
 
       it "generates a title" do
-        expect(decorator.title).to eq("name1 name2 epithet (1894 - 1961)")
+        expect(decorator.title).to eq("name1 name2 epithet (1894 - )")
       end
     end
   end


### PR DESCRIPTION
Minor fixes for NumismaticPerson implementation.

- Add `replaces` property to change set. Corrects an initial mistake.
- Updates decorator to account for cases where born, died, years_active_start, and years_active_end are not all described.