### PR TITLE
Ensures that ImageMagick errors for ScannedMap derivative generation are logged and that derivatives are cleaned up when these errors occur

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -133,6 +133,7 @@ Metrics/LineLength:
     - 'spec/views/catalog/_members_coin.html.erb_spec.rb'
     - 'spec/helpers/application_helper_spec.rb'
     - 'spec/resources/collections/collections_controller_spec.rb'
+    - 'spec/jobs/create_derivatives_job_spec.rb'
 Metrics/MethodLength:
   Exclude:
     - 'db/migrate/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -187,6 +187,7 @@ Metrics/MethodLength:
     - 'app/services/ingest_ephemera_mods.rb'
     - 'app/helpers/thumbnail_helper.rb'
     - 'app/exporters/hathi/submission_information_package.rb'
+    - 'app/jobs/create_derivatives_job.rb'
 Metrics/ModuleLength:
   Exclude:
     - 'app/models/schema/marc_relators.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -182,6 +182,7 @@ Metrics/MethodLength:
     - 'app/services/preserver/importer.rb'
     - 'app/jobs/bulk_update_job.rb'
     - 'app/jobs/browse_everything_ingest_job.rb'
+    - 'app/derivative_services/scanned_map_derivative_service.rb'
     - 'app/controllers/application_controller.rb'
     - 'app/services/ingest_ephemera_mods.rb'
     - 'app/helpers/thumbnail_helper.rb'

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,13 @@ Release notes template:
 
 ## Removed
 
+-->
+# 2019-12-20
+
+## Fixed
+
+* Derivative files are now deleted for geospatial resources (ScannedMaps, RasterResources, and VectorResources) when derivative generation fails.
+
 # 2019-12-16
 
 ## Fixed

--- a/app/derivative_services/scanned_map_derivative_service.rb
+++ b/app/derivative_services/scanned_map_derivative_service.rb
@@ -43,6 +43,9 @@ class ScannedMapDerivativeService
   def create_derivatives
     jp2_derivative_service.create_derivatives if jp2_derivative_service.valid?
     thumbnail_derivative_service.create_derivatives if thumbnail_derivative_service.valid?
+  rescue MiniMagick::Error => mini_magick_error
+    Rails.logger.error "Failed to generate JP2000 derivatives for #{id}: #{mini_magick_error.message}"
+    cleanup_derivatives
   end
 
   # Removes Valkyrie::StorageAdapter::File member Objects for any given Resource (usually a FileSet)

--- a/app/derivative_services/scanned_map_derivative_service.rb
+++ b/app/derivative_services/scanned_map_derivative_service.rb
@@ -43,10 +43,6 @@ class ScannedMapDerivativeService
   def create_derivatives
     jp2_derivative_service.create_derivatives if jp2_derivative_service.valid?
     thumbnail_derivative_service.create_derivatives if thumbnail_derivative_service.valid?
-  rescue MiniMagick::Error => mini_magick_error
-    Rails.logger.error "Failed to generate JP2000 derivatives for #{id}: #{mini_magick_error.message}"
-    cleanup_derivatives
-    raise mini_magick_error
   end
 
   # Removes Valkyrie::StorageAdapter::File member Objects for any given Resource (usually a FileSet)

--- a/app/derivative_services/scanned_map_derivative_service.rb
+++ b/app/derivative_services/scanned_map_derivative_service.rb
@@ -46,6 +46,7 @@ class ScannedMapDerivativeService
   rescue MiniMagick::Error => mini_magick_error
     Rails.logger.error "Failed to generate JP2000 derivatives for #{id}: #{mini_magick_error.message}"
     cleanup_derivatives
+    raise mini_magick_error
   end
 
   # Removes Valkyrie::StorageAdapter::File member Objects for any given Resource (usually a FileSet)

--- a/app/jobs/create_derivatives_job.rb
+++ b/app/jobs/create_derivatives_job.rb
@@ -4,14 +4,21 @@ class CreateDerivativesJob < ApplicationJob
 
   # @param file_set_id [string] stringified Valkyrie id
   def perform(file_set_id)
-    Valkyrie::Derivatives::DerivativeService.for(id: file_set_id).create_derivatives
+    derivative_service = find_derivative_service(file_set_id)
+    derivative_service.create_derivatives
     file_set = query_service.find_by(id: Valkyrie::ID.new(file_set_id))
     file_set.processing_status = "processed"
     metadata_adapter.persister.save(resource: file_set)
     messenger.derivatives_created(file_set)
     CheckFixityJob.perform_later(file_set_id)
