### PR TITLE
Ensures that MiniMagick errors are handled within CreateDerivativesJobs and RegenerateDerivativesJob by logging the error message and explicitly restarting the jobs

### DIFF
--- a/app/jobs/create_derivatives_job.rb
+++ b/app/jobs/create_derivatives_job.rb
@@ -12,6 +12,9 @@ class CreateDerivativesJob < ApplicationJob
     CheckFixityJob.perform_later(file_set_id)
   rescue Valkyrie::Persistence::ObjectNotFoundError => error
     Valkyrie.logger.warn "#{self.class}: #{error}: Failed to find the resource #{file_set_id}"
+  rescue MiniMagick::Error => mini_magick_error
+    Rails.logger.error "Failed to create the derivatives for #{file_set.id}: #{mini_magick_error.message}"
+    self.class.perform_later(file_set_id.to_s)
   end
 
   def metadata_adapter

--- a/app/jobs/regenerate_derivatives_job.rb
+++ b/app/jobs/regenerate_derivatives_job.rb
@@ -10,6 +10,9 @@ class RegenerateDerivativesJob < ApplicationJob
     messenger.derivatives_created(file_set)
   rescue Valkyrie::Persistence::ObjectNotFoundError
     Rails.logger.error "Unable to find FileSet #{file_set_id}"
+  rescue MiniMagick::Error => mini_magick_error
+    Rails.logger.error "Failed to regenerate the derivatives for #{file_set.id}: #{mini_magick_error.message}"
+    self.class.perform_later(file_set_id.to_s)
   end
 
   def metadata_adapter

--- a/spec/jobs/create_derivatives_job_spec.rb
+++ b/spec/jobs/create_derivatives_job_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "rails_helper"
+include ActionDispatch::TestProcess
 
 RSpec.describe CreateDerivativesJob do
   let(:derivatives_service) { instance_double(Valkyrie::Derivatives::DerivativeService) }
@@ -7,15 +8,15 @@ RSpec.describe CreateDerivativesJob do
   let(:fixity_job) { instance_double(CheckFixityJob) }
   let(:generator) { EventGenerator.new }
 
-  before do
-    allow(Valkyrie::Derivatives::DerivativeService).to receive(:for).and_return(derivatives_service)
-    allow(derivatives_service).to receive(:create_derivatives)
-    allow(EventGenerator).to receive(:new).and_return(generator)
-    allow(generator).to receive(:derivatives_created).and_call_original
-    allow(CheckFixityJob).to receive(:set).and_return(CheckFixityJob)
-  end
-
   describe "#perform_now" do
+    before do
+      allow(Valkyrie::Derivatives::DerivativeService).to receive(:for).and_return(derivatives_service)
+      allow(derivatives_service).to receive(:create_derivatives)
+      allow(EventGenerator).to receive(:new).and_return(generator)
+      allow(generator).to receive(:derivatives_created).and_call_original
+      allow(CheckFixityJob).to receive(:set).and_return(CheckFixityJob)
+    end
+
     it "triggers a derivatives_created message", rabbit_stubbed: true do
       described_class.perform_now(file_set.id.to_s)
       expect(generator).to have_received(:derivatives_created)
@@ -47,6 +48,18 @@ RSpec.describe CreateDerivativesJob do
         expect(derivatives_service).to have_received(:create_derivatives).once
         expect(described_class).to have_received(:perform_later)
       end
+    end
+  end
+
+  context "with ImageMagick uninstalled on your MacBook" do
+    let(:file) { fixture_file_upload("files/abstract.tiff", "image/tiff") }
+    let(:scanned_resource) { FactoryBot.create_for_repository(:scanned_resource, files: [file]) }
+    let(:file_set) { scanned_resource.decorate.file_sets.first }
+    let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
+    let(:query_service) { adapter.query_service }
+
+    it "propagates an ImageMagick error", run_real_derivatives: true do
+      expect { described_class.perform_now(file_set.id.to_s) }.to raise_error(MiniMagick::Invalid)
     end
   end
 end


### PR DESCRIPTION
Resolves #2539 