### PR TITLE
Preserve everything

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,6 +20,12 @@ Release notes template:
 * Automatically adding links to Figgy objects to finding aids as DAO elements.
 * Exporting collections as PDFs.
 
+# 2019-10-16
+
+## Added
+
+* Figgy resources are now preserved by default
+
 # 2019-10-14
 
 ## Added

--- a/app/change_sets/change_set.rb
+++ b/app/change_sets/change_set.rb
@@ -54,20 +54,6 @@ class ChangeSet < Valkyrie::ChangeSet
     self.feature_terms += [:pdf_type]
   end
 
-  def self.enable_preservation_support
-    property :preservation_policy, multiple: false, required: false, default: nil
-    self.feature_terms += [:preservation_policy]
-    define_method :preserve? do
-      return false unless persisted? && resource.respond_to?(:preservation_policy)
-      parent = Wayfinder.for(resource).try(:parent)
-      if parent.present? && parent.id != resource.id
-        DynamicChangeSet.new(parent).try(:preserve?)
-      else
-        resource.preservation_policy.present? && state == "complete"
-      end
-    end
-  end
-
   # This property is set by ChangeSetPersister::CreateFile and is used to keep
   # track of which FileSets were created by the ChangeSetPersister as part of
   # saving this change_set. We may want to look into passing some sort of scope
@@ -77,6 +63,19 @@ class ChangeSet < Valkyrie::ChangeSet
   def initialize(*args)
     super.tap do
       fix_multivalued_keys
+    end
+  end
+
+  # Enable preservation by default
+  def preserve?
+    return false unless persisted?
+    parent = Wayfinder.for(resource).try(:parent)
+    if parent.present? && parent.id != resource.id
+      DynamicChangeSet.new(parent).try(:preserve?)
+    elsif resource.respond_to?(:state)
+      state == "complete"
+    else
+      true
     end
   end
 

--- a/app/jobs/ingest_archival_media_bag_job.rb
+++ b/app/jobs/ingest_archival_media_bag_job.rb
@@ -173,7 +173,6 @@ class IngestArchivalMediaBagJob < ApplicationJob
             property => value,
             visibility: collection.visibility.first,
             downloadable: "public",
-            preservation_policy: "cloud",
             **recording_attributes
           )
         end
@@ -217,7 +216,6 @@ class IngestArchivalMediaBagJob < ApplicationJob
             visibility: collection.visibility.first,
             upload_set_id: upload_set_id,
             downloadable: "public",
-            preservation_policy: "cloud",
             rights_statement: RightsStatements.copyright_not_evaluated
           )
         end

--- a/app/models/controlled_vocabulary.rb
+++ b/app/models/controlled_vocabulary.rb
@@ -310,16 +310,6 @@ class ControlledVocabulary
     end
   end
 
-  class PreservationPolicy < ControlledVocabulary
-    ControlledVocabulary.register(:preservation_policy, self)
-
-    def all(_scope = nil)
-      [
-        Term.new(label: "Cloud Storage", value: "cloud")
-      ]
-    end
-  end
-
   # Controlled vocabularies for PDF types
   # Unlike with other authorities, no YAML file is used for these values
   class DownloadableState < ControlledVocabulary

--- a/app/models/schema/common.rb
+++ b/app/models/schema/common.rb
@@ -78,8 +78,7 @@ module Schema
           :imported_author, # Local
           :rendered_rights_statement, # Local
           :coverage_point, # local, used for latitude / longitude
-          :downloadable, # Determines whether or not users can download a resource
-          :preservation_policy
+          :downloadable # Determines whether or not users can download a resource
         ]
     end
 

--- a/app/resources/events/event_change_set.rb
+++ b/app/resources/events/event_change_set.rb
@@ -6,4 +6,8 @@ class EventChangeSet < ChangeSet
   property :child_property, multiple: false
   property :child_id, multiple: false, type: Valkyrie::Types::ID
   property :message, multiple: false, required: true
+
+  def preserve?
+    false
+  end
 end

--- a/app/resources/media_resources/media_resource_change_set.rb
+++ b/app/resources/media_resources/media_resource_change_set.rb
@@ -2,7 +2,6 @@
 class MediaResourceChangeSet < ChangeSet
   apply_workflow(DraftCompleteWorkflow)
   delegate :human_readable_type, to: :resource
-  enable_preservation_support
 
   include VisibilityProperty
   include RemoteMetadataProperty

