### PR TITLE
Retrieve Kakadu binaries from Princeton google cloud storage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,10 +68,9 @@ group :test do
   gem "formulaic"
   gem "rspec-graphql_matchers"
   gem "rspec_junit_formatter"
-  gem "selenium-webdriver"
   gem "simplecov", require: false
   gem "timecop"
-  gem "webdrivers", "~> 3.0"
+  gem "webdrivers"
   gem "webmock"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,8 +225,8 @@ GEM
     capybara-screenshot (1.0.22)
       capybara (>= 1.0, < 4)
       launchy
-    childprocess (0.7.1)
-      ffi (~> 1.0, >= 1.0.11)
+    childprocess (1.0.1)
+      rake (< 13.0)
     chronic (0.10.2)
     cocoon (1.2.12)
     coderay (1.1.1)
@@ -329,7 +329,7 @@ GEM
       i18n (~> 0.5)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
-    ffi (1.10.0)
+    ffi (1.11.1)
     flutie (2.0.0)
     font-awesome-rails (4.7.0.4)
       railties (>= 3.2, < 6.0)
@@ -538,7 +538,7 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (4.1.0)
     nio4r (2.3.1)
-    nokogiri (1.10.1)
+    nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
     normalize-rails (4.1.1)
     oauth2 (1.4.1)
@@ -699,7 +699,7 @@ GEM
     ruby-progressbar (1.9.0)
     ruby-rc4 (0.1.5)
     ruby_dep (1.5.0)
-    rubyzip (1.2.2)
+    rubyzip (1.2.3)
     safe_yaml (1.0.4)
     sass (3.7.3)
       sass-listen (~> 4.0.0)
@@ -716,9 +716,9 @@ GEM
       ffi (~> 1.9)
       rake
     scrub_rb (1.0.1)
-    selenium-webdriver (3.4.4)
-      childprocess (~> 0.5)
-      rubyzip (~> 1.0)
+    selenium-webdriver (3.142.3)
+      childprocess (>= 0.5, < 2.0)
+      rubyzip (~> 1.2, >= 1.2.2)
     sequel (5.20.0)
     sequel_pg (1.12.1)
       pg (>= 0.18.0)
@@ -839,7 +839,7 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
-    webdrivers (3.8.0)
+    webdrivers (4.0.0)
       nokogiri (~> 1.6)
       rubyzip (~> 1.0)
       selenium-webdriver (~> 3.0)
@@ -949,7 +949,6 @@ DEPENDENCIES
   ruby_tika_app!
   rubyzip (>= 1.2.2)
   sass-rails (~> 5.0)
-  selenium-webdriver
   shrine-google_cloud_storage
   sidekiq
   simple_form
@@ -969,7 +968,7 @@ DEPENDENCIES
   valkyrie-sequel (= 1.1.0)
   valkyrie-shrine
   web-console
-  webdrivers (~> 3.0)
+  webdrivers
   webmock
   webpacker (>= 4.0.x)
   whenever (~> 0.10)

--- a/bin/ci_kakadu_install.sh
+++ b/bin/ci_kakadu_install.sh
@@ -1,8 +1,8 @@
 if [ ! -d "kakadu" ]; then
   mkdir ~/downloads
-  wget http://kakadusoftware.com/wp-content/uploads/2014/06/KDU77_Demo_Apps_for_Linux-x86-64_150710.zip -O ~/downloads/kakadu.zip
+  wget https://storage.googleapis.com/kdubackupfiles/KDU78_Demo_Apps_for_Linux-x86-64_160226.zip -O ~/downloads/kakadu.zip
   unzip ~/downloads/kakadu.zip
-  mv KDU77_Demo_Apps_for_Linux-x86-64_150710 kakadu
+  mv KDU78_Demo_Apps_for_Linux-x86-64_160226 kakadu
 fi
 sudo cp kakadu/*.so /usr/lib
 sudo cp kakadu/* /usr/bin


### PR DESCRIPTION
Fixes issue with CI related to the unreliability of the http://kakadusoftware.com website.