### PR TITLE
Keep Track of and display status of FileSet derivative creation

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -87,6 +87,7 @@ class CatalogController < ApplicationController
     config.show.document_actions.clear
     config.add_show_tools_partial(:admin_controls, partial: "admin_controls", if: :can_edit?)
     config.show.partials = config.show.partials.insert(1, :parent_breadcrumb)
+    config.show.partials = config.show.partials.insert(1, :in_process_notification)
     config.show.partials += [:universal_viewer]
     config.show.partials += [:resource_attributes]
     config.show.partials += [:auth_link]

--- a/app/jobs/create_derivatives_job.rb
+++ b/app/jobs/create_derivatives_job.rb
@@ -4,8 +4,10 @@ class CreateDerivativesJob < ApplicationJob
 
   # @param file_set_id [string] stringified Valkyrie id
   def perform(file_set_id)
-    file_set = query_service.find_by(id: Valkyrie::ID.new(file_set_id))
     Valkyrie::Derivatives::DerivativeService.for(id: file_set_id).create_derivatives
+    file_set = query_service.find_by(id: Valkyrie::ID.new(file_set_id))
+    file_set.processing_status = "processed"
+    metadata_adapter.persister.save(resource: file_set)
     messenger.derivatives_created(file_set)
     CheckFixityJob.perform_later(file_set_id)
   rescue Valkyrie::Persistence::ObjectNotFoundError => error

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -25,4 +25,8 @@ class SolrDocument
   def decorated_resource
     @decorated_resource ||= resource.decorate
   end
+
+  def wayfinder
+    @wayfinder ||= Wayfinder.for(resource)
+  end
 end

--- a/app/queries/find_deep_children_with_property.rb
+++ b/app/queries/find_deep_children_with_property.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+class FindDeepChildrenWithProperty
+  def self.queries
+    [:find_deep_children_with_property]
+  end
+
+  attr_reader :query_service
+  delegate :resource_factory, to: :query_service
+  delegate :run_query, to: :query_service
+  def initialize(query_service:)
+    @query_service = query_service
+  end
+
+  def find_deep_children_with_property(resource:, model:, property:, value:)
+    run_query(relationship_query, id: resource.id.to_s, model: model.to_s, property_query: { property => Array.wrap(value) }.to_json)
+  end
+
+  def relationship_query
+    <<-SQL
+        WITH RECURSIVE deep_members AS (
+          select member.*
+          FROM orm_resources a,
+          jsonb_array_elements(a.metadata->'member_ids') AS b(member)
+          JOIN orm_resources member ON (b.member->>'id')::UUID = member.id
+          WHERE a.id = :id
+          UNION
+          SELECT mem.*
+          FROM deep_members f,
+          jsonb_array_elements(f.metadata->'member_ids') AS g(member)
+          JOIN orm_resources mem ON (g.member->>'id')::UUID = mem.id
+        )
+        select * from deep_members
+        WHERE internal_resource = :model
+        AND metadata @> :property_query
+    SQL
+  end
+
+  def id_type
+    "UUID"
+  end
+end

--- a/app/queries/find_deep_children_with_property.rb
+++ b/app/queries/find_deep_children_with_property.rb
@@ -38,8 +38,4 @@ class FindDeepChildrenWithProperty
         AND metadata @> :property_query
     SQL
   end
-
-  def id_type
-    "UUID"
-  end
 end

--- a/app/resources/file_sets/file_set.rb
+++ b/app/resources/file_sets/file_set.rb
@@ -13,6 +13,7 @@ class FileSet < Resource
   attribute :side, Valkyrie::Types::Set
   attribute :part, Valkyrie::Types::Set
   attribute :transfer_notes
+  attribute :processing_status, Valkyrie::Types::String.optional
 
   delegate :width,
            :height,

--- a/app/resources/scanned_resources/scanned_resource_wayfinder.rb
+++ b/app/resources/scanned_resources/scanned_resource_wayfinder.rb
@@ -16,6 +16,10 @@ class ScannedResourceWayfinder < BaseWayfinder
     @in_process_file_sets_count ||= query_service.custom_queries.find_deep_children_with_property(resource: resource, model: FileSet, property: :processing_status, value: "in process", count: true)
   end
 
+  def processed_file_sets_count
+    @in_process_file_sets_count ||= query_service.custom_queries.find_deep_children_with_property(resource: resource, model: FileSet, property: :processing_status, value: "processed", count: true)
+  end
+
   def members_with_parents
     @members_with_parents ||= members.map do |member|
       member.loaded[:parents] = [resource]

