### PR TITLE
Fix file set cloud fixity display.

### DIFF
--- a/app/resources/file_sets/file_set_decorator.rb
+++ b/app/resources/file_sets/file_set_decorator.rb
@@ -49,7 +49,9 @@ class FileSetDecorator < Valkyrie::ResourceDecorator
   end
 
   def cloud_fixity_events_for(file_id)
-    custom_queries.find_by_property(property: :child_id, value: preservation_id_of(file_id))
+    preservation_id = preservation_id_of(file_id)
+    return [] unless preservation_id.present?
+    custom_queries.find_by_property(property: :child_id, value: preservation_id)
   end
 
   def preservation_id_of(file_id)

--- a/spec/resources/file_sets/file_set_decorator_spec.rb
+++ b/spec/resources/file_sets/file_set_decorator_spec.rb
@@ -71,5 +71,13 @@ RSpec.describe FileSetDecorator do
       expect(decorator.cloud_fixity_success_of(bad_file.id)).to eq("FAILURE")
       expect(decorator.cloud_fixity_last_success_date_of(bad_file.id)).to eq("n/a")
     end
+
+    context "when there's no preservation for a file" do
+      let(:good_file_pres) { FileMetadata.new(preservation_copy_of_id: SecureRandom.uuid, id: SecureRandom.uuid) }
+      it "returns in progress" do
+        expect(decorator.cloud_fixity_success_of(good_file.id)).to eq nil
+        expect(decorator.cloud_fixity_last_success_date_of(good_file.id)).to eq("n/a")
+      end
+    end
   end
 end


### PR DESCRIPTION
For IDs which aren't in a PreservationObject it was returning all
events.