### PR TITLE
Ensuring that the link to view Numismatic Issues within the Numismatic dashboard does not erroneously use "Numismatic Issue" as the facet value

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,13 @@ Release notes template:
 
 ## Removed
 
+# 2020-01-02
+
+## Fixed
+
+* Ensuring that Numismatic Issue facet links in the dashboard interface are
+  properly structured
+
 # 2019-12-16
 
 ## Fixed

--- a/app/views/numismatics_dashboard/_issues_row.html.erb
+++ b/app/views/numismatics_dashboard/_issues_row.html.erb
@@ -3,7 +3,7 @@
     <ul class="classify-work classify-<%= label.downcase %>">
       <li class="work-type">
         <h4 class="title"><%= label %></h4>
-        <%= link_to "View", search_catalog_path(params: {"f":{"human_readable_type_ssim":["Numismatic Issue"]},"q":""}), class: "add-button btn btn-primary" %><br>
+        <%= link_to "View", search_catalog_path(params: {"f":{"human_readable_type_ssim":["Issue"]},"q":""}), class: "add-button btn btn-primary" %><br>
         <%= link_to "New Issue", new_numismatics_issue_path, class: "add-button btn btn-primary" %>
       </li>
     </ul>

--- a/spec/views/numismatics_dashboard/show.html.erb_spec.rb
+++ b/spec/views/numismatics_dashboard/show.html.erb_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe "numismatics_dashboard/show" do
 
   context "when the user is an admin" do
     let(:user) { FactoryBot.create(:admin) }
+    let(:view_issues_path) do
+      search_catalog_path(params: { "f": { "human_readable_type_ssim": ["Issue"] }, "q": "" })
+    end
 
     it "has panels" do
       expect(rendered).to have_css("h3", text: "Numismatics")
@@ -20,6 +23,7 @@ RSpec.describe "numismatics_dashboard/show" do
       expect(rendered).to have_css("ul.classify-work.classify-references > li > h4")
       expect(rendered).to have_link("Manage", href: numismatics_references_path)
       expect(rendered).to have_link "New Issue", href: new_numismatics_issue_path
+      expect(rendered).to have_link("View", href: view_issues_path)
     end
   end
 end


### PR DESCRIPTION
Resolves #3534 