### PR TITLE
Descriptive Proxy Recordings display as Recordings

### DIFF
--- a/app/resources/scanned_resources/scanned_resource_decorator.rb
+++ b/app/resources/scanned_resources/scanned_resource_decorator.rb
@@ -125,10 +125,10 @@ class ScannedResourceDecorator < Valkyrie::ResourceDecorator
   end
 
   def human_readable_type
-    if model.id.present? && wayfinder.scanned_resources_count.positive?
-      I18n.translate("models.multi_volume_work", default: "Multi Volume Work")
-    elsif model.change_set
+    if model.change_set
       I18n.translate("models.#{model.change_set}")
+    elsif model.id.present? && wayfinder.scanned_resources_count.positive?
+      I18n.translate("models.multi_volume_work", default: "Multi Volume Work")
     else
       model.human_readable_type
     end

--- a/app/resources/scanned_resources/scanned_resource_wayfinder.rb
+++ b/app/resources/scanned_resources/scanned_resource_wayfinder.rb
@@ -12,6 +12,10 @@ class ScannedResourceWayfinder < BaseWayfinder
     @scanned_resources_count ||= query_service.custom_queries.count_members(resource: resource, model: ScannedResource)
   end
 
+  def file_sets_count
+    @file_sets_count ||= query_service.custom_queries.count_members(resource: resource, model: FileSet)
+  end
+
   def in_process_file_sets_count
     @in_process_file_sets_count ||= query_service.custom_queries.find_deep_children_with_property(resource: resource, model: FileSet, property: :processing_status, value: "in process", count: true)
   end

--- a/app/views/catalog/_admin_controls_recording.html.erb
+++ b/app/views/catalog/_admin_controls_recording.html.erb
@@ -12,7 +12,7 @@
         <%= link_to "Order Manager", main_app.polymorphic_path([:order_manager, resource]), class: 'btn btn-default' %>
       <% end %>
     <% end %>
-    <% if can?(:update, resource) && Wayfinder.for(resource).scanned_resources_count == 0 %>
+    <% if can?(:update, resource) && Wayfinder.for(resource).file_sets_count > 0 %>
       <%= link_to "Create Playlist", main_app.playlists_path(recording_id: resource.id), method: :post, class: 'btn btn-primary' %>
     <% end %>
 

--- a/app/views/catalog/_admin_controls_recording.html.erb
+++ b/app/views/catalog/_admin_controls_recording.html.erb
@@ -12,7 +12,7 @@
         <%= link_to "Order Manager", main_app.polymorphic_path([:order_manager, resource]), class: 'btn btn-default' %>
       <% end %>
     <% end %>
-    <% if can?(:update, resource) %>
+    <% if can?(:update, resource) && Wayfinder.for(resource).scanned_resources_count == 0 %>
       <%= link_to "Create Playlist", main_app.playlists_path(recording_id: resource.id), method: :post, class: 'btn btn-primary' %>
     <% end %>
 

--- a/app/views/catalog/_members_recording.html.erb
+++ b/app/views/catalog/_members_recording.html.erb
@@ -1,0 +1,28 @@
+<% unless decorated_resource.volumes.empty? %>
+  <h2>Members</h2>
+  <table id="members" class="table table-striped">
+    <tr>
+     <th>Thumbnail</th>
+     <th>Title</th>
+     <th>Date Uploaded</th>
+     <th>Visibility</th>
+     <th>Actions</th>
+    </tr>
+    <% decorated_resource.volumes.each do |volume| %>
+      <% volume_url = parent_solr_document_path("#{resource.id}", "#{volume.id}") %>
+      <tr>
+        <td><%= link_to figgy_thumbnail_path(volume, { class: 'thumbnail-inner', onerror: default_icon_fallback }), volume_url %></td>
+        <td><%= volume.first_title %></td>
+        <td><%= volume.created_at %></td>
+        <td><%= volume.visibility_badge.first.html_safe %></td>
+        <td>
+          <%= link_to 'View', volume_url, class: 'btn btn-default' %>
+          <%= link_to 'Edit', main_app.polymorphic_path([:edit, volume]), class: 'btn btn-default' %>
+          <%= link_to "Delete", main_app.polymorphic_path([volume]), class: 'btn btn-danger',
+                                data: { confirm: "Delete this #{resource.human_readable_type}?" },
+                                method: :delete %>
+        </td>
+      </tr>
+    <% end %>
+  </table>
+<% end %>

--- a/app/views/catalog/_members_simple_resource.html.erb
+++ b/app/views/catalog/_members_simple_resource.html.erb
@@ -1,0 +1,1 @@
+<%= render "catalog/members_multi_volume_work" %>

--- a/spec/jobs/ingest_archival_media_bag_job_spec.rb
+++ b/spec/jobs/ingest_archival_media_bag_job_spec.rb
@@ -294,6 +294,7 @@ RSpec.describe IngestArchivalMediaBagJob do
           "C0652_c0383",
           "C0652_c0389"
         )
