### PR TITLE
Add migration to fix PreservationObjects with no FileMetadata IDs

### DIFF
--- a/app/services/migrations/add_preservation_object_ids_migrator.rb
+++ b/app/services/migrations/add_preservation_object_ids_migrator.rb
@@ -11,6 +11,14 @@ class Migrations::AddPreservationObjectIdsMigrator
       preservation_objects(buffered_change_set_persister).each do |obj|
         migrate_preservation_object(obj, change_set_persister)
       end
+      delete_bad_events(buffered_change_set_persister)
+    end
+  end
+
+  def delete_bad_events(change_set_persister)
+    events = query_service.custom_queries.find_by_property(property: :child_id, value: Valkyrie::ID.new(""))
+    events.each do |event|
+      change_set_persister.metadata_adapter.persister.delete(resource: event)
     end
   end
 

--- a/app/services/migrations/add_preservation_object_ids_migrator.rb
+++ b/app/services/migrations/add_preservation_object_ids_migrator.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+class Migrations::AddPreservationObjectIdsMigrator
+  def self.call
+    new.call
+  end
+
+  delegate :query_service, to: :change_set_persister
+
+  def call
+    change_set_persister.buffer_into_index do |buffered_change_set_persister|
+      preservation_objects(buffered_change_set_persister).each do |obj|
+        migrate_preservation_object(obj, change_set_persister)
+      end
+    end
+  end
+
+  def migrate_preservation_object(preservation_object, change_set_persister)
+    # Don't migrate if there's already IDs
+    return if metadata_node_id?(preservation_object) && binary_node_ids?(preservation_object)
+    (preservation_object.metadata_node.id ||= SecureRandom.uuid) if preservation_object.metadata_node
+    preservation_object.binary_nodes.map do |node|
+      node.id ||= SecureRandom.uuid
+    end
+    change_set_persister.metadata_adapter.persister.save(resource: preservation_object)
+  end
+
+  def metadata_node_id?(preservation_object)
+    preservation_object.metadata_node&.id.present?
+  end
+
+  def binary_node_ids?(preservation_object)
+    preservation_object.binary_nodes.empty? || preservation_object.binary_nodes.map(&:id).compact.length == preservation_object.binary_nodes.length
+  end
+
+  # This is an inlined custom query to be memory efficient. As this class will
+  # get removed, it seemed better than writing a whole new custom query.
+  def preservation_objects(change_set_persister)
+    @preservation_objects ||= change_set_persister.query_service.resources.use_cursor.where(internal_resource: "PreservationObject").lazy.map do |attributes|
+      query_service.adapter.resource_factory.to_resource(object: attributes)
+    end
+  end
+
+  def change_set_persister
+    @change_set_persister ||= ScannedResourcesController.change_set_persister
+  end
+end

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -78,6 +78,11 @@ namespace :migrate do
     RecordingDownloadableMigrator.call
   end
 
+  desc "Add FileMetadata IDs to PreservationObjects"
+  task preservation_object_file_metadata_ids: :environment do
+    AddPreservationObjectIdsMigrator.call
+  end
+
   private
 
     # Construct or retrieve the memoized logger for STDOUT

--- a/spec/services/migrations/add_preservation_object_ids_migrator_spec.rb
+++ b/spec/services/migrations/add_preservation_object_ids_migrator_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Migrations::AddPreservationObjectIdsMigrator do
+  describe ".call" do
+    let(:query_service) { ScannedResourcesController.change_set_persister.query_service }
+    it "adds IDs to the MetadataNodes of all PreservationObjects" do
+      preservation_object1 = create_preservation_object(metadata_id: SecureRandom.uuid)
+      create_preservation_object
+
+      before_count = query_service.custom_queries.find_by_property(property: :metadata_node, value: { id: {} }).size
+      expect(before_count).to eq 1
+
+      described_class.call
+
+      after_result = query_service.custom_queries.find_by_property(property: :metadata_node, value: { id: {} })
+      expect(after_result.size).to eq 2
+      expect(after_result.map(&:metadata_node).map(&:id)).to include preservation_object1.metadata_node.id
+      expect(after_result.flat_map(&:binary_nodes).map(&:id).compact.length).to eq 2
+    end
+
+    def create_preservation_object(metadata_id: nil)
+      FactoryBot.create_for_repository(
+        :preservation_object,
+        metadata_node: FileMetadata.new(
+          id: metadata_id
+        ),
+        binary_nodes: [
+          FileMetadata.new(
+            id: metadata_id
+          )
+        ]
+      )
+    end
+  end
+end


### PR DESCRIPTION
This generates IDs for those PreservationObjects which don't have them in their FileMetadata nodes (a result of a bug which has since been fixed), and also deletes any events which try to associate with child_ids that don't exist.

Edit: A fair warning that since most of our events are from the pilot, a vast majority of our events are going to get deleted (all but 553 of them.) However, there's no reasonable way to determine which binary_node an Event was meant for, so it can't really be helped.