### PR TITLE
Fix issue with blank pulfa report since_date

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -33,7 +33,7 @@ class ReportsController < ApplicationController
 
   def pulfa_ark_report
     authorize! :show, Report
-    if params[:since_date]
+    unless params[:since_date].blank?
       @resources = query_service.custom_queries.updated_archival_resources(since_date: params[:since_date])
     end
 

--- a/app/views/reports/pulfa_ark_report.html.erb
+++ b/app/views/reports/pulfa_ark_report.html.erb
@@ -32,7 +32,7 @@
     <li>View Pulfa Ark Report for objects updated since</li>
   </ol>
   <%= form_with(url: pulfa_ark_report_path, method: :get, local: true) do |f| %>
-    <%= f.text_field :since_date %>
+    <%= f.text_field :since_date, class: 'timepicker', required: true, autocomplete: "off" %>
     <%= f.submit("View") %>
   <% end %>
 <% end %>

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -126,5 +126,12 @@ RSpec.describe ReportsController, type: :controller do
       get :pulfa_ark_report, params: { since_date: "2018-01-01" }, format: "csv"
       expect(response.body).to eq(data)
     end
+
+    context "with an empty since_date" do
+      it "does not raise an error" do
+        get :pulfa_ark_report, params: { since_date: "" }
+        expect { response }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
- Guards against blank `since_date` on the controller.
- Makes `since_date` a required field.
- Adds date picker.

Closes #2999