### PR TITLE
 Adds NumismaticSubject resource

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -94,6 +94,7 @@ Metrics/ClassLength:
     - 'app/controllers/bulk_ingest_controller.rb'
     - 'app/controllers/application_controller.rb'
     - 'app/controllers/base_resource_controller.rb'
+    - 'app/resources/numismatic_issues/numismatic_issue_decorator.rb'
 Metrics/CyclomaticComplexity:
   Exclude:
     - 'app/helpers/application_helper.rb'

--- a/app/resources/coins/coin_decorator.rb
+++ b/app/resources/coins/coin_decorator.rb
@@ -27,19 +27,19 @@ class CoinDecorator < Valkyrie::ResourceDecorator
           :visibility,
           :append_id
 
-  delegate :members, :decorated_file_sets, :decorated_parent, :decorated_numismatic_accession, to: :wayfinder
+  delegate :decorated_file_sets, :decorated_numismatic_accession, :decorated_parent, :members, to: :wayfinder
   delegate :id, :label, to: :accession, prefix: true
 
   def ark_mintable_state?
     false
   end
 
-  def citations
-    numismatic_citation.map { |c| c.decorate.title }
+  def call_number
+    "Coin #{coin_number}"
   end
 
-  def pub_created_display
-    [decorated_parent.ruler, decorated_parent.denomination&.first, decorated_parent.decorated_numismatic_place&.city].compact.join(", ") if decorated_parent
+  def citations
+    numismatic_citation.map { |c| c.decorate.title }
   end
 
   def manageable_files?
@@ -54,8 +54,15 @@ class CoinDecorator < Valkyrie::ResourceDecorator
     "coin-#{coin_number}"
   end
 
-  def call_number
-    "Coin #{coin_number}"
+  def pdf_file
+    pdf = file_metadata.find { |x| x.mime_type == ["application/pdf"] }
+    pdf if pdf && Valkyrie::StorageAdapter.find(:derivatives).find_by(id: pdf.file_identifiers.first)
+  rescue Valkyrie::StorageAdapter::FileNotFound
+    nil
+  end
+
+  def pub_created_display
+    [decorated_parent.ruler, decorated_parent.denomination&.first, decorated_parent.decorated_numismatic_place&.city].compact.join(", ") if decorated_parent
   end
 
   def rendered_accession
@@ -64,12 +71,5 @@ class CoinDecorator < Valkyrie::ResourceDecorator
 
   def state
     super.first
-  end
-
-  def pdf_file
-    pdf = file_metadata.find { |x| x.mime_type == ["application/pdf"] }
-    pdf if pdf && Valkyrie::StorageAdapter.find(:derivatives).find_by(id: pdf.file_identifiers.first)
-  rescue Valkyrie::StorageAdapter::FileNotFound
-    nil
   end
 end

--- a/app/resources/coins/coin_decorator.rb
+++ b/app/resources/coins/coin_decorator.rb
@@ -17,7 +17,7 @@ class CoinDecorator < Valkyrie::ResourceDecorator
           :find_locus,
           :find_feature,
           :find_description,
-          :numismatic_citations,
+          :citations,
           :numismatic_collection,
           :rendered_accession,
           :number_in_accession,
@@ -34,7 +34,7 @@ class CoinDecorator < Valkyrie::ResourceDecorator
     false
   end
 
-  def numismatic_citations
+  def citations
     numismatic_citation.map { |c| c.decorate.title }
   end
 

--- a/app/resources/coins/orangelight_coin_builder.rb
+++ b/app/resources/coins/orangelight_coin_builder.rb
@@ -101,10 +101,10 @@ class OrangelightCoinBuilder
         issue_reverse_figure_relationship_s: parent.reverse_figure_relationship,
         issue_reverse_legend_s: parent.reverse_legend,
         issue_reverse_attributes_s: parent.reverse_attributes,
-        issue_references_s: parent.numismatic_citations,
-        issue_references_sort: parent.numismatic_citations&.first,
-        issue_artists_s: parent.numismatic_artists,
-        issue_artists_sort: parent.numismatic_artists&.first
+        issue_references_s: parent.citations,
+        issue_references_sort: parent.citations&.first,
+        issue_artists_s: parent.artists,
+        issue_artists_sort: parent.artists&.first
       }
     end
 

