### PR TITLE
Use global variable to store order manager fetching state

### DIFF
--- a/app/javascript/components/OrderManagerControls.vue
+++ b/app/javascript/components/OrderManagerControls.vue
@@ -97,7 +97,7 @@ export default {
       return this.resource.isMultiVolume
     },
     isDisabled: function () {
-      if (this.$store.getters.stateChanged && !this.fetching) {
+      if (this.$store.getters.stateChanged && !window.fetching) {
         return false
       } else {
         return true
@@ -188,7 +188,7 @@ export default {
       for (let i = 0; i < memberNum; i++) {
         resource.filesets.push(membersBody[i])
       }
-      this.fetching = true
+      window.fetching = true
       window.resource = resource
       this.$store.dispatch('saveStateGql', resource)
     },
@@ -203,7 +203,7 @@ export default {
         thumbnail_id: this.thumbnail,
         id: this.id
       }
-      this.fetching = true
+      window.fetching = true
       this.$store.dispatch('saveStateGql', body)
     }
   }

--- a/app/javascript/store/resource/index.js
+++ b/app/javascript/store/resource/index.js
@@ -33,7 +33,7 @@ export const resourceMutations = {
   },
   SAVED_STATE(state, saveStatus) {
     state.resource.saveState = saveStatus
-    state.fetching = false
+    window.fetching = false
   },
   SET_RESOURCE(state, resource) {
     state.resource.id = resource.id

--- a/app/javascript/test/orderManagerControls.spec.js
+++ b/app/javascript/test/orderManagerControls.spec.js
@@ -143,6 +143,7 @@ describe("OrderManagerControls.vue", () => {
   })
 
   it('will not allow save when nothing has changed', () => {
+    expect(window.fetching).toBeFalsy()
     expect(wrapper.vm.isDisabled).toBeTruthy()
   })
 
@@ -255,7 +256,7 @@ describe("OrderManagerControls.vue", () => {
 
     // calls the appropriate action on save
     wrapper.vm.saveHandler()
-    expect(wrapper.vm.fetching).toBeTruthy()
+    expect(window.fetching).toBeTruthy()
     expect(actions.saveStateGql).toHaveBeenCalled()
   })
 


### PR DESCRIPTION
Order manager fetch state is never returned to true.

The context of `this` in the `isDisabled` method:

https://github.com/pulibrary/figgy/blob/f4d6b17e6c0dc422c8e541a97727fb7a43376cf9/app/javascript/components/OrderManagerControls.vue#L100

is different from the context of `this` in the `SAVED_STATE` method:
https://github.com/pulibrary/figgy/blob/f4d6b17e6c0dc422c8e541a97727fb7a43376cf9/app/javascript/store/resource/index.js#L36

The result is that the fetching state is never returned to `false`. This PR uses a global variable to store this state. 

Closes #3399 