### PR TITLE
Use Discover permissions for Reading Room

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,11 @@ Release notes template:
 -->
 # 2019-08-06
 
+## Added
+
+* If in a configured IP, reading room users can now log in to view Reading Room
+Only material.
+
 ## Fixed
 
 * The file upload interface should now filter hidden files on the file system within the File Manager for Resources

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -54,8 +54,7 @@ class ApplicationController < ActionController::Base
   end
 
   def manifest_denial
-    decorated_resource = @resource.decorate
-    if decorated_resource.public_readable_state? && decorated_resource.read_groups.include?(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED)
+    if current_ability.can?(:discover, @resource)
       head :unauthorized
     else
       head :forbidden

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -178,7 +178,9 @@ class Ability
   end
 
   def valkyrie_test_discover(obj)
-    obj.decorate.public_readable_state?
+    return true if valkyrie_test_read(obj)
+    return false if obj.read_groups.include?(::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_READING_ROOM) && !reading_room_ip?
+    obj.decorate.public_readable_state? && !obj.read_groups.empty?
   end
 
   def valkyrie_test_read(obj)

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -296,7 +296,7 @@ describe Ability do
 
       is_expected.to be_able_to(:discover, open_scanned_resource)
       is_expected.not_to be_able_to(:discover, pending_scanned_resource)
-      is_expected.to be_able_to(:discover, reading_room_scanned_resource)
+      is_expected.not_to be_able_to(:discover, reading_room_scanned_resource)
       is_expected.to be_able_to(:discover, campus_ip_scanned_resource)
     }
 
@@ -306,6 +306,19 @@ describe Ability do
       it {
         is_expected.to be_able_to(:read, campus_ip_scanned_resource)
         is_expected.to be_able_to(:manifest, campus_ip_scanned_resource)
+      }
+    end
+
+    context "with a whitelisted reading room IP" do
+      subject { described_class.new(current_user, ip_address: "1.2.3") }
+      let(:config_hash) { { "access_control" => { "reading_room_ips" => ["1.2.3"] } } }
+      before do
+        allow(Figgy).to receive(:config).and_return(config_hash)
+      end
+      it {
+        is_expected.not_to be_able_to(:read, reading_room_scanned_resource)
+        is_expected.not_to be_able_to(:manifest, reading_room_scanned_resource)
+        is_expected.to be_able_to(:discover, reading_room_scanned_resource)
       }
     end
 
@@ -384,6 +397,7 @@ describe Ability do
       it {
         is_expected.not_to be_able_to(:read, reading_room_scanned_resource)
         is_expected.not_to be_able_to(:manifest, reading_room_scanned_resource)
+        is_expected.not_to be_able_to(:discover, reading_room_scanned_resource)
       }
     end
 
@@ -395,6 +409,7 @@ describe Ability do
       it {
         is_expected.to be_able_to(:read, reading_room_scanned_resource)
         is_expected.to be_able_to(:manifest, reading_room_scanned_resource)
+        is_expected.to be_able_to(:discover, reading_room_scanned_resource)
       }
     end
   end
@@ -467,8 +482,9 @@ describe Ability do
       is_expected.not_to be_able_to(:destroy, admin_file)
 
       is_expected.to be_able_to(:discover, open_scanned_resource)
+      is_expected.not_to be_able_to(:discover, private_scanned_resource)
       is_expected.not_to be_able_to(:discover, pending_scanned_resource)
-      is_expected.to be_able_to(:discover, reading_room_scanned_resource)
+      is_expected.not_to be_able_to(:discover, reading_room_scanned_resource)
       is_expected.to be_able_to(:discover, campus_ip_scanned_resource)
     }
 

--- a/spec/resources/scanned_resources/scanned_resources_controller_spec.rb
+++ b/spec/resources/scanned_resources/scanned_resources_controller_spec.rb
@@ -40,6 +40,20 @@ RSpec.describe ScannedResourcesController, type: :controller do
         expect(response).to be_unauthorized
       end
     end
+    context "when not logged, but in a reading room" do
+      let(:config_hash) { { "access_control" => { "reading_room_ips" => ["1.2.3"] } } }
+      before do
+        # rubocop:disable RSpec/InstanceVariable
+        @request.remote_addr = "1.2.3"
+        # rubocop:enable RSpec/InstanceVariable
+        allow(Figgy).to receive(:config).and_return(config_hash)
+      end
+      it "returns a 401" do
+        resource = FactoryBot.create_for_repository(:reading_room_scanned_resource)
+        get :manifest, params: { id: resource.id, format: :json }
+        expect(response).to be_unauthorized
+      end
+    end
   end
 
   describe "change_set_class" do


### PR DESCRIPTION
* If a user can discover a resource, but can't read it, they'll get an
Unauthorized message which will prompt the viewer to let them log in.

* Users can Discover reading room resources if they're in the reading
room.

* Users can not discover private resources unless they're some sort of
administrator.