--- a/app/resources/numismatic_accessions/numismatic_accession_decorator.rb
+++ b/app/resources/numismatic_accessions/numismatic_accession_decorator.rb
@@ -14,20 +14,7 @@ class NumismaticAccessionDecorator < Valkyrie::ResourceDecorator
 
   delegate :decorated_person, to: :wayfinder
 
-  def date
-    Array.wrap(super).first
-  end
-
-  def person
-    return nil unless decorated_person
-    [decorated_person.name1, decorated_person.name2].compact.join(" ")
-  end
-
-  def firm
-    Array.wrap(super).first
-  end
-
-  def type
+  def account
     Array.wrap(super).first
   end
 
@@ -35,12 +22,30 @@ class NumismaticAccessionDecorator < Valkyrie::ResourceDecorator
     Array.wrap(super).first
   end
 
-  def account
-    Array.wrap(super).first
+  def cost_label
+    "" unless cost
+    "(#{cost})"
   end
 
   def citations
     numismatic_citation.map { |c| c.decorate.title }
+  end
+
+  def date
+    Array.wrap(super).first
+  end
+
+  def firm
+    Array.wrap(super).first
+  end
+
+  def from_label
+    divider = "/" if person && firm
+    "#{person}#{divider}#{firm}"
+  end
+
+  def label
+    "#{accession_number}: #{date} #{type} #{from_label} #{cost_label}"
   end
 
   def manageable_files?
@@ -51,17 +56,12 @@ class NumismaticAccessionDecorator < Valkyrie::ResourceDecorator
     false
   end
 
-  def label
-    "#{accession_number}: #{date} #{type} #{from_label} #{cost_label}"
+  def person
+    return nil unless decorated_person
+    [decorated_person.name1, decorated_person.name2].compact.join(" ")
   end
 
-  def from_label
-    divider = "/" if person && firm
-    "#{person}#{divider}#{firm}"
-  end
-
-  def cost_label
-    "" unless cost
-    "(#{cost})"
+  def type
+    Array.wrap(super).first
   end
 end

--- a/app/resources/numismatic_accessions/numismatic_accession_decorator.rb
+++ b/app/resources/numismatic_accessions/numismatic_accession_decorator.rb
@@ -10,7 +10,7 @@ class NumismaticAccessionDecorator < Valkyrie::ResourceDecorator
           :firm,
           :note,
           :private_note,
-          :numismatic_citations
+          :citations
 
   delegate :decorated_person, to: :wayfinder
 
@@ -39,7 +39,7 @@ class NumismaticAccessionDecorator < Valkyrie::ResourceDecorator
     Array.wrap(super).first
   end
 
-  def numismatic_citations
+  def citations
     numismatic_citation.map { |c| c.decorate.title }
   end
 

--- a/app/resources/numismatic_issues/numismatic_issue.rb
+++ b/app/resources/numismatic_issues/numismatic_issue.rb
@@ -14,6 +14,7 @@ class NumismaticIssue < Resource
   # descriptive metadata
   attribute :numismatic_artist, Valkyrie::Types::Array.of(NumismaticArtist).meta(ordered: true)
   attribute :numismatic_citation, Valkyrie::Types::Array.of(NumismaticCitation).meta(ordered: true)
+  attribute :numismatic_subject, Valkyrie::Types::Array.of(NumismaticSubject).meta(ordered: true)
   attribute :color
   attribute :date_range
   attribute :denomination
@@ -43,7 +44,6 @@ class NumismaticIssue < Resource
   attribute :reverse_symbol
   attribute :series
   attribute :shape
-  attribute :subject
   attribute :workshop
 
   # adminstrative metadata

--- a/app/resources/numismatic_issues/numismatic_issue_change_set.rb
+++ b/app/resources/numismatic_issues/numismatic_issue_change_set.rb
@@ -7,6 +7,7 @@ class NumismaticIssueChangeSet < ChangeSet
   include DateRangeProperty
   collection :numismatic_citation, multiple: true, required: false, form: NumismaticCitationChangeSet, populator: :populate_nested_collection, default: []
   collection :numismatic_artist, multiple: true, required: false, form: NumismaticArtistChangeSet, populator: :populate_nested_collection, default: []
+  collection :numismatic_subject, multiple: true, required: false, form: NumismaticSubjectChangeSet, populator: :populate_nested_collection, default: []
   property :color, multiple: false, required: false
   property :denomination, multiple: false, required: false
   property :edge, multiple: false, required: false
