### PR TITLE
Use VIPS to remove compression from Tiffs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
       - checkout
       - run: sudo sh bin/ci_mediainfo_install.sh
       - run: sudo apt-get update
-      - run: sudo apt-get install gdal-bin libgdal-dev libcairo2-dev libpango1.0-dev mediainfo
+      - run: sudo apt-get install gdal-bin libgdal-dev libcairo2-dev libpango1.0-dev mediainfo libvips libvips-dev
       - run: sudo sh bin/ci_simple_tiles_install.sh
       - run: sudo sh bin/ci_free_tds_install.sh
       # Restore Cached Dependencies
@@ -88,7 +88,7 @@ jobs:
             sudo apt-get update
             sudo apt-get -y install google-chrome-stable
       - run: sudo apt-get update
-      - run: sudo apt-get install gdal-bin libgdal-dev libcairo2-dev libpango1.0-dev tesseract-ocr tesseract-ocr-ita tesseract-ocr-eng mediainfo ffmpeg postgresql-client
+      - run: sudo apt-get install gdal-bin libgdal-dev libcairo2-dev libpango1.0-dev tesseract-ocr tesseract-ocr-ita tesseract-ocr-eng mediainfo ffmpeg postgresql-client libvips libvips-dev
       - run: sudo sh bin/ci_simple_tiles_install.sh
       - run: sudo sh bin/ci_free_tds_install.sh
       # Wait for DB
@@ -156,7 +156,7 @@ jobs:
           at: '~/figgy'
       - run: sudo sh bin/ci_mediainfo_install.sh
       - run: sudo apt-get update
-      - run: sudo apt-get install gdal-bin libgdal-dev libcairo2-dev libpango1.0-dev mediainfo
+      - run: sudo apt-get install gdal-bin libgdal-dev libcairo2-dev libpango1.0-dev mediainfo libvips libvips-dev
       - run: sudo sh bin/ci_simple_tiles_install.sh
       - run: sudo sh bin/ci_free_tds_install.sh
       # Remove cached simpler-tiles - needs to be reinstalled every time.

--- a/Gemfile
+++ b/Gemfile
@@ -131,3 +131,4 @@ end
 
 gem "aws-sdk-s3"
 gem "extra_extra"
+gem "ruby-vips"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -724,6 +724,8 @@ GEM
     ruby-prof (0.18.0)
     ruby-progressbar (1.9.0)
     ruby-rc4 (0.1.5)
+    ruby-vips (2.0.15)
+      ffi (~> 1.9)
     ruby_dep (1.5.0)
     rubyzip (1.3.0)
     safe_yaml (1.0.4)
@@ -971,6 +973,7 @@ DEPENDENCIES
   rspec-rails (~> 3.5)
   rspec_junit_formatter
   ruby-prof
+  ruby-vips
   ruby_tika_app!
   rubyzip (>= 1.2.2)
   sass-rails (~> 5.0)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ A digital repository application in use at Princeton University Library for stor
 * [FreeTDS]
     * Needed for migration of music reserve data; we'll likely remove this dependency once that's all done
     * `brew install FreeTDS`
+* [VIPS]
+    * `brew install vips`
 
 ## Simple Tiles
 

--- a/app/derivative_services/jp2_derivative_service.rb
+++ b/app/derivative_services/jp2_derivative_service.rb
@@ -169,11 +169,8 @@ class Jp2DerivativeService
     @cleaned_file ||=
       begin
         t = Tempfile.new
-        MiniMagick::Tool::Convert.new do |convert|
-          convert << file_object.disk_path.to_s
-          convert.compress.+
-          convert << t.path.to_s
-        end
+        image = Vips::Image.new_from_file file_object.disk_path.to_s
+        image.tiffsave t.path.to_s, compression: 0
         t
       end
   end


### PR DESCRIPTION
It's more memory efficient, we're hoping it fixes the problem with large
TIFFs.

We'll need to install libvips and libvips-dev on the machines if we
deploy this.