### PR TITLE
Disables manifest sequence renderings for audio recording resources

### DIFF
--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -198,6 +198,7 @@ class ManifestBuilder
     end
 
     def sequence_rendering
+      return [] if audio_manifest?
       [
         {
           "@id" => helper.pdf_url(resource),

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -259,6 +259,9 @@ RSpec.describe ManifestBuilder do
         it "generates the Canvases for the FileSets" do
           expect(output).not_to be_empty
 
+          expect(output).to include("rendering")
+          expect(output["rendering"]).to be_empty
+
           expect(output).to include("items")
           expect(output["items"].length).to eq(3)
 


### PR DESCRIPTION
This is necessary to fully resolve #3070, as PDF renderings are offered in cases where a `Recording` has both image and audio `FileSets` as members.