--- a/app/resources/scanned_resources/scanned_resource_wayfinder.rb
+++ b/app/resources/scanned_resources/scanned_resource_wayfinder.rb
@@ -17,7 +17,7 @@ class ScannedResourceWayfinder < BaseWayfinder
   end
 
   def processed_file_sets_count
-    @in_process_file_sets_count ||= query_service.custom_queries.find_deep_children_with_property(resource: resource, model: FileSet, property: :processing_status, value: "processed", count: true)
+    @processed_file_sets_count ||= query_service.custom_queries.find_deep_children_with_property(resource: resource, model: FileSet, property: :processing_status, value: "processed", count: true)
   end
 
   def members_with_parents

--- a/app/resources/scanned_resources/scanned_resource_wayfinder.rb
+++ b/app/resources/scanned_resources/scanned_resource_wayfinder.rb
@@ -12,6 +12,10 @@ class ScannedResourceWayfinder < BaseWayfinder
     @scanned_resources_count ||= query_service.custom_queries.count_members(resource: resource, model: ScannedResource)
   end
 
+  def in_process_file_sets_count
+    @in_process_file_sets_count ||= query_service.custom_queries.find_deep_children_with_property(resource: resource, model: FileSet, property: :processing_status, value: "in process", count: true)
+  end
+
   def members_with_parents
     @members_with_parents ||= members.map do |member|
       member.loaded[:parents] = [resource]

--- a/app/services/file_appender.rb
+++ b/app/services/file_appender.rb
@@ -87,7 +87,8 @@ class FileAppender
     def create_file_set(file_node, file)
       attributes = {
         title: file_node.original_filename,
-        file_metadata: [file_node]
+        file_metadata: [file_node],
+        processing_status: "in process"
       }.merge(
         file.try(:container_attributes) || {}
       )

--- a/app/views/catalog/_in_process_notification_default.html.erb
+++ b/app/views/catalog/_in_process_notification_default.html.erb
@@ -1,0 +1,6 @@
+<% if @document.wayfinder.try(:in_process_file_sets_count).to_i > 0 %>
+  <div class="alert alert-warning" role="alert">Files currently processing: <%= @document.wayfinder.in_process_file_sets_count %></div>
+<% end %>
+<% if @document.resource.try(:pending_uploads).present? %>
+  <div class="alert alert-warning" role="alert">Files currently attaching: <%= @document.resource.pending_uploads.length %></div>
+<% end %>

--- a/app/views/catalog/_in_process_notification_default.html.erb
+++ b/app/views/catalog/_in_process_notification_default.html.erb
@@ -2,5 +2,5 @@
   <div class="alert alert-warning" role="alert">Files Processed: <%= @document.wayfinder.processed_file_sets_count %> / <%= @document.wayfinder.processed_file_sets_count + @document.wayfinder.in_process_file_sets_count %></div>
 <% end %>
 <% if @document.resource.try(:pending_uploads).present? %>
-  <div class="alert alert-warning" role="alert">Files currently attaching: <%= @document.resource.pending_uploads.length %></div>
+  <div class="alert alert-warning" role="alert">Pending Uploads: <%= @document.resource.pending_uploads.length %></div>
 <% end %>

--- a/app/views/catalog/_in_process_notification_default.html.erb
+++ b/app/views/catalog/_in_process_notification_default.html.erb
@@ -1,5 +1,5 @@
 <% if @document.wayfinder.try(:in_process_file_sets_count).to_i > 0 %>
-  <div class="alert alert-warning" role="alert">Files currently processing: <%= @document.wayfinder.in_process_file_sets_count %></div>
+  <div class="alert alert-warning" role="alert">Files Processed: <%= @document.wayfinder.processed_file_sets_count %> / <%= @document.wayfinder.processed_file_sets_count + @document.wayfinder.in_process_file_sets_count %></div>
 <% end %>
 <% if @document.resource.try(:pending_uploads).present? %>
   <div class="alert alert-warning" role="alert">Files currently attaching: <%= @document.resource.pending_uploads.length %></div>

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -358,7 +358,8 @@ Rails.application.config.to_prepare do
     FindIdUsageByModel,
     UpdatedArchivalResources,
     FindRandomResourcesByModel,
