### PR TITLE
Ensures that tombstones are generated for deleted ScannedResources and can be used for reinstating ScannedResources

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,7 @@ Metrics/AbcSize:
     - 'app/services/preserver.rb'
     - 'app/jobs/ingest_archival_media_bag_job.rb'
     - 'app/utils/data_seeder.rb'
+    - 'app/services/preserver/blind_importer.rb'
 Metrics/BlockLength:
   Exclude:
     - 'app/controllers/catalog_controller.rb'
@@ -178,6 +179,7 @@ Metrics/MethodLength:
     - 'app/controllers/application_controller.rb'
     - 'app/services/ingest_ephemera_mods.rb'
     - 'app/helpers/thumbnail_helper.rb'
+    - 'app/services/preserver/blind_importer.rb'
 Metrics/ModuleLength:
   Exclude:
     - 'app/models/schema/marc_relators.rb'

--- a/app/change_set_persisters/change_set_persister/create_tombstone.rb
+++ b/app/change_set_persisters/change_set_persister/create_tombstone.rb
@@ -7,19 +7,9 @@ class ChangeSetPersister
       @change_set_persister = change_set_persister
     end
 
-    def file_set_with_parent?
-      if resource.is_a?(FileSet)
-        resource.try(:original_file) && parent
-      else
-        file_sets = resource.decorate.try(:file_sets)
-        return if file_sets.blank?
-
-        file_sets.first.try(:original_file)
-      end
-    end
-
     def run
-      return unless file_set_with_parent?
+      return unless resource.is_a?(FileSet) || resource.decorate.respond_to?(:file_sets)
+
       tombstone = Tombstone.new
       tombstone_change_set = DynamicChangeSet.new(tombstone)
       tombstone_change_set.validate(attributes)
@@ -31,10 +21,13 @@ class ChangeSetPersister
       def file_set
         return resource if resource.is_a?(FileSet)
 
-        resource.decorate.file_sets.first
+        file_sets = resource.decorate.file_sets
+        file_sets.first
       end
 
       def original_filename
+        return unless file_set && file_set.original_file
+
         file_set.original_file.original_filename
       end
 

--- a/app/change_set_persisters/change_set_persister/create_tombstone.rb
+++ b/app/change_set_persisters/change_set_persister/create_tombstone.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 class ChangeSetPersister
   class CreateTombstone
-    attr_reader :resource, :change_set_persister
+    attr_reader :change_set, :change_set_persister
+    delegate :resource, to: :change_set
     def initialize(change_set_persister: nil, change_set:, post_save_resource: nil)
-      @resource = change_set.resource
+      @change_set = change_set
       @change_set_persister = change_set_persister
     end
 
     def run
-      return unless resource.is_a?(FileSet) || resource.decorate.respond_to?(:file_sets)
+      return unless change_set.try(:preserve?)
 
       tombstone = Tombstone.new
       tombstone_change_set = DynamicChangeSet.new(tombstone)

--- a/app/change_set_persisters/change_set_persister/create_tombstone.rb
+++ b/app/change_set_persisters/change_set_persister/create_tombstone.rb
@@ -39,14 +39,13 @@ class ChangeSetPersister
       end
 
       def attributes
