### PR TITLE
Index imported metadata values as plain strings without brackets, class names, etc.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,6 +23,7 @@ Only material.
 ## Fixed
 
 * The file upload interface should now filter hidden files on the file system within the File Manager for Resources
+* Imported metadata attributes are now indexed without brackets, class names, etc.
 
 # 2019-08-05
 

--- a/app/indexers/imported_metadata_indexer.rb
+++ b/app/indexers/imported_metadata_indexer.rb
@@ -26,8 +26,13 @@ class ImportedMetadataIndexer
 
     def primary_imported_properties
       resource.primary_imported_metadata.to_h.except(*suppressed_keys).map do |k, v|
-        ["imported_#{k}_tesim", v.to_s]
+        ["imported_#{k}_tesim", format_values(v)]
       end.to_h
+    end
+
+    def format_values(value)
+      return value.map(&:to_s) if value.is_a?(Array)
+      return value.to_s if value
     end
 
     def suppressed_keys

--- a/spec/indexers/imported_metadata_indexer_spec.rb
+++ b/spec/indexers/imported_metadata_indexer_spec.rb
@@ -21,6 +21,14 @@ RSpec.describe ImportedMetadataIndexer do
       output = described_class.new(resource: resource).to_solr
 
       expect(output[:call_number_tsim]).to eq ["G8731.F7 1949 .C6 (b)"]
+      expect(output["imported_cartographer_tesim"]).to eq ["Nigeria. Survey Department"]
+    end
+
+    it "indexes objects as plain strings" do
+      resource = FactoryBot.build(:scanned_resource)
+      resource.imported_metadata = [ImportedMetadata.new(creator: RDF::Literal.new("Test Literal"))]
+      output = described_class.new(resource: resource).to_solr
+      expect(output["imported_creator_tesim"]).to eq ["Test Literal"]
     end
   end
 end


### PR DESCRIPTION
Fixes #3268