### PR TITLE
Require underscores to separate PULFA collection/component IDs

### DIFF
--- a/app/change_set_persisters/change_set_persister/extract_archival_collection_code.rb
+++ b/app/change_set_persisters/change_set_persister/extract_archival_collection_code.rb
@@ -11,14 +11,9 @@ class ChangeSetPersister
       return unless change_set.respond_to?(:source_metadata_identifier)
       return unless change_set.model.respond_to?(:archival_collection_code)
       return unless updated_values?
-      return if PulMetadataServices::Client.bibdata?(change_set.source_metadata_identifier)
-      change_set.model.archival_collection_code = self.class.extract_collection_code(change_set.source_metadata_identifier)
+      return unless RemoteRecord.pulfa?(change_set.source_metadata_identifier)
+      change_set.model.archival_collection_code = RemoteRecord.pulfa_collection(change_set.source_metadata_identifier)
       change_set
-    end
-
-    def self.extract_collection_code(pulfa_id)
-      m = pulfa_id.match(/^([a-zA-Z0-9.-]+)[_\/]?.*/)
-      m[1] if m
     end
 
     private

--- a/app/jobs/extract_archival_collection_code_job.rb
+++ b/app/jobs/extract_archival_collection_code_job.rb
@@ -3,10 +3,10 @@ class ExtractArchivalCollectionCodeJob < ApplicationJob
   def perform(logger: Logger.new(STDOUT))
     query_service.find_all_of_model(model: ScannedResource).each do |sr|
       next unless sr.source_metadata_identifier.present?
-      next if PulMetadataServices::Client.bibdata?(sr.source_metadata_identifier.first)
+      next unless RemoteRecord.pulfa?(sr.source_metadata_identifier.first)
       next if sr.archival_collection_code
 
-      sr.archival_collection_code = ChangeSetPersister::ExtractArchivalCollectionCode.extract_collection_code(sr.source_metadata_identifier.first)
+      sr.archival_collection_code = RemoteRecord.pulfa_collection(sr.source_metadata_identifier.first)
 
       logger.info "extracting archival collection code for #{sr.id}"
       metadata_adapter.persister.save(resource: sr)