-  rescue Valkyrie::Persistence::ObjectNotFoundError => error
-    Valkyrie.logger.warn "#{self.class}: #{error}: Failed to find the resource #{file_set_id}"
+  rescue Valkyrie::Persistence::ObjectNotFoundError => not_found_error
+    Valkyrie.logger.warn "#{self.class}: #{not_found_error}: Failed to find the resource #{file_set_id}"
+  rescue StandardError => error
+    Valkyrie.logger.error "Failed to generate derivatives for #{file_set_id}: #{error.class}: #{error.message}"
+    # A StaleObject error will be raised if this is not reloaded
+    reloaded_derivative_service = find_derivative_service(file_set_id)
+    reloaded_derivative_service.cleanup_derivatives
+    raise error
   end
 
   def metadata_adapter
@@ -21,4 +28,12 @@ class CreateDerivativesJob < ApplicationJob
   def messenger
     @messenger ||= EventGenerator.new
   end
+
+  private
+
+    # @param file_set_id [String] the ID for the FileSet
+    # @return
+    def find_derivative_service(file_set_id)
+      Valkyrie::Derivatives::DerivativeService.for(id: file_set_id)
+    end
 end

--- a/spec/derivative_services/scanned_map_derivative_service_spec.rb
+++ b/spec/derivative_services/scanned_map_derivative_service_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+require "rails_helper"
+require "valkyrie/derivatives/specs/shared_specs"
+include ActionDispatch::TestProcess
+
+RSpec.describe ScannedMapDerivativeService do
+  it_behaves_like "a Valkyrie::Derivatives::DerivativeService"
+
+  let(:derivative_service) do
+    ScannedMapDerivativeService::Factory.new(change_set_persister: change_set_persister)
+  end
+  let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
+  let(:storage_adapter) { Valkyrie.config.storage_adapter }
+  let(:persister) { adapter.persister }
+  let(:query_service) { adapter.query_service }
+  let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }
+  let(:change_set_persister) { ChangeSetPersister.new(metadata_adapter: adapter, storage_adapter: storage_adapter) }
+  let(:scanned_map) do
+    change_set_persister.save(change_set: ScannedMapChangeSet.new(ScannedMap.new, files: [file]))
+  end
+  let(:scanned_map_members) { query_service.find_members(resource: scanned_map) }
+  let(:valid_resource) { scanned_map_members.first }
+  let(:valid_change_set) { DynamicChangeSet.new(valid_resource) }
+  let(:valid_id) { valid_change_set.id }
+
+  describe "#valid?" do
+    subject(:valid_file) { derivative_service.new(id: valid_change_set.id) }
+
+    context "when given a valid mime_type" do
+      it { is_expected.to be_valid }
+    end
+  end
+
+  context "with a scanned map tif" do
+    it "creates a JPEG thumbnail and attaches it to the fileset" do
+      derivative_service.new(id: valid_change_set.id).create_derivatives
+      reloaded = query_service.find_by(id: valid_resource.id)
+      thumbnail = reloaded.thumbnail_files.first
+      expect(thumbnail).to be_present
+      thumbnail_file = Valkyrie::StorageAdapter.find_by(id: thumbnail.file_identifiers.first)
+      image = MiniMagick::Image.open(thumbnail_file.disk_path)
+      expect(image.width).to eq 200
+      expect(image.height).to eq 287
+    end
+  end
+
+  context "with a malformed scanned map tiff" do
+    let(:file) { fixture_file_upload("files/bad.tif", "image/tiff") }
+
+    it "stores an error message on the fileset" do
+      expect { derivative_service.new(id: valid_change_set.id).create_derivatives }.to raise_error(MiniMagick::Invalid)
+      file_set = query_service.find_all_of_model(model: FileSet).first
+      expect(file_set.original_file.error_message).to include(/bad magic number/)
+    end
+  end
+
+  context "when the JP2000 derivative generation raises an error" do
+    let(:jp2_derivative_service) { instance_double(Jp2DerivativeService) }
+    let(:jp2_derivative_service_factory) { instance_double(Jp2DerivativeService::Factory) }
+
+    before do
+      allow(jp2_derivative_service).to receive(:cleanup_derivatives)
+      allow(jp2_derivative_service).to receive(:create_derivatives).and_raise(MiniMagick::Error)
+      allow(jp2_derivative_service).to receive(:valid?).and_return(true)
+      allow(jp2_derivative_service_factory).to receive(:new).and_return(jp2_derivative_service)
+      allow(Jp2DerivativeService::Factory).to receive(:new).and_return(jp2_derivative_service_factory)
+      allow(Rails.logger).to receive(:error)
+
+      derivative_service.new(id: valid_change_set.id).create_derivatives
+    end
+
+    it "logs the error and cleans up the derivatives" do
+      expect(jp2_derivative_service).to have_received(:cleanup_derivatives).once
+      reloaded = query_service.find_by(id: valid_resource.id)
+      expect(reloaded.thumbnail_files).to be_empty
+
+      expect(Rails.logger).to have_received(:error).with("Failed to generate JP2000 derivatives for #{valid_resource.id}: MiniMagick::Error")
+    end
+  end
+end

