### PR TITLE
Implements a CleanPendingUploadsJob, a FindPendingUploadsFailures query, and the Rake task clean:pending_uploads

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -133,6 +133,7 @@ Metrics/LineLength:
     - 'spec/views/catalog/_members_coin.html.erb_spec.rb'
     - 'spec/helpers/application_helper_spec.rb'
     - 'spec/resources/collections/collections_controller_spec.rb'
+    - 'spec/jobs/clean_pending_uploads_job_spec.rb'
 Metrics/MethodLength:
   Exclude:
     - 'db/migrate/**/*'

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,13 @@ Release notes template:
 
 ## Removed
 
+# 2020-01-03
+
+## Added
+
+* Added a query, job, and Rake task for cleaning resources with failed file
+  uploads.
+
 # 2020-01-02
 
 ## Added
@@ -57,11 +64,6 @@ MARC items. Currently only the marc21 `metadata_prefix` is supported.
 * Gracefully handling error reporting when an EAD can't be found for an item linked to PULFA.
 
 # 2019-11-12
-
-## Added
-
-* Added a query, job, and Rake task for cleaning resources with failed file
-  uploads.
 
 ## Fixed
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -58,6 +58,11 @@ MARC items. Currently only the marc21 `metadata_prefix` is supported.
 
 # 2019-11-12
 
+## Added
+
+* Added a query, job, and Rake task for cleaning resources with failed file
+  uploads.
+
 ## Fixed
 
 * Fixes a problem with Google Drive uploads in which authorization headers were

--- a/app/jobs/clean_pending_uploads_job.rb
+++ b/app/jobs/clean_pending_uploads_job.rb
@@ -6,11 +6,11 @@ class CleanPendingUploadsJob < ApplicationJob
         if resource.respond_to?(:pending_uploads) && resource.pending_uploads.empty? && resource.state.include?("pending")
           change_set = DynamicChangeSet.new(resource)
           if dry_run
-            Valkyrie.logger.info("Found #{resource.id} as an uploaded resource without any FileSets - this would normally be deleted by CleanPendingUploadsJob")
+            Valkyrie.logger.info("Found #{resource.decorate.first_title} (#{resource.id}) as an uploaded resource without any FileSets - this would normally be deleted by CleanPendingUploadsJob")
           else
             buffered_changeset_persister.delete(change_set: change_set)
+            Valkyrie.logger.info "Deleted a resource with failed uploads with the title: #{resource.decorate.first_title} (#{resource.id})"
           end
-          Valkyrie.logger.info "Deleted a resource with failed uploads with the ID: #{resource.id}"
         end
       end
     end

--- a/app/jobs/clean_pending_uploads_job.rb
+++ b/app/jobs/clean_pending_uploads_job.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 class CleanPendingUploadsJob < ApplicationJob
-  def perform
+  def perform(dry_run: false)
     query_service.custom_queries.find_pending_upload_failures.each do |resource|
       change_set_persister.buffer_into_index do |buffered_changeset_persister|
         if resource.respond_to?(:pending_uploads) && resource.pending_uploads.empty? && resource.state.include?("pending")
           change_set = DynamicChangeSet.new(resource)
-          buffered_changeset_persister.delete(change_set: change_set)
+          if dry_run
+            Valkyrie.logger.info("Found #{resource.id} as an uploaded resource without any FileSets - this would normally be deleted by CleanPendingUploadsJob")
+          else
+            buffered_changeset_persister.delete(change_set: change_set)
+          end
           Valkyrie.logger.info "Deleted a resource with failed uploads with the ID: #{resource.id}"
         end
       end

--- a/app/jobs/clean_pending_uploads_job.rb
+++ b/app/jobs/clean_pending_uploads_job.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+class CleanPendingUploadsJob < ApplicationJob
+  def perform
+    query_service.custom_queries.find_pending_upload_failures.each do |resource|
+      change_set_persister.buffer_into_index do |buffered_changeset_persister|
+        if resource.respond_to?(:pending_uploads) && resource.pending_uploads.empty? && resource.state.include?("pending")
+          change_set = DynamicChangeSet.new(resource)
+          buffered_changeset_persister.delete(change_set: change_set)
+          Valkyrie.logger.info "Deleted a resource with failed uploads with the ID: #{resource.id}"
+        end
+      end
+    end
+  end
+
+  private
+
+    def metadata_adapter
+      Valkyrie::MetadataAdapter.find(:indexing_persister)
+    end
+    delegate :query_service, to: :metadata_adapter
+
+    def change_set_persister
+      @change_set_persister ||= ChangeSetPersister.new(
+        metadata_adapter: metadata_adapter,
+        storage_adapter: Valkyrie.config.storage_adapter
+      )
+    end
+end

