### PR TITLE
Clear error messages when clearing derivatives

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 Release notes template:
 
-# 2019-07-26
+# 2019-08-07
 
 ## Added
 
@@ -13,6 +13,12 @@ Release notes template:
 ## Removed
 
 -->
+# 2019-08-07
+
+## Fixed
+
+* Clear derivative generation error message from file set when that file set's derivatives are cleaned up
+
 # 2019-08-06
 
 ## Fixed

--- a/app/derivative_services/image_derivative_service.rb
+++ b/app/derivative_services/image_derivative_service.rb
@@ -139,10 +139,12 @@ class ImageDerivativeService
   private
 
     # This removes all Valkyrie::StorageAdapter::File member Objects from a given Resource (usually a FileSet)
+    # and clears error messages from remaining files
     # Resources consistently store the membership using #file_metadata
     # A ChangeSet for the purged members is created and persisted
     def cleanup_derivative_metadata(derivatives:)
       resource.file_metadata = resource.file_metadata.reject { |file| derivatives.include?(file.id) }
+      resource.file_metadata.map { |fm| fm.error_message = [] }
       updated_change_set = DynamicChangeSet.new(resource)
       change_set_persister.buffer_into_index do |buffered_persister|
         buffered_persister.save(change_set: updated_change_set)

--- a/app/derivative_services/jp2_derivative_service.rb
+++ b/app/derivative_services/jp2_derivative_service.rb
@@ -189,10 +189,12 @@ class Jp2DerivativeService
   private
 
     # This removes all Valkyrie::StorageAdapter::File member Objects from a given Resource (usually a FileSet)
+    # and clears error messages from remaining files
     # Resources consistently store the membership using #file_metadata
     # A ChangeSet for the purged members is created and persisted
     def cleanup_derivative_metadata(derivatives:)
       resource.file_metadata = resource.file_metadata.reject { |file| derivatives.include?(file.id) }
+      resource.file_metadata.map { |fm| fm.error_message = [] }
       updated_change_set = DynamicChangeSet.new(resource)
       change_set_persister.buffer_into_index do |buffered_persister|
         buffered_persister.save(change_set: updated_change_set)

--- a/app/derivative_services/raster_resource_derivative_service.rb
+++ b/app/derivative_services/raster_resource_derivative_service.rb
@@ -143,10 +143,12 @@ class RasterResourceDerivativeService
   private
 
     # This removes all Valkyrie::StorageAdapter::File member Objects from a given Resource (usually a FileSet)
+    # and clears error messages from remaining files
     # Resources consistently store the membership using #file_metadata
     # A ChangeSet for the purged members is created and persisted
     def cleanup_derivative_metadata(derivatives:)
       resource.file_metadata = resource.file_metadata.reject { |file| derivatives.include?(file.id) }
+      resource.file_metadata.map { |fm| fm.error_message = [] }
       updated_change_set = DynamicChangeSet.new(resource)
       change_set_persister.buffer_into_index do |buffered_persister|
         buffered_persister.save(change_set: updated_change_set)

--- a/app/derivative_services/vector_resource_derivative_service.rb
+++ b/app/derivative_services/vector_resource_derivative_service.rb
@@ -157,10 +157,12 @@ class VectorResourceDerivativeService
   private
 
     # This removes all Valkyrie::StorageAdapter::File member Objects from a given Resource (usually a FileSet)
+    # and clears error messages from remaining files
     # Resources consistently store the membership using #file_metadata
     # A ChangeSet for the purged members is created and persisted
     def cleanup_derivative_metadata(derivatives:)
       resource.file_metadata = resource.file_metadata.reject { |file| derivatives.include?(file.id) }
+      resource.file_metadata.map { |fm| fm.error_message = [] }
       updated_change_set = DynamicChangeSet.new(resource)
       change_set_persister.buffer_into_index do |buffered_persister|
         buffered_persister.save(change_set: updated_change_set)

--- a/spec/derivative_services/jp2_derivative_service_spec.rb
+++ b/spec/derivative_services/jp2_derivative_service_spec.rb
@@ -148,5 +148,15 @@ RSpec.describe Jp2DerivativeService do
       file_set = query_service.find_all_of_model(model: FileSet).first
       expect(file_set.original_file.error_message).to include(/bad magic number/)
     end
+
+    it "deletes the error_message" do
+      resource = query_service.find_by(id: valid_resource.id)
+      resource.original_file.error_message = ["it went poorly"]
+      persister.save(resource: resource)
+      derivative_service.new(id: resource.id).cleanup_derivatives
+
+      resource = query_service.find_by(id: valid_resource.id)
+      expect(resource.original_file.error_message).to be_empty
+    end
   end
 end

--- a/spec/resources/raster_resources/raster_resource_derivative_service_spec.rb
+++ b/spec/resources/raster_resources/raster_resource_derivative_service_spec.rb
@@ -64,5 +64,15 @@ RSpec.describe RasterResourceDerivativeService do
       reloaded = query_service.find_by(id: valid_resource.id)
       expect(reloaded.file_metadata.select(&:derivative?)).to be_empty
     end
+
+    it "deletes the error_message" do
+      resource = query_service.find_by(id: valid_resource.id)
+      resource.original_file.error_message = ["it went poorly"]
+      persister.save(resource: resource)
+      derivative_service.new(id: resource.id).cleanup_derivatives
+
+      resource = query_service.find_by(id: valid_resource.id)
+      expect(resource.original_file.error_message).to be_empty
+    end
   end
 end

--- a/spec/resources/scanned_maps/scanned_map_derivative_service_spec.rb
+++ b/spec/resources/scanned_maps/scanned_map_derivative_service_spec.rb
@@ -69,5 +69,15 @@ RSpec.describe ScannedMapDerivativeService do
       reloaded = query_service.find_by(id: valid_resource.id)
       expect(reloaded.file_metadata.select(&:derivative?)).to be_empty
     end
+
+    it "deletes the error_message" do
+      resource = query_service.find_by(id: valid_resource.id)
+      resource.original_file.error_message = ["Testing this"]
+      persister.save(resource: resource)
+      derivative_service.new(id: resource.id).cleanup_derivatives
+
+      resource = query_service.find_by(id: valid_resource.id)
+      expect(resource.original_file.error_message).to be_empty
+    end
   end
 end

--- a/spec/resources/vector_resources/vector_resource_derivative_service_spec.rb
+++ b/spec/resources/vector_resources/vector_resource_derivative_service_spec.rb
@@ -69,5 +69,15 @@ RSpec.describe VectorResourceDerivativeService do
       reloaded = query_service.find_by(id: valid_resource.id)
       expect(reloaded.file_metadata.select(&:derivative?)).to be_empty
     end
+
+    it "deletes the error_message" do
+      resource = query_service.find_by(id: valid_resource.id)
+      resource.original_file.error_message = ["it went poorly"]
+      persister.save(resource: resource)
+      derivative_service.new(id: resource.id).cleanup_derivatives
+
+      resource = query_service.find_by(id: valid_resource.id)
+      expect(resource.original_file.error_message).to be_empty
+    end
   end
 end


### PR DESCRIPTION
fixes #3235

Related issue created: https://github.com/pulibrary/figgy/issues/3265

Just an update; I commented in the issue that I wanted to do this in the regenerate derivatives job; that ended up being a bad place for 2 reasons:
 1. When I did it there the jobs stepped on one another and there were stale object errors. 
 2. It fits logically with the clean_derivatives code in the services themselves.