### PR TITLE
Add support for ingesting ephemera with MODS metadata

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,7 @@ Lint/ParenthesesAsGroupedExpression:
     - 'spec/services/manifest_builder_spec.rb'
 Metrics/AbcSize:
   Exclude:
+    - 'app/services/ingest_ephemera_mods.rb'
     - 'app/services/ingest_ephemera_service.rb'
     - 'app/services/pdf_generator/cover_page_generator.rb'
     - 'app/models/concerns/linked_data/linked_ephemera_folder.rb'
@@ -175,6 +176,7 @@ Metrics/MethodLength:
     - 'app/jobs/bulk_update_job.rb'
     - 'app/jobs/browse_everything_ingest_job.rb'
     - 'app/controllers/application_controller.rb'
+    - 'app/services/ingest_ephemera_mods.rb'
 Metrics/ModuleLength:
   Exclude:
     - 'app/models/schema/marc_relators.rb'

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,10 @@ Release notes template:
 -->
 # 2019-08-06
 
+## Added
+
+* Added ability to ingest ephemera with MODS metadata.
+
 ## Fixed
 
 * The file upload interface should now filter hidden files on the file system within the File Manager for Resources

--- a/app/jobs/ingest_ukrainian_ephemera_mods_job.rb
+++ b/app/jobs/ingest_ukrainian_ephemera_mods_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+class IngestUkrainianEphemeraMODSJob < ApplicationJob
+  def perform(project, mods, dir)
+    logger.info "Ingesting ephemera folder #{dir}"
+    change_set_persister = ChangeSetPersister.new(
+      metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister),
+      storage_adapter: Valkyrie::StorageAdapter.find(:disk_via_copy)
+    )
+    change_set_persister.queue = queue_name
+    output = nil
+    change_set_persister.buffer_into_index do |buffered_changeset_persister|
+      output = IngestEphemeraMODS::IngestUkrainianEphemeraMODS.new(project, mods, dir, buffered_changeset_persister, logger).ingest
+    end
+    logger.info "Imported #{dir} from pulstore: #{output.id}"
+  end
+end

--- a/app/models/mets_document/mods_document.rb
+++ b/app/models/mets_document/mods_document.rb
@@ -188,6 +188,10 @@ class METSDocument
       normalize_whitespace(value_from(xpath: "mods:originInfo/mods:place")).map(&:strip)
     end
 
+    def geographic_subject
+      value_from(xpath: "mods:subject/mods:geographic").map(&:strip).uniq
+    end
+
     def language
       value_from(xpath: "mods:language/mods:languageTerm")
     end

--- a/app/queries/find_ephemera_term_by_label.rb
+++ b/app/queries/find_ephemera_term_by_label.rb
@@ -12,15 +12,18 @@ class FindEphemeraTermByLabel
     @query_service = query_service
   end
 
-  def find_ephemera_term_by_label(label:, parent_vocab_label: nil)
+  def find_ephemera_term_by_label(label: nil, code: nil, parent_vocab_label: nil)
+    raise(ArgumentError, "Either label or code must be specified") unless label || code
     if parent_vocab_label
       internal_array = { label: Array.wrap(parent_vocab_label) }.to_json
       parent_vocab = run_query(query, EphemeraVocabulary.to_s, internal_array).first
-      internal_array = { label: Array.wrap(label), member_of_vocabulary_id: Array.wrap(parent_vocab.id) }.to_json
+      internal_array = { member_of_vocabulary_id: Array.wrap(parent_vocab.id) }
     else
-      internal_array = { label: Array.wrap(label) }.to_json
+      internal_array = {}
     end
-    run_query(query, EphemeraTerm.to_s, internal_array).first
+    internal_array[:code] = Array.wrap(code) if code
+    internal_array[:label] = Array.wrap(label) if label
+    run_query(query, EphemeraTerm.to_s, internal_array.to_json).first
   end
 
   def query