--- a/app/queries/find_pending_upload_failures.rb
+++ b/app/queries/find_pending_upload_failures.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+class FindPendingUploadFailures
+  def self.queries
+    [:find_pending_upload_failures]
+  end
+
+  attr_reader :query_service
+  delegate :resources, to: :query_service
+  delegate :resource_factory, to: :query_service
+  def initialize(query_service:)
+    @query_service = query_service
+  end
+
+  def find_pending_upload_failures
+    relation = { "pending_uploads" => [], "state" => ["pending"] }
+    metadata = Sequel.pg_jsonb_op(:metadata)
+    # rubocop:disable Style/PreferredHashMethods
+    resources.use_cursor.where(
+      metadata.has_key?("pending_uploads") && metadata.has_key?("state")
+    ).where(
+      metadata.contains(relation)
+    ).use_cursor.lazy.map do |attributes|
+      resource_factory.to_resource(object: attributes)
+    end
+    # rubocop:enable Style/PreferredHashMethods
+  end
+end

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -358,6 +358,7 @@ Rails.application.config.to_prepare do
     FindIdsWithPropertyNotEmpty,
     FindDeepFailedCloudFixityCount,
     FindDeepPreservationObjectCount,
+    FindPendingUploadFailures,
     PagedAllQuery
   ].each do |query_handler|
     Valkyrie.config.metadata_adapter.query_service.custom_queries.register_query_handler(query_handler)

--- a/lib/tasks/clean.rake
+++ b/lib/tasks/clean.rake
@@ -18,7 +18,8 @@ namespace :clean do
   end
 
   desc "Clean failed PendingUpload Resources."
-  task pending_uploads: [:environment] do
-    CleanPendingUploadsJob.set(queue: :low).perform_later
+  task :pending_uploads, [:dry_run] => [:environment] do |_t, args|
+    args.with_defaults(dry_run: false)
+    CleanPendingUploadsJob.set(queue: :low).perform_later(dry_run: args[:dry_run].present?)
   end
 end

--- a/lib/tasks/clean.rake
+++ b/lib/tasks/clean.rake
@@ -16,4 +16,9 @@ namespace :clean do
   task :dead_queues do
     CleanDeadQueuesJob.set(queue: :low).perform_later
   end
+
+  desc "Clean failed PendingUpload Resources."
+  task pending_uploads: [:environment] do
+    CleanPendingUploadsJob.set(queue: :low).perform_later
+  end
 end

--- a/spec/jobs/clean_pending_uploads_job_spec.rb
+++ b/spec/jobs/clean_pending_uploads_job_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe CleanPendingUploadsJob do
+  let(:query_service) { Valkyrie.config.metadata_adapter.query_service }
+  let(:resource1) do
+    FactoryBot.create_for_repository(
+      :pending_scanned_resource,
+      pending_uploads: []
+    )
+  end
+  let(:resource_id) { resource1.id }
+
+  describe "#perform" do
+    before do
+      allow(Valkyrie.logger).to receive(:info)
+      resource1
+    end
+
+    it "deletes resources with failed file uploads" do
+      described_class.perform_now
+      expect { query_service.find_by(id: resource_id) }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+      expect(Valkyrie.logger).to have_received(:info).with("Deleted a resource with failed uploads with the ID: #{resource_id}")
+    end
+  end
+end

--- a/spec/jobs/clean_pending_uploads_job_spec.rb
+++ b/spec/jobs/clean_pending_uploads_job_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe CleanPendingUploadsJob do
     it "deletes resources with failed file uploads" do
       described_class.perform_now
       expect { query_service.find_by(id: resource_id) }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
-      expect(Valkyrie.logger).to have_received(:info).with("Deleted a resource with failed uploads with the ID: #{resource_id}")
+      expect(Valkyrie.logger).to have_received(:info).with("Deleted a resource with failed uploads with the title: #{resource1.decorate.first_title} (#{resource_id})")
     end
 
     it "does not delete successful file uploads" do
@@ -67,7 +67,7 @@ RSpec.describe CleanPendingUploadsJob do
       expect(found_resource2.id).to eq(found_resource2.id)
 
       expect { query_service.find_by(id: resource_id) }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