--- a/app/resources/preservation_objects/preservation_object_change_set.rb
+++ b/app/resources/preservation_objects/preservation_object_change_set.rb
@@ -1,3 +1,6 @@
 # frozen_string_literal: true
 class PreservationObjectChangeSet < ChangeSet
+  def preserve?
+    false
+  end
 end

--- a/app/resources/scanned_resources/recording_change_set.rb
+++ b/app/resources/scanned_resources/recording_change_set.rb
@@ -2,7 +2,6 @@
 class RecordingChangeSet < ChangeSet
   apply_workflow(DraftCompleteWorkflow)
   delegate :human_readable_type, to: :resource
-  enable_preservation_support
 
   include VisibilityProperty
   include RemoteMetadataProperty

--- a/app/resources/scanned_resources/recording_change_set.rb
+++ b/app/resources/scanned_resources/recording_change_set.rb
@@ -41,4 +41,25 @@ class RecordingChangeSet < ChangeSet
       :change_set
     ]
   end
+
+  # Do not preserve Audio Reserves recordings
+  def preserve?
+    return false unless persisted?
+    if in_archival_media_collection?
+      true
+    else
+      false
+    end
+  end
+
+  private
+
+    def in_archival_media_collection?
+      collections = Wayfinder.for(resource).collections
+      collections.each do |collection|
+        return true if collection.change_set == "archival_media_collection"
+      end
+
+      false
+    end
 end

--- a/app/resources/scanned_resources/scanned_resource_change_set.rb
+++ b/app/resources/scanned_resources/scanned_resource_change_set.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 class ScannedResourceChangeSet < ChangeSet
   apply_workflow(BookWorkflow)
-  enable_preservation_support
   delegate :human_readable_type, to: :model
 
   include VisibilityProperty

--- a/app/resources/tombstones/tombstone_change_set.rb
+++ b/app/resources/tombstones/tombstone_change_set.rb
@@ -6,4 +6,8 @@ class TombstoneChangeSet < ChangeSet
   property :file_set_original_filename
   property :preservation_object
   property :parent_id
+
+  def preserve?
+    false
+  end
 end

--- a/app/resources/vector_resources/vector_resource_change_set.rb
+++ b/app/resources/vector_resources/vector_resource_change_set.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 class VectorResourceChangeSet < ChangeSet
   apply_workflow(GeoWorkflow)
-  enable_preservation_support
   delegate :human_readable_type, to: :model
 
   include GeoChangeSetProperties

--- a/spec/change_set_persisters/change_set_persister_spec.rb
+++ b/spec/change_set_persisters/change_set_persister_spec.rb
@@ -1532,7 +1532,7 @@ RSpec.describe ChangeSetPersister do
   end
 
   describe "preservation" do
-    context "when a completed resource is updated with a `cloud` preservation_policy outside of the change_set_persister" do
+    context "when a completed preserved resource is updated outside of the change_set_persister" do
       it "backgrounds any child preserving" do
         allow(Preserver).to receive(:new).and_call_original
         allow(PreserveChildrenJob).to receive(:perform_later).and_call_original
@@ -1541,21 +1541,20 @@ RSpec.describe ChangeSetPersister do
         resource = FactoryBot.create_for_repository(:complete_scanned_resource, files: [file])
         file_set = Wayfinder.for(resource).members.first
         file_set.read_groups = []
-        resource.preservation_policy = "cloud"
         resource = change_set_persister.metadata_adapter.persister.save(resource: resource)
         change_set_persister.metadata_adapter.persister.save(resource: file_set)
         change_set = DynamicChangeSet.new(resource)
 
         change_set_persister.save(change_set: change_set)
         expect(PreserveChildrenJob).to have_received(:perform_later).exactly(1).times
-        expect(Preserver).to have_received(:new).exactly(2).times
+        expect(Preserver).to have_received(:new).exactly(5).times
         expect(CleanupFilesJob).not_to have_received(:perform_later)
       end
     end
-    context "when completing a `cloud` preservation_policy resource" do
+    context "when completing preserved resource" do
       it "saves to a backup location" do
         file = fixture_file_upload("files/example.tif", "image/tiff")
-        resource = FactoryBot.create_for_repository(:pending_scanned_resource, preservation_policy: "cloud", files: [file])
+        resource = FactoryBot.create_for_repository(:pending_scanned_resource, files: [file])
         change_set = DynamicChangeSet.new(resource)
         change_set.validate(state: "complete")
 
@@ -1581,7 +1580,7 @@ RSpec.describe ChangeSetPersister do
       with_queue_adapter :test
       it "preserves it inline" do
         file = fixture_file_upload("files/example.tif", "image/tiff")
-        resource = FactoryBot.create_for_repository(:pending_scanned_resource, preservation_policy: "cloud", files: [file])
+        resource = FactoryBot.create_for_repository(:pending_scanned_resource, files: [file])
         change_set = DynamicChangeSet.new(resource)
         change_set.validate(state: "complete")
 
@@ -1596,7 +1595,7 @@ RSpec.describe ChangeSetPersister do
     context "when a preserved ScannedResource's metadata is updated" do
       it "refreshes the preserved metadata" do
         file = fixture_file_upload("files/example.tif", "image/tiff")
-        resource = FactoryBot.create_for_repository(:complete_scanned_resource, preservation_policy: "cloud", files: [file])
+        resource = FactoryBot.create_for_repository(:complete_scanned_resource, files: [file])
         change_set_persister.save(change_set: DynamicChangeSet.new(resource))
         file_set = Wayfinder.for(resource).members.first
 
@@ -1622,7 +1621,7 @@ RSpec.describe ChangeSetPersister do
         file_set.preservation_file.file_identifiers = preservation.id
         file_set.preservation_file.label = "example.tif"
         change_set_persister.persister.save(resource: file_set)
-        resource = FactoryBot.create_for_repository(:complete_scanned_resource, preservation_policy: "cloud", member_ids: [file_set.id])
+        resource = FactoryBot.create_for_repository(:complete_scanned_resource, member_ids: [file_set.id])
 
         change_set = DynamicChangeSet.new(resource)
         change_set_persister.save(change_set: change_set)
@@ -1632,10 +1631,10 @@ RSpec.describe ChangeSetPersister do
       end
     end
 
-    context "when deleting a `cloud` preservation_policy FileSet" do
+    context "when deleting a preserved FileSet" do
       it "Deletes FileSet PreservationObjects, moves file set PreservationObjects into tombstones" do
         file = fixture_file_upload("files/example.tif", "image/tiff")
-        resource = FactoryBot.create_for_repository(:pending_scanned_resource, preservation_policy: "cloud", files: [file])
+        resource = FactoryBot.create_for_repository(:pending_scanned_resource, files: [file])
         change_set = DynamicChangeSet.new(resource)
         change_set.validate(state: "complete")
 
@@ -1659,10 +1658,10 @@ RSpec.describe ChangeSetPersister do
         expect(tombstone.parent_id).to eq resource.id
       end
     end
-    context "when deleting a `cloud` preservation_policy resource" do
+    context "when deleting preserved resource" do
       it "deletes all previously created FileSet tombstones for that parent, related PreservationObjects, and cleans up the Preservation file store" do
         file = fixture_file_upload("files/example.tif", "image/tiff")
-        resource = FactoryBot.create_for_repository(:pending_scanned_resource, preservation_policy: "cloud", files: [file])
+        resource = FactoryBot.create_for_repository(:pending_scanned_resource, files: [file])
         change_set = DynamicChangeSet.new(resource)
         change_set.validate(state: "complete")
 
@@ -1696,7 +1695,7 @@ RSpec.describe ChangeSetPersister do
       end
       it "re-adds the FileSet" do
         file = fixture_file_upload("files/example.tif", "image/tiff")
-        resource = FactoryBot.create_for_repository(:pending_scanned_resource, preservation_policy: "cloud", files: [file])
+        resource = FactoryBot.create_for_repository(:pending_scanned_resource, files: [file])
         change_set = DynamicChangeSet.new(resource)
         change_set.validate(state: "complete")
 
@@ -1721,12 +1720,12 @@ RSpec.describe ChangeSetPersister do
       end
     end
 
-    context "when adding FGDC metadata to a `cloud` preserved object", run_real_derivatives: true, run_real_characterization: true do
+    context "when adding FGDC metadata to a preserved object", run_real_derivatives: true, run_real_characterization: true do
       with_queue_adapter :inline
       it "updates the binary content in the preservation store" do
         file = fixture_file_upload("files/vector/shapefile.zip", "application/zip")
         xml = fixture_file_upload("files/geo_metadata/fgdc.xml", "application/xml; schema=fgdc")
-        vector_resource = FactoryBot.create_for_repository(:complete_vector_resource, files: [file, xml], preservation_policy: "cloud")
+        vector_resource = FactoryBot.create_for_repository(:complete_vector_resource, files: [file, xml])
 
         output = change_set_persister.save(change_set: DynamicChangeSet.new(vector_resource))
         preservation_object = Wayfinder.for(output).preservation_objects.first
@@ -1742,7 +1741,7 @@ RSpec.describe ChangeSetPersister do
       with_queue_adapter :inline
       it "preserves the file nodes" do
         file = fixture_file_upload("files/audio_file.wav", "audio/x-wav")
-        resource = FactoryBot.create_for_repository(:complete_media_resource, preservation_policy: "cloud")
+        resource = FactoryBot.create_for_repository(:complete_media_resource)
         change_set = DynamicChangeSet.new(resource, files: [file])
         output = change_set_persister.save(change_set: change_set)
 
@@ -1775,10 +1774,10 @@ RSpec.describe ChangeSetPersister do
       it "moves the preservation structure" do
         file = fixture_file_upload("files/example.tif", "image/tiff")
         resource = FactoryBot.create_for_repository(:pending_scanned_resource, files: [file])
-        parent = FactoryBot.create_for_repository(:pending_scanned_resource, preservation_policy: "cloud", member_ids: resource.id)
+        parent = FactoryBot.create_for_repository(:pending_scanned_resource, member_ids: resource.id)
         change_set = DynamicChangeSet.new(parent)
         change_set.validate(state: "complete")
-        other_parent = FactoryBot.create_for_repository(:complete_scanned_resource, preservation_policy: "cloud")
+        other_parent = FactoryBot.create_for_repository(:complete_scanned_resource)
         # Save in nested structure.
         change_set_persister.save(change_set: change_set)
         # Preserve `other_parent`
@@ -1805,11 +1804,11 @@ RSpec.describe ChangeSetPersister do
         expect(File.exist?(cloud_path.join(parent.id.to_s, "data", resource.id.to_s, "data", file_set.id.to_s, "example-#{file_set.original_file.id}.tif"))).to eq false
       end
     end
-    context "when completing a `cloud` preservation_policy MVW" do
+    context "when completing a preserved MVW" do
       it "deeply nests file sets" do
         file = fixture_file_upload("files/example.tif", "image/tiff")
         volume = FactoryBot.create_for_repository(:pending_scanned_resource, files: [file])
-        parent = FactoryBot.create_for_repository(:pending_scanned_resource, preservation_policy: "cloud", member_ids: volume.id)
+        parent = FactoryBot.create_for_repository(:pending_scanned_resource, member_ids: volume.id)
         change_set = DynamicChangeSet.new(parent)
         change_set.validate(state: "complete")
 
@@ -1821,10 +1820,10 @@ RSpec.describe ChangeSetPersister do
         expect(File.exist?(Rails.root.join("tmp", "cloud_backup_test", parent.id.to_s, "data", volume.id.to_s, "data", file_set.id.to_s, "example-#{file_set.original_file.id}.tif"))).to eq true
       end
     end
-    context "when adding a file to a `cloud` preservation_policy resource" do
+    context "when adding a file to a preserved resource" do
       with_queue_adapter :inline
       it "preserves it" do
-        resource = FactoryBot.create_for_repository(:complete_scanned_resource, preservation_policy: "cloud")
+        resource = FactoryBot.create_for_repository(:complete_scanned_resource)
         file = fixture_file_upload("files/example.tif", "image/tiff")
         change_set_persister.buffer_into_index do |buffered_change_set_persister|
           change_set = DynamicChangeSet.new(resource)

--- a/spec/change_set_persisters/change_set_persister_spec.rb
+++ b/spec/change_set_persisters/change_set_persister_spec.rb
@@ -1851,6 +1851,22 @@ RSpec.describe ChangeSetPersister do
       end
     end
   end
+  context "when preserving a collection" do
+    before do
+      allow(PreserveChildrenJob).to receive(:perform_later)
+    end
+
+    it "does not preserve it's members" do
+      collection = FactoryBot.create_for_repository(:collection)
+      FactoryBot.create_for_repository(:complete_scanned_resource, member_of_collection_ids: collection.id)
+      change_set = DynamicChangeSet.new(collection)
+      change_set.validate(state: "complete")
+      change_set_persister.save(change_set: change_set)
+
+      expect(PreserveChildrenJob).to have_received(:perform_later).exactly(0).times
+    end
+  end
+
   context "when uploading a PDF to a ScannedResource", run_real_characterization: true, run_real_derivatives: true do
     with_queue_adapter :inline
     it "characterizes" do

--- a/spec/factories/scanned_resource.rb
+++ b/spec/factories/scanned_resource.rb
@@ -53,6 +53,9 @@ FactoryBot.define do
       factory :draft_recording do
         state "draft"
       end
+      factory :complete_recording do
+        state "complete"
+      end
     end
     factory :open_scanned_resource do
       visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC

--- a/spec/features/fixity_dashboard_spec.rb
+++ b/spec/features/fixity_dashboard_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Fixity dashboard" do
   let(:user) { FactoryBot.create(:admin) }
   let(:metadata_adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
   let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }
-  let(:scanned_resource) { FactoryBot.create_for_repository(:complete_scanned_resource, preservation_policy: "cloud", files: [file]) }
+  let(:scanned_resource) { FactoryBot.create_for_repository(:complete_scanned_resource, files: [file]) }
   let(:preservation_object) { Wayfinder.for(scanned_resource).preservation_objects.first }
   let(:file_set) { metadata_adapter.query_service.find_by(id: preservation_object.preserved_object_id) }
   let(:metadata_node) { preservation_object.metadata_node }

--- a/spec/jobs/ingest_archival_media_bag_job_spec.rb
+++ b/spec/jobs/ingest_archival_media_bag_job_spec.rb
@@ -271,14 +271,12 @@ RSpec.describe IngestArchivalMediaBagJob do
 
         expect(resources.size).to eq 1
         expect(resources.first.source_metadata_identifier).to eq ["C0652_c0377"]
-        expect(DynamicChangeSet.new(resources.first).preservation_policy).to eq "cloud"
 
         member = Wayfinder.for(resources.first).members.first
         expect(member).to be_a ScannedResource
         expect(member.change_set).to eq "recording"
         expect(member.local_identifier.first).to eq "32101047382401"
         expect(member.title).to eq ["Interview: ERM / Jose Donoso (A2)"]
-        expect(DynamicChangeSet.new(member).preservation_policy).to eq "cloud"
 
         file_sets = Wayfinder.for(member).members
         expect(file_sets.count).to eq 4

--- a/spec/models/controlled_vocabulary_spec.rb
+++ b/spec/models/controlled_vocabulary_spec.rb
@@ -31,14 +31,4 @@ RSpec.describe ControlledVocabulary do
       end
     end
   end
-
-  describe "preservation_policy" do
-    describe "#all" do
-      it "returns the cloud preservation policy" do
-        vocabulary = described_class.for(:preservation_policy)
-
-        expect(vocabulary.all).to contain_exactly ControlledVocabulary::Term.new(label: "Cloud Storage", value: "cloud")
-      end
-    end
-  end
 end

--- a/spec/queries/find_cloud_fixity_failures_spec.rb
+++ b/spec/queries/find_cloud_fixity_failures_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe FindCloudFixityFailures do
   let(:shoulder) { "99999/fk4" }
   let(:blade) { "123456" }
   let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }
-  let(:resource) { FactoryBot.create_for_repository(:complete_scanned_resource, preservation_policy: "cloud", files: [file]) }
-  let(:resource2) { FactoryBot.create_for_repository(:complete_scanned_resource, preservation_policy: "cloud", files: [file]) }
+  let(:resource) { FactoryBot.create_for_repository(:complete_scanned_resource, files: [file]) }
+  let(:resource2) { FactoryBot.create_for_repository(:complete_scanned_resource, files: [file]) }
   let(:preservation_object) do
     Wayfinder.for(resource).preservation_objects.first
   end

--- a/spec/queries/find_cloud_fixity_spec.rb
+++ b/spec/queries/find_cloud_fixity_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe FindCloudFixity do
   let(:shoulder) { "99999/fk4" }
   let(:blade) { "123456" }
   let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }
-  let(:resource) { FactoryBot.create_for_repository(:complete_scanned_resource, preservation_policy: "cloud", files: [file]) }
+  let(:resource) { FactoryBot.create_for_repository(:complete_scanned_resource, files: [file]) }
   let(:file_set) { resource.decorate.file_sets.first }
   let(:event) { FactoryBot.create_for_repository(:event, resource_id: file_set.id) }
   let(:event2) { FactoryBot.create_for_repository(:event, resource_id: file_set.id) }

--- a/spec/resources/events/event_change_set_spec.rb
+++ b/spec/resources/events/event_change_set_spec.rb
@@ -55,4 +55,10 @@ RSpec.describe EventChangeSet do
       expect(change_set.message).to eq message
     end
   end
+
+  describe "#preserve?" do
+    it "is not preserved" do
+      expect(change_set.preserve?).to be false
+    end
+  end
 end

--- a/spec/resources/media_resources/media_resource_change_set_spec.rb
+++ b/spec/resources/media_resources/media_resource_change_set_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe MediaResourceChangeSet do
   end
 
   describe "#preserve?" do
-    let(:media_resource) { FactoryBot.create_for_repository(:media_resource, preservation_policy: "cloud", state: "complete") }
+    let(:media_resource) { FactoryBot.create_for_repository(:media_resource, state: "complete") }
 
     it "determines whether or not a resource should be preserved" do
       expect(change_set.preserve?).to be true

--- a/spec/resources/preservation_objects/preservation_object_change_set_spec.rb
+++ b/spec/resources/preservation_objects/preservation_object_change_set_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe PreservationObjectChangeSet do
+  subject(:change_set) { described_class.new(resource) }
+
+  let(:resource) { FactoryBot.build(:preservation_object) }
+
+  describe "#preserve?" do
+    it "is not preserved" do
+      expect(change_set.preserve?).to be false
+    end
+  end
+end

--- a/spec/resources/scanned_resources/recording_change_set_spec.rb
+++ b/spec/resources/scanned_resources/recording_change_set_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe RecordingChangeSet do
+  subject(:change_set) { described_class.new(resource) }
+
+  describe "#preserve?" do
+    context "when not a member of an archival media collection" do
+      let(:resource) { FactoryBot.create_for_repository(:complete_recording) }
+
+      it "is not preserved" do
+        expect(change_set.preserve?).to be false
+      end
+    end
+
+    context "when a member of an archival media collection" do
+      let(:collection) { FactoryBot.create_for_repository(:archival_media_collection) }
+      let(:resource) { FactoryBot.create_for_repository(:complete_recording, member_of_collection_ids: [collection.id]) }
+
+      it "is preserved" do
+        expect(change_set.preserve?).to be true
+      end
+    end
+  end
+end

--- a/spec/resources/scanned_resources/scanned_resource_change_set_spec.rb
+++ b/spec/resources/scanned_resources/scanned_resource_change_set_spec.rb
@@ -123,12 +123,6 @@ RSpec.describe ScannedResourceChangeSet do
     end
   end
 
-  describe "#primary_terms" do
-    it "does not have preservation_policy" do
-      expect(change_set.primary_terms).not_to include :preservation_policy
-    end
-  end
-
   describe "#replaces" do
     let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
     let(:storage_adapter) { Valkyrie.config.storage_adapter }

--- a/spec/resources/tombstones/tombstone_change_set_spec.rb
+++ b/spec/resources/tombstones/tombstone_change_set_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 RSpec.describe TombstoneChangeSet do
   subject(:change_set) { described_class.new(resource) }
 
-  let(:resource) { FactoryBot.build(:tombstone) }
+  let(:resource) { FactoryBot.create_for_repository(:tombstone) }
 
   describe "#preserve?" do
     it "is not preserved" do

--- a/spec/resources/tombstones/tombstone_change_set_spec.rb
+++ b/spec/resources/tombstones/tombstone_change_set_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe TombstoneChangeSet do
+  subject(:change_set) { described_class.new(resource) }
+
+  let(:resource) { FactoryBot.build(:tombstone) }
+
+  describe "#preserve?" do
+    it "is not preserved" do
+      expect(change_set.preserve?).to be false
+    end
+  end
+end

--- a/spec/services/bulk_edit_service_spec.rb
+++ b/spec/services/bulk_edit_service_spec.rb
@@ -39,18 +39,6 @@ RSpec.describe BulkEditService do
       end
     end
 
-    context "when updating preservation_policy" do
-      it "succeeds" do
-        obj1 = FactoryBot.create_for_repository(:scanned_resource, member_of_collection_ids: [collection.id])
-
-        attrs = { preservation_policy: "cloud" }
-        described_class.perform(collection_id: collection.id.to_s, attributes: attrs, logger: logger)
-
-        after = query_service.find_by(id: obj1.id)
-        expect(after.preservation_policy).to eq ["cloud"]
-      end
-    end
-
     context "when change set validation fails" do
       let(:logger) { instance_double ActiveSupport::Logger }
 

--- a/spec/services/cloud_fixity_spec.rb
+++ b/spec/services/cloud_fixity_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe CloudFixity do
 
     context "with a resource preserved in a cloud service" do
       let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }
-      let(:scanned_resource) { FactoryBot.create_for_repository(:complete_scanned_resource, files: [file], preservation_policy: "cloud") }
+      let(:scanned_resource) { FactoryBot.create_for_repository(:complete_scanned_resource, files: [file]) }
       let(:resource) { Wayfinder.for(scanned_resource).preservation_objects.first }
       let(:file_metadata) { resource.metadata_node }
       let(:json) do

--- a/spec/services/preserver/blind_importer_spec.rb
+++ b/spec/services/preserver/blind_importer_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Preserver::BlindImporter do
   describe ".import" do
     it "can import arbitrarily deep" do
       volume = FactoryBot.create_for_repository(:complete_scanned_resource, files: [file, file2])
-      mvw = FactoryBot.create_for_repository(:complete_scanned_resource, preservation_policy: "cloud", member_ids: [volume.id], run_callbacks: true)
+      mvw = FactoryBot.create_for_repository(:complete_scanned_resource, member_ids: [volume.id], run_callbacks: true)
 
       # Wipe everything
       Blacklight.default_index.connection.delete_by_query("*:*")
@@ -42,7 +42,7 @@ RSpec.describe Preserver::BlindImporter do
       expect { Valkyrie::StorageAdapter.find_by(id: file_set2.original_file.file_identifiers.first) }.not_to raise_error
     end
     it "imports a preserved resource given an ID" do
-      resource = FactoryBot.create_for_repository(:complete_scanned_resource, preservation_policy: "cloud", files: [file])
+      resource = FactoryBot.create_for_repository(:complete_scanned_resource, files: [file])
       children = query_service.find_members(resource: resource)
 
       # Delete them without running callbacks which clean up from disk.
@@ -69,7 +69,7 @@ RSpec.describe Preserver::BlindImporter do
       expect(file_set.derivative_files.length).to eq 1
     end
     it "imports everything it can, even if a member didn't get preserved for some reason" do
-      resource = FactoryBot.create_for_repository(:complete_scanned_resource, preservation_policy: "cloud", files: [file])
+      resource = FactoryBot.create_for_repository(:complete_scanned_resource, files: [file])
       children = query_service.find_members(resource: resource)
 
       # Delete them without running callbacks which clean up from disk.

--- a/spec/services/preserver/importer_spec.rb
+++ b/spec/services/preserver/importer_spec.rb
@@ -12,7 +12,6 @@ describe Preserver::Importer do
   let(:change_set_persister) { ScannedResourcesController.change_set_persister }
   let(:storage_adapter) { Valkyrie::StorageAdapter.find(:google_cloud_storage) }
   let(:persisted_resource) do
-    resource.preservation_policy = "cloud"
     change_set_persister.metadata_adapter.persister.save(resource: resource)
   end
   let(:persisted_file_set) do

--- a/spec/services/preserver_spec.rb
+++ b/spec/services/preserver_spec.rb
@@ -9,7 +9,6 @@ describe Preserver do
   let(:resource) do
     FactoryBot.create_for_repository(:complete_scanned_resource,
                                      source_metadata_identifier: "123456",
-                                     preservation_policy: "cloud",
                                      files: [file])
   end
   let(:unpreserved_resource) do

--- a/spec/wayfinders/wayfinder_spec.rb
+++ b/spec/wayfinders/wayfinder_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Wayfinder do
         stub_ezid(shoulder: "99999/fk4", blade: "123456")
         file = fixture_file_upload("files/example.tif", "image/tiff")
         change_set_persister = ScannedResourcesController.change_set_persister
-        resource = FactoryBot.create_for_repository(:pending_scanned_resource, preservation_policy: "cloud", files: [file])
+        resource = FactoryBot.create_for_repository(:pending_scanned_resource, files: [file])
         change_set = DynamicChangeSet.new(resource)
         change_set.validate(state: "complete")
 


### PR DESCRIPTION
- Makes preservation the default for resources.
- Removes the `preservation_policy` property to simplify implementation.
- Adds test to ensure collections do not preserve members.

Closes #3283