### PR TITLE
Archival audio fixes

### DIFF
--- a/app/jobs/ingest_archival_media_bag_job.rb
+++ b/app/jobs/ingest_archival_media_bag_job.rb
@@ -113,7 +113,7 @@ class IngestArchivalMediaBagJob < ApplicationJob
         def add_av(media_resource_change_set, sides)
           sides.each do |side|
             file_sets = create_av_file_sets(side)
-            media_resource_change_set.member_ids += file_sets.map(&:id)
+            media_resource_change_set.member_ids += file_sets.map(&:id).uniq
             media_resource_change_set.sync
           end
         end
@@ -157,7 +157,7 @@ class IngestArchivalMediaBagJob < ApplicationJob
 
           file_set.read_groups = file_set_read_groups
 
-          @av_file_sets[ingestable_audio_file.barcode_with_side_and_part] = file_set
+          file_set
         end
 
         # Creates and persists a FileSet for a media object
@@ -170,7 +170,8 @@ class IngestArchivalMediaBagJob < ApplicationJob
             file_metadata_node = create_node(ingestable_audio_file)
             file_set.file_metadata += [file_metadata_node]
 
-            changeset_persister.save(change_set: FileSetChangeSet.new(file_set))
+            file_set = changeset_persister.save(change_set: FileSetChangeSet.new(file_set))
+            @av_file_sets[ingestable_audio_file.barcode_with_side_and_part] = file_set
           end
         end
 

--- a/app/views/catalog/_media_html5_player_default.html.erb
+++ b/app/views/catalog/_media_html5_player_default.html.erb
@@ -1,4 +1,4 @@
-<% if file_set.audio? %>
+<% if file_set.audio? && file_set.derivative_file %>
   <% if can?(:download, file_set) %>
     <%= audio_tag download_path(file_set.id, file_set.derivative_file.id), controls: true %>
   <% end %>

--- a/spec/jobs/ingest_archival_media_bag_job_spec.rb
+++ b/spec/jobs/ingest_archival_media_bag_job_spec.rb
@@ -74,7 +74,6 @@ RSpec.describe IngestArchivalMediaBagJob do
 
         file_sets = query_service.find_all_of_model(model: FileSet)
         expect(file_sets.map(&:read_groups).to_a).to eq [
-          [read_auth], [read_auth], [read_auth], [read_auth],
           [read_auth], [read_auth], [read_auth], [read_auth]
         ]
       end
@@ -89,7 +88,6 @@ RSpec.describe IngestArchivalMediaBagJob do
 
         file_sets = query_service.find_all_of_model(model: FileSet)
         expect(file_sets.map(&:read_groups).to_a).to eq [
-          [read_auth], [read_auth], [read_auth], [read_auth],
           [read_auth], [read_auth], [read_auth], [read_auth]
         ]
       end


### PR DESCRIPTION
* Don't display the player unless there is a derivative file
* Cache filesets after saving to avoid duplicate filesets

Related to #1960