### PR TITLE
Reorganize Barcodes within Archival Media Collection

### DIFF
--- a/app/change_set_persisters/change_set_persister.rb
+++ b/app/change_set_persisters/change_set_persister.rb
@@ -32,7 +32,8 @@ class ChangeSetPersister
         PublishMessage::Factory.new(operation: :update),
         ReindexChildrenOnState::Factory.new(model: EphemeraBox, state: "all_in_production"),
         IngestBag,
-        PreserveResource
+        PreserveResource,
+        ReorganizeCollection
       ],
       after_update_commit: [
         ReindexCollectionMembers,

--- a/app/change_set_persisters/change_set_persister/reorganize_collection.rb
+++ b/app/change_set_persisters/change_set_persister/reorganize_collection.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+class ChangeSetPersister
+  class ReorganizeCollection
+    attr_reader :change_set_persister, :change_set, :post_save_resource
+    delegate :metadata_adapter, to: :change_set_persister
+
+    def initialize(change_set_persister:, change_set:, post_save_resource: nil)
+      @change_set = change_set
+      @change_set_persister = change_set_persister
+      @post_save_resource = post_save_resource
+    end
+
+    def run
+      return unless change_set.try(:reorganize) == true
+      barcode_members
+      barcode_lookup
+      clean_old_relations
+      IngestArchivalMediaBagJob::Ingester::DescriptiveProxyBuilder.new(
+        barcode_lookup: barcode_lookup,
+        component_groups: component_groups,
+        changeset_persister: change_set_persister,
+        collection: post_save_resource
+      ).build!
+    end
+
+    def barcode_members
+      @barcode_members ||=
+        begin
+          members = Wayfinder.for(post_save_resource).members.flat_map do |member|
+            Wayfinder.for(member).members
+          end
+          members.select { |member| member.local_identifier.present? }
+        end
+    end
+
+    def barcode_lookup
+      @barcode_lookup ||= Hash[
+        barcode_members.map do |member|
+          [member.local_identifier.first, member.id]
+        end
+      ]
+    end
+
+    def clean_old_relations
+      Wayfinder.for(post_save_resource).members.each do |resource|
+        resource.member_ids = []
+        change_set_persister.persister.save(resource: resource)
+      end
+    end
+
+    def component_groups
+      @component_groups ||=
+        ArchivalMediaBagParser.new(path: nil, component_id: post_save_resource.source_metadata_identifier.first, barcodes: barcode_lookup.keys).component_groups
+    end
+  end
+end

--- a/app/models/archival_media_bag_parser.rb
+++ b/app/models/archival_media_bag_parser.rb
@@ -5,9 +5,10 @@ class ArchivalMediaBagParser
   BARCODE_WITH_SIDE_AND_PART_REGEX = /(\d{14}_\d+?_p\d+).*/
   attr_reader :path, :audio_files, :component_groups, :component_dict, :pbcore_parsers
 
-  def initialize(path:, component_id:)
+  def initialize(path:, component_id:, barcodes: nil)
     @path = path
     @component_dict = BarcodeComponentDict.new(component_id)
+    @barcodes = barcodes
   end
 
   # Constructs IngestableAudioFile objects for each wav/mp3 file in the Bag
@@ -17,7 +18,7 @@ class ArchivalMediaBagParser
   end
 
   def barcodes
-    audio_files.map(&:barcode).uniq
+    @barcodes ||= audio_files.map(&:barcode).uniq
   end
 
   def audio_files_by_barcode
@@ -35,7 +36,7 @@ class ArchivalMediaBagParser
     @component_groups ||=
       begin
         h = {}
-        audio_files.map(&:barcode).uniq.each do |barcode|
+        barcodes.each do |barcode|
           cid = component_dict.component_id(barcode: barcode)
           h[cid] = h.fetch(cid, []).append(barcode).uniq
         end

--- a/app/resources/collections/archival_media_collection_change_set.rb
+++ b/app/resources/collections/archival_media_collection_change_set.rb
@@ -16,6 +16,8 @@ class ArchivalMediaCollectionChangeSet < ChangeSet
   property :read_groups, multiple: true, required: false
   property :change_set, require: true, default: "archival_media_collection"
 
+  property :reorganize, virtual: true, require: false, default: false, type: Dry::Types["params.bool"]
+
   validates :source_metadata_identifier, presence: true
   validates_with BagPathValidator
   validates_with SourceMetadataIdentifierValidator

--- a/app/resources/collections/archival_media_collection_change_set.rb
+++ b/app/resources/collections/archival_media_collection_change_set.rb
@@ -30,7 +30,8 @@ class ArchivalMediaCollectionChangeSet < ChangeSet
       :source_metadata_identifier,
       :slug,
       :bag_path,
-      :change_set
+      :change_set,
+      :reorganize
     ]
   end
 end

--- a/app/views/records/edit_fields/_reorganize.html.erb
+++ b/app/views/records/edit_fields/_reorganize.html.erb
@@ -1,0 +1,3 @@
+<% if f.object.persisted? %>
+  <%= f.input :reorganize, label: 'Reorganize Children by EAD', as: :boolean %>
+<% end %>

--- a/spec/resources/archival_media_collections/archival_media_collection_change_set_spec.rb
+++ b/spec/resources/archival_media_collections/archival_media_collection_change_set_spec.rb
@@ -159,7 +159,8 @@ RSpec.describe ArchivalMediaCollectionChangeSet do
         :source_metadata_identifier,
         :bag_path,
         :slug,
-        :change_set
+        :change_set,
+        :reorganize
       )
     end
   end


### PR DESCRIPTION
This provides a checkbox in the AMC edit form which, when the form is submitted, will parse the EAD and reorganize all of the AMC's existing barcodes based on where the EAD says they should be.

Closes #3021