### PR TITLE
Bulk Ingest Updates

### DIFF
--- a/app/controllers/bulk_ingest_controller.rb
+++ b/app/controllers/bulk_ingest_controller.rb
@@ -79,9 +79,28 @@ class BulkIngestController < ApplicationController
     def attributes
       {
         member_of_collection_ids: collections_param,
+        source_metadata_identifier: source_metadata_id_from_path,
         state: params[:workflow][:state],
         visibility: params[:visibility]
       }
+    end
+
+    def source_metadata_id_from_path
+      base_path if valid_remote_identifier?(base_path)
+    end
+
+    def base_path
+      File.basename(parent_path.to_s)
+    end
+
+    # Determines whether or not the string encodes a bib. ID or a PULFA ID
+    # See SourceMetadataIdentifierValidator#validate
+    # @param [String] value
+    # @return [Boolean]
+    def valid_remote_identifier?(value)
+      RemoteRecord.valid?(value) && RemoteRecord.retrieve(value).success?
+    rescue URI::InvalidURIError
+      false
     end
 
     def collections

--- a/app/resources/scanned_resources/scanned_resource_change_set.rb
+++ b/app/resources/scanned_resources/scanned_resource_change_set.rb
@@ -28,6 +28,7 @@ class ScannedResourceChangeSet < ChangeSet
   property :file_metadata, multiple: true, required: false, default: []
   property :depositor, multiple: false, require: false
   property :ocr_language, multiple: true, require: false, default: []
+  property :replaces, multiple: true, require: false
 
   # Virtual Attributes
   property :files, virtual: true, multiple: true, required: false

--- a/app/services/bulk_ingest_service.rb
+++ b/app/services/bulk_ingest_service.rb
@@ -26,16 +26,6 @@ class BulkIngestService
     end
   end
 
-  # Determines whether or not the string encodes a bib. ID or a PULFA ID
-  # See SourceMetadataIdentifierValidator#validate
-  # @param [String] value
-  # @return [Boolean]
-  def valid_remote_identifier?(value)
-    RemoteRecord.valid?(value) && RemoteRecord.retrieve(value).success?
-  rescue URI::InvalidURIError
-    false
-  end
-
   # Attach files within a directory
   # This may attach to existing resources (such as EphemeraFolder objects) using a property (e. g. "barcode")
   # This may also create new resources (such as ScannedResource objects)
@@ -53,8 +43,6 @@ class BulkIngestService
 
     base_name = File.basename(base_directory)
     file_name = attributes[:id] || base_name
-    # Assign a bibid to from the base directory name
-    attributes[:source_metadata_identifier] = base_name if attributes.fetch(:source_metadata_identifier, []).blank? && valid_remote_identifier?(base_name)
     # Assign a title if source_metadata_identifier is not set
     title = [directory_path.basename]
     attributes[:title] = title if attributes.fetch(:title, []).blank? && attributes.fetch(:source_metadata_identifier, []).blank?

--- a/spec/controllers/bulk_ingest_controller_spec.rb
+++ b/spec/controllers/bulk_ingest_controller_spec.rb
@@ -66,6 +66,10 @@ RSpec.describe BulkIngestController do
     end
 
     context "with one single-volume resource" do