--- a/app/services/ingest_ephemera_mods.rb
+++ b/app/services/ingest_ephemera_mods.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+class IngestEphemeraMODS
+  attr_accessor :project_id, :mods, :dir, :change_set_persister, :logger
+  delegate :query_service, to: :change_set_persister
+
+  def initialize(project_id, mods, dir, change_set_persister, logger)
+    @project_id = project_id
+    @mods = mods
+    @dir = dir
+    @change_set_persister = change_set_persister
+    @logger = logger
+  end
+
+  def ingest
+    change_set.validate(base_attributes)
+    change_set.validate(mods_attributes)
+    change_set.validate(files: files)
+    change_set.validate(append_id: project_id)
+    change_set_persister.save(change_set: change_set)
+  end
+
+  class IngestUkrainianEphemeraMODS < IngestEphemeraMODS
+    def mods_class
+      UkrainianEphemeraMODS
+    end
+  end
+
+  class UkrainianEphemeraMODS < METSDocument::MODSDocument
+    def geographic_origin
+      ["Ukraine"]
+    end
+
+    def non_name_subjects
+      [
+        "Politics and government--Elections",
+        "Politics and government--Foreign relations",
+        "Politics and government--Political campaigns",
+        "Politics and government--Political parties",
+        "Politics and government--Presidents",
+        "Politics and government--Protest movements"
+      ]
+    end
+  end
+
+  private
+
+    def change_set
+      @change_set ||= BoxlessEphemeraFolderChangeSet.new(EphemeraFolder.new)
+    end
+
+    def mods_attributes
+      {
+        title: native_title,
+        transliterated_title: transliterated_title,
+        sort_title: mods_doc.sort_title,
+        alternative_title: mods_doc.alternative_title,
+        series: mods_doc.series,
+        description: mods_doc.note,
+        publisher: mods_doc.publisher,
+        creator: mods_doc.creator,
+        date_created: mods_doc.date_created,
+        genre: find_term(label: mods_doc.genre, vocab: "LAE Genres"),
+        subject: subjects,
+        language: [find_term(code: mods_doc.language.first, vocab: "LAE Languages")],
+        geographic_origin: [find_term(label: mods_doc.geographic_origin.first, vocab: "LAE Areas")],
+        geo_subject: [find_term(label: mods_doc.geographic_subject.first, vocab: "LAE Areas")],
+        height: height_from_extent,
+        width: width_from_extent,
+        page_count: page_count
+      }
+    end
+
+    def subjects
+      mods_doc.non_name_subjects.map do |t|
+        parts = t.split("--")
+        find_term(label: parts[1], vocab: parts[0])
+      end
+    end
+
+    def mods_doc
+      @mods_doc ||= mods_class.new(Nokogiri::XML(File.read(mods)).root)
+    end
+
+    def mods_class
+      METSDocument::MODSDocument
+    end
+
+    def height_from_extent
+      match = mods_doc.extent.first&.match(/.* (\d+) cm\.*/)
+      match[1] if match
+    end
+
+    def width_from_extent
+      match = mods_doc.extent.first&.match(/.*?(\d+) cm.*/)
+      match[1] if match
+    end
+
+    def page_count
+      match = mods_doc.extent.first&.match(/(\d+) .+ ; .*/)
+      return match[1] if match
+      files.length
+    end
+
+    def find_term(label: nil, code: nil, vocab: nil)
+      query_service.custom_queries.find_ephemera_term_by_label(label: label, code: code, parent_vocab_label: vocab).id
+    rescue
+      label
+    end
+
+    def native_title
+      mods_doc.title.select { |t| !t.language.to_s.downcase.end_with?("latn") }.first
+    end
+
+    def transliterated_title
+      mods_doc.title.select { |t| t.language.to_s.downcase.end_with?("latn") }.first
+    end
+
+    def base_attributes
+      {
+        rights_statement: RightsStatements.copyright_not_evaluated.to_s
+      }
+    end
+
+    def files
+      @files ||= Dir["#{dir}/*.tif"].map do |file|
+        IngestableFile.new(
+          file_path: file,
+          mime_type: "image/tiff",
+          original_filename: File.basename(file),
+          copyable: true
+        )
+      end
+    end
+end

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -20,6 +20,17 @@ namespace :migrate do
     end
   end
 
