### PR TITLE
Ensures that ScannedResourcesController#change_set_class returns DynamicChangeSet when the change_set parameter is invalid

### DIFF
--- a/app/change_sets/dynamic_change_set.rb
+++ b/app/change_sets/dynamic_change_set.rb
@@ -10,5 +10,8 @@ class DynamicChangeSet
 
   def self.class_from_param(param)
     "#{param.camelize}ChangeSet".constantize
+  rescue NameError
+    Valkyrie.logger.error("Failed to find the ChangeSet class for #{param}.")
+    nil
   end
 end

--- a/app/controllers/concerns/resource_controller.rb
+++ b/app/controllers/concerns/resource_controller.rb
@@ -11,10 +11,6 @@ module ResourceController
   def new
     @change_set = change_set_class.new(new_resource, append_id: params[:parent_id]).prepopulate!
     authorize! :create, resource_class
-  rescue NameError # This handles cases where the ChangeSet name cannot be resolved
-    Rails.logger.error("ScannedResources do not support #{params[:change_set]} as a ChangeSet.")
-    flash[:error] = "#{params[:change_set]} is not a valid resource type."
-    redirect_to new_scanned_resource_path
   end
 
   def new_resource

--- a/app/controllers/concerns/resource_controller.rb
+++ b/app/controllers/concerns/resource_controller.rb
@@ -9,8 +9,14 @@ module ResourceController
   end
 
   def new
-    @change_set = change_set_class.new(new_resource, append_id: params[:parent_id]).prepopulate!
-    authorize! :create, resource_class
+    if change_set_class.nil?
+      Valkyrie.logger.error("Failed to find the ChangeSet class for #{change_set_param}.")
+      flash[:error] = "#{change_set_param} is not a valid resource type."
+      redirect_to new_scanned_resource_path
+    else
+      @change_set = change_set_class.new(new_resource, append_id: params[:parent_id]).prepopulate!
+      authorize! :create, resource_class
+    end
   end
 
   def new_resource
@@ -143,5 +149,9 @@ module ResourceController
 
     def find_resource(id)
       query_service.find_by(id: Valkyrie::ID.new(id))
+    end
+
+    def change_set_param
+      params[:change_set] || (resource_params && resource_params[:change_set])
     end
 end

--- a/app/decorators/valkyrie/resource_decorator.rb
+++ b/app/decorators/valkyrie/resource_decorator.rb
@@ -179,6 +179,7 @@ class Valkyrie::ResourceDecorator < ApplicationDecorator
     @workflow_class ||=
       begin
         change_set = DynamicChangeSet.new(model)
+        raise(WorkflowRegistry::EntryNotFound) if change_set.is_a?(DynamicChangeSet)
         change_set.try(:workflow_class) || raise(WorkflowRegistry::EntryNotFound)
       end
   # If there's no change set for the model, raise an entry not found.

--- a/app/resources/scanned_resources/scanned_resources_controller.rb
+++ b/app/resources/scanned_resources/scanned_resources_controller.rb
@@ -22,15 +22,11 @@ class ScannedResourcesController < BaseResourceController
   end
 
   def change_set_class
-    if params[:change_set].present? || (resource_params && resource_params[:change_set].present?)
-      change_set_name = params[:change_set] || resource_params[:change_set]
-      DynamicChangeSet.class_from_param(change_set_name)
+    if change_set_param.present?
+      DynamicChangeSet.class_from_param(change_set_param)
     else
       DynamicChangeSet
     end
-  rescue NameError
-    Valkyrie.logger.error("Failed to find the ChangeSet class for #{change_set_name}.")
-    DynamicChangeSet
   end
 
   def handle_save_and_ingest(obj)

--- a/app/resources/scanned_resources/scanned_resources_controller.rb
+++ b/app/resources/scanned_resources/scanned_resources_controller.rb
@@ -23,10 +23,14 @@ class ScannedResourcesController < BaseResourceController
 
   def change_set_class
     if params[:change_set].present? || (resource_params && resource_params[:change_set].present?)
-      DynamicChangeSet.class_from_param(params[:change_set] || resource_params[:change_set])
+      change_set_name = params[:change_set] || resource_params[:change_set]
+      DynamicChangeSet.class_from_param(change_set_name)
     else
       DynamicChangeSet
     end
+  rescue NameError
+    Valkyrie.logger.error("Failed to find the ChangeSet class for #{change_set_name}.")
+    DynamicChangeSet
   end
 
   def handle_save_and_ingest(obj)

--- a/spec/change_sets/dynamic_change_set_spec.rb
+++ b/spec/change_sets/dynamic_change_set_spec.rb
@@ -25,8 +25,12 @@ RSpec.describe DynamicChangeSet do
 
   describe "#class_from_param" do
     context "when given something that can't be constantized" do
-      it "raises a NameError" do
-        expect { described_class.class_from_param("bla") }.to raise_error NameError
+      before do
+        allow(Valkyrie.logger).to receive(:error)
+      end
+      it "returns a DynamicChangeSet and logs an error" do
+        expect(described_class.class_from_param("bla")).to be nil
+        expect(Valkyrie.logger).to have_received(:error).with("Failed to find the ChangeSet class for bla.")
       end
     end
     context "when given something that can be converted" do

--- a/spec/resources/scanned_resources/scanned_resources_controller_spec.rb
+++ b/spec/resources/scanned_resources/scanned_resources_controller_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe ScannedResourcesController, type: :controller do
       end
       it "creates a new ScannedResource and flashes a warning" do
         get :new, params: { change_set: "invalid" }
-        expect(Valkyrie.logger).to have_received(:error).with("Failed to find the ChangeSet class for invalid.")
+        expect(Valkyrie.logger).to have_received(:error).with("Failed to find the ChangeSet class for invalid.").at_least(:once)
       end
     end
   end

--- a/spec/resources/scanned_resources/scanned_resources_controller_spec.rb
+++ b/spec/resources/scanned_resources/scanned_resources_controller_spec.rb
@@ -57,13 +57,11 @@ RSpec.describe ScannedResourcesController, type: :controller do
 
     context "when the params specify an invalid change_set" do
       before do
-        allow(Rails.logger).to receive(:error)
+        allow(Valkyrie.logger).to receive(:error)
       end
       it "creates a new ScannedResource and flashes a warning" do
         get :new, params: { change_set: "invalid" }
-        expect(Rails.logger).to have_received(:error).with("ScannedResources do not support invalid as a ChangeSet.")
-        expect(response).to redirect_to new_scanned_resource_path
-        expect(flash[:error]).to eq("invalid is not a valid resource type.")
+        expect(Valkyrie.logger).to have_received(:error).with("Failed to find the ChangeSet class for invalid.")
       end
     end
   end


### PR DESCRIPTION
Resolves #2722 (previously this was only handled at the level of `ResourceController#new`, but this is invoked from other contexts; please see https://app.honeybadger.io/projects/53391/faults/46908296)