@@ -35,7 +36,6 @@ class NumismaticIssueChangeSet < ChangeSet
   property :reverse_symbol, multiple: false, required: false
   property :series, multiple: false, required: false
   property :shape, multiple: false, required: false
-  property :subject, multiple: true, required: false, default: []
   property :workshop, multiple: false, required: false
 
   property :read_groups, multiple: true, required: false
@@ -84,7 +84,6 @@ class NumismaticIssueChangeSet < ChangeSet
         :master_id,
         :workshop,
         :series,
-        :subject,
         :numismatic_monogram_ids,
         :numismatic_place_id
       ],
@@ -120,15 +119,22 @@ class NumismaticIssueChangeSet < ChangeSet
       ],
       "Artist" => [
         :numismatic_artist
+      ],
+      "Subject" => [
+        :numismatic_subject
       ]
     }
+  end
+
+  def build_numismatic_artist
+    schema["numismatic_artist"][:nested].new(model.class.schema[:numismatic_artist][[{}]].first)
   end
 
   def build_numismatic_citation
     schema["numismatic_citation"][:nested].new(model.class.schema[:numismatic_citation][[{}]].first)
   end
 
-  def build_numismatic_artist
-    schema["numismatic_artist"][:nested].new(model.class.schema[:numismatic_artist][[{}]].first)
+  def build_numismatic_subject
+    schema["numismatic_subject"][:nested].new(model.class.schema[:numismatic_subject][[{}]].first)
   end
 end

--- a/app/resources/numismatic_issues/numismatic_issue_decorator.rb
+++ b/app/resources/numismatic_issues/numismatic_issue_decorator.rb
@@ -36,7 +36,7 @@ class NumismaticIssueDecorator < Valkyrie::ResourceDecorator
           :numismatic_artists,
           :member_of_collections,
           :rendered_rights_statement,
-          :subject,
+          :numismatic_subjects,
           :replaces,
           :visibility
 
@@ -81,6 +81,10 @@ class NumismaticIssueDecorator < Valkyrie::ResourceDecorator
 
   def numismatic_citations
     numismatic_citation.map { |c| c.decorate.title }
+  end
+
+  def numismatic_subjects
+    numismatic_subject.map { |s| s.decorate.title }
   end
 
   # Whether this box has a workflow state that grants access to its contents

--- a/app/resources/numismatic_issues/numismatic_issue_decorator.rb
+++ b/app/resources/numismatic_issues/numismatic_issue_decorator.rb
@@ -32,11 +32,11 @@ class NumismaticIssueDecorator < Valkyrie::ResourceDecorator
           :reverse_legend,
           :decorated_numismatic_monograms,
           :note,
-          :numismatic_citations,
-          :numismatic_artists,
+          :citations,
+          :artists,
+          :subjects,
           :member_of_collections,
           :rendered_rights_statement,
-          :numismatic_subjects,
           :replaces,
           :visibility
 
@@ -48,43 +48,30 @@ class NumismaticIssueDecorator < Valkyrie::ResourceDecorator
                          :rendered_rights_statement,
                          :thumbnail_id
 
-  delegate :members, :decorated_file_sets, :decorated_coins, :coin_count, :decorated_master, :decorated_numismatic_place, :decorated_ruler, :decorated_numismatic_monograms, to: :wayfinder
+  delegate :coin_count,
+           :decorated_coins,
+           :decorated_file_sets,
+           :decorated_numismatic_monograms,
+           :decorated_numismatic_place,
+           :decorated_master,
+           :decorated_ruler,
+           :members,
+           to: :wayfinder
+
+  def artists
+    numismatic_artist.map { |a| a.decorate.title }
+  end
 
   def attachable_objects
     [Coin]
   end
 
-  def first_range
-    @first_range ||= Array.wrap(date_range).map(&:decorate).first
-  end
-
-  def master
-    decorated_master&.title
-  end
-
-  def rendered_date_range
-    return unless first_range.present?
-    first_range.range_string
-  end
-
-  def rendered_place
-    decorated_numismatic_place&.title
-  end
-
-  def ruler
-    decorated_ruler&.title
-  end
-
-  def numismatic_artists
-    numismatic_artist.map { |a| a.decorate.title }
-  end
-
-  def numismatic_citations
+  def citations
     numismatic_citation.map { |c| c.decorate.title }
   end
 
