### PR TITLE
Removing the CatalogHelper#can_have_manifests? method due to performance issues introduced for non-ArchivalMediaCollection resources

### DIFF
--- a/app/change_sets/change_set.rb
+++ b/app/change_sets/change_set.rb
@@ -147,8 +147,4 @@ class ChangeSet < Valkyrie::ChangeSet
 
     params[name.to_sym] = value
   end
-
-  def can_have_manifests?
-    model.class.can_have_manifests?
-  end
 end

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -31,9 +31,4 @@ module CatalogHelper
     return "" unless facet && values
     super(facet, values)
   end
-
-  def can_have_manifests?(resource)
-    return DynamicChangeSet.new(resource).can_have_manifests? if resource.respond_to?(:change_set)
-    resource.class.can_have_manifests?
-  end
 end

--- a/app/resources/collections/archival_media_collection_change_set.rb
+++ b/app/resources/collections/archival_media_collection_change_set.rb
@@ -34,8 +34,4 @@ class ArchivalMediaCollectionChangeSet < ChangeSet
       :reorganize
     ]
   end
-
-  def can_have_manifests?
-    true
-  end
 end

--- a/app/views/catalog/_universal_viewer_default.html.erb
+++ b/app/views/catalog/_universal_viewer_default.html.erb
@@ -1,4 +1,4 @@
-<% if can_have_manifests?(resource) && resource.decorate.try(:members).present? %>
+<% if resource.class.can_have_manifests? && resource.try(:member_ids).present? %>
   <div class="intrinsic-container intrinsic-container-16x9 uv-container">
     <%# note: UV html file is '/uv/uv' %>
     <iframe src="<%= universal_viewer_path(resource) %>" allowfullscreen="true"></iframe>


### PR DESCRIPTION
Resolves #3176 by reverting some of the changes introduced in https://github.com/pulibrary/figgy/commit/afdc8ac86474dd6af4fa73e22f6ebb236dfe3bf0 