### PR TITLE
Retrieves the auth_header without parsing it into JSON when constructing PendingUpload objects

### DIFF
--- a/app/controllers/base_resource_controller.rb
+++ b/app/controllers/base_resource_controller.rb
@@ -42,8 +42,7 @@ class BaseResourceController < ApplicationController
     # This is provided within BrowseEverything::Parameters#selected_files
     selected_files.each do |selected_file|
       file_attributes = selected_file.to_h
-      auth_header_values = file_attributes.delete("auth_header")
-      auth_header = JSON.generate(auth_header_values)
+      auth_header = file_attributes.delete("auth_header")
 
       new_pending_upload = PendingUpload.new(
         file_attributes.merge(

--- a/app/controllers/bulk_ingest_controller.rb
+++ b/app/controllers/bulk_ingest_controller.rb
@@ -167,8 +167,7 @@ class BulkIngestController < ApplicationController
 
         # This is needed in order to ensure that files are authorized for the
         # download from the Cloud Service provider
-        auth_header_values = file_attributes.delete(:auth_header)
-        auth_header = JSON.generate(auth_header_values)
+        auth_header = file_attributes.delete(:auth_header)
 
         @new_pending_uploads << PendingUpload.new(file_attributes.merge(id: SecureRandom.uuid, created_at: Time.current.utc.iso8601, auth_header: auth_header))
       end

--- a/spec/controllers/bulk_ingest_controller_spec.rb
+++ b/spec/controllers/bulk_ingest_controller_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe BulkIngestController do
             url: "https://www.example.com/files/1.tif?alt=media",
             file_name: "1.tif",
             file_size: "100",
-            auth_header: "{\"Authorization\":\"Bearer secret\"}"
+            auth_header: { "Authorization": "Bearer secret" }
           )
         )
         expect(BrowseEverythingIngestJob).to have_received(:perform_later).with(resources.first.id.to_s, "BulkIngestController", [resources.first.pending_uploads.first.id.to_s])
@@ -276,7 +276,7 @@ RSpec.describe BulkIngestController do
               url: "https://www.example.com/files/1.tif?alt=media",
               file_name: "1.tif",
               file_size: "100",
-              auth_header: "{\"Authorization\":\"Bearer secret\"}"
+              auth_header: { "Authorization": "Bearer secret" }
             )
           )
 


### PR DESCRIPTION
This was pushed upstream with https://github.com/jrgriffiniii/browse-everything/blob/figgy-issues-3587-jrgriffiniii/lib/browse_everything/driver/google_drive.rb#L182. Resolves #3593 