-  def numismatic_subjects
-    numismatic_subject.map { |s| s.decorate.title }
+  def first_range
+    @first_range ||= Array.wrap(date_range).map(&:decorate).first
   end
 
   # Whether this box has a workflow state that grants access to its contents
@@ -99,6 +86,19 @@ class NumismaticIssueDecorator < Valkyrie::ResourceDecorator
 
   def manageable_structure?
     false
+  end
+
+  def master
+    decorated_master&.title
+  end
+
+  def rendered_date_range
+    return unless first_range.present?
+    first_range.range_string
+  end
+
+  def rendered_place
+    decorated_numismatic_place&.title
   end
 
   def rendered_rights_statement
@@ -116,7 +116,15 @@ class NumismaticIssueDecorator < Valkyrie::ResourceDecorator
     end
   end
 
+  def ruler
+    decorated_ruler&.title
+  end
+
   def state
     super.first
+  end
+
+  def subjects
+    numismatic_subject.map { |s| s.decorate.title }
   end
 end

--- a/app/resources/numismatic_subjects/numismatic_subject.rb
+++ b/app/resources/numismatic_subjects/numismatic_subject.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class NumismaticSubject < Resource
+  include Valkyrie::Resource::AccessControls
+  attribute :type
+  attribute :subject
+end

--- a/app/resources/numismatic_subjects/numismatic_subject_change_set.rb
+++ b/app/resources/numismatic_subjects/numismatic_subject_change_set.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+class NumismaticSubjectChangeSet < ChangeSet
+  delegate :human_readable_type, to: :model
+
+  property :type, multiple: false, required: false
+  property :subject, multiple: false, required: false
+
+  # Virtual Attributes
+  property :_destroy, virtual: true
+
+  def new_record?
+    false
+  end
+
+  def marked_for_destruction?
+    false
+  end
+
+  def primary_terms
+    [
+      :type,
+      :subject
+    ]
+  end
+end

--- a/app/resources/numismatic_subjects/numismatic_subject_decorator.rb
+++ b/app/resources/numismatic_subjects/numismatic_subject_decorator.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+class NumismaticSubjectDecorator < Valkyrie::ResourceDecorator
+  display :type,
+          :subject
+
+  def manageable_files?
+    false
+  end
+
+  def manageable_structure?
+    false
+  end
+
+  def type
+    Array.wrap(super).first
+  end
+
+  def subject
+    Array.wrap(super).first
+  end
+
+  def title
+    "#{type}, #{subject}"
+  end
+end

--- a/app/views/numismatic_issues/_numismatic_subject_fields.html.erb
+++ b/app/views/numismatic_issues/_numismatic_subject_fields.html.erb
@@ -1,0 +1,18 @@
+<div class='nested-fields'>
+  <div class="row">
+    <div class="col-md-6">
+      <%= f.input :type, required: f.object.required?(:type), label: "Type" %>
+    </div>
+    <div class="col-md-6">
+      <%= f.input :subject, required: f.object.required?(:subject), label: "Subject" %>
+    </div>
+  </div>
+  <%= f.hidden_field :id %>
+  <%= link_to_remove_association f do %>
+    <button type="button" class="btn btn-link remove">
+      <span class="glyphicon glyphicon-remove"></span>
+      <span class="controls-remove-text">Remove</span>
+    </button>
+  <% end %>
+</div>
+

--- a/app/views/numismatic_issues/edit_fields/_numismatic_subject.html.erb
+++ b/app/views/numismatic_issues/edit_fields/_numismatic_subject.html.erb
@@ -1,0 +1,15 @@
+<div class="row">
+  <div id="numismatic_subject">
+    <%= f.simple_fields_for :numismatic_subject, wrapper: :inline_form do |g| %>
+      <%= render 'numismatic_subject_fields', f: g %>
+    <% end %>
+  </div>
+  <div class="links">
+    <%= link_to_add_association f, :numismatic_subject, partial: 'numismatic_subject_fields', force_non_association_create: true do %>
+      <button type="button" class="btn btn-link add">
+        <span class="glyphicon glyphicon-plus"></span>
+        <span class="controls-add-text">Add another Subject</span>
+      </button>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,10 +85,6 @@ en:
           label: "Collections"
         md5:
           label: "MD5"
