### PR TITLE
Add Rake task to reindex everything except FileSets

### DIFF
--- a/lib/tasks/reindex.rake
+++ b/lib/tasks/reindex.rake
@@ -17,6 +17,10 @@ desc "Reindexes everything without wiping Solr."
 task reindex: :environment do
   Reindexer.reindex_all(wipe: false, solr_adapter: reindexer_solr_adapter)
 end
+desc "Reindexes everything but FileSets without wiping Solr."
+task reindex_works: :environment do
+  Reindexer.reindex_works(wipe: false, solr_adapter: reindexer_solr_adapter)
+end
 
 namespace :geoblacklight do
   desc "Reindex Geospatial Resources (for synchronized GeoBlacklight installations)"

--- a/spec/services/reindexer_spec.rb
+++ b/spec/services/reindexer_spec.rb
@@ -102,4 +102,15 @@ RSpec.describe Reindexer do
       end
     end
   end
+
+  describe ".reindex_works" do
+    context "when there are FileSets" do
+      it "doesn't index them" do
+        postgres_adapter.persister.save(resource: FactoryBot.build(:file_set))
+        scanned_resource = postgres_adapter.persister.save(resource: FactoryBot.build(:scanned_resource))
+        described_class.reindex_works(logger: logger, wipe: true)
+        expect(solr_adapter.query_service.find_all.map(&:id)).to eq([scanned_resource.id])
+      end
+    end
+  end
 end


### PR DESCRIPTION
* Add Rake task to reindex everything but FileSets
* Reduces batch size to 500 to avoid `Request Entity Too Large` errors

Fixes #3031