-        values = {
-          file_set_id: resource.id,
-          file_set_title: resource.title,
-          file_set_original_filename: original_filename,
-          preservation_object: preservation_object
+        {
+          resource_id: resource.id,
+          resource_title: resource.try(:title),
+          resource_original_filename: original_filename,
+          preservation_object: preservation_object,
+          parent_id: parent.try(:id)
         }
-        values[:parent_id] = parent.id if resource.is_a?(FileSet)
-        values
       end
 
       def preservation_object

--- a/app/change_set_persisters/change_set_persister/create_tombstone.rb
+++ b/app/change_set_persisters/change_set_persister/create_tombstone.rb
@@ -42,6 +42,8 @@ class ChangeSetPersister
       end
 
       def preservation_object
+        return unless wayfinder.respond_to?(:preservation_object)
+
         wayfinder.preservation_object
       end
 

--- a/app/resources/tombstones/tombstone.rb
+++ b/app/resources/tombstones/tombstone.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class Tombstone < Valkyrie::Resource
-  attribute :file_set_id, Valkyrie::Types::ID
-  attribute :file_set_title
-  attribute :file_set_original_filename
+  attribute :resource_id, Valkyrie::Types::ID
+  attribute :resource_title
+  attribute :resource_original_filename
   attribute :preservation_object, PreservationObject.optional
   attribute :parent_id, Valkyrie::Types::ID
   alias deleted_at created_at

--- a/app/resources/tombstones/tombstone_change_set.rb
+++ b/app/resources/tombstones/tombstone_change_set.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 class TombstoneChangeSet < ChangeSet
-  property :file_set_id
-  property :file_set_title
-  property :file_set_original_filename
+  property :resource_id
+  property :resource_title
+  property :resource_original_filename
   property :preservation_object
   property :parent_id
 end

--- a/app/services/preserver/blind_importer.rb
+++ b/app/services/preserver/blind_importer.rb
@@ -33,6 +33,14 @@ class Preserver::BlindImporter
     end
     # Get rid of non-preserved members.
     source_change_set.try(:member_ids=, member_ids)
+    # Delete any tombstones
+    source_change_set.created_file_sets.each do |_created_file_set|
+      persisted_tombstones = change_set_persister.query_service.custom_queries.find_by_property(property: :resource_id, value: source_resource.id)
+      persisted_tombstones.each do |tombstone|
+        tombstone_change_set = TombstoneChangeSet.new(tombstone)
+        change_set_persister.delete(change_set: tombstone_change_set)
+      end
+    end
     output = change_set_persister.save(change_set: source_change_set)
     output
   end

--- a/app/services/preserver/blind_importer.rb
+++ b/app/services/preserver/blind_importer.rb
@@ -34,12 +34,10 @@ class Preserver::BlindImporter
     # Get rid of non-preserved members.
     source_change_set.try(:member_ids=, member_ids)
     # Delete any tombstones
-    source_change_set.created_file_sets.each do |_created_file_set|
-      persisted_tombstones = change_set_persister.query_service.custom_queries.find_by_property(property: :resource_id, value: source_resource.id)
-      persisted_tombstones.each do |tombstone|
-        tombstone_change_set = TombstoneChangeSet.new(tombstone)
-        change_set_persister.delete(change_set: tombstone_change_set)
-      end
+    persisted_tombstones = change_set_persister.query_service.custom_queries.find_by_property(property: :resource_id, value: source_resource.id)
+    persisted_tombstones.each do |tombstone|
+      tombstone_change_set = TombstoneChangeSet.new(tombstone)
+      change_set_persister.delete(change_set: tombstone_change_set)
     end
     output = change_set_persister.save(change_set: source_change_set)
     output

--- a/app/views/base/file_manager.html.erb
+++ b/app/views/base/file_manager.html.erb
@@ -35,7 +35,7 @@
     <tbody>
       <% decorated_change_set_resource.wayfinder.child_tombstones.each do |tombstone| %>
         <tr>
-          <td><%= tombstone.file_set_title&.first %> (<%= tombstone.file_set_original_filename&.first %>)</td>
+          <td><%= tombstone.resource_title&.first %> (<%= tombstone.resource_original_filename&.first %>)</td>
           <td>
             <% if tombstone.preservation_object.present? && @change_set.respond_to?(:tombstone_restore_ids) %>
               <%= simple_form_for(@change_set) do |f| %>

--- a/spec/change_set_persisters/change_set_persister_spec.rb
+++ b/spec/change_set_persisters/change_set_persister_spec.rb
@@ -1651,9 +1651,9 @@ RSpec.describe ChangeSetPersister do
         tombstones = change_set_persister.query_service.find_all_of_model(model: Tombstone)
         expect(tombstones.to_a.length).to eq 1
         tombstone = tombstones.first
-        expect(tombstone.file_set_id).to eq file_set.id
-        expect(tombstone.file_set_title).to eq file_set.title
-        expect(tombstone.file_set_original_filename).to eq file_set.original_file.original_filename
+        expect(tombstone.resource_id).to eq file_set.id
+        expect(tombstone.resource_title).to eq file_set.title
+        expect(tombstone.resource_original_filename).to eq file_set.original_file.original_filename
         expect(tombstone.deleted_at).to eq tombstones.first.created_at
         expect(tombstone.preservation_object.preserved_object_id).to eq file_set.id
         expect(tombstone.parent_id).to eq resource.id

--- a/spec/views/scanned_resources/file_manager.html.erb_spec.rb
+++ b/spec/views/scanned_resources/file_manager.html.erb_spec.rb
@@ -34,14 +34,14 @@ RSpec.describe "base/file_manager.html.erb", type: :view do
       FactoryBot.create_for_repository(
         :tombstone,
         parent_id: scanned_resource.id,
-        file_set_id: "1",
-        file_set_title: "Test Title",
-        file_set_original_filename: "02.tif",
+        resource_id: "1",
+        resource_title: "Test Title",
+        resource_original_filename: "02.tif",
         preservation_object: PreservationObject.new
       )
     end
     let(:unpreserved_tombstone) do
-      FactoryBot.create_for_repository(:tombstone, parent_id: scanned_resource.id, file_set_id: "1", file_set_title: "Test Title 2", file_set_original_filename: "01.tif")
+      FactoryBot.create_for_repository(:tombstone, parent_id: scanned_resource.id, resource_id: "1", resource_title: "Test Title 2", resource_original_filename: "01.tif")
     end
     it "renders a form to reinstate it" do
       expect(rendered).to include "<h2>Deleted Files</h2>"


### PR DESCRIPTION
Advances #3349 (I have not tested this beyond ScannedResources, but that may not be necessary).  This also may relate to #3347. 