### PR TITLE
Fixes paths and routes for Numismatic Coins with improper namespaces

### DIFF
--- a/app/views/numismatics/coins/_file_manager_extra_tools.html.erb
+++ b/app/views/numismatics/coins/_file_manager_extra_tools.html.erb
@@ -1,7 +1,7 @@
 <div class="col-md-12" id="uploading-stuff">
   <% if @children.empty? %>
     <div class="pull-right">
-      <%= simple_form_for @change_set, url: auto_ingest_coin_path(@change_set), method: :post do |f| %>
+      <%= simple_form_for @change_set, url: auto_ingest_numismatics_coin_path(@change_set), method: :post do |f| %>
         <%= f.submit "Searching...", disabled: true, id: 'auto-ingest-button', class: 'btn btn-primary',
                                      data: { id: @change_set.id.to_s } %>
         <div id="auto-ingest-info">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -157,7 +157,7 @@ Rails.application.routes.draw do
       resources :references
     end
 
-    get "/numismatics/issues/:parent_id/coin" => "coins#new", as: :parent_new_numismatics_coin
+    get "/numismatics/issues/:parent_id/coin" => "numismatics/coins#new", as: :parent_new_numismatics_coin
     get "/numismatics/references/:parent_id/new", to: "numismatics/references#new", as: :parent_new_numismatics_reference
 
     resources :ephemera_projects do


### PR DESCRIPTION
Fixes cases where attempting to add a `Coin` to a Numismatic `Issue` fails with an error:
![image](https://user-images.githubusercontent.com/1443986/60616059-9fa07f00-9d9e-11e9-8bb8-64857b18f1c1.png)
![image](https://user-images.githubusercontent.com/1443986/60616175-e2faed80-9d9e-11e9-9473-3d68f9b5b577.png)

There was also this namespacing issue when users attempt to upload files for `Coins`:
![image](https://user-images.githubusercontent.com/1443986/60616220-fc9c3500-9d9e-11e9-9978-8e14b77b1bf4.png)