-        numismatic_artists:
-          label: "Artists"
-        numismatic_citations:
-          label: "Citations"
         sha1:
           label: "SHA-1"
         sha256:

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -877,7 +877,6 @@ RSpec.describe CatalogController do
         rights_statement: "issue-rights-statement",
         series: "issue-series",
         shape: "issue-series",
-        subject: "issue-subject",
         workshop: "issue-workshop"
       }
     end

--- a/spec/resources/coins/coin_decorator_spec.rb
+++ b/spec/resources/coins/coin_decorator_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe CoinDecorator do
     end
   end
 
-  describe "#numismatic_citations" do
-    it "renders the linked numismatic_citations" do
-      expect(decorator.numismatic_citations).to eq(["short-title citation part citation number"])
+  describe "#citations" do
+    it "renders the linked citations" do
+      expect(decorator.citations).to eq(["short-title citation part citation number"])
     end
   end
 

--- a/spec/resources/coins/coin_feature_spec.rb
+++ b/spec/resources/coins/coin_feature_spec.rb
@@ -111,7 +111,7 @@ RSpec.feature "Coins" do
       expect(page).to have_css ".attribute.visibility", text: "open"
       expect(page).to have_css ".attribute.number_in_accession", text: 123
       expect(page).to have_css ".attribute.analysis", text: "test value"
-      expect(page).to have_css ".attribute.numismatic_citations", text: "short-title part number"
+      expect(page).to have_css ".attribute.citations", text: "short-title part number"
       expect(page).to have_css ".attribute.counter_stamp", text: "test value"
       expect(page).to have_css ".attribute.die_axis", text: "test value"
       expect(page).to have_css ".attribute.find_date", text: "test value"

--- a/spec/resources/numismatic_accessions/numismatic_accession_decorator_spec.rb
+++ b/spec/resources/numismatic_accessions/numismatic_accession_decorator_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe NumismaticAccessionDecorator do
     end
   end
 
-  describe "#numismatic_citations" do
-    it "renders the linked numismatic_citations" do
-      expect(decorator.numismatic_citations).to eq(["short-title citation part citation number"])
+  describe "#citations" do
+    it "renders the linked citations" do
+      expect(decorator.citations).to eq(["short-title citation part citation number"])
     end
   end
 end

--- a/spec/resources/numismatic_issues/numismatic_issue_change_set_spec.rb
+++ b/spec/resources/numismatic_issues/numismatic_issue_change_set_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NumismaticIssueChangeSet do
   describe "#primary_terms" do
     it "includes displayed fields" do
       expect(change_set.primary_terms).to be_a(Hash)
-      expect(change_set.primary_terms.keys).to eq(["", "Obverse", "Reverse", "Rights and Notes", "Citation", "Artist"])
+      expect(change_set.primary_terms.keys).to eq(["", "Obverse", "Reverse", "Rights and Notes", "Citation", "Artist", "Subject"])
       expect(change_set.primary_terms[""]).to include(:object_type, :denomination, :metal, :workshop)
       expect(change_set.primary_terms.values.flatten).not_to include(:issue_number)
     end

--- a/spec/resources/numismatic_issues/numismatic_issue_decorator_spec.rb
+++ b/spec/resources/numismatic_issues/numismatic_issue_decorator_spec.rb
@@ -32,21 +32,21 @@ RSpec.describe NumismaticIssueDecorator do
     end
   end
 
-  describe "#numismatic_citations" do
-    it "renders the nested numismatic_citations" do
-      expect(decorator.numismatic_citations).to eq(["short-title citation part citation number"])
+  describe "#citations" do
+    it "renders the nested citations" do
+      expect(decorator.citations).to eq(["short-title citation part citation number"])
     end
   end
 
-  describe "#numismatic_artists" do
+  describe "#artists" do
     it "renders the nested artists" do
-      expect(decorator.numismatic_artists).to eq(["artist person, artist role"])
+      expect(decorator.artists).to eq(["artist person, artist role"])
     end
   end
 
-  describe "#numismatic_subjects" do
+  describe "#subjects" do
     it "renders the nested subjects" do
-      expect(decorator.numismatic_subjects).to eq(["Animal, unicorn"])
+      expect(decorator.subjects).to eq(["Animal, unicorn"])
     end
   end
 

