### PR TITLE
Fix viewer empty space.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,7 @@ Release notes template:
 
 * Archival media collection upload will accept images with all-caps `JPG`
   extension
+* Removed dead space at the top of the viewer.
 
 # 2019-08-08
 

--- a/public/viewer.html
+++ b/public/viewer.html
@@ -59,6 +59,8 @@
               var title = titleMatch[1];
               var titleElement = document.getElementById('title');
               titleElement.textContent = title;
+              titleElement.style.display = "block"
+              resize();
             }
           }
           $('#uv').show();
@@ -85,20 +87,21 @@
     </script>
   </head>
   <body>
-    <h1 id="title" class="lux-heading h1"></h1>
+    <h1 id="title" class="lux-heading h1" style="display: none;"></h1>
     <div id="loginContainer" style="display: none;">
       <button type="button" class="lux-button text medium" id="login">Princeton Users: Log in to View</button>
     </div>
     <div id="uv" class="uv"></div>
     <script>
+      var $UV = $('#uv');
+      function resize() {
+        var windowWidth = window.innerWidth;
+        var windowHeight = window.innerHeight;
+        var titleHeight = $("#title").outerHeight($("#title").is(":visible"));
+        $UV.width(windowWidth);
+        $UV.height(windowHeight-titleHeight);
+      }
       $(function() {
-        var $UV = $('#uv');
-        function resize() {
-          var windowWidth = window.innerWidth;
-          var windowHeight = window.innerHeight;
-          $UV.width(windowWidth);
-          $UV.height(windowHeight);
-        }
         $(window).on('resize' ,function() {
           resize();
         });


### PR DESCRIPTION
This has no empty space if there's no title meant to be displayed
(playlists only), and fixes the height if the title -is- displayed.

Closes #3249