### PR TITLE
Ensures that authorization headers are passed to the PendingUpload constructor for Google Drive resources

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,13 @@ Release notes template:
 ## Removed
 
 -->
+# 2019-11-12
+
+## Fixed
+
+* Fixes a problem with Google Drive uploads in which authorization headers were
+  not being passed to the PendingUpload Resources.
+
 # 2019-11-8
 
 ## Fixed

--- a/app/controllers/base_resource_controller.rb
+++ b/app/controllers/base_resource_controller.rb
@@ -39,7 +39,7 @@ class BaseResourceController < ApplicationController
     # Use the new structure for the resources
     selected_files.each do |selected_file|
       file_attributes = selected_file.to_h.symbolize_keys
-      auth_header_values = file_attributes.delete("auth_header")
+      auth_header_values = file_attributes.delete(:auth_header)
       auth_header = JSON.generate(auth_header_values)
 
       file_uri = file_attributes[:url]

--- a/app/controllers/bulk_ingest_controller.rb
+++ b/app/controllers/bulk_ingest_controller.rb
@@ -167,7 +167,7 @@ class BulkIngestController < ApplicationController
 
         # This is needed in order to ensure that files are authorized for the
         # download from the Cloud Service provider
-        auth_header_values = file_attributes.delete("auth_header")
+        auth_header_values = file_attributes.delete(:auth_header)
         auth_header = JSON.generate(auth_header_values)
 
         @new_pending_uploads << PendingUpload.new(file_attributes.merge(id: SecureRandom.uuid, created_at: Time.current.utc.iso8601, auth_header: auth_header))

--- a/spec/controllers/bulk_ingest_controller_spec.rb
+++ b/spec/controllers/bulk_ingest_controller_spec.rb
@@ -239,7 +239,8 @@ RSpec.describe BulkIngestController do
           hash_including(
             url: "https://www.example.com/files/1.tif?alt=media",
             file_name: "1.tif",
-            file_size: "100"
+            file_size: "100",
+            auth_header: "{\"Authorization\":\"Bearer secret\"}"
           )
         )
         expect(BrowseEverythingIngestJob).to have_received(:perform_later).with(resources.first.id.to_s, "BulkIngestController", [resources.first.pending_uploads.first.id.to_s])
@@ -274,7 +275,8 @@ RSpec.describe BulkIngestController do
             hash_including(
               url: "https://www.example.com/files/1.tif?alt=media",
               file_name: "1.tif",
-              file_size: "100"
+              file_size: "100",
+              auth_header: "{\"Authorization\":\"Bearer secret\"}"
             )
           )
 


### PR DESCRIPTION
Resolves #3490 