### PR TITLE
orders the audio file query response by selection id

### DIFF
--- a/app/services/music_import_service/recording_collector.rb
+++ b/app/services/music_import_service/recording_collector.rb
@@ -358,7 +358,7 @@ class MusicImportService::RecordingCollector
       )
       AND a.FilePath IS NOT NULL
       AND a.entryid IS NOT NULL
-      ORDER BY jAudioFiles.SortOrder, idFile
+      ORDER BY idSelection, jAudioFiles.SortOrder, idFile
     SQL
   end
 


### PR DESCRIPTION
Closes #3568. Note that sometimes the "Complete Concert" playlists have higher selection ids than the pieces causing them to appear at the bottom, but we discard them. (It's probably sorted by jSelection time reverse)