### PR TITLE
Disable anonymous downloads for non-downloadable resources

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,13 @@ Release notes template:
 
 -->
 
+# 2019-10-23
+
+## Fixed
+
+* Removed the IIIF viewer download drop-down menu for non-downloadable public resources.
+* Anonymous downloads are disabled for non-downloadable public resources.
+
 # 2019-10-18
 
 ## Fixed

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -176,7 +176,7 @@ module ApplicationHelper
   # @param [Valkyrie::Resource]
   # @return [String]
   def universal_viewer_path(resource)
-    "/viewer#?manifest=#{manifest_url(resource)}&config=#{viewer_config_url(resource.id)}"
+    "/viewer#?manifest=#{manifest_url(resource)}&config=#{viewer_config_url(resource.id)}.json"
   end
 
   def collection_present?

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -42,7 +42,7 @@ class Ability
       download_file_with_metadata?(resource)
     end
     can :download, FileSet do |resource|
-      authorized_by_token?(resource) || geo_file_set?(resource) || can_read_parent?(resource)
+      downloadable?(resource) && (authorized_by_token?(resource) || geo_file_set?(resource) || can_read_parent?(resource))
     end
     can :color_pdf, curation_concerns do |resource|
       resource.pdf_type == ["color"]
@@ -232,6 +232,10 @@ class Ability
 
   def user_editable?(obj)
     obj.edit_users.include?(current_user.user_key)
+  end
+
+  def downloadable?(obj)
+    obj.decorate.downloadable? || (!current_user.nil? && (current_user.staff? || current_user.admin?))
   end
 
   # Null object pattern for auth. tokens

--- a/app/values/viewer_configuration.rb
+++ b/app/values/viewer_configuration.rb
@@ -30,6 +30,13 @@ class ViewerConfiguration < ActiveSupport::HashWithIndifferentAccess
             "shareEnabled" => false
           }
         },
