### PR TITLE
Recordings instead of MediaResources

### DIFF
--- a/app/derivative_services/audio_derivative_service.rb
+++ b/app/derivative_services/audio_derivative_service.rb
@@ -40,7 +40,7 @@ class AudioDerivativeService
   end
 
   def valid?
-    ["audio/x-wav"].include?(mime_type.first)
+    ["audio/x-wav", "audio/vnd.wave"].include?(mime_type.first)
   end
 
   def create_derivatives

--- a/app/derivative_services/default_derivative_service.rb
+++ b/app/derivative_services/default_derivative_service.rb
@@ -31,6 +31,7 @@ class DefaultDerivativeService
   end
 
   def valid?
+    return false unless original_file
     ["image/tiff", "image/jpeg"].include?(mime_type.first) && !parent.is_a?(ScannedMap)
   end
 

--- a/app/derivative_services/external_metadata_derivative_service.rb
+++ b/app/derivative_services/external_metadata_derivative_service.rb
@@ -45,6 +45,7 @@ class ExternalMetadataDerivativeService
   end
 
   def valid_mime_type?
+    return false unless original_file
     ["application/xml; schema=fgdc", "application/xml; schema=iso19139"].include? mime_type.first
   end
 

--- a/app/derivative_services/scanned_map_derivative_service.rb
+++ b/app/derivative_services/scanned_map_derivative_service.rb
@@ -31,6 +31,7 @@ class ScannedMapDerivativeService
   end
 
   def valid?
+    return false unless original_file
     mime_type == ["image/tiff"] && parent.is_a?(ScannedMap)
   end
 

--- a/app/jobs/ingest_archival_media_bag_job.rb
+++ b/app/jobs/ingest_archival_media_bag_job.rb
@@ -152,13 +152,13 @@ class IngestArchivalMediaBagJob < ApplicationJob
           file_metadata_node
         end
 
-        # Creates or finds an existing MediaResource Object using an EAD Component ID
+        # Creates or finds an existing Recording Object using an EAD Component ID
         # @param component_id [String]
-        # @return [MediaResourceChangeSet]
+        # @return [RecordingChangeSet]
         def find_or_create_media_resource(property, value)
           results = value.nil? ? [] : query_service.custom_queries.find_by_property(property: property, value: value)
