### PR TITLE
Index issued property in geoblacklight documents

### DIFF
--- a/app/services/geo_discovery/document_builder/date_builder.rb
+++ b/app/services/geo_discovery/document_builder/date_builder.rb
@@ -14,6 +14,7 @@ module GeoDiscovery
         document.layer_year = layer_year
         document.layer_modified = layer_modified
         document.issued = issued
+        document.temporal = temporal
       end
 
       private
@@ -21,11 +22,11 @@ module GeoDiscovery
         # Returns the date the layer was issued.
         # @return [String] date in XMLSchema format.
         def issued
-          datetime = resource_decorator.issued.first
+          issued_val = resource_decorator.issued.first
+          return unless issued_val
+          datetime = "#{issued_val}-01-01"
           datetime = DateTime.parse(datetime).utc
           datetime.utc.xmlschema
-        rescue
-          ""
         end
 
         # Returns the date the work was modified.
@@ -51,6 +52,15 @@ module GeoDiscovery
         def layer_year_temporal
           return if resource_decorator.temporal.empty?
           year_from_date(resource_decorator.temporal.first)
+        end
+
+        # Adds issued year to an array of temporal values.
+        # For better indexing.
+        # @return [String] temporal values
+        def temporal
+          issued = resource_decorator.issued&.first&.to_s
+          return resource_decorator.temporal unless issued
+          resource_decorator.temporal << issued
         end
 
         # Extracts year as your digit integer from date string

--- a/spec/services/geo_discovery/document_builder_spec.rb
+++ b/spec/services/geo_discovery/document_builder_spec.rb
@@ -24,8 +24,8 @@ describe GeoDiscovery::DocumentBuilder do
 
   let(:document_class) { GeoDiscovery::GeoblacklightDocument.new }
   let(:coverage) { GeoCoverage.new(43.039, -69.856, 42.943, -71.032) }
-  let(:issued) { "01/02/2013" }
-  let(:issued_xmlschema) { "2013-02-01T00:00:00Z" }
+  let(:issued) { "2013" }
+  let(:issued_xmlschema) { "2013-01-01T00:00:00Z" }
   let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
   let(:change_set) { VectorResourceChangeSet.new(geo_work, files: [file, metadata_file]) }
   let(:change_set_persister) { ChangeSetPersister.new(metadata_adapter: metadata_adapter, storage_adapter: Valkyrie.config.storage_adapter) }
@@ -63,7 +63,7 @@ describe GeoDiscovery::DocumentBuilder do
       expect(document["dc_creator_sm"]).to eq(["Yosiwo George"])
       expect(document["dc_subject_sm"]).to eq(["Society"])
       expect(document["dct_spatial_sm"]).to eq(["Micronesia"])
-      expect(document["dct_temporal_sm"]).to eq(["2011"])
+      expect(document["dct_temporal_sm"]).to eq(["2011", "2013"])
       expect(document["dc_language_s"]).to eq("Esperanto")
       expect(document["dc_publisher_s"]).to eq("National Geographic")
 


### PR DESCRIPTION
Fixes problem with dates that prevented `issue` property from being correctly added to GeoBlacklight documents.