+  desc "Migrates Ukrainian Ephemera Folders from MODS metadata records"
+  task ukrainian_ephemera_mods: :environment do
+    project = ENV["PROJECT"]
+    mods = ENV["MODS"]
+    dir = ENV["DIR"]
+
+    usage = "usage: rake migrate:ukrainian_ephemera_mods PROJECT=project_id MODS=/path/to/metadata.mods DIR=/path/to/files"
+    abort usage unless project && dir && mods && Dir.exist?(dir) && File.exist?(mods)
+    IngestUkrainianEphemeraMODSJob.set(queue: :low).perform_now(project, mods, dir)
+  end
+
   desc "Migrates Collection members with children who have values in the member_of_collection_ids attribute"
   task collection_members_with_children: :environment do
     resources(model: Collection).each do |collection|

--- a/spec/fixtures/files/ukrainian-001.mods
+++ b/spec/fixtures/files/ukrainian-001.mods
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?oxygen SCHSchema="http://library.princeton.edu/departments/tsd/metadoc/main/mods.sch"?>
+<?xml-stylesheet type="text/css" href="../css/ukraine_form.css" title="ukraine_form" alternate="no"?>
+<mods:mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:mods="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink"
+    xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd"
+    version="3.4">
+    <mods:titleInfo script="Latn" lang="rus" altRepGroup="00">
+        <mods:title>Narodnyĭ prezident: Ol'ga Bogomolet͡s</mods:title>
+    </mods:titleInfo>
+    <mods:titleInfo script="Cyrl" lang="rus" altRepGroup="00">
+        <mods:title>Народный президент: Ольга Богомолец</mods:title>
+    </mods:titleInfo>
+    <mods:name authority="naf" type="personal" script="Latn" altRepGroup="1">
+        <mods:namePart type="family"></mods:namePart>
+        <mods:namePart type="given"></mods:namePart>
+        <mods:namePart type="date"></mods:namePart>
+        <mods:role>
+            <mods:roleTerm type="code" authority="marcrelator">author</mods:roleTerm>
+        </mods:role>
+    </mods:name>
+    <mods:name authority="local" type="personal" script="Cyrl" lang="rus" altRepGroup="1">
+        <mods:namePart type="family"></mods:namePart>
+        <mods:namePart type="given"></mods:namePart>
+        <mods:namePart type="date"></mods:namePart>
+        <mods:role>
+            <mods:roleTerm type="code" authority="marcrelator">author</mods:roleTerm>
+        </mods:role>
+    </mods:name>
+    <mods:typeOfResource>text</mods:typeOfResource>
+    <mods:originInfo>
+        <mods:place>
+            <mods:placeTerm type="text">Kiev</mods:placeTerm>
+        </mods:place>
+        <mods:publisher/>
+        <mods:dateCreated encoding="w3cdtf" keyDate="yes">2014</mods:dateCreated>
+    </mods:originInfo>
+    <mods:language>
+        <mods:languageTerm type="code" authority="iso639-2b">rus</mods:languageTerm>
+    </mods:language>
+    <mods:physicalDescription>
+        <mods:extent>40 cm.</mods:extent>
+    </mods:physicalDescription>
+    <mods:note script="Latn" lang="rus" altRepGroup="03"/>
+    <mods:note script="Cyrl" lang="rus" altRepGroup="03"/>
+    <mods:note/>
+    <mods:note>Bohomolet︠s︡ʹ, Olʹha, 1966- </mods:note>
+    <mods:subject authority="lcsh">
+        <mods:geographic>Ukraine</mods:geographic>
+        <mods:topic>History</mods:topic>
+        <mods:topic>Euromaidan Protests, 2013-2014</mods:topic>
+    </mods:subject>
+    <mods:subject authority="lcsh">
+        <mods:geographic>Ukraine</mods:geographic>
+        <mods:topic>Politics and government</mods:topic>
+        <mods:temporal>1991-</mods:temporal>
+    </mods:subject>
+    <mods:subject authority="lcsh">
+        <mods:geographic>Ukraine</mods:geographic>
+        <mods:topic>Relations</mods:topic>
+        <mods:geographic>Russia (Federation)</mods:geographic>
+    </mods:subject>
+    <mods:subject authority="lcsh">
+        <mods:topic>Presidents</mods:topic>
+        <mods:geographic>Ukraine</mods:geographic>
+        <mods:topic>Election</mods:topic>
+        <mods:temporal>2014</mods:temporal>
+    </mods:subject>
+    <mods:subject authority="lcsh">
+        <mods:topic>Elections</mods:topic>
+        <mods:geographic>Ukraine</mods:geographic>
+    </mods:subject>
+    <mods:subject authority="lcsh">
+        <mods:topic>Political parties</mods:topic>
+        <mods:geographic>Ukraine</mods:geographic>
+    </mods:subject>
+    <mods:subject authority="lcsh">
+        <mods:topic>Political campaigns</mods:topic>
+        <mods:geographic>Ukraine</mods:geographic>
+    </mods:subject>
+    <mods:relatedItem type="host">
+        <mods:titleInfo>
+            <mods:title>Ukrainian Election Ephemera</mods:title>
+        </mods:titleInfo>
+        <mods:location>
+            <mods:url>http://pudl.princeton.edu/collections/pudl0144</mods:url>
+        </mods:location>
+    </mods:relatedItem>
+    <mods:identifier type="local"><!-- TODO: identifier from filename --></mods:identifier>
+    <mods:location>
+        <mods:physicalLocation type="text">Rare Books Off-Site Storage (rcpxr)</mods:physicalLocation>
+        <mods:physicalLocation type="code" authority="marcorg">NjP</mods:physicalLocation>
+    </mods:location>
+    <mods:accessCondition type="useAndReproduction"
+        xlink:href="http://www.princeton.edu/~rbsc/research/rights.html">Use and
+        reproduction</mods:accessCondition>
+    <mods:accessCondition type="restrictionOnAccess"
+        xlink:href="http://www.princeton.edu/~rbsc/research/rules.html">Restrictions on
+        access</mods:accessCondition>
+    <mods:recordInfo>
+        <mods:recordContentSource authority="marcorg">NjP</mods:recordContentSource>
+        <mods:recordIdentifier>http://diglib.princeton.edu/mdata/pudl0144/XXXX.mods</mods:recordIdentifier>
+        <mods:languageOfCataloging>
+            <mods:languageTerm authority="iso639-2b" type="code">eng</mods:languageTerm>
+        </mods:languageOfCataloging>
+    </mods:recordInfo>
+</mods:mods>