--- a/spec/derivative_services/scanned_map_derivative_service_spec.rb
+++ b/spec/derivative_services/scanned_map_derivative_service_spec.rb
@@ -65,11 +65,10 @@ RSpec.describe ScannedMapDerivativeService do
       allow(jp2_derivative_service_factory).to receive(:new).and_return(jp2_derivative_service)
       allow(Jp2DerivativeService::Factory).to receive(:new).and_return(jp2_derivative_service_factory)
       allow(Rails.logger).to receive(:error)
-
-      derivative_service.new(id: valid_change_set.id).create_derivatives
     end
 
     it "logs the error and cleans up the derivatives" do
+      expect { derivative_service.new(id: valid_change_set.id).create_derivatives }.to raise_error(MiniMagick::Error)
       expect(jp2_derivative_service).to have_received(:cleanup_derivatives).once
       reloaded = query_service.find_by(id: valid_resource.id)
       expect(reloaded.thumbnail_files).to be_empty

--- a/spec/derivative_services/scanned_map_derivative_service_spec.rb
+++ b/spec/derivative_services/scanned_map_derivative_service_spec.rb
@@ -53,27 +53,4 @@ RSpec.describe ScannedMapDerivativeService do
       expect(file_set.original_file.error_message).to include(/bad magic number/)
     end
   end
-
-  context "when the JP2000 derivative generation raises an error" do
-    let(:jp2_derivative_service) { instance_double(Jp2DerivativeService) }
-    let(:jp2_derivative_service_factory) { instance_double(Jp2DerivativeService::Factory) }
-
-    before do
-      allow(jp2_derivative_service).to receive(:cleanup_derivatives)
-      allow(jp2_derivative_service).to receive(:create_derivatives).and_raise(MiniMagick::Error)
-      allow(jp2_derivative_service).to receive(:valid?).and_return(true)
-      allow(jp2_derivative_service_factory).to receive(:new).and_return(jp2_derivative_service)
-      allow(Jp2DerivativeService::Factory).to receive(:new).and_return(jp2_derivative_service_factory)
-      allow(Rails.logger).to receive(:error)
-    end
-
-    it "logs the error and cleans up the derivatives" do
-      expect { derivative_service.new(id: valid_change_set.id).create_derivatives }.to raise_error(MiniMagick::Error)
-      expect(jp2_derivative_service).to have_received(:cleanup_derivatives).once
-      reloaded = query_service.find_by(id: valid_resource.id)
-      expect(reloaded.thumbnail_files).to be_empty
-
-      expect(Rails.logger).to have_received(:error).with("Failed to generate JP2000 derivatives for #{valid_resource.id}: MiniMagick::Error")
-    end
-  end
 end

--- a/spec/jobs/create_derivatives_job_spec.rb
+++ b/spec/jobs/create_derivatives_job_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe CreateDerivativesJob do
 
       before do
         allow(jp2_derivative_service).to receive(:cleanup_derivatives)
-        allow(jp2_derivative_service).to receive(:create_derivatives).and_raise(MiniMagick::Error)
+        allow(jp2_derivative_service).to receive(:create_derivatives).and_raise(MiniMagick::Error, "ImageMagick/GraphicsMagick is not installed")
         allow(Valkyrie::Derivatives::DerivativeService).to receive(:for).and_return(jp2_derivative_service)
         allow(Valkyrie.logger).to receive(:error)
       end
@@ -48,7 +48,7 @@ RSpec.describe CreateDerivativesJob do
         reloaded = query_service.find_by(id: file_set.id)
         expect(reloaded.thumbnail_files).to be_empty
 