-    CountAllOfModel
+    CountAllOfModel,
+    FindDeepChildrenWithProperty
   ].each do |query_handler|
     Valkyrie.config.metadata_adapter.query_service.custom_queries.register_query_handler(query_handler)
   end

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe FileSet do
       expect(described_class.optimistic_locking_enabled?).to eq true
     end
   end
+  describe "processing_status" do
+    it "is a property" do
+      expect(described_class.schema.key?(:processing_status)).to eq true
+    end
+  end
   describe ".run_fixity" do
     let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }
     let(:resource) { FactoryBot.build(:scanned_resource) }

--- a/spec/queries/find_deep_children_with_property_spec.rb
+++ b/spec/queries/find_deep_children_with_property_spec.rb
@@ -21,5 +21,20 @@ RSpec.describe FindDeepChildrenWithProperty do
 
       expect(output.map(&:id)).to contain_exactly fs1.id, fs2.id, fs3.id
     end
+    it "provides a count if given one" do
+      fs1 = FactoryBot.create_for_repository(:file_set, processing_status: "in process")
+      fs2 = FactoryBot.create_for_repository(:file_set, processing_status: "in process")
+      fs3 = FactoryBot.create_for_repository(:file_set, processing_status: "in process")
+      ok_fs = FactoryBot.create_for_repository(:file_set, processing_status: "processed")
+      # Create unrelated FS
+      FactoryBot.create_for_repository(:file_set)
+      volume1 = FactoryBot.create_for_repository(:scanned_resource, member_ids: fs1.id)
+      volume2 = FactoryBot.create_for_repository(:scanned_resource, member_ids: [fs2.id, ok_fs.id])
+      mvw = FactoryBot.create_for_repository(:scanned_resource, member_ids: [volume1.id, volume2.id, fs3.id])
+
+      output = query.find_deep_children_with_property(resource: mvw, model: FileSet, property: :processing_status, value: "in process", count: true)
+
+      expect(output).to eq 3
+    end
   end
 end

--- a/spec/queries/find_deep_children_with_property_spec.rb
+++ b/spec/queries/find_deep_children_with_property_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe FindDeepChildrenWithProperty do
+  subject(:query) { described_class.new(query_service: query_service) }
+  let(:query_service) { Valkyrie.config.metadata_adapter.query_service }
+
+  describe "#find_deep_children_with_property" do
+    it "finds all children through a hierarchy with a given property" do
+      fs1 = FactoryBot.create_for_repository(:file_set, processing_status: "in process")
+      fs2 = FactoryBot.create_for_repository(:file_set, processing_status: "in process")
+      fs3 = FactoryBot.create_for_repository(:file_set, processing_status: "in process")
+      ok_fs = FactoryBot.create_for_repository(:file_set, processing_status: "processed")
+      # Create unrelated FS
+      FactoryBot.create_for_repository(:file_set)
+      volume1 = FactoryBot.create_for_repository(:scanned_resource, member_ids: fs1.id)
+      volume2 = FactoryBot.create_for_repository(:scanned_resource, member_ids: [fs2.id, ok_fs.id])
+      mvw = FactoryBot.create_for_repository(:scanned_resource, member_ids: [volume1.id, volume2.id, fs3.id])
+
+      output = query.find_deep_children_with_property(resource: mvw, model: FileSet, property: :processing_status, value: "in process")
+
+      expect(output.map(&:id)).to contain_exactly fs1.id, fs2.id, fs3.id
+    end
+  end
+end

--- a/spec/views/catalog/_in_process_notification_default.html.erb_spec.rb
+++ b/spec/views/catalog/_in_process_notification_default.html.erb_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "catalog/_in_process_notification_default" do
   end
   context "when there's file sets in process" do
     it "gives an alert" do
-      expect(rendered).to have_text "Files currently processing: 1"
+      expect(rendered).to have_text "Files Processed: 0/1"
     end
   end
   context "when there's pending uploads" do

