### PR TITLE
Second attempt: Revert "Prohibit anonymous downloads when a resource is not publicly downloadable"

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -42,7 +42,7 @@ class Ability
       download_file_with_metadata?(resource)
     end
     can :download, FileSet do |resource|
-      downloadable?(resource) && (authorized_by_token?(resource) || geo_file_set?(resource) || can_read_parent?(resource))
+      authorized_by_token?(resource) || geo_file_set?(resource) || can_read_parent?(resource)
     end
     can :color_pdf, curation_concerns do |resource|
       resource.pdf_type == ["color"]
@@ -232,10 +232,6 @@ class Ability
 
   def user_editable?(obj)
     obj.edit_users.include?(current_user.user_key)
-  end
-
-  def downloadable?(obj)
-    obj.decorate.downloadable? || (!current_user.nil? && (current_user.staff? || current_user.admin?))
   end
 
   # Null object pattern for auth. tokens

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -6,7 +6,6 @@ describe Ability do
   subject { described_class.new(current_user) }
   let(:page_file) { fixture_file_upload("files/example.tif", "image/tiff") }
   let(:page_file_2) { fixture_file_upload("files/example.tif", "image/tiff") }
-  let(:page_file_3) { fixture_file_upload("files/example.tif", "image/tiff") }
   let(:shoulder) { "99999/fk4" }
   let(:blade) { "123456" }
 
@@ -23,12 +22,6 @@ describe Ability do
   let(:open_file_set) do
     query_service.find_by(id: open_scanned_resource.member_ids.first)
   end
-
-  let(:no_public_download_open_scanned_resource) do
-    FactoryBot.create_for_repository(:complete_open_scanned_resource, user: creating_user, title: "Open", downloadable: "none", files: [page_file_3])
-  end
-
-  let(:no_public_download_open_file) { no_public_download_open_scanned_resource.decorate.members.first }
 
   let(:closed_file_set) do
     query_service.find_by(id: private_scanned_resource.member_ids.first)
@@ -154,7 +147,6 @@ describe Ability do
       is_expected.to be_able_to(:discover, reading_room_scanned_resource)
       is_expected.to be_able_to(:discover, campus_ip_scanned_resource)
       is_expected.to be_able_to(:read, :graphql)
-      is_expected.to be_able_to(:download, no_public_download_open_file)
     }
 
     context "when read-only mode is on" do
@@ -236,7 +228,6 @@ describe Ability do
       is_expected.to be_able_to(:discover, reading_room_scanned_resource)
       is_expected.to be_able_to(:discover, campus_ip_scanned_resource)
       is_expected.to be_able_to(:read, :graphql)
-      is_expected.to be_able_to(:download, no_public_download_open_file)
     }
 
     context "when read-only mode is on" do
@@ -323,7 +314,6 @@ describe Ability do
       is_expected.not_to be_able_to(:destroy, role)
       is_expected.not_to be_able_to(:complete, pending_scanned_resource)
       is_expected.not_to be_able_to(:destroy, admin_file)
-      is_expected.not_to be_able_to(:download, no_public_download_open_file)
 
       is_expected.to be_able_to(:discover, open_scanned_resource)
       is_expected.not_to be_able_to(:discover, pending_scanned_resource)
@@ -552,7 +542,6 @@ describe Ability do
       is_expected.not_to be_able_to(:destroy, role)
       is_expected.not_to be_able_to(:complete, pending_scanned_resource)
       is_expected.not_to be_able_to(:destroy, admin_file)
-      is_expected.not_to be_able_to(:download, no_public_download_open_file)
 
       is_expected.to be_able_to(:discover, open_scanned_resource)
       is_expected.not_to be_able_to(:discover, private_scanned_resource)
@@ -673,7 +662,6 @@ describe Ability do
 
       it "provides access to a resource" do
         is_expected.to be_able_to(:read, vector_resource)
-        is_expected.to be_able_to(:download, no_public_download_open_file)
       end
     end
 

--- a/spec/views/catalog/_members_file_set.html.erb_spec.rb
+++ b/spec/views/catalog/_members_file_set.html.erb_spec.rb
@@ -9,14 +9,12 @@ RSpec.describe "catalog/_members_file_set" do
   let(:file_set) do
     FactoryBot.create_for_repository(:file_set, file_metadata: [original_file, derivative_file, thumbnail_file, derivative_file_partial])
   end
-  let(:parent) { FactoryBot.create_for_repository(:scanned_resource, member_ids: [file_set.id]) }
   let(:solr) { Valkyrie::MetadataAdapter.find(:index_solr) }
   let(:document) { solr.resource_factory.from_resource(resource: file_set) }
   let(:solr_document) { SolrDocument.new(document) }
   let(:user) { FactoryBot.create(:user) }
 
   before do
-    parent
     assign :resource, file_set
     assign :document, solr_document
     sign_in user


### PR DESCRIPTION
This reverts commit cbf748712d4997ec136cc150c386f12b62393865.

Keeps the config param off the viewer url