### PR TITLE
Index decorated titles

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,12 @@ Release notes template:
 
 -->
 
+# 2020-01-06
+
+## Fixed
+
+* Ensures that titles for all numismatic resources are indexed.
+
 # 2020-01-03
 
 ## Fixed

--- a/app/indexers/title_indexer.rb
+++ b/app/indexers/title_indexer.rb
@@ -6,7 +6,7 @@ class TitleIndexer
   end
 
   def to_solr
-    return {} unless resource.respond_to?(:title) && resource.title.present?
+    return {} unless resource.decorate.respond_to?(:title) && resource.decorate.title.present?
     {
       figgy_title_tesim: title_strings,
       figgy_title_tesi: title_strings.first,
@@ -16,6 +16,6 @@ class TitleIndexer
   end
 
   def title_strings
-    @title_strings ||= resource.title.map(&:to_s)
+    @title_strings ||= Array.wrap(resource.decorate.title).map(&:to_s)
   end
 end

--- a/spec/indexers/title_indexer_spec.rb
+++ b/spec/indexers/title_indexer_spec.rb
@@ -35,5 +35,18 @@ RSpec.describe TitleIndexer do
       output = described_class.new(resource: resource).to_solr
       expect(output).to eq({})
     end
+
+    context "with a decorated title" do
+      it "properly indexes the title values" do
+        resource = FactoryBot.build(:numismatic_place)
+        title = "city, state, region"
+
+        output = described_class.new(resource: resource).to_solr
+        expect(output[:figgy_title_tesim]).to contain_exactly(title)
+        expect(output[:figgy_title_tesi]).to eq title
+        expect(output[:figgy_title_ssim]).to contain_exactly(title)
+        expect(output[:figgy_title_ssi]).to eq title
+      end
+    end
   end
 end


### PR DESCRIPTION
Index decorated titles in addition to titles in defined on the model. Needed for resources like Numismatics::Artist where components of the title are delegated to a wayfinder.

https://github.com/pulibrary/figgy/blob/master/app/resources/numismatics/artists/numismatics/artist_decorator.rb#L25

Closes #3565