### PR TITLE
small update in the drop down select box

### DIFF
--- a/app/assets/stylesheets/components/select_box.scss
+++ b/app/assets/stylesheets/components/select_box.scss
@@ -10,9 +10,9 @@ a span.check-mark {
 }
 
 .bootstrap-select.btn-group .dropdown-menu.open {
-	max-height: 300px !important;
+	max-height: 500px !important;
 }
 
 .bootstrap-select.btn-group .dropdown-menu.inner {
-	max-height: 300px !important;
+	max-height: 400px !important;
 }


### PR DESCRIPTION
Small update in the drop down select. 
I noticed that changing into the same px number the max-height in open and inner class, some information (select options) might not be visible. Now I'm setting the open max-height > than the inner max-height to fix this.