### PR TITLE
Add another layer of messaging to the lae folder import task

### DIFF
--- a/lib/tasks/lae.rake
+++ b/lib/tasks/lae.rake
@@ -11,7 +11,8 @@ namespace :lae do
   end
   task ingest_disk_files: :environment do
     folder_dir = ARGV[1]
-    abort "usage: rake lae:ingest_disk_files /path/to/lae/folder" unless Dir.exist?(folder_dir)
+    abort "usage: rake lae:ingest_disk_files /path/to/lae/folder" unless folder_dir
+    abort "Error: No such file or directory: #{folder_dir}" unless Dir.exist?(folder_dir)
     IngestLaeFolderJob.set(queue: :low).perform_later(folder_dir)
   end
   task ingest_posters: :environment do


### PR DESCRIPTION
This will give a more clear error in a case like the one we just saw,
where the directory had the wrong name.