### PR TITLE
remove broken monogram thumbnail link

### DIFF
--- a/app/views/numismatic_monograms/index.html.erb
+++ b/app/views/numismatic_monograms/index.html.erb
@@ -11,7 +11,7 @@
   <tbody>
       <% @numismatic_monograms.each do |monogram| %>
         <tr>
-          <td><%= render_thumbnail_tag monogram, { onerror: default_icon_fallback } %></td>
+          <td><%= render_thumbnail_tag monogram, { onerror: default_icon_fallback }, suppress_link: true %></td>
           <td><%= monogram.title %></td></td>
           <td>
             <%= link_to 'View', solr_document_path(monogram.id.to_s), class: 'btn btn-default' %>


### PR DESCRIPTION
Removes the manage monogram thumbnail link because it points to an invalid url:
https://figgy-staging.princeton.edu/concern/numismatic_monograms

Click "view" instead to view monogram object.