+        expect(resources.map(&:change_set).uniq).to contain_exactly "recording"
 
         # c0383 has two barcodes associated with it in the EAD.
         resource383 = resources.find { |x| x.source_metadata_identifier == ["C0652_c0383"] }

--- a/spec/resources/scanned_resources/scanned_resource_decorator_spec.rb
+++ b/spec/resources/scanned_resources/scanned_resource_decorator_spec.rb
@@ -29,6 +29,22 @@ RSpec.describe ScannedResourceDecorator do
     end
   end
 
+  describe "#human_readable_type" do
+    context "with a Recording" do
+      let(:resource) { FactoryBot.build(:scanned_resource, change_set: "recording") }
+      it "returns Recording" do
+        expect(decorator.human_readable_type).to eq "Recording"
+      end
+    end
+    context "with a Recording descriptive proxy" do
+      let(:resource) { FactoryBot.create_for_repository(:scanned_resource, change_set: "recording", member_ids: [child.id]) }
+      let(:child) { FactoryBot.create_for_repository(:scanned_resource, change_set: "recording") }
+      it "returns Recording" do
+        expect(decorator.human_readable_type).to eq "Recording"
+      end
+    end
+  end
+
   context "with imported metadata" do
     let(:resource) do
       FactoryBot.build(:scanned_resource,

--- a/spec/resources/scanned_resources/scanned_resource_feature_spec.rb
+++ b/spec/resources/scanned_resources/scanned_resource_feature_spec.rb
@@ -73,7 +73,8 @@ RSpec.feature "Scanned Resources" do
 
   context "when a media reserve" do
     let(:scanned_resource) do
-      res = FactoryBot.create_for_repository(:recording)
+      file_set = FactoryBot.create_for_repository(:file_set)
+      res = FactoryBot.create_for_repository(:recording, member_ids: file_set.id)
       adapter.persister.save(resource: res)
     end
     it "displays a Create Playlist button" do

--- a/spec/views/catalog/_admin_controls_recording.html.erb_spec.rb
+++ b/spec/views/catalog/_admin_controls_recording.html.erb_spec.rb
@@ -20,5 +20,11 @@ RSpec.describe "catalog/_admin_controls_recording" do
     it "has a link to create a playlist" do
       expect(rendered).to have_selector "a[href='#{playlists_path(recording_id: recording.id.to_s)}'][data-method=post]", text: "Create Playlist"
     end
+    context "when it's a descriptive proxy" do
+      let(:file_set) { FactoryBot.create_for_repository(:recording) }
+      it "does not have a link to create a playlist" do
+        expect(rendered).not_to have_link "Create Playlist"
+      end
+    end
   end
 end

--- a/spec/views/catalog/_members_recording.html.erb_spec.rb
+++ b/spec/views/catalog/_members_recording.html.erb_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "catalog/_members_recording" do
+  context "when the Recording has members" do
+    let(:child) { FactoryBot.create_for_repository(:recording, title: "vol1", rights_statement: "x") }
+    let(:parent) { FactoryBot.create_for_repository(:recording, title: "Mui", rights_statement: "y", member_ids: [child.id]) }
+    let(:document) { Valkyrie::MetadataAdapter.find(:index_solr).resource_factory.from_resource(resource: parent) }
+    let(:solr_document) { SolrDocument.new(document) }
+    before do
+      assign :document, solr_document
+      render
+    end
+
+    it "shows them" do
+      expect(rendered).to have_selector "h2", text: "Members"
+      expect(rendered).to have_selector "td", text: "vol1"
+      expect(rendered).to have_selector "div.label-success .text", text: "open"
+      expect(rendered).not_to have_link href: solr_document_path(child)
+      expect(rendered).to have_link "View", href: parent_solr_document_path(parent, child.id)
+      expect(rendered).to have_link "Edit", href: edit_scanned_resource_path(child.id)
+    end
+  end
+end

--- a/spec/wayfinders/wayfinder_spec.rb
+++ b/spec/wayfinders/wayfinder_spec.rb
@@ -85,6 +85,19 @@ RSpec.describe Wayfinder do
       end
     end
 
+    describe "#file_sets_count" do
+      it "returns the count of file set members" do
+        member = FactoryBot.create_for_repository(:scanned_resource)
+        member2 = FactoryBot.create_for_repository(:file_set)
+        member3 = FactoryBot.create_for_repository(:scanned_resource)
+        parent = FactoryBot.create_for_repository(:scanned_resource, member_ids: [member.id, member2.id, member3.id])
+
+        wayfinder = described_class.for(parent)
+
+        expect(wayfinder.file_sets_count).to eq 1
+      end
+    end
+
     describe "#scanned_resources" do
       it "returns undecorated scanned_resource members" do
         member = FactoryBot.create_for_repository(:scanned_resource)


### PR DESCRIPTION
1. This makes the change set human readable model take priority over the fact that it has ScannedResource children.
2. Hides "Create a Playlist" button for descriptive proxies
3. Displays the member list if it's a descriptive proxy.

Closes #3100