### PR TITLE
Refresh remote metadata on change of SMID, no matter what

### DIFF
--- a/app/change_sets/concerns/remote_metadata_property.rb
+++ b/app/change_sets/concerns/remote_metadata_property.rb
@@ -7,7 +7,7 @@ module RemoteMetadataProperty
     property :refresh_remote_metadata, virtual: true, multiple: false
 
     def apply_remote_metadata?
-      source_metadata_identifier.present? && (!persisted? || refresh_remote_metadata == "1")
+      source_metadata_identifier.present? && (!persisted? || refresh_remote_metadata == "1" || changed["source_metadata_identifier"])
     end
   end
 end

--- a/spec/change_set_persisters/change_set_persister_spec.rb
+++ b/spec/change_set_persisters/change_set_persister_spec.rb
@@ -271,12 +271,23 @@ RSpec.describe ChangeSetPersister do
   end
   context "when a source_metadata_identifier is set afterwards" do
     it "does not change anything" do
-      resource = FactoryBot.create_for_repository(:scanned_resource, title: "Title", source_metadata_identifier: nil)
+      stub_bibdata(bib_id: "123456")
+      resource = FactoryBot.create_for_repository(:scanned_resource, title: "Title", source_metadata_identifier: "123456")
       change_set = change_set_class.new(resource)
       change_set.validate(source_metadata_identifier: "123456", title: [], refresh_remote_metadata: "0")
       output = change_set_persister.save(change_set: change_set)
 
       expect(output.primary_imported_metadata.title).to be_blank
+    end
+    it "refreshes the metadata if it's a different value" do
+      stub_bibdata(bib_id: "123456")
+      stub_bibdata(bib_id: "123456789")
+      resource = FactoryBot.create_for_repository(:scanned_resource, title: "Title", source_metadata_identifier: "123456")
+      change_set = change_set_class.new(resource)
+      change_set.validate(source_metadata_identifier: "123456789", title: [], refresh_remote_metadata: "0")
+      output = change_set_persister.save(change_set: change_set)
+
+      expect(output.primary_imported_metadata.title).not_to be_blank
     end
   end
   context "when a source_metadata_identifier is set for the first time, and it doesn't exist" do

--- a/spec/resources/scanned_resources/scanned_resource_feature_spec.rb
+++ b/spec/resources/scanned_resources/scanned_resource_feature_spec.rb
@@ -16,6 +16,8 @@ RSpec.feature "Scanned Resources" do
   end
 
   before do
+    stub_bibdata(bib_id: "4612596")
+    stub_bibdata(bib_id: "8543429")
     change_set.source_metadata_identifier = "4612596"
     change_set_persister.save(change_set: change_set)
     sign_in user

--- a/spec/resources/scanned_resources/scanned_resources_controller_spec.rb
+++ b/spec/resources/scanned_resources/scanned_resources_controller_spec.rb
@@ -226,6 +226,7 @@ RSpec.describe ScannedResourcesController, type: :controller do
         }
       end
       it "strips them" do
+        stub_pulfa(pulfa_id: "AC044_c0003")
         patch :update, params: { id: resource.id.to_s, scanned_resource: params }
 
         reloaded = find_resource(resource.id)


### PR DESCRIPTION
Closes #1542