### PR TITLE
Updated the Gemfile to pin to Webpacker 4.0.z releases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem "title"
 gem "uglifier"
 gem "valkyrie", "~> 2.0.0"
 gem "valkyrie-derivatives", git: "https://github.com/samvera-labs/valkyrie-derivatives.git"
-gem "webpacker", ">= 4.0.x"
+gem "webpacker", "~> 4.0"
 
 group :development do
   gem "benchmark-ips"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -861,7 +861,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    webpacker (4.0.0.pre.3)
+    webpacker (4.0.7)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
       railties (>= 4.2)
@@ -989,7 +989,7 @@ DEPENDENCIES
   web-console
   webdrivers
   webmock
-  webpacker (>= 4.0.x)
+  webpacker (~> 4.0)
   whenever (~> 0.10)
 
 BUNDLED WITH


### PR DESCRIPTION
Figgy was previously using a prerelease version of `Webpacker`, and this triggered errors in certain development environments.