-      expect(Valkyrie.logger).to have_received(:info).with("Deleted a resource with failed uploads with the ID: #{resource_id}")
+      expect(Valkyrie.logger).to have_received(:info).with("Deleted a resource with failed uploads with the title: #{resource1.decorate.first_title} (#{resource_id})")
     end
 
     context "when being processed as a dry run" do
@@ -76,7 +76,7 @@ RSpec.describe CleanPendingUploadsJob do
 
         found_resource = query_service.find_by(id: resource_id)
         expect(found_resource).not_to be_nil
-        expect(Valkyrie.logger).to have_received(:info).with("Found #{resource_id} as an uploaded resource without any FileSets - this would normally be deleted by CleanPendingUploadsJob")
+        expect(Valkyrie.logger).to have_received(:info).with("Found #{found_resource.decorate.first_title} (#{resource_id}) as an uploaded resource without any FileSets - this would normally be deleted by CleanPendingUploadsJob")
       end
     end
   end

--- a/spec/jobs/clean_pending_uploads_job_spec.rb
+++ b/spec/jobs/clean_pending_uploads_job_spec.rb
@@ -2,6 +2,10 @@
 require "rails_helper"
 
 RSpec.describe CleanPendingUploadsJob do
+  with_queue_adapter :inline
+
+  let(:shoulder) { "99999/fk4" }
+  let(:blade) { "123456" }
   let(:query_service) { Valkyrie.config.metadata_adapter.query_service }
   let(:resource1) do
     FactoryBot.create_for_repository(
@@ -10,15 +14,57 @@ RSpec.describe CleanPendingUploadsJob do
     )
   end
   let(:resource_id) { resource1.id }
+  let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }
+  let(:resource2) do
+    FactoryBot.create_for_repository(
+      :complete_scanned_resource,
+      files: [file]
+    )
+  end
+  let(:pending_upload) do
+    # rubocop:disable Rails/FilePath
+    PendingUpload.new(
+      id: SecureRandom.uuid,
+      created_at: Time.current.utc.iso8601,
+      expires: "2018-06-06T22:12:11Z",
+      file_name: "example.tif",
+      file_size: "1874822",
+      url: "file://#{Rails.root.join('spec', 'fixtures', 'files', 'example.tif')}"
+    )
+    # rubocop:enable Rails/FilePath
+  end
+  let(:resource3) do
+    FactoryBot.create_for_repository(
+      :pending_scanned_resource,
+      pending_uploads: [pending_upload]
+    )
+  end
 
   describe "#perform" do
     before do
+      stub_ezid(shoulder: shoulder, blade: blade)
       allow(Valkyrie.logger).to receive(:info)
       resource1
     end
 
     it "deletes resources with failed file uploads" do
       described_class.perform_now
+      expect { query_service.find_by(id: resource_id) }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+      expect(Valkyrie.logger).to have_received(:info).with("Deleted a resource with failed uploads with the ID: #{resource_id}")
+    end
+
+    it "does not delete successful file uploads" do
+      resource2
+      resource3
+      described_class.perform_now
+      # Ensure that the Resource with the PendingUploads has not been deleted
+      query_service.find_by(id: resource3.id)
+
+      found_resource2 = query_service.find_by(id: resource2.id)
+      expect(found_resource2.decorate.file_sets).not_to be_empty
+      expect(found_resource2.decorate.file_sets.first).to be_a FileSet
+      expect(found_resource2.id).to eq(found_resource2.id)
+
       expect { query_service.find_by(id: resource_id) }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
       expect(Valkyrie.logger).to have_received(:info).with("Deleted a resource with failed uploads with the ID: #{resource_id}")
     end

--- a/spec/queries/find_pending_upload_failures_spec.rb
+++ b/spec/queries/find_pending_upload_failures_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe FindPendingUploadFailures do
+  subject(:query) { described_class.new(query_service: query_service) }
+  let(:query_service) { Valkyrie.config.metadata_adapter.query_service }
+  let(:resource1) do
+    FactoryBot.create_for_repository(
+      :pending_scanned_resource,
+      pending_uploads: []
+    )
+  end
+  let(:resource2) do
+    FactoryBot.create_for_repository(
+      :complete_scanned_resource
+    )
+  end
+
+  describe "#find_pending_upload_failures" do
+    it "can find resources where uploads failed to append files to a resource" do
+      resource1
+      resource2
+      output = query.find_pending_upload_failures.to_a
+      expect(output.map(&:id)).to include resource1.id
+      expect(output.map(&:id)).not_to include resource2.id
+    end
+  end
+end


### PR DESCRIPTION
These provide one with the ability to delete resources which have failed file uploads as members. Introduced in response to #3488 