-          media_resource = results.size.zero? ? MediaResource.new : results.first
-          MediaResourceChangeSet.new(
+          media_resource = results.size.zero? ? ScannedResource.new : results.first
+          RecordingChangeSet.new(
             media_resource,
             property => value,
             files: [],

--- a/app/resources/scanned_resources/recording_change_set.rb
+++ b/app/resources/scanned_resources/recording_change_set.rb
@@ -16,6 +16,7 @@ class RecordingChangeSet < ChangeSet
   property :read_groups, multiple: true, required: false
   property :change_set, require: true, default: "recording"
   property :part_of, require: false, default: []
+  property :upload_set_id, multiple: false, require: false, type: Valkyrie::Types::ID
 
   # Virtual Attributes
   property :files, virtual: true, multiple: true, required: false

--- a/app/resources/scanned_resources/scanned_resource.rb
+++ b/app/resources/scanned_resources/scanned_resource.rb
@@ -16,6 +16,7 @@ class ScannedResource < Resource
   attribute :date_range
   attribute :sender, Valkyrie::Types::Array.of(NameWithPlace).meta(ordered: true)
   attribute :recipient, Valkyrie::Types::Array.of(NameWithPlace).meta(ordered: true)
+  attribute :upload_set_id, Valkyrie::Types::ID
 
   def self.can_have_manifests?
     true
@@ -42,6 +43,7 @@ class ScannedResource < Resource
   # Determines if this is an image resource
   # @return [TrueClass, FalseClass]
   def image_resource?
+    return false if change_set == "recording"
     true
   end
 end

--- a/app/validators/unique_archival_media_barcode_validator.rb
+++ b/app/validators/unique_archival_media_barcode_validator.rb
@@ -36,7 +36,7 @@ class UniqueArchivalMediaBarcodeValidator < ActiveModel::Validator
         return [] if record.model.id.nil? # it's a new resource
         @previously_imported ||=
           begin
-            decorator.media_resources.flat_map do |component_id_resource|
+            decorator.members.flat_map do |component_id_resource|
               Wayfinder.for(component_id_resource).members.flat_map(&:local_identifier)
             end
           end

--- a/spec/derivative_services/audio_derivative_service_spec.rb
+++ b/spec/derivative_services/audio_derivative_service_spec.rb
@@ -59,6 +59,8 @@ RSpec.describe AudioDerivativeService do
         derivative_partials = reloaded.derivative_partial_files
         expect(derivative_partials.length).to eq 1
         expect(derivative_partials[0].mime_type).to eq ["video/MP2T"]
+
+        expect(Valkyrie::Derivatives::DerivativeService.for(id: reloaded.id)).to be_a described_class
       end
     end
     it "creates HLS partials and a playlist and attaches it to the fileset" do

--- a/spec/jobs/ingest_archival_media_bag_job_spec.rb
+++ b/spec/jobs/ingest_archival_media_bag_job_spec.rb
@@ -43,12 +43,12 @@ RSpec.describe IngestArchivalMediaBagJob do
       expect(file_set.transfer_notes.first).to start_with "Side A"
     end
 
-    it "creates one MediaResource for the barcode and one for the component ID" do
-      expect(query_service.find_all_of_model(model: MediaResource).size).to eq 2
+    it "creates one ScannedResource for the barcode and one for the component ID" do
+      expect(query_service.find_all_of_model(model: ScannedResource).size).to eq 2
     end
 
     it "adds an upload set id to the MediaResource" do
-      expect(query_service.find_all_of_model(model: MediaResource).first.upload_set_id).to be_present
+      expect(query_service.find_all_of_model(model: ScannedResource).first.upload_set_id).to be_present
     end
 
     it "for each component id-based MediaRsource, puts it on the collection" do
@@ -70,7 +70,7 @@ RSpec.describe IngestArchivalMediaBagJob do
       let(:read_auth) { Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED }
 
       it "assigns correct visibility and read_groups access control to each resource and file_set" do
-        expect(query_service.find_all_of_model(model: MediaResource).map(&:visibility)).to contain_exactly [vis_auth], [vis_auth]
+        expect(query_service.find_all_of_model(model: ScannedResource).map(&:visibility)).to contain_exactly [vis_auth], [vis_auth]
 
         file_sets = query_service.find_all_of_model(model: FileSet)
         expect(file_sets.map(&:read_groups).to_a).to eq [
@@ -84,7 +84,7 @@ RSpec.describe IngestArchivalMediaBagJob do
       let(:read_auth) { Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC }
 
       it "assigns correct visibility and read_groups access control to each resource and file_set" do
-        expect(query_service.find_all_of_model(model: MediaResource).map(&:visibility)).to contain_exactly [vis_auth], [vis_auth]
+        expect(query_service.find_all_of_model(model: ScannedResource).map(&:visibility)).to contain_exactly [vis_auth], [vis_auth]
 
         file_sets = query_service.find_all_of_model(model: FileSet)
         expect(file_sets.map(&:read_groups).to_a).to eq [
@@ -216,7 +216,7 @@ RSpec.describe IngestArchivalMediaBagJob do
 
     it "doesn't try to use that other resource as an archival media collection" do
       collection = query_service.find_all_of_model(model: ArchivalMediaCollection).first
-      expect(query_service.find_all_of_model(model: ScannedResource).first.source_metadata_identifier.first).to eq collection_cid
+
       expect(query_service.find_inverse_references_by(resource: collection, property: :member_of_collection_ids).size).to eq 1
     end
   end
@@ -267,7 +267,7 @@ RSpec.describe IngestArchivalMediaBagJob do
         expect(resources.first.source_metadata_identifier).to eq ["C0652_c0377"]
 
         member = Wayfinder.for(resources.first).members.first
-        expect(member).to be_a MediaResource
+        expect(member).to be_a ScannedResource
         expect(member.local_identifier.first).to eq "32101047382401"
         expect(member.title).to eq ["Interview: ERM / Jose Donoso (A2)"]
 
@@ -306,7 +306,7 @@ RSpec.describe IngestArchivalMediaBagJob do
         resource383 = resources.find { |x| x.source_metadata_identifier == ["C0652_c0383"] }
         members383 = Wayfinder.for(resource383).members
         expect(members383.count).to eq 2
-        expect(members383.map(&:class).uniq).to contain_exactly MediaResource
+        expect(members383.map(&:class).uniq).to contain_exactly ScannedResource
         expect(members383.map(&:local_identifier)).to contain_exactly(
           ["32101047382484"], ["32101047382492"]
         )
@@ -340,7 +340,7 @@ RSpec.describe IngestArchivalMediaBagJob do
         resource389 = resources.find { |x| x.source_metadata_identifier == ["C0652_c0389"] }
         members389 = Wayfinder.for(resource389).members
         expect(members389.count).to eq 1
-        expect(members389.map(&:class).uniq).to contain_exactly MediaResource
+        expect(members389.map(&:class).uniq).to contain_exactly ScannedResource
         expect(members389.map(&:local_identifier)).to contain_exactly(
           ["32101047382617"]
         )
@@ -361,10 +361,10 @@ RSpec.describe IngestArchivalMediaBagJob do
         )
       end
 
-      it "gives all MediaResources the same upload set id" do
+      it "gives all ScannedResources the same upload set id" do
         described_class.perform_now(collection_component: collection_cid, bag_path: bag_path, user: user)
 
-        expect(query_service.find_all_of_model(model: MediaResource).map(&:upload_set_id).to_a.uniq.size).to eq 1
+        expect(query_service.find_all_of_model(model: ScannedResource).map(&:upload_set_id).to_a.uniq.size).to eq 1
       end
     end
   end

--- a/spec/jobs/ingest_archival_media_bag_job_spec.rb
+++ b/spec/jobs/ingest_archival_media_bag_job_spec.rb
@@ -43,15 +43,15 @@ RSpec.describe IngestArchivalMediaBagJob do
       expect(file_set.transfer_notes.first).to start_with "Side A"
     end
 
-    it "creates one ScannedResource for the barcode and one for the component ID" do
+    it "creates one Recording for the barcode and one for the component ID" do
       expect(query_service.find_all_of_model(model: ScannedResource).size).to eq 2
     end
 
-    it "adds an upload set id to the MediaResource" do
+    it "adds an upload set id to the Recording" do
       expect(query_service.find_all_of_model(model: ScannedResource).first.upload_set_id).to be_present
     end
 
-    it "for each component id-based MediaRsource, puts it on the collection" do
+    it "for each component id-based Recording puts it on the collection" do
       collection = query_service.find_all_of_model(model: ArchivalMediaCollection).first
       expect(query_service.find_inverse_references_by(resource: collection, property: :member_of_collection_ids).size).to eq 1
     end
@@ -268,6 +268,7 @@ RSpec.describe IngestArchivalMediaBagJob do
 
         member = Wayfinder.for(resources.first).members.first
         expect(member).to be_a ScannedResource
+        expect(member.change_set).to eq "recording"
         expect(member.local_identifier.first).to eq "32101047382401"
         expect(member.title).to eq ["Interview: ERM / Jose Donoso (A2)"]
 
@@ -307,6 +308,7 @@ RSpec.describe IngestArchivalMediaBagJob do
         members383 = Wayfinder.for(resource383).members
         expect(members383.count).to eq 2
         expect(members383.map(&:class).uniq).to contain_exactly ScannedResource
+        expect(members383.map(&:change_set).uniq).to contain_exactly "recording"
         expect(members383.map(&:local_identifier)).to contain_exactly(
           ["32101047382484"], ["32101047382492"]
         )
@@ -361,7 +363,7 @@ RSpec.describe IngestArchivalMediaBagJob do
         )
       end
 
-      it "gives all ScannedResources the same upload set id" do
+      it "gives all Recordings the same upload set id" do
         described_class.perform_now(collection_component: collection_cid, bag_path: bag_path, user: user)
 
         expect(query_service.find_all_of_model(model: ScannedResource).map(&:upload_set_id).to_a.uniq.size).to eq 1

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -636,6 +636,17 @@ RSpec.describe ManifestBuilder do
         expect(output["service"]).to be_nil
       end
     end
+    it "builds a manifest for an ArchivalMediaBag ingested Recording", run_real_characterization: true, run_real_derivatives: true do
+      bag_path = Rails.root.join("spec", "fixtures", "av", "la_c0652_2017_05_bag")
+      user = User.first
+      stub_pulfa(pulfa_id: "C0652")
+      stub_pulfa(pulfa_id: "C0652_c0377")
+      IngestArchivalMediaBagJob.perform_now(collection_component: "C0652", bag_path: bag_path, user: user)
+
+      recording = query_service.custom_queries.find_by_property(property: :local_identifier, value: "32101047382401").first
+      manifest_builder = described_class.new(recording)
+      expect { manifest_builder.build }.not_to raise_error
+    end
     it "builds a presentation 3 manifest", run_real_characterization: true do
       output = change_set_persister.save(change_set: change_set)
       output.logical_structure = [


### PR DESCRIPTION
I got a little ahead of myself. This PR does three things:

IngestArchivalMediaBagJob ingests Recordings instead.
Regenerating HLS derivatives works when there's an intermediate file.
Initial Manifest generation works

Closes #3079