### PR TITLE
Display in the viewer only the coins that have an image

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -111,6 +111,7 @@ Metrics/CyclomaticComplexity:
     - 'config/initializers/sequel_active_support_notification.rb'
     - 'app/services/music_import_service.rb'
     - 'app/services/pdf_generator/cover_page_generator.rb'
+    - 'app/services/manifest_builder.rb'
 Metrics/LineLength:
   Exclude:
     - 'spec/views/scanned_resources/order_manager.html.erb_spec.rb'

--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -28,6 +28,8 @@ class ManifestBuilder
         IndexCollectionNode.new(resource)
       when ScannedMap
         ScannedMapNode.new(resource)
+      when NumismaticIssue
+        NumismaticIssueNode.new(resource)
       when Playlist
         PlaylistNode.new(resource, auth_token)
       else
@@ -321,6 +323,14 @@ class ManifestBuilder
       def geo_image?(member)
         ControlledVocabulary.for(:geo_image_format).include?(member.mime_type.first)
       end
+  end
+
+  class NumismaticIssueNode < CollectionNode
+    # Only include coins which have file sets;
+    # otherwise there is no image for the viewer.
+    def members
+      @members ||= super.select { |coin| coin.member_ids.present? }
+    end
   end
 
   class PlaylistNode < RootNode

--- a/spec/resources/numismatic_issues/numismatic_issues_controller_spec.rb
+++ b/spec/resources/numismatic_issues/numismatic_issues_controller_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe NumismaticIssuesController, type: :controller do
 
       expect(response.headers["Content-Type"]).to include "application/json"
       expect(manifest_response[:manifests].length).to eq 1
-      expect(manifest_response[:viewingHint]).to eq "multi-part"
+      expect(manifest_response[:viewingHint]).to eq nil
     end
   end
 end

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -680,4 +680,27 @@ RSpec.describe ManifestBuilder do
       expect(output["viewingDirection"]).to eq nil
     end
   end
+
+  context "when given a numismatic issue" do
+    subject(:manifest_builder) { described_class.new(query_service.find_by(id: numismatic_issue.id)) }
+    let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }
+    let(:numismatic_issue) { FactoryBot.create_for_repository(:numismatic_issue) }
+    let(:change_set) { NumismaticIssueChangeSet.new(numismatic_issue, member_ids: [coin1.id, coin2.id, coin3.id]) }
+    let(:coin1) { FactoryBot.create_for_repository(:coin, files: [file1]) }
+    let(:coin2) { FactoryBot.create_for_repository(:coin, files: [file2]) }
+    let(:coin3) { FactoryBot.create_for_repository(:coin) }
+    let(:file1) { fixture_file_upload("files/abstract.tiff", "image/tiff") }
+    let(:file2) { fixture_file_upload("files/abstract.tiff", "image/tiff") }
+    before do
+      numismatic_issue
+      change_set_persister.save(change_set: change_set)
+    end
+    it "builds a IIIF document with only the coins that have images" do
+      output = manifest_builder.build
+      expect(output["@type"]).to eq "sc:Collection"
+      expect(output["manifests"].length).to eq 2
+      expect(output["manifests"][0]["label"]).to eq ["Coin: 1"]
+      expect(output["manifests"][1]["label"]).to eq ["Coin: 2"]
+    end
+  end
 end


### PR DESCRIPTION
Prevents a sequence 0 error in the UV viewer by building the manifest with only the coins that have an image

Co-authored-by: Trey Pendragon <tpendragon@princeton.edu>