-        expect(Valkyrie.logger).to have_received(:error).with(/Failed to generate derivatives for #{file_set.id}: MiniMagick::Error/)
+        expect(Valkyrie.logger).to have_received(:error).with("Failed to generate derivatives for #{file_set.id}: MiniMagick::Error: ImageMagick/GraphicsMagick is not installed")
       end
     end
 

--- a/spec/jobs/create_derivatives_job_spec.rb
+++ b/spec/jobs/create_derivatives_job_spec.rb
@@ -3,11 +3,19 @@ require "rails_helper"
 
 RSpec.describe CreateDerivativesJob do
   let(:derivatives_service) { instance_double(Valkyrie::Derivatives::DerivativeService) }
-  let(:file_set) { FactoryBot.create_for_repository(:file_set) }
+  let(:file) { fixture_file_upload("files/holding_locations.json", "image/tiff") }
+  let(:metadata_adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
+  let(:query_service) { metadata_adapter.query_service }
+  let(:storage_adapter) { Valkyrie.config.storage_adapter }
+  let(:change_set_persister) { ChangeSetPersister.new(metadata_adapter: metadata_adapter, storage_adapter: storage_adapter) }
+  let(:scanned_resource) do
+    FactoryBot.create_for_repository(:complete_scanned_resource, files: [file])
+  end
+  let(:file_set) do
+    scanned_resource.decorate.file_sets.first
+  end
   let(:fixity_job) { instance_double(CheckFixityJob) }
   let(:generator) { EventGenerator.new }
-  let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
-  let(:query_service) { adapter.query_service }
 
   before do
     allow(Valkyrie::Derivatives::DerivativeService).to receive(:for).and_return(derivatives_service)
@@ -15,6 +23,7 @@ RSpec.describe CreateDerivativesJob do
     allow(EventGenerator).to receive(:new).and_return(generator)
     allow(generator).to receive(:derivatives_created).and_call_original
     allow(CheckFixityJob).to receive(:set).and_return(CheckFixityJob)
+    stub_ezid(shoulder: "99999/fk4", blade: "1234567")
   end
 
   describe "#perform_now" do
@@ -40,10 +49,11 @@ RSpec.describe CreateDerivativesJob do
         allow(jp2_derivative_service).to receive(:create_derivatives).and_raise(MiniMagick::Error, "ImageMagick/GraphicsMagick is not installed")
         allow(Valkyrie::Derivatives::DerivativeService).to receive(:for).and_return(jp2_derivative_service)
         allow(Valkyrie.logger).to receive(:error)
+
+        described_class.perform_now(file_set.id.to_s)
       end
 
       it "logs the error and cleans up the derivatives" do
-        expect { described_class.perform_now(file_set.id.to_s) }.to raise_error(MiniMagick::Error)
         expect(jp2_derivative_service).to have_received(:cleanup_derivatives).once
         reloaded = query_service.find_by(id: file_set.id)
         expect(reloaded.thumbnail_files).to be_empty
@@ -52,24 +62,25 @@ RSpec.describe CreateDerivativesJob do
       end
     end
 
-    context "when the JP2000 derivative generation raises a generic error" do
+    context "when the JP2000 derivative generation raises a generic error", run_real_derivatives: true do
+      with_queue_adapter :inline
       let(:jp2_derivative_service) { instance_double(Jp2DerivativeService) }
       let(:jp2_derivative_service_factory) { instance_double(Jp2DerivativeService::Factory) }
 
       before do
         allow(jp2_derivative_service).to receive(:cleanup_derivatives)
         allow(jp2_derivative_service).to receive(:create_derivatives).and_raise(Valkyrie::Persistence::StaleObjectError, "The object foo has been updated by another process.")
-        allow(Valkyrie::Derivatives::DerivativeService).to receive(:for).and_return(jp2_derivative_service)
+        allow(Valkyrie::Derivatives::DerivativeService).to receive(:for).and_call_original
         allow(Valkyrie.logger).to receive(:error)
       end
 
       it "logs the error and cleans up the derivatives" do
-        expect { described_class.perform_now(file_set.id.to_s) }.to raise_error(Valkyrie::Persistence::StaleObjectError)
-        expect(jp2_derivative_service).to have_received(:cleanup_derivatives).once
-        reloaded = query_service.find_by(id: file_set.id)
-        expect(reloaded.thumbnail_files).to be_empty
+        file_set
+        reloaded = query_service.find_by(id: scanned_resource.id)
+        persisted_file_set = reloaded.decorate.file_sets.first
+        expect(persisted_file_set.thumbnail_files).to be_empty
 
-        expect(Valkyrie.logger).to have_received(:error).with("Failed to generate derivatives for #{file_set.id}: Valkyrie::Persistence::StaleObjectError: The object foo has been updated by another process.")
+        expect(Valkyrie.logger).to have_received(:error).with(/Failed to generate derivatives for #{file_set.id}: MiniMagick::Invalid/)
       end
     end
   end

--- a/spec/support/stub_rabbit.rb
+++ b/spec/support/stub_rabbit.rb
@@ -30,6 +30,8 @@ RSpec.configure do |config|
       # silence bunny logging
       logger = instance_double(Logger)
       allow(logger).to receive(:warn)
+      allow(logger).to receive(:debug)
+      allow(logger).to receive(:info)
       allow_any_instance_of(Bunny::Session).to receive(:init_default_logger).and_return(logger)
     end
   end


### PR DESCRIPTION
Resolves #2978 and #2539