### PR TITLE
Restores the Kakadu downloads (the website has been restored)

### DIFF
--- a/bin/ci_kakadu_install.sh
+++ b/bin/ci_kakadu_install.sh
@@ -1,10 +1,8 @@
 if [ ! -d "kakadu" ]; then
   mkdir ~/downloads
-  # Get kakadu from temporary location until website is back online
-  wget https://s3.amazonaws.com/kdubackupfiles/KDU78_Demo_Apps_for_Linux-x86-64_160226.zip -O ~/downloads/kakadu.zip
-  # wget http://kakadusoftware.com/wp-content/uploads/2014/06/KDU77_Demo_Apps_for_Linux-x86-64_150710.zip -O ~/downloads/kakadu.zip
+  wget http://kakadusoftware.com/wp-content/uploads/2014/06/KDU77_Demo_Apps_for_Linux-x86-64_150710.zip -O ~/downloads/kakadu.zip
   unzip ~/downloads/kakadu.zip
-  mv KDU78_Demo_Apps_for_Linux-x86-64_160226 kakadu
+  mv KDU77_Demo_Apps_for_Linux-x86-64_150710 kakadu
 fi
 sudo cp kakadu/*.so /usr/lib
 sudo cp kakadu/* /usr/bin


### PR DESCRIPTION
The Kakadu downloads should be restored:
```
% curl -I "http://kakadusoftware.com/wp-content/uploads/2014/06/KDU77_Demo_Apps_for_Linux-x86-64_150710.zip"
HTTP/1.1 200 OK
Date: Fri, 17 May 2019 15:09:29 GMT
...
```