### PR TITLE
Ensures that the browse-everything bag uploader for ArchivalMediaCollections does not collide with the DOM binding for ScannedResource file uploader

### DIFF
--- a/app/assets/javascripts/collection_bag_uploader.es6
+++ b/app/assets/javascripts/collection_bag_uploader.es6
@@ -1,7 +1,7 @@
 
 export default class CollectionBagUploader {
   constructor() {
-    this.element = $(".browse-everything")
+    this.element = $(".new_collection .browse-everything, .edit_collection .browse-everything")
     this.element.click((event) => event.preventDefault())
     this.mount_browse_everything()
   }


### PR DESCRIPTION
Otherwise, https://github.com/pulibrary/figgy/pull/3145/files#diff-18b55a2cbdd21595a7dfdc75b12c3e8bR4 breaks this for resource (e. g. `ScannedResource`) file management