### PR TITLE
Fix import recording rake task.

### DIFF
--- a/lib/tasks/music_reserves.rake
+++ b/lib/tasks/music_reserves.rake
@@ -25,7 +25,7 @@ namespace :music do
         logger: logger
       )
       new_collector = collector.with_recordings_query(
-        collector.prerequisite_recordings_query([recording_id])
+        collector.dependent_recordings_query([recording_id])
       )
       importer = MusicImportService.new(
         recording_collector: new_collector,


### PR DESCRIPTION
The naming of the method was changed in a previous refactor, but it was missed in the rake task.

Previous refactor commit: https://github.com/pulibrary/figgy/pull/2414/commits/87412abe5ae0b72bd6e218a67c73808809f7aae0