### PR TITLE
Default pulfa exporter to rails log so we can see it in datadog

### DIFF
--- a/app/services/pulfa_exporter.rb
+++ b/app/services/pulfa_exporter.rb
@@ -2,7 +2,7 @@
 # Export Figgy content to PULFA, inserting DAOs into the EAD XML files linking to the Figgy manifest URLs
 class PulfaExporter
   attr_reader :since_date, :svn_client, :logger
-  def initialize(since_date:, logger: Logger.new(STDOUT), svn_client: nil)
+  def initialize(since_date:, logger: Rails.logger, svn_client: nil)
     @logger = logger
     @since_date = since_date
     @svn_client = svn_client || SvnClient.new


### PR DESCRIPTION
It's usually run by cron via the rake task at this point.

This will give us more information when a filename comes through that
code down the line doesn't like.

fixes #3485