### PR TITLE
Generating Manifests with Recordings for ArchivalMediaCollections

### DIFF
--- a/app/change_sets/change_set.rb
+++ b/app/change_sets/change_set.rb
@@ -147,4 +147,8 @@ class ChangeSet < Valkyrie::ChangeSet
 
     params[name.to_sym] = value
   end
+
+  def can_have_manifests?
+    model.class.can_have_manifests?
+  end
 end

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -31,4 +31,9 @@ module CatalogHelper
     return "" unless facet && values
     super(facet, values)
   end
+
+  def can_have_manifests?(resource)
+    return DynamicChangeSet.new(resource).can_have_manifests? if resource.respond_to?(:change_set)
+    resource.class.can_have_manifests?
+  end
 end

--- a/app/resources/collections/archival_media_collection_change_set.rb
+++ b/app/resources/collections/archival_media_collection_change_set.rb
@@ -34,4 +34,8 @@ class ArchivalMediaCollectionChangeSet < ChangeSet
       :reorganize
     ]
   end
+
+  def can_have_manifests?
+    true
+  end
 end

--- a/app/services/manifest_builder/logo_builder.rb
+++ b/app/services/manifest_builder/logo_builder.rb
@@ -18,8 +18,12 @@ class ManifestBuilder
 
     private
 
+      def resource_logo
+        Array.wrap(@record.resource.rights_statement)
+      end
+
       def logo
-        if @record.resource.respond_to?(:rights_statement) && @record.resource.rights_statement.include?(RDF::URI("http://cicognara.org/microfiche_copyright"))
+        if @record.resource.respond_to?(:rights_statement) && resource_logo.include?(RDF::URI("http://cicognara.org/microfiche_copyright"))
           "vatican.png"
         else
           "pul_logo_icon.png"

--- a/app/views/catalog/_universal_viewer_default.html.erb
+++ b/app/views/catalog/_universal_viewer_default.html.erb
@@ -1,4 +1,4 @@
-<% if resource.class.can_have_manifests? && resource.try(:member_ids).present? %>
+<% if can_have_manifests?(resource) && resource.decorate.try(:members).present? %>
   <div class="intrinsic-container intrinsic-container-16x9 uv-container">
     <%# note: UV html file is '/uv/uv' %>
     <iframe src="<%= universal_viewer_path(resource) %>" allowfullscreen="true"></iframe>


### PR DESCRIPTION
Resolves #3156 by addressing the following:
- Generating `Manifests` with `Recordings` for `ArchivalMediaCollections`
- Integrating Universal Viewer support for `ArchivalMediaCollections`
- Ensuring that `Manifest` `Range` labels are retrieved from `FileSets`
- Ensuring that `ArchivalMediaCollection` manifests exclude image `FileSets` from `Ranges`