+      before do
+        stub_bibdata(bib_id: 4609321)
+      end
+
       let(:attributes) do
         {
           workflow: { state: "pending" },
@@ -78,7 +82,7 @@ RSpec.describe BulkIngestController do
       let(:selected_files) do
         {
           "0" => {
-            "url" => "file:///base/resource1/1.tif",
+            "url" => "file:///base/4609321/1.tif",
             "file_name" => "1.tif",
             "file_size" => "100"
           }
@@ -87,7 +91,7 @@ RSpec.describe BulkIngestController do
 
       it "ingests the directory as a single resource" do
         post :browse_everything_files, params: { resource_type: "scanned_resource", **attributes }
-        expect(IngestFolderJob).to have_received(:perform_later).with(hash_including(directory: "/base/resource1", state: "pending", visibility: "open", member_of_collection_ids: ["1234567"]))
+        expect(IngestFolderJob).to have_received(:perform_later).with(hash_including(directory: "/base/4609321", state: "pending", visibility: "open", member_of_collection_ids: ["1234567"], source_metadata_identifier: "4609321"))
       end
 
       context "when no files have been selected" do

--- a/spec/controllers/bulk_ingest_controller_spec.rb
+++ b/spec/controllers/bulk_ingest_controller_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe BulkIngestController do
       allow(IngestFoldersJob).to receive(:perform_later)
     end
 
-    context "with one single-volume resource" do
+    context "with one single-volume resource where the directory is the bibid" do
       before do
         stub_bibdata(bib_id: "4609321")
       end
@@ -111,6 +111,38 @@ RSpec.describe BulkIngestController do
         post :browse_everything_files, params: { resource_type: "scanned_resource", **attributes }
         expected_attributes = {
           directory: "/base/4609321",
+          state: "pending",
+          visibility: "open",
+          member_of_collection_ids: ["1234567"]
+        }
+        expect(IngestFolderJob).to have_received(:perform_later).with(hash_including(expected_attributes))
+      end
+    end
+
+    context "when the directory does not look like a bibid" do
+      let(:attributes) do
+        {
+          workflow: { state: "pending" },
+          collections: ["1234567"],
+          visibility: "open",
+          mvw: false,
+          selected_files: selected_files
+        }
+      end
+      let(:selected_files) do
+        {
+          "0" => {
+            "url" => "file:///base/June 31/1.tif",
+            "file_name" => "1.tif",
+            "file_size" => "100"
+          }
+        }
+      end
+
+      it "ingests the directory as a single resource" do
+        post :browse_everything_files, params: { resource_type: "scanned_resource", **attributes }
+        expected_attributes = {
+          directory: "/base/June 31",
           state: "pending",
           visibility: "open",
           member_of_collection_ids: ["1234567"]

--- a/spec/resources/scanned_resources/scanned_resource_change_set_spec.rb
+++ b/spec/resources/scanned_resources/scanned_resource_change_set_spec.rb
@@ -128,4 +128,16 @@ RSpec.describe ScannedResourceChangeSet do
       expect(change_set.primary_terms).not_to include :preservation_policy
     end
   end
+
+  describe "#replaces" do
+    let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
+    let(:storage_adapter) { Valkyrie.config.storage_adapter }
+    let(:change_set_persister) { ChangeSetPersister.new(metadata_adapter: adapter, storage_adapter: storage_adapter) }
+
+    it "applies the value to the underlying resource" do
+      change_set.validate(replaces: "foo/xyz")
+      persisted = change_set_persister.save(change_set: change_set)
+      expect(persisted.replaces).to eq(["foo/xyz"])
+    end
+  end
 end

--- a/spec/services/bulk_ingest_service_spec.rb
+++ b/spec/services/bulk_ingest_service_spec.rb
@@ -142,22 +142,6 @@ RSpec.describe BulkIngestService do
       end
     end
 
-    context "when a directory has a bibid as a name" do
-      let(:single_dir) { Rails.root.join("spec", "fixtures", "ingest_bibid", "4609321") }
-      it "assigns the bibid to the source metada identifier" do
-        ingester.attach_dir(
-          base_directory: single_dir,
-          file_filters: [".tif"],
-          collection: coll
-        )
-
-        updated_collection = query_service.find_by(id: coll.id)
-        decorated_collection = updated_collection.decorate
-        resource = decorated_collection.members.to_a.first
-        expect(resource.source_metadata_identifier).to include(bib)
-      end
-    end
-
     context "with a relative path for the directory" do
       let(:bulk_ingester) { described_class.new(change_set_persister: change_set_persister, logger: logger) }
       let(:single_dir) { File.join("spec", "fixtures", "ingest_single") }
@@ -265,17 +249,6 @@ RSpec.describe BulkIngestService do
       end
       it "raises an error" do
         expect { ingester.attach_each_dir(base_directory: empty_dir) }.to raise_error(ArgumentError, "BulkIngestService: Directory is empty: #{empty_dir}")
-      end
-    end
-  end
-
-  describe "#valid_remote_identifier?" do
-    context "with a non-bibid identifier that contains invalid characters" do
-      # We might see a value like this in a directory tree, and therefore check it as a source metadata id
-      let(:value) { "June 31" }
-
-      it "returns false" do
-        expect(ingester.valid_remote_identifier?(value)).to be false
       end
     end
   end


### PR DESCRIPTION
* Support the `replaces` attribute
* Move BibID-guessing to BulkIngestController, to allow command-line ingest of items without BibIDs