--- a/spec/resources/numismatic_issues/numismatic_issue_decorator_spec.rb
+++ b/spec/resources/numismatic_issues/numismatic_issue_decorator_spec.rb
@@ -3,10 +3,18 @@ require "rails_helper"
 
 RSpec.describe NumismaticIssueDecorator do
   subject(:decorator) { described_class.new(issue) }
-  let(:issue) { FactoryBot.create_for_repository(:numismatic_issue, member_ids: [coin.id], state: "complete", numismatic_citation: numismatic_citation, numismatic_artist: numismatic_artist) }
+  let(:issue) do
+    FactoryBot.create_for_repository(:numismatic_issue,
+                                     member_ids: [coin.id],
+                                     state: "complete",
+                                     numismatic_citation: numismatic_citation,
+                                     numismatic_artist: numismatic_artist,
+                                     numismatic_subject: numismatic_subject)
+  end
   let(:coin) { FactoryBot.create_for_repository(:coin) }
   let(:numismatic_citation) { NumismaticCitation.new(part: "citation part", number: "citation number", numismatic_reference_id: [reference.id]) }
   let(:numismatic_artist) { NumismaticArtist.new(person: "artist person", role: "artist role") }
+  let(:numismatic_subject) { NumismaticSubject.new(type: "Animal", subject: "unicorn") }
   let(:reference) { FactoryBot.create_for_repository(:numismatic_reference) }
 
   describe "#decorated_coins" do
@@ -25,14 +33,20 @@ RSpec.describe NumismaticIssueDecorator do
   end
 
   describe "#numismatic_citations" do
-    it "renders the linked numismatic_citations" do
+    it "renders the nested numismatic_citations" do
       expect(decorator.numismatic_citations).to eq(["short-title citation part citation number"])
     end
   end
 
-  describe "#artists" do
-    it "renders the linked artists" do
+  describe "#numismatic_artists" do
+    it "renders the nested artists" do
       expect(decorator.numismatic_artists).to eq(["artist person, artist role"])
+    end
+  end
+
+  describe "#numismatic_subjects" do
+    it "renders the nested subjects" do
+      expect(decorator.numismatic_subjects).to eq(["Animal, unicorn"])
     end
   end
 

--- a/spec/resources/numismatic_issues/numismatic_issues_feature_spec.rb
+++ b/spec/resources/numismatic_issues/numismatic_issues_feature_spec.rb
@@ -69,6 +69,7 @@ RSpec.feature "NumismaticIssues" do
     expect(page).to have_field "Signature"
     expect(page).to have_field "State"
     expect(page).to have_field "Subject"
+    expect(page).to have_field "Type"
     expect(page).to have_field "Workshop"
 
     fill_in "Object type", with: "ancient coin"
@@ -84,6 +85,7 @@ RSpec.feature "NumismaticIssues" do
     let(:numismatic_citation) { NumismaticCitation.new(part: "part", number: "number", numismatic_reference_id: numismatic_reference.id) }
     let(:numismatic_place) { FactoryBot.create_for_repository(:numismatic_place) }
     let(:numismatic_person) { FactoryBot.create_for_repository(:numismatic_person) }
+    let(:numismatic_subject) { NumismaticSubject.new(type: "Animal", subject: "unicorn") }
     let(:numismatic_issue) do
       FactoryBot.create_for_repository(
         :numismatic_issue,
@@ -92,6 +94,7 @@ RSpec.feature "NumismaticIssues" do
         numismatic_place_id: numismatic_place.id,
         numismatic_artist: numismatic_artist,
         numismatic_citation: numismatic_citation,
+        numismatic_subject: numismatic_subject,
         ruler_id: numismatic_person.id,
         master_id: numismatic_person.id,
         color: "test value",
@@ -122,7 +125,6 @@ RSpec.feature "NumismaticIssues" do
         reverse_symbol: "test value",
         series: "test value",
         shape: "test value",
-        subject: "test value",
         workshop: "test value"
       )
     end
@@ -165,7 +167,7 @@ RSpec.feature "NumismaticIssues" do
       expect(page).to have_css ".attribute.ruler", text: "name1 name2 epithet (1868 - 1963)"
       expect(page).to have_css ".attribute.series", text: "test value"
       expect(page).to have_css ".attribute.shape", text: "test value"
-      expect(page).to have_css ".attribute.subject", text: "test value"
+      expect(page).to have_css ".attribute.numismatic_subjects", text: "Animal, unicorn"
       expect(page).to have_css ".attribute.workshop", text: "test value"
     end
   end

