### PR TITLE
Handles Valkyrie::Persistence::StaleObjectErrors during Resource updates

### DIFF
--- a/app/controllers/concerns/resource_controller.rb
+++ b/app/controllers/concerns/resource_controller.rb
@@ -82,7 +82,7 @@ module ResourceController
   rescue Valkyrie::Persistence::ObjectNotFoundError => not_found_error
     after_update_error not_found_error
   rescue Valkyrie::Persistence::StaleObjectError
-    flash[:alert] = "Sorry, another user updated this resource simultaneously.  Please resubmit your changes."
+    flash[:alert] = "Sorry, another user or process updated this resource simultaneously.  Please resubmit your changes."
     after_update_failure
   end
 

--- a/app/controllers/concerns/resource_controller.rb
+++ b/app/controllers/concerns/resource_controller.rb
@@ -79,8 +79,11 @@ module ResourceController
     else
       after_update_failure
     end
-  rescue Valkyrie::Persistence::ObjectNotFoundError => e
-    after_update_error e
+  rescue Valkyrie::Persistence::ObjectNotFoundError => not_found_error
+    after_update_error not_found_error
+  rescue Valkyrie::Persistence::StaleObjectError
+    flash[:alert] = "Sorry, another user updated this resource simultaneously.  Please resubmit your changes."
+    after_update_failure
   end
 
   def after_update_success(obj, change_set)

--- a/spec/resources/scanned_resources/scanned_resources_controller_spec.rb
+++ b/spec/resources/scanned_resources/scanned_resources_controller_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe ScannedResourcesController, type: :controller do
           patch :update, params: { id: resource.id.to_s, scanned_resource: { title: ["Two"] } }
 
           expect(response).to render_template "base/edit"
-          expect(flash[:alert]).to eq "Sorry, another user updated this resource simultaneously.  Please resubmit your changes."
+          expect(flash[:alert]).to eq "Sorry, another user or process updated this resource simultaneously.  Please resubmit your changes."
         end
       end
     end

--- a/spec/resources/scanned_resources/scanned_resources_controller_spec.rb
+++ b/spec/resources/scanned_resources/scanned_resources_controller_spec.rb
@@ -199,6 +199,23 @@ RSpec.describe ScannedResourcesController, type: :controller do
       context "when it does exist" do
         it_behaves_like "a workflow controller", :scanned_resource
       end
+
+      context "when the resource is locked for updates" do
+        before do
+          change_set_persister_mock = instance_double(ChangeSetPersister::Basic)
+          allow(change_set_persister_mock).to receive(:metadata_adapter).and_return(described_class.change_set_persister.metadata_adapter)
+          allow(change_set_persister_mock).to receive(:buffer_into_index).and_raise(Valkyrie::Persistence::StaleObjectError)
+          allow(described_class).to receive(:change_set_persister).and_return(change_set_persister_mock)
+        end
+
+        it "notifies the user with an error and redirects them to the edit view" do
+          resource = FactoryBot.create_for_repository(:scanned_resource)
+          patch :update, params: { id: resource.id.to_s, scanned_resource: { title: ["Two"] } }
+
+          expect(response).to render_template "base/edit"
+          expect(flash[:alert]).to eq "Sorry, another user updated this resource simultaneously.  Please resubmit your changes."
+        end
+      end
     end
 
     context "when an attribute has leading / trailing spaces" do


### PR DESCRIPTION
Ensures that when `Valkyrie::Persistence::StaleObjectErrors` are raised while attempting to update a resource, users are redirected to the edit view and alerted with a warning message.  Resolves #2970 