### PR TITLE
Updating the browse-everything branch for a bug fix for Rails controller request parameter parsing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 
 GIT
   remote: git://github.com/jrgriffiniii/browse-everything.git
-  revision: fba7d1ae4d18fb4a63eb7d331253d250393c68a6
+  revision: 7390981fb96c038a5713da1984026dd0f1ea36cb
   branch: figgy-issues-3273-jrgriffiniii-rebase
   specs:
     browse-everything (1.0.1)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,6 +16,12 @@ Release notes template:
 
 # 2020-01-03
 
+## Fixed
+
+* Restored directory browsing for the File Manager interface (this was breaking,
+  as users could no longer expand a directory in order to browse its contents
+  for file uploads).
+
 ## Added
 
 * Users now select monograms from a gallery UI component when they create or edit a numismatic issue


### PR DESCRIPTION
Resolves #3562 by handling cases where Rails controllers strip the leading "/" characters from file paths passed in the request parameter (please see https://github.com/samvera/browse-everything/commit/7390981fb96c038a5713da1984026dd0f1ea36cb)