--- a/spec/resources/numismatic_issues/numismatic_issues_feature_spec.rb
+++ b/spec/resources/numismatic_issues/numismatic_issues_feature_spec.rb
@@ -134,8 +134,8 @@ RSpec.feature "NumismaticIssues" do
       expect(page).to have_css ".attribute.rendered_rights_statement", text: "Copyright Not Evaluated"
       expect(page).to have_css ".attribute.visibility", text: "open"
       expect(page).to have_css ".attribute.member_of_collections", text: "Title"
-      expect(page).to have_css ".attribute.numismatic_artists", text: "artist person, artist role"
-      expect(page).to have_css ".attribute.numismatic_citations", text: "short-title part number"
+      expect(page).to have_css ".attribute.artists", text: "artist person, artist role"
+      expect(page).to have_css ".attribute.citations", text: "short-title part number"
       expect(page).to have_css ".attribute.color", text: "test value"
       expect(page).to have_css ".attribute.rendered_date_range", text: "2017-2018"
       expect(page).to have_css ".attribute.denomination", text: "test value"
@@ -167,7 +167,7 @@ RSpec.feature "NumismaticIssues" do
       expect(page).to have_css ".attribute.ruler", text: "name1 name2 epithet (1868 - 1963)"
       expect(page).to have_css ".attribute.series", text: "test value"
       expect(page).to have_css ".attribute.shape", text: "test value"
-      expect(page).to have_css ".attribute.numismatic_subjects", text: "Animal, unicorn"
+      expect(page).to have_css ".attribute.subjects", text: "Animal, unicorn"
       expect(page).to have_css ".attribute.workshop", text: "test value"
     end
   end

--- a/spec/resources/numismatic_subjects/numismatic_subject_change_set_spec.rb
+++ b/spec/resources/numismatic_subjects/numismatic_subject_change_set_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe NumismaticSubjectChangeSet do
+  subject(:change_set) { described_class.new(numismatic_subject) }
+  let(:numismatic_subject) { NumismaticSubject.new }
+
+  describe "#primary_terms" do
+    it "includes displayed fields" do
+      expect(change_set.primary_terms).to include(:type, :subject)
+    end
+  end
+end

--- a/spec/resources/numismatic_subjects/numismatic_subject_decorator_spec.rb
+++ b/spec/resources/numismatic_subjects/numismatic_subject_decorator_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe NumismaticSubjectDecorator do
+  subject(:decorator) { described_class.new(numismatic_subject) }
+  let(:numismatic_subject) { NumismaticSubject.new(type: "Animal", subject: "unicorn") }
+
+  describe "manage files and structure" do
+    it "does not manage files or structure" do
+      expect(decorator.manageable_files?).to be false
+      expect(decorator.manageable_structure?).to be false
+    end
+  end
+
+  describe "#title" do
+    it "renders the numismatic_subject title" do
+      expect(decorator.title).to eq("Animal, unicorn")
+    end
+  end
+end

--- a/spec/resources/numismatic_subjects/numismatic_subject_spec.rb
+++ b/spec/resources/numismatic_subjects/numismatic_subject_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe NumismaticSubject do
+  subject(:numismatic_subject) { described_class.new type: "Animal", subject: "unicorn" }
+
+  it "has properties" do
+    expect(numismatic_subject.type).to eq(["Animal"])
+    expect(numismatic_subject.subject).to eq(["unicorn"])
+  end
+end

--- a/spec/services/orangelight_document_spec.rb
+++ b/spec/services/orangelight_document_spec.rb
@@ -75,8 +75,7 @@ describe OrangelightDocument do
                                          reverse_figure_description: "Harp at right side, 11 strings. Right arm holding up a palm-branch",
                                          reverse_figure_relationship: "corn-ear behind head",
                                          reverse_legend: "•HIBERNIA•1723•",
-                                         reverse_attributes: ["above", "2 within Є"],
-                                         subject: ["unicorn"])
+                                         reverse_attributes: ["above", "2 within Є"])
       end
 
       before do


### PR DESCRIPTION
- Adds NumismaticSubject resource
- Use nested NumismaticSubject in NumismaticIssue
- Rename nested resources in numismatic decorators to be less confusing
- Reorganize / alphabetize NumismaticIssue, Coin, NumismaticAccession decorators

Closes #2899 