### PR TITLE
Preserve in a background job, always.

### DIFF
--- a/app/change_set_persisters/change_set_persister/preserve_resource.rb
+++ b/app/change_set_persisters/change_set_persister/preserve_resource.rb
@@ -12,7 +12,9 @@ class ChangeSetPersister
     end
 
     def run
-      Preserver.for(change_set: change_set.class.new(post_save_resource), change_set_persister: change_set_persister).preserve!
+      cs = change_set.class.new(post_save_resource)
+      return unless cs.try(:preserve?)
+      PreserveResourceJob.perform_later(id: cs.id.to_s)
     end
   end
 end

--- a/spec/features/fixity_dashboard_spec.rb
+++ b/spec/features/fixity_dashboard_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 include ActionDispatch::TestProcess
 
 RSpec.feature "Fixity dashboard" do
+  with_queue_adapter :inline
   let(:user) { FactoryBot.create(:admin) }
   let(:metadata_adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
   let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }


### PR DESCRIPTION
Updates were way too slow for preserved resources that were updating all
children.