### PR TITLE
Introduces an IssueMonograms Vue component for selecting numismatic Monograms for Issues

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -185,6 +185,7 @@ Metrics/MethodLength:
     - 'app/services/ingest_ephemera_mods.rb'
     - 'app/helpers/thumbnail_helper.rb'
     - 'app/exporters/hathi/submission_information_package.rb'
+    - 'app/resources/numismatics/issues/numismatics/issues_controller.rb'
 Metrics/ModuleLength:
   Exclude:
     - 'app/models/schema/marc_relators.rb'

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,8 @@ Release notes template:
 
 ## Added
 
+* Users now select monograms from a gallery UI component when they create or edit a numismatic issue
+
 * Added Collection membership to Ephemera folders
 
 # 2020-01-02

--- a/app/assets/stylesheets/components/form.scss
+++ b/app/assets/stylesheets/components/form.scss
@@ -233,3 +233,51 @@ form.button-to {
   position: sticky;
   top: 20px;
 }
+
+#numismatic-monograms {
+  tbody {
+    border-left-width: 2px;
+    border-left-style: solid;
+    border-left-color: #dddddd;
+    border-right-width: 2px;
+    border-right-style: solid;
+    border-right-color: #dddddd;
+
+    tr {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      overflow: scroll;
+      height: 26.75rem;
+
+      td {
+        width: inherit;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        border-top-width: 0px;
+
+        .monogram-content {
+          height: 21.000rem;
+
+          &-thumbnail {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            height: 17.000rem;
+
+            .thumbnail-inner {
+              min-height: 221px;
+            }
+          }
+        }
+
+        .monogram-options {
+          display: inline;
+        }
+      }
+    }
+  }
+}

--- a/app/javascript/components/issue_monogram.vue
+++ b/app/javascript/components/issue_monogram.vue
@@ -1,0 +1,64 @@
+<template>
+  <td>
+    <div class="monogram-content">
+      <div class="monogram-content-thumbnail">
+        <img
+          :src="resource.thumbnail"
+          alt="Default"
+          class="thumbnail-inner"
+        >
+      </div>
+      <p>{{ resource.title }}</p>
+    </div>
+
+    <div class="monogram-options">
+      <a :href="resource.url" class="btn btn-default">View</a>
+      <template v-if="isAttached">
+        <button
+          name="button"
+          class="btn btn-default btn btn-danger btn-remove-row"
+          @click.prevent="detach">
+          Detach
+        </button>
+      </template>
+      <template v-else>
+        <button
+          name="button"
+          class="btn btn-default btn btn-primary btn-add-row"
+          @click.prevent="attach">
+          Attach
+        </button>
+      </template>
+    </div>
+  </td>
+</template>
+<script>
+export default {
+  name: 'IssueMonogram',
+  props: {
+    resource: {
+      type: Object,
+      default: null
+    },
+    attached: {
+      type: Boolean,
+      default: false
+    }
+  },
+  data () {
+    return {
+      isAttached: this.attached
+    }
+  },
+  methods: {
+    attach: function () {
+      this.isAttached = true
+      this.$emit('attach', this.resource)
+    },
+    detach: function () {
+      this.isAttached = false
+      this.$emit('detach', this.resource)
+    }
+  }
+}
+</script>

--- a/app/javascript/components/issue_monograms.vue
+++ b/app/javascript/components/issue_monograms.vue
@@ -1,0 +1,87 @@
+<template>
+  <table
+    id="numismatic-monograms"
+    class="table table-striped member-resources numismatic-monograms">
+    <thead>
+      <tr>
+        <th />
+      </tr>
+    </thead>
+
+    <tbody>
+      <tr>
+        <template v-for="monogram in members">
+          <td :key="monogram.id">
+            <issue-monogram
+              :key="monogram.id"
+              :resource="monogram"
+              :attached="monogram.attached"
+              @attach="attach"
+              @detach="detach"
+            />
+          </td>
+        </template>
+      </tr>
+
+      <tr class="hidden">
+        <template v-for="monogram in attachedMembers">
+          <td :key="monogram.id">
+            <input
+              type="hidden"
+              name="numismatics_issue[numismatic_monogram_ids][]"
+              :value="monogram.id" />
+          </td>
+        </template>
+      </tr>
+    </tbody>
+
+    <tfoot>
+      <tr class="">
+        <td />
+      </tr>
+    </tfoot>
+  </table>
+
+</template>
+<script>
+import IssueMonogram from './issue_monogram'
+
+export default {
+  name: 'IssueMonograms',
+  components: {
+    'issue-monogram': IssueMonogram
+  },
+  props: {
+    resource: {
+      type: Object,
+      default: null
+    },
+    members: {
+      type: Array,
+      default: function () { return [] }
+    },
+    nonMembers: {
+      type: Array,
+      default: function () { return [] }
+    },
+    defaultThumbnailUrl: {
+      type: String,
+      default: null
+    }
+  },
+  data: function () {
+    return {
+      attachedMembers: this.members.filter((e) => e.attached)
+    }
+  },
+  methods: {
+    attach (attached) {
+      this.attachedMembers.push(attached)
+    },
+    detach (detached) {
+      const idx = this.attachedMembers.findIndex((e) => e.id === detached.id)
+      this.attachedMembers.splice(idx, 1)
+    }
+  }
+}
+</script>

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -5,6 +5,7 @@ import 'lux-design-system/dist/system/tokens/tokens.scss'
 import store from '../store'
 import DocumentAdder from '../components/document_adder'
 import PlaylistMembers from '../components/playlist_members'