--- a/spec/jobs/ingest_ukrainian_ephemera_mods_job_spec.rb
+++ b/spec/jobs/ingest_ukrainian_ephemera_mods_job_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe IngestUkrainianEphemeraMODSJob do
+  describe ".perform" do
+    let(:service) { instance_double(IngestEphemeraMODS::IngestUkrainianEphemeraMODS) }
+    let(:record) { FactoryBot.build(:ephemera_folder) }
+    before do
+      allow(IngestEphemeraMODS::IngestUkrainianEphemeraMODS).to receive(:new).and_return(service)
+      allow(service).to receive(:ingest).and_return(record)
+    end
+    it "Ingests an ephemera MODS file" do
+      described_class.perform_now("project_id", "/path/to/mods", "/path/to/files")
+      expect(service).to have_received(:ingest)
+    end
+  end
+end

--- a/spec/queries/find_ephemera_term_by_label_spec.rb
+++ b/spec/queries/find_ephemera_term_by_label_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 RSpec.describe FindEphemeraTermByLabel do
   subject(:query) { described_class.new(query_service: query_service) }
   let(:term) { FactoryBot.create_for_repository(:ephemera_term, label: "Test", member_of_vocabulary_id: vocab.id) }
-  let(:term2) { FactoryBot.create_for_repository(:ephemera_term, label: "Test", member_of_vocabulary_id: vocab2.id) }
+  let(:term2) { FactoryBot.create_for_repository(:ephemera_term, label: "Test", code: "t", member_of_vocabulary_id: vocab2.id) }
   let(:vocab) { FactoryBot.create_for_repository(:ephemera_vocabulary) }
   let(:vocab2) { FactoryBot.create_for_repository(:ephemera_vocabulary, label: "Test2") }
   let(:query_service) { Valkyrie.config.metadata_adapter.query_service }