--- a/spec/views/catalog/_in_process_notification_default.html.erb_spec.rb
+++ b/spec/views/catalog/_in_process_notification_default.html.erb_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "catalog/_in_process_notification_default" do
+  let(:scanned_resource) { FactoryBot.create_for_repository(:scanned_resource, member_ids: [file_set1.id, file_set2.id]) }
+  let(:solr) { Valkyrie::MetadataAdapter.find(:index_solr) }
+  let(:document) { solr.resource_factory.from_resource(resource: scanned_resource) }
+  let(:solr_document) { SolrDocument.new(document) }
+  let(:user) { FactoryBot.create(:admin) }
+  let(:file_set1) { FactoryBot.create_for_repository(:file_set, processing_status: "in process") }
+  let(:file_set2) { FactoryBot.create_for_repository(:file_set, processing_status: "processed") }
+
+  before do
+    assign :resource, scanned_resource
+    assign :document, solr_document
+    sign_in user
+    render
+  end
+  context "when there's file sets in process" do
+    it "gives an alert" do
+      expect(rendered).to have_text "Files currently processing: 1"
+    end
+  end
+  context "when there's pending uploads" do
+    let(:scanned_resource) { FactoryBot.create_for_repository(:scanned_resource, pending_uploads: PendingUpload.new) }
+    it "gives an alert" do
+      expect(rendered).to have_text "Files currently attaching: 1"
+    end
+  end
+end

--- a/spec/views/catalog/_in_process_notification_default.html.erb_spec.rb
+++ b/spec/views/catalog/_in_process_notification_default.html.erb_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "catalog/_in_process_notification_default" do
   context "when there's pending uploads" do
     let(:scanned_resource) { FactoryBot.create_for_repository(:scanned_resource, pending_uploads: PendingUpload.new) }
     it "gives an alert" do
-      expect(rendered).to have_text "Files currently attaching: 1"
+      expect(rendered).to have_text "Pending Uploads: 1"
     end
   end
 end

--- a/spec/views/catalog/_in_process_notification_default.html.erb_spec.rb
+++ b/spec/views/catalog/_in_process_notification_default.html.erb_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "catalog/_in_process_notification_default" do
   end
   context "when there's file sets in process" do
     it "gives an alert" do
-      expect(rendered).to have_text "Files Processed: 0/1"
+      expect(rendered).to have_text "Files Processed: 1 / 2"
     end
   end
   context "when there's pending uploads" do

--- a/spec/wayfinders/wayfinder_spec.rb
+++ b/spec/wayfinders/wayfinder_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe Wayfinder do
         mvw = FactoryBot.create_for_repository(:scanned_resource, member_ids: [volume1.id, volume2.id, fs3.id])
 
         expect(described_class.for(mvw).in_process_file_sets_count).to eq 3
+        expect(described_class.for(mvw).processed_file_sets_count).to eq 1
       end
     end
 

--- a/spec/wayfinders/wayfinder_spec.rb
+++ b/spec/wayfinders/wayfinder_spec.rb
@@ -15,6 +15,22 @@ RSpec.describe Wayfinder do
       end
     end
 
+    describe "#in_process_file_sets_count" do
+      it "returns a count of all in process file sets, deep" do
+        fs1 = FactoryBot.create_for_repository(:file_set, processing_status: "in process")
+        fs2 = FactoryBot.create_for_repository(:file_set, processing_status: "in process")
+        fs3 = FactoryBot.create_for_repository(:file_set, processing_status: "in process")
+        ok_fs = FactoryBot.create_for_repository(:file_set, processing_status: "processed")
+        # Create unrelated FS
+        FactoryBot.create_for_repository(:file_set)
+        volume1 = FactoryBot.create_for_repository(:scanned_resource, member_ids: fs1.id)
+        volume2 = FactoryBot.create_for_repository(:scanned_resource, member_ids: [fs2.id, ok_fs.id])
+        mvw = FactoryBot.create_for_repository(:scanned_resource, member_ids: [volume1.id, volume2.id, fs3.id])
+
+        expect(described_class.for(mvw).in_process_file_sets_count).to eq 3
+      end
+    end
+
     describe "#members_with_parents" do
       it "returns undecorated members with parents pre-loaded" do
         member = FactoryBot.create_for_repository(:scanned_resource)


### PR DESCRIPTION
After browse everything attached, but files not moved to repository:
<img width="1158" alt="Screen Shot 2019-05-16 at 3 03 40 PM" src="https://user-images.githubusercontent.com/2806645/57890202-d53bd980-77eb-11e9-930c-895ce73f3254.png">

Before derivatives done being created:

<img width="1156" alt="Screen Shot 2019-05-16 at 3 04 38 PM" src="https://user-images.githubusercontent.com/2806645/57890253-f7cdf280-77eb-11e9-9515-f4129a2b9580.png">

Wanted to add a note: I benchmarked this query for production. On a MVW with 1300 total filesets it takes ~ 70 ms to count them.

Closes #2447 