### PR TITLE
Removing lib-proc4 and lib-proc5 from the deployment hosts

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -9,8 +9,6 @@
 # server 'db.example.com', user: 'deploy', roles: %w{db}
 server "figgy1", user: "deploy", roles: %w[app db web]
 server "figgy2", user: "deploy", roles: %w[app web]
-server "lib-proc4", user: "deploy", roles: %w[worker]
-server "lib-proc5", user: "deploy", roles: %w[worker]
 server "lib-proc6", user: "deploy", roles: %w[worker]
 server "lib-proc7", user: "deploy", roles: %w[worker]
 server "lib-proc8", user: "deploy", roles: %w[worker]


### PR DESCRIPTION
This is needed in order to restore production deployments from the `master` branch