--- a/app/models/remote_record.rb
+++ b/app/models/remote_record.rb
@@ -18,19 +18,19 @@ class RemoteRecord
 
   def self.pulfa?(source_metadata_identifier)
     return false if source_metadata_identifier.match?(/\//)
-    source_metadata_identifier.match?(/^([A-Z][a-zA-Z0-9\.-]+)(_[c0-9]+)?/)
+    source_metadata_identifier.match?(/^([A-Z][a-zA-Z0-9\.-]+)(_[a-z0-9]+)?/)
   end
 
   def self.pulfa_collection(source_metadata_identifier)
     return if source_metadata_identifier.match?(/\//)
-    m = source_metadata_identifier.match(/^([A-Z][a-zA-Z0-9.-]+)[_]?.*/)
+    m = source_metadata_identifier.match(/^([A-Z][a-zA-Z0-9.-]+)([_][a-z0-9]+)?/)
     m[1] if m
   end
 
   def self.pulfa_component(source_metadata_identifier)
     return if source_metadata_identifier.match?(/\//)
     return unless source_metadata_identifier.match?(/_/)
-    m = source_metadata_identifier.match(/^[A-Z][a-zA-Z0-9.-]+[_]?(.*)/)
+    m = source_metadata_identifier.match(/^[A-Z][a-zA-Z0-9.-]+_([a-z0-9]+)/)
     m[1] if m
   end
 
@@ -40,7 +40,7 @@ class RemoteRecord
 
   def self.source_metadata_url(id)
     return "https://bibdata.princeton.edu/bibliographic/#{id}" if bibdata?(id)
-    return "https://findingaids.princeton.edu/collections/#{id.tr('_', '/')}.xml?scope=record" if pulfa?(id)
+    "https://findingaids.princeton.edu/collections/#{id.tr('_', '/')}.xml?scope=record" if pulfa?(id)
   end
 
   class PulfaRecord

--- a/app/models/remote_record.rb
+++ b/app/models/remote_record.rb
@@ -5,9 +5,9 @@ class RemoteRecord
   # @param resource [Resource]
   # @return [RemoteRecord, RemoteRecord::PulfaRecord]
   def self.retrieve(source_metadata_identifier, resource_klass: nil)
-    if PulMetadataServices::Client.bibdata?(source_metadata_identifier)
+    if bibdata?(source_metadata_identifier)
       new(source_metadata_identifier)
-    else
+    elsif pulfa?(source_metadata_identifier)
       PulfaRecord.new(source_metadata_identifier, resource_klass)
     end
   end
@@ -16,9 +16,31 @@ class RemoteRecord
     PulMetadataServices::Client.bibdata?(source_metadata_identifier)
   end
 
+  def self.pulfa?(source_metadata_identifier)
+    return false if source_metadata_identifier.match?(/\//)
+    source_metadata_identifier.match?(/^([A-Z][a-zA-Z0-9\.-]+)(_[c0-9]+)?/)
+  end
+
+  def self.pulfa_collection(source_metadata_identifier)
+    return if source_metadata_identifier.match?(/\//)
+    m = source_metadata_identifier.match(/^([A-Z][a-zA-Z0-9.-]+)[_]?.*/)
+    m[1] if m
+  end
+
+  def self.pulfa_component(source_metadata_identifier)
+    return if source_metadata_identifier.match?(/\//)
+    return unless source_metadata_identifier.match?(/_/)
+    m = source_metadata_identifier.match(/^[A-Z][a-zA-Z0-9.-]+[_]?(.*)/)
+    m[1] if m
+  end
+
+  def self.valid?(source_metadata_identifier)
+    bibdata?(source_metadata_identifier) || pulfa?(source_metadata_identifier)
+  end
+
   def self.source_metadata_url(id)
     return "https://bibdata.princeton.edu/bibliographic/#{id}" if bibdata?(id)
-    "https://findingaids.princeton.edu/collections/#{id.tr('_', '/')}.xml?scope=record"
+    return "https://findingaids.princeton.edu/collections/#{id.tr('_', '/')}.xml?scope=record" if pulfa?(id)
   end
 
   class PulfaRecord

--- a/app/services/bulk_ingest_service.rb
+++ b/app/services/bulk_ingest_service.rb
@@ -31,7 +31,7 @@ class BulkIngestService
   # @param [String] value
   # @return [Boolean]
   def valid_remote_identifier?(value)
-    RemoteRecord.valid?(value)
+    RemoteRecord.valid?(value) && RemoteRecord.retrieve(value).success?
   rescue URI::InvalidURIError
     false
   end

--- a/app/services/bulk_ingest_service.rb
+++ b/app/services/bulk_ingest_service.rb
@@ -31,7 +31,7 @@ class BulkIngestService
   # @param [String] value
   # @return [Boolean]
   def valid_remote_identifier?(value)
-    RemoteRecord.retrieve(value).success?
+    RemoteRecord.valid?(value)
   rescue URI::InvalidURIError
     false
   end

--- a/app/services/source_metadata_identifier_migrator.rb
+++ b/app/services/source_metadata_identifier_migrator.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 class SourceMetadataIdentifierMigrator
   def self.call
+    Rails.logger.info "Updating all source_metadata_identifiers to use underscores instead of slashes"
+    ids = ids_to_process
+    progress_bar = ProgressBar.create format: "%a %e %P% Processed: %c from %C", total: ids.count
     ids.each_slice(100) do |slice|
       adapter.persister.buffer_into_index do |buf|
         slice.each do |id|
+          progress_bar.progress += 1
           r = query_service.find_by(id: id)
-          next unless r.source_metadata_identifier.first.match?(/\//)
+          next unless r.source_metadata_identifier.first&.match?(/\//)
 
           r.source_metadata_identifier = [r.source_metadata_identifier.first.tr("/", "_")]
           buf.persister.save(resource: r)
@@ -14,7 +18,7 @@ class SourceMetadataIdentifierMigrator
     end
   end
 
-  def self.ids
+  def self.ids_to_process
     query_service.custom_queries.find_ids_with_property_not_empty(property: :source_metadata_identifier)
   end
 

--- a/app/services/source_metadata_identifier_migrator.rb
+++ b/app/services/source_metadata_identifier_migrator.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+class SourceMetadataIdentifierMigrator
+  def self.call
+    ids.each_slice(100) do |slice|
+      adapter.persister.buffer_into_index do |buf|
+        slice.each do |id|
+          r = query_service.find_by(id: id)
+          next unless r.source_metadata_identifier.first.match?(/\//)
+
+          r.source_metadata_identifier = [r.source_metadata_identifier.first.tr("/", "_")]
+          buf.persister.save(resource: r)
+        end
+      end
+    end
+  end
+
+  def self.ids
+    query_service.custom_queries.find_ids_with_property_not_empty(property: :source_metadata_identifier)
+  end
+
+  def self.adapter
+    Valkyrie::MetadataAdapter.find(:indexing_persister)
+  end
+
+  def self.query_service
+    adapter.query_service
+  end
+end

--- a/app/validators/source_metadata_identifier_validator.rb
+++ b/app/validators/source_metadata_identifier_validator.rb
@@ -9,7 +9,7 @@ class SourceMetadataIdentifierValidator < ActiveModel::Validator
   def validate(record)
     return unless record.apply_remote_metadata?
     metadata_id = Array(record.source_metadata_identifier).first
-    return if RemoteRecord.retrieve(metadata_id).success?
+    raise URI::InvalidURIError unless RemoteRecord.valid?(metadata_id)
     record.errors.add(:source_metadata_identifier, "Error retrieving metadata")
   rescue URI::InvalidURIError
     error_message = "Invalid source metadata ID: #{metadata_id}"

--- a/app/validators/source_metadata_identifier_validator.rb
+++ b/app/validators/source_metadata_identifier_validator.rb
@@ -10,6 +10,7 @@ class SourceMetadataIdentifierValidator < ActiveModel::Validator
     return unless record.apply_remote_metadata?
     metadata_id = Array(record.source_metadata_identifier).first
     raise URI::InvalidURIError unless RemoteRecord.valid?(metadata_id)
+    return if RemoteRecord.retrieve(metadata_id).success?
     record.errors.add(:source_metadata_identifier, "Error retrieving metadata")
   rescue URI::InvalidURIError
     error_message = "Invalid source metadata ID: #{metadata_id}"

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -59,6 +59,7 @@ en:
         title: "Template Name"
     hints:
       scanned_resource:
+        source_metadata_identifier: 'Bib ID (1234567) or PULFA ID (C123 or C123_c456)'
         title: 'Required if Source Metadata ID is blank'
     required:
       html: '<span class="label label-info required-tag">required</span>'

--- a/db/migrate/20190521200107_update_source_metadata_identifier.rb
+++ b/db/migrate/20190521200107_update_source_metadata_identifier.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class UpdateSourceMetadataIdentifier < ActiveRecord::Migration[5.1]
+  def change
+    SourceMetadataIdentifierMigrator.call
+  end
+end

--- a/db/migrate/20190521200107_update_source_metadata_identifier.rb
+++ b/db/migrate/20190521200107_update_source_metadata_identifier.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-class UpdateSourceMetadataIdentifier < ActiveRecord::Migration[5.1]
-  def change
-    SourceMetadataIdentifierMigrator.call
-  end
-end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -9,20 +9,6 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
-
---
 -- Name: uuid-ossp; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -615,6 +601,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180810215750'),
 ('20181030210350'),
 ('20181115195544'),
-('20190102173711');
+('20190102173711'),
+('20190521200107');
 
 

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -59,6 +59,11 @@ namespace :migrate do
     RecordingDownloadableMigrator.call
   end
 
+  desc "Update source_metadata_identifier to always use underscores instead of slashes"
+  task source_metadata_identifiers: :environment do
+    SourceMetadataIdentifierMigrator.call
+  end
+
   private
 
     # Construct or retrieve the memoized logger for STDOUT

--- a/spec/change_set_persisters/change_set_persister/extract_archival_collection_code_spec.rb
+++ b/spec/change_set_persisters/change_set_persister/extract_archival_collection_code_spec.rb
@@ -2,17 +2,36 @@
 require "rails_helper"
 
 RSpec.describe ChangeSetPersister::ExtractArchivalCollectionCode do
-  subject(:hook) { described_class }
+  let(:change_set) { DynamicChangeSet.new(resource) }
+  let(:resource) { FactoryBot.build(:scanned_resource, source_metadata_identifier: source_metadata_id) }
 
-  describe "#extract_collection_code" do
-    it "can handle lots of variants" do
-      expect(hook.extract_collection_code("RCPXG-5830371.2_c0001")).to eq "RCPXG-5830371.2"
-      expect(hook.extract_collection_code("C0744.04_c0082")).to eq "C0744.04"
-      expect(hook.extract_collection_code("C0723.1-47_c0276")).to eq "C0723.1-47"
-      expect(hook.extract_collection_code("C0723.306e_c013")).to eq "C0723.306e"
-      expect(hook.extract_collection_code("MC001.03.03_c0171")).to eq "MC001.03.03"
-      expect(hook.extract_collection_code("MC016/c11318")).to eq "MC016"
-      expect(hook.extract_collection_code("MC001")).to eq "MC001"
+  context "with pulfa collection and component ids" do
+    let(:source_metadata_id) { "C0652_c0377" }
+    before { stub_pulfa(pulfa_id: source_metadata_id) }
+
+    it "extracts the collection code" do
+      updated = described_class.new(change_set_persister: nil, change_set: change_set).run
+      expect(updated.model.archival_collection_code).to eq "C0652"
+    end
+  end
+
+  context "with a pulfa collection id" do
+    let(:source_metadata_id) { "C0652" }
+    before { stub_pulfa(pulfa_id: source_metadata_id) }
+
+    it "extracts the collection code" do
+      updated = described_class.new(change_set_persister: nil, change_set: change_set).run
+      expect(updated.model.archival_collection_code).to eq "C0652"
+    end
+  end
+
+  context "with a bibdata id" do
+    let(:source_metadata_id) { "4609321" }
+    before { stub_bibdata(bib_id: source_metadata_id) }
+
+    it "does nothing" do
+      updated = described_class.new(change_set_persister: nil, change_set: change_set).run
+      expect(updated).to be nil
     end
   end
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -126,9 +126,9 @@ RSpec.describe CatalogController do
     end
     context "with metadata imported from pulfa" do
       it "can search by box and folder numbers" do
-        stub_pulfa(pulfa_id: "AC044/c0003")
+        stub_pulfa(pulfa_id: "AC044_c0003")
         stub_ezid(shoulder: "99999/fk4", blade: "8543429")
-        persister.save(resource: FactoryBot.create_for_repository(:complete_scanned_resource, title: [], source_metadata_identifier: "AC044/c0003", import_metadata: true))
+        persister.save(resource: FactoryBot.create_for_repository(:complete_scanned_resource, title: [], source_metadata_identifier: "AC044_c0003", import_metadata: true))
         get :index, params: { q: "Box 1 Folder 2" }
         expect(assigns(:document_list).length).to eq 1
       end

--- a/spec/models/remote_record_spec.rb
+++ b/spec/models/remote_record_spec.rb
@@ -30,6 +30,57 @@ RSpec.describe RemoteRecord, type: :model do
     end
   end
 
+  describe ".pulfa?" do
+    it "handles a lot of variants" do
+      expect(described_class.pulfa?("RCPXG-5830371.2_c0001")).to be true
+      expect(described_class.pulfa?("C0744.04_c0082")).to be true
+      expect(described_class.pulfa?("C0723.1-47_c0276")).to be true
+      expect(described_class.pulfa?("C0723.306e_c013")).to be true
+      expect(described_class.pulfa?("MC001.03.03_c0171")).to be true
+      expect(described_class.pulfa?("MC001")).to be true
+    end
+
+    it "does not allow slashes" do
+      expect(described_class.pulfa?("MC016/c11318")).to be false
+    end
+
+    it "is false for bib ids" do
+      expect(described_class.pulfa?("123456")).to be false
+    end
+  end
+
+  describe ".pulfa_collection" do
+    it "handles a lot of variants" do
+      expect(described_class.pulfa_collection("RCPXG-5830371.2_c0001")).to eq "RCPXG-5830371.2"
+      expect(described_class.pulfa_collection("C0744.04_c0082")).to eq "C0744.04"
+      expect(described_class.pulfa_collection("C0723.1-47_c0276")).to eq "C0723.1-47"
+      expect(described_class.pulfa_collection("C0723.306e_c013")).to eq "C0723.306e"
+      expect(described_class.pulfa_collection("MC001.03.03_c0171")).to eq "MC001.03.03"
+      expect(described_class.pulfa_collection("MC016_c11318")).to eq "MC016"
+      expect(described_class.pulfa_collection("MC001")).to eq "MC001"
+    end
+
+    it "does not allow slashes" do
+      expect(described_class.pulfa_collection("MC016/c11318")).to be nil
+    end
+  end
+
+  describe ".pulfa_component" do
+    it "handles a lot of variants" do
+      expect(described_class.pulfa_component("RCPXG-5830371.2_c0001")).to eq "c0001"
+      expect(described_class.pulfa_component("C0744.04_c0082")).to eq "c0082"
+      expect(described_class.pulfa_component("C0723.1-47_c0276")).to eq "c0276"
+      expect(described_class.pulfa_component("C0723.306e_c013")).to eq "c013"
+      expect(described_class.pulfa_component("MC001.03.03_c0171")).to eq "c0171"
+      expect(described_class.pulfa_component("MC016_c11318")).to eq "c11318"
+      expect(described_class.pulfa_component("MC001")).to eq nil
+    end
+
+    it "does not allow slashes" do
+      expect(described_class.pulfa_component("MC016/c11318")).to be nil
+    end
+  end
+
   describe ".source_metadata_url" do
     context "with a Voyager record ID" do
       it "validates that this is not a bib. ID" do

--- a/spec/resources/archival_media_collections/archival_media_collection_change_set_spec.rb
+++ b/spec/resources/archival_media_collections/archival_media_collection_change_set_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe ArchivalMediaCollectionChangeSet do
 
       it "is invalid" do
         FactoryBot.create_for_repository(:archival_media_collection, source_metadata_identifier: "AC044_c0003")
-        stub_pulfa(pulfa_id: "AC044/c0003")
+        stub_pulfa(pulfa_id: "AC044_c0003")
 
         expect(change_set).not_to be_valid
       end
@@ -62,7 +62,7 @@ RSpec.describe ArchivalMediaCollectionChangeSet do
       let(:collection) { FactoryBot.build(:archival_media_collection, source_metadata_identifier: "AC044_c0003") }
 
       it "is invalid" do
-        stub_pulfa(pulfa_id: "AC044/c0003")
+        stub_pulfa(pulfa_id: "AC044_c0003")
         FactoryBot.create_for_repository(:scanned_resource, source_metadata_identifier: "AC044_c0003")
 
         expect(change_set).to be_valid
@@ -72,7 +72,7 @@ RSpec.describe ArchivalMediaCollectionChangeSet do
     context "when source_metadata_identifier is set" do
       let(:collection) { FactoryBot.build(:archival_media_collection, source_metadata_identifier: "AC044_c0003") }
       it "is valid" do
-        stub_pulfa(pulfa_id: "AC044/c0003")
+        stub_pulfa(pulfa_id: "AC044_c0003")
         expect(change_set).to be_valid
       end
     end

--- a/spec/resources/archival_media_collections/archival_media_collections_controller_spec.rb
+++ b/spec/resources/archival_media_collections/archival_media_collections_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe ArchivalMediaCollectionsController, type: :controller do
     let(:bag_path) { Rails.root.join("spec", "fixtures", "av", "la_c0652_2017_05_bag") }
 
     before do
-      stub_pulfa(pulfa_id: "AC044/c0003")
+      stub_pulfa(pulfa_id: "AC044_c0003")
       allow(Dir).to receive(:exist?).and_return(true)
       allow(IngestArchivalMediaBagJob).to receive(:perform_later)
     end

--- a/spec/services/identifier_service_spec.rb
+++ b/spec/services/identifier_service_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe IdentifierService do
 
     context "with a pulfa source_metadata_identifier" do
       let(:cid) { "MC016_c9616" }
-      let(:metadata) { base_metadata.merge(target: "http://findingaids.princeton.edu/collections/#{cid.gsub("_", "/")}") }
+      let(:metadata) { base_metadata.merge(target: "http://findingaids.princeton.edu/collections/#{cid.tr('_', '/')}") }
       let(:obj) { FactoryBot.build :scanned_resource, source_metadata_identifier: cid }
 
       before do

--- a/spec/services/identifier_service_spec.rb
+++ b/spec/services/identifier_service_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe IdentifierService do
       let(:obj) { FactoryBot.build :scanned_resource, source_metadata_identifier: cid }
 
       before do
-        stub_pulfa(pulfa_id: "MC016/c9616")
+        stub_pulfa(pulfa_id: "MC016_c9616")
       end
 
       it "links to OrangeLight" do

--- a/spec/services/identifier_service_spec.rb
+++ b/spec/services/identifier_service_spec.rb
@@ -104,8 +104,8 @@ RSpec.describe IdentifierService do
     end
 
     context "with a pulfa source_metadata_identifier" do
-      let(:cid) { "MC016/c9616" }
-      let(:metadata) { base_metadata.merge(target: "http://findingaids.princeton.edu/collections/#{cid}") }
+      let(:cid) { "MC016_c9616" }
+      let(:metadata) { base_metadata.merge(target: "http://findingaids.princeton.edu/collections/#{cid.gsub("_", "/")}") }
       let(:obj) { FactoryBot.build :scanned_resource, source_metadata_identifier: cid }
 
       before do

--- a/spec/services/manifest_builder/see_also_builder_spec.rb
+++ b/spec/services/manifest_builder/see_also_builder_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe ManifestBuilder::SeeAlsoBuilder do
     before do
       allow(remote_record_class).to receive(:source_metadata_url).with("4609321").and_return("https://bibdata.princeton.edu/bibliographic/4609321")
       allow(remote_record_class).to receive(:source_metadata_url).with("AC044_c0003").and_return("https://findingaids.princeton.edu/collections/AC044/c0003.xml?scope=record")
+      allow(remote_record_class).to receive(:valid?).and_return(true)
       allow(remote_record_class).to receive(:retrieve).and_return(remote_record_response)
       allow(remote_record_response).to receive(:success?).and_return(true)
       builder.apply(manifest)

--- a/spec/services/source_metadata_identifier_migrator_spec.rb
+++ b/spec/services/source_metadata_identifier_migrator_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe SourceMetadataIdentifierMigrator do
+  before do
+    class MyResource < Valkyrie::Resource
+      attribute :source_metadata_identifier
+    end
+  end
+
+  after do
+    Object.send(:remove_const, :MyResource)
+  end
+
+  describe ".call" do
+    it "changes slashes to underscores in source_metadata_identifiers" do
+      # create record with a slash in its source_metadata_identifier
+      adapter = Valkyrie::MetadataAdapter.find(:indexing_persister)
+      resource = adapter.persister.save(resource: MyResource.new(source_metadata_identifier: "C0652/c0377"))
+
+      # run the migrator
+      described_class.call
+
+      # verify that the slash has been changed to an underscore
+      migrated = adapter.query_service.find_by(id: resource.id)
+      expect(migrated.source_metadata_identifier).to eq(["C0652_c0377"])
+    end
+  end
+end


### PR DESCRIPTION
* Refactor PULFA id validation and parsing
* Require underscores to separate PULFA collection/component IDs (instead of allowing either slash or underscore)
* Add form hints on acceptable ID formats