### PR TITLE
Ensures that PendingUpload constructors receive Hashes with symbolized keys

### DIFF
--- a/app/controllers/base_resource_controller.rb
+++ b/app/controllers/base_resource_controller.rb
@@ -38,11 +38,11 @@ class BaseResourceController < ApplicationController
     @new_pending_uploads = []
     # Use the new structure for the resources
     selected_files.each do |selected_file|
-      file_attributes = selected_file.to_h
+      file_attributes = selected_file.to_h.symbolize_keys
       auth_header_values = file_attributes.delete("auth_header")
       auth_header = JSON.generate(auth_header_values)
 
-      file_uri = file_attributes["url"]
+      file_uri = file_attributes[:url]
       file_path_match = /file\:\/\/(.+)/.match(file_uri)
       if file_path_match
         file_path = file_path_match[1]

--- a/app/controllers/bulk_ingest_controller.rb
+++ b/app/controllers/bulk_ingest_controller.rb
@@ -163,7 +163,7 @@ class BulkIngestController < ApplicationController
 
       @new_pending_uploads = []
       selected_files.each do |selected_file|
-        file_attributes = selected_file.to_h
+        file_attributes = selected_file.to_h.symbolize_keys
 
         # This is needed in order to ensure that files are authorized for the
         # download from the Cloud Service provider


### PR DESCRIPTION
This was triggering failures for BrowseEverything uploads, as the file metadata was not actually being stored in the PendingUpload Resource.