+import IssueMonograms from '../components/issue_monograms'
 import axios from 'axios'
 import OrderManager from '../components/OrderManager.vue'
 import setupAuthLinkClipboard from '../packs/auth_link_clipboard.js'
@@ -22,8 +23,9 @@ document.addEventListener('DOMContentLoaded', () => {
       store,
       components: {
         'document-adder': DocumentAdder,
-	      'playlistMembers': PlaylistMembers,
-        'order-manager': OrderManager
+        'playlistMembers': PlaylistMembers,
+        'order-manager': OrderManager,
+        'issue-monograms': IssueMonograms
       }
     })
   }

--- a/app/resources/numismatics/issues/numismatics/issues_controller.rb
+++ b/app/resources/numismatics/issues/numismatics/issues_controller.rb
@@ -10,6 +10,7 @@ module Numismatics
 
     before_action :load_numismatic_references, only: [:new, :edit]
     before_action :load_monograms, only: [:new, :edit]
+    before_action :load_monogram_attributes, only: [:new, :edit]
     before_action :load_numismatic_places, only: [:new, :edit]
     before_action :load_numismatic_people, only: [:new, :edit]
 
@@ -27,6 +28,7 @@ module Numismatics
 
     def load_monograms
       @numismatic_monograms = query_service.find_all_of_model(model: Numismatics::Monogram).map(&:decorate)
+
       return [] if @numismatic_monograms.to_a.blank?
     end
 
@@ -38,5 +40,43 @@ module Numismatics
         end
       end
     end
+
+    private
+
+      def build_monogram_thumbnail_url(resource)
+        file_sets = resource.decorate.decorated_file_sets.reject { |fs| fs.thumbnail_id.nil? }
+
+        if file_sets.empty?
+          helpers.asset_url("default.png")
+        else
+          ManifestBuilder::ManifestHelper.new.manifest_image_thumbnail_path(file_sets.first)
+        end
+      end
+
+      # Generates the Vue JSON for the Numismatic Monogram membership component
+      # @return [Array<Hash>]
+      def load_monogram_attributes
+        numismatic_monogram_attributes = @numismatic_monograms.map do |monogram|
+          member_thumbnail_url = build_monogram_thumbnail_url(monogram)
+          member_url = solr_document_path(id: monogram.id)
+          member_monogram_ids = resource.decorate.decorated_numismatic_monograms.map(&:id)
+
+          {
+            id: monogram.id.to_s,
+            url: member_url,
+            thumbnail: member_thumbnail_url,
+            title: monogram.decorate.first_title,
+            attached: member_monogram_ids.include?(monogram.id)
+          }
+        end
+
+        @numismatic_monogram_attributes = numismatic_monogram_attributes.sort do |u, v|
+          if u[:attached] <=> v[:attached]
+            0
+          else
+            v[:attached] && !u[:attached] ? 1 : -1
+          end
+        end
+      end
   end
 end

--- a/app/views/records/edit_fields/_numismatic_monogram_ids.html.erb
+++ b/app/views/records/edit_fields/_numismatic_monogram_ids.html.erb
@@ -1,7 +1,3 @@
-<%= f.input :numismatic_monogram_ids,
-            collection: @numismatic_monograms&.sort_by(&:title),
-            label_method: :title,
-            value_method: :id,
-            input_html: { multiple: f.object.multiple?(key) },
-            include_blank: false,
-            required: f.object.required?(key) %>
+<label>Monogram</label>
+
+<issue-monograms :members="<%= @numismatic_monogram_attributes.to_json %>"></issue-monograms>


### PR DESCRIPTION
Resolves #3063 by introducing an IssueMonograms Vue component in order to provide users with the ability to select monograms from a gallery display when creating or editing numismatic issues