### PR TITLE
Ensures that the ThumbnailHelper#iiif_thumbnail_path handles cases where thumbnails can only be retrieved from member resources

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -177,6 +177,7 @@ Metrics/MethodLength:
     - 'app/jobs/browse_everything_ingest_job.rb'
     - 'app/controllers/application_controller.rb'
     - 'app/services/ingest_ephemera_mods.rb'
+    - 'app/helpers/thumbnail_helper.rb'
 Metrics/ModuleLength:
   Exclude:
     - 'app/models/schema/marc_relators.rb'

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -44,6 +44,7 @@ Release notes template:
 ## Fixed
 
 * Users should now be prevented from submitting multiple Order Manager updates before the initial update has successfully updated the Resource
+* Ensure that cases where thumbnails cannot be resolved for resources are handle with attempts to load thumbnails from any members
 
 * The file upload interface should now filter hidden files on the file system within the File Manager for Resources
 * Imported metadata attributes are now indexed without brackets, class names, etc.


### PR DESCRIPTION
Resolves #3236 