@@ -18,6 +18,14 @@ RSpec.describe FindEphemeraTermByLabel do
       term2
       output = query.find_ephemera_term_by_label(label: term.label, parent_vocab_label: vocab.label)
       expect(output.id).to eq term.id
+    end
+    it "can find by code" do
+      term2
+      output = query.find_ephemera_term_by_label(code: "t", parent_vocab_label: vocab2.label)
+      expect(output.id).to eq term2.id
+    end
+    it "errors if neither label nor code is specified" do
+      expect { query.find_ephemera_term_by_label }.to raise_error(ArgumentError)
     end
   end
 end

--- a/spec/services/ingest_ephemera_mods_spec.rb
+++ b/spec/services/ingest_ephemera_mods_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe IngestEphemeraMODS do
+  subject(:service) { described_class.new(project.id, mods, dir, change_set_persister, logger) }
+  let(:project) { FactoryBot.create(:ephemera_project) }
+  let(:mods) { Rails.root.join("spec", "fixtures", "files", "ukrainian-001.mods") }
+  let(:dir) { Rails.root.join("spec", "fixtures", "files", "raster") }
+  let(:change_set_persister) { ChangeSetPersister.new(metadata_adapter: db, storage_adapter: files) }
+  let(:db) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
+  let(:files) { Valkyrie::StorageAdapter.find(:disk_via_copy) }
+  let(:logger) { Logger.new(nil) }
+
+  before do
+    languages = FactoryBot.create_for_repository(:ephemera_vocabulary, label: "LAE Languages")
+    FactoryBot.create_for_repository(:ephemera_term, label: ["Russian"], code: ["rus"], member_of_vocabulary_id: languages.id)
+
+    areas = FactoryBot.create_for_repository(:ephemera_vocabulary, label: "LAE Areas")
+    FactoryBot.create_for_repository(:ephemera_term, label: ["Ukraine"], member_of_vocabulary_id: areas.id)
+  end
+
+  describe "#ingest" do
+    it "ingests the MODS file and TIFFs" do
+      output = service.ingest
+      expect(output).to be_kind_of EphemeraFolder
+      expect(output.date_created).to eq ["2014"]
+      expect(output.decorate.language.first.label).to eq "Russian"
+      expect(output.member_ids.length).to eq 1
+    end
+  end
+
+  context "Ukrainian ephemera" do
+    subject(:service) { IngestEphemeraMODS::IngestUkrainianEphemeraMODS.new(project.id, mods, dir, change_set_persister, logger) }
+
+    it "ingests the MODS file and TIFFs with metadata overrides" do
+      output = service.ingest
+      expect(output).to be_kind_of EphemeraFolder
+      expect(output.date_created).to eq ["2014"]
+      expect(output.decorate.language.first.label).to eq "Russian"
+      expect(output.decorate.geo_subject.first.label).to eq "Ukraine"
+      expect(output.decorate.geographic_origin.label).to eq "Ukraine"
+      expect(output.decorate.subject).to include "Protest movements"
+      expect(output.member_ids.length).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
Mostly targeting Ukrainian ephemera with a subclass that hard-codes some values.  But should be the vast majority of what's needed to ingest other ephemera with MODS metadata.