### PR TITLE
Updating browse-everything in order to ensure that selected directories are parsed from within Controllers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,7 +81,7 @@ gem "rsolr", ">= 1.0"
 
 gem "aasm"
 gem "arabic-letter-connector"
-gem "browse-everything", github: "jrgriffiniii/browse-everything", branch: "figgy-issues-3273-jrgriffiniii-rebase"
+gem "browse-everything", github: "jrgriffiniii/browse-everything", branch: "figgy-issues-3587-jrgriffiniii"
 gem "capistrano", "~> 3.7.1"
 gem "capistrano-passenger"
 gem "capistrano-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: git://github.com/jrgriffiniii/browse-everything.git
-  revision: 7390981fb96c038a5713da1984026dd0f1ea36cb
-  branch: figgy-issues-3273-jrgriffiniii-rebase
+  revision: e03156af1b93b1884bdfa5e5d915fd8f25b41191
+  branch: figgy-issues-3587-jrgriffiniii
   specs:
     browse-everything (1.0.1)
       addressable (~> 2.5)

--- a/app/values/browse_everything_file_paths.rb
+++ b/app/values/browse_everything_file_paths.rb
@@ -11,7 +11,7 @@ class BrowseEverythingFilePaths
   # @return [Pathname]
   def parent_path
     return if file_paths.empty?
-    return file_paths.first.dirname if file_paths.count == 1
+    return file_paths.first if file_paths.count == 1
     @parent_path ||= begin
       out_path = file_paths.first
       file_paths[1..-1].each do |f|

--- a/spec/controllers/bulk_ingest_controller_spec.rb
+++ b/spec/controllers/bulk_ingest_controller_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe BulkIngestController do
     let(:selected_files) do
       {
         "0" => {
-          "url" => "file:///base/4609321/1.tif",
+          "url" => "file:///base/4609321",
           "file_name" => "1.tif",
           "file_size" => "100"
         }
@@ -132,7 +132,7 @@ RSpec.describe BulkIngestController do
       let(:selected_files) do
         {
           "0" => {
-            "url" => "file:///base/June 31/1.tif",
+            "url" => "file:///base/June 31",
             "file_name" => "1.tif",
             "file_size" => "100"
           }


### PR DESCRIPTION
Resolves #3587 by addressing the following:
- Updating browse-everything in order to ensure that selected directories are parsed from within Controllers are parsed from within Controllers including
BrowseEverything::Parameters
- Ensuring that BrowseEverythingFilePaths#parent_path returns the path of a selected directory (when only a single directory is chosen for upload)