### PR TITLE
Fix DataSeeder.

### DIFF
--- a/app/utils/data_seeder.rb
+++ b/app/utils/data_seeder.rb
@@ -283,7 +283,8 @@ class DataSeeder
     def geo_attributes
       {
         coverage: coverage,
-        provenance: "Princeton"
+        provenance: "Princeton",
+        held_by: "Princeton"
       }
     end
 

--- a/spec/utils/data_seeder_spec.rb
+++ b/spec/utils/data_seeder_spec.rb
@@ -43,6 +43,11 @@ RSpec.describe DataSeeder do
       expect(query_service.find_all_of_model(model: RasterResource).count).to eq 2
       expect(query_service.find_all_of_model(model: VectorResource).count).to eq 1
 
+      scanned_maps = query_service.find_all_of_model(model: ScannedMap)
+      # held_by must be populated or the events can't be generated.
+      expect(scanned_maps.flat_map(&:held_by).compact.length).to eq 12
+      expect(scanned_maps.flat_map(&:held_by).uniq).to eq ["Princeton"]
+
       seeder.wipe_metadata!
       expect(Valkyrie::MetadataAdapter.find(:indexing_persister).query_service.find_all.count).to eq 0
 


### PR DESCRIPTION
Running this was causing an error generating events because held_by
wasn't always being populated. This fixes that.

I was unable to get the data seeder to actually generate this error even
when running background jobs, so there must be some difference in running
in dev vs test.