+        "avCenterPanel" =>
+        {
+          "options" =>
+          {
+            "posterImageExpanded" => true
+          }
+        },
         "seadragonCenterPanel" =>
         {
           "options" =>

--- a/public/viewer.html
+++ b/public/viewer.html
@@ -67,7 +67,7 @@
           uv = createUV('#uv', {
             root: 'uv',
             iiifResourceUri: urlDataProvider.get('manifest'),
-            configUri: 'uv/uv_config.json',
+            configUri: urlDataProvider.get('config'),
             collectionIndex: Number(urlDataProvider.get('c', 0)),
             manifestIndex: Number(urlDataProvider.get('m', 0)),
             sequenceIndex: Number(urlDataProvider.get('s', 0)),

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe ApplicationHelper, type: :helper do
     let(:resource) { FactoryBot.create_for_repository(:complete_scanned_resource) }
 
     it "generates the path for the embedded UV partial" do
-      expect(helper.universal_viewer_path(resource)).to eq "/viewer#?manifest=http://test.host/concern/scanned_resources/#{resource.id}/manifest&config=http://test.host/viewer/config/#{resource.id}"
+      expect(helper.universal_viewer_path(resource)).to eq "/viewer#?manifest=http://test.host/concern/scanned_resources/#{resource.id}/manifest&config=http://test.host/viewer/config/#{resource.id}.json"
     end
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -6,6 +6,7 @@ describe Ability do
   subject { described_class.new(current_user) }
   let(:page_file) { fixture_file_upload("files/example.tif", "image/tiff") }
   let(:page_file_2) { fixture_file_upload("files/example.tif", "image/tiff") }
+  let(:page_file_3) { fixture_file_upload("files/example.tif", "image/tiff") }
   let(:shoulder) { "99999/fk4" }
   let(:blade) { "123456" }
 
@@ -22,6 +23,12 @@ describe Ability do
   let(:open_file_set) do
     query_service.find_by(id: open_scanned_resource.member_ids.first)
   end
+
+  let(:no_public_download_open_scanned_resource) do
+    FactoryBot.create_for_repository(:complete_open_scanned_resource, user: creating_user, title: "Open", downloadable: "none", files: [page_file_3])
+  end
+
+  let(:no_public_download_open_file) { no_public_download_open_scanned_resource.decorate.members.first }
 
   let(:closed_file_set) do
     query_service.find_by(id: private_scanned_resource.member_ids.first)
@@ -147,6 +154,7 @@ describe Ability do
       is_expected.to be_able_to(:discover, reading_room_scanned_resource)
       is_expected.to be_able_to(:discover, campus_ip_scanned_resource)
       is_expected.to be_able_to(:read, :graphql)
+      is_expected.to be_able_to(:download, no_public_download_open_file)
     }
 
     context "when read-only mode is on" do
@@ -228,6 +236,7 @@ describe Ability do
       is_expected.to be_able_to(:discover, reading_room_scanned_resource)
       is_expected.to be_able_to(:discover, campus_ip_scanned_resource)
       is_expected.to be_able_to(:read, :graphql)
+      is_expected.to be_able_to(:download, no_public_download_open_file)
     }
 
     context "when read-only mode is on" do
@@ -314,6 +323,7 @@ describe Ability do
       is_expected.not_to be_able_to(:destroy, role)
       is_expected.not_to be_able_to(:complete, pending_scanned_resource)
       is_expected.not_to be_able_to(:destroy, admin_file)
+      is_expected.not_to be_able_to(:download, no_public_download_open_file)
 
       is_expected.to be_able_to(:discover, open_scanned_resource)
       is_expected.not_to be_able_to(:discover, pending_scanned_resource)
@@ -542,6 +552,7 @@ describe Ability do
       is_expected.not_to be_able_to(:destroy, role)
       is_expected.not_to be_able_to(:complete, pending_scanned_resource)
       is_expected.not_to be_able_to(:destroy, admin_file)
+      is_expected.not_to be_able_to(:download, no_public_download_open_file)
 
       is_expected.to be_able_to(:discover, open_scanned_resource)
       is_expected.not_to be_able_to(:discover, private_scanned_resource)
@@ -662,6 +673,7 @@ describe Ability do
 
       it "provides access to a resource" do
         is_expected.to be_able_to(:read, vector_resource)
+        is_expected.to be_able_to(:download, no_public_download_open_file)
       end
     end
 

--- a/spec/values/viewer_configuration_spec.rb
+++ b/spec/values/viewer_configuration_spec.rb
@@ -24,6 +24,9 @@ describe ViewerConfiguration do
       expect(described_class.default_values["modules"]["footerPanel"]["options"]).to include(
         "shareEnabled" => false
       )
+      expect(described_class.default_values["modules"]["avCenterPanel"]["options"]).to include(
+        "posterImageExpanded" => true
+      )
     end
   end
 

--- a/spec/views/catalog/_members_file_set.html.erb_spec.rb
+++ b/spec/views/catalog/_members_file_set.html.erb_spec.rb
@@ -9,12 +9,14 @@ RSpec.describe "catalog/_members_file_set" do
   let(:file_set) do
     FactoryBot.create_for_repository(:file_set, file_metadata: [original_file, derivative_file, thumbnail_file, derivative_file_partial])
   end
+  let(:parent) { FactoryBot.create_for_repository(:scanned_resource, member_ids: [file_set.id]) }
   let(:solr) { Valkyrie::MetadataAdapter.find(:index_solr) }
   let(:document) { solr.resource_factory.from_resource(resource: file_set) }
   let(:solr_document) { SolrDocument.new(document) }
   let(:user) { FactoryBot.create(:user) }
 
   before do
+    parent
     assign :resource, file_set
     assign :document, solr_document
     sign_in user


### PR DESCRIPTION
- Configures UV to use the Figgy-generated config document. This config document changes depending on the downloadable status of the resource.
- Disables non-admin and non-staff download of files whose parent is not downloadable.

Closes #3443