### PR TITLE
Introduces a combobox for Numismatic::Issue form fields

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,13 @@ Release notes template:
 ## Removed
 
 -->
+# 2020-02-11
+
+## Added
+
+* Numismatic Issue forms now have autocompletion and selection for the fields
+  Object Type, Denomination, Metal, Shape, Color, and Edge.
+
 # 2020-02-10
 
 ## Fixed

--- a/app/assets/javascripts/figgy_boot.es6
+++ b/app/assets/javascripts/figgy_boot.es6
@@ -36,7 +36,7 @@ export default class Initializer {
     // causing this to not run. Manually calling it so facet more links work.
     Blacklight.ajaxModal.setup_modal()
     $("optgroup:not([label=Favorites])").addClass("closed")
-    $("select").selectpicker({'liveSearch': true})
+    $("select:not(.select2)").selectpicker({'liveSearch': true})
     $(".datatable").DataTable()
   }
 
@@ -79,6 +79,19 @@ export default class Initializer {
       const $element = $(element)
       const $form = $element.parent('form')
       new ParentResourcesTables($element, $form)
+    })
+
+    $('select.select2').select2({
+      tags: true,
+      placeholder: "Nothing selected"
+    }).on('select2:select', (event) => {
+      const $target = $(event.target)
+      const selected = $target.select2('data')
+      const selectedItem = selected.shift()
+      const value = selectedItem.text
+      const $hidden = $($target.data('hidden'))
+
+      $hidden.val(value)
     })
   }
 

--- a/app/assets/stylesheets/components/form.scss
+++ b/app/assets/stylesheets/components/form.scss
@@ -187,6 +187,19 @@ form {
     margin-top: 0;
     margin-bottom: 10px;
   }
+
+  .select2-selection.select2-selection--single {
+    height: 39px;
+    width: 100%;
+
+    span {
+      margin-top: 4px;
+    }
+
+    .select2-selection__arrow {
+      margin-right: 6px;
+    }
+  }
 }
 
 .set-access-controls {
@@ -278,6 +291,21 @@ form.button-to {
           display: inline;
         }
       }
+    }
+  }
+}
+
+.select2-container {
+  .select2-search__field {
+    height: 36px;
+  }
+
+  .select2-results__options {
+    padding-bottom: 6px;
+
+    .select2-results__option--highlighted {
+      background-color: #337ab7 !important;
+      min-height: 31px;
     }
   }
 }

--- a/app/resources/numismatics/issues/numismatics/issue_decorator.rb
+++ b/app/resources/numismatics/issues/numismatics/issue_decorator.rb
@@ -58,6 +58,7 @@ module Numismatics
              :decorated_master,
              :decorated_rulers,
              :members,
+             :issues,
              to: :wayfinder
 
     def artists
@@ -135,6 +136,30 @@ module Numismatics
 
     def subjects
       numismatic_subject.map { |s| s.decorate.title }
+    end
+
+    def object_types
+      issues.map(&:object_type).flatten.compact.uniq
+    end
+
+    def denominations
+      issues.map(&:denomination).flatten.compact.uniq
+    end
+
+    def metals
+      issues.map(&:metal).flatten.compact.uniq
+    end
+
+    def shapes
+      issues.map(&:shape).flatten.compact.uniq
+    end
+
+    def colors
+      issues.map(&:color).flatten.compact.uniq
+    end
+
+    def edges
+      issues.map(&:edge).flatten.compact.uniq
     end
   end
 end

--- a/app/resources/numismatics/issues/numismatics/issue_wayfinder.rb
+++ b/app/resources/numismatics/issues/numismatics/issue_wayfinder.rb
@@ -16,7 +16,11 @@ module Numismatics
     end
 
     def issues_count
-      @issues = query_service.custom_queries.count_all_of_model(model: Numismatics::Issue)
+      @issues_count = query_service.custom_queries.count_all_of_model(model: Numismatics::Issue)
+    end
+
+    def issues
+      @issues = query_service.find_all_of_model(model: Numismatics::Issue)
     end
 
     def members_with_parents

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,6 +40,19 @@
     <%= content_for?(:body) ? yield(:body) : yield %>
     <%= render 'shared/ajax_modal' %>
     <%= javascript_include_tag 'application' %>
+    <link href="https://cdn.jsdelivr.net/npm/select2@4.0.13/dist/css/select2.min.css" rel="stylesheet" />
+
+    <%= javascript_tag do %>
+      oldDefine = define;
+      define = null;
+    <% end %>
+
+    <script src="https://cdn.jsdelivr.net/npm/select2@4.0.13/dist/js/select2.js"></script>
+
+    <%= javascript_tag do %>
+      define = oldDefine;
+    <% end %>
+
     <%= javascript_tag do %>
       window.Global = {
         figgy: { resource: { defaultThumbnail: "<%= image_url('default_thumbnail.png') %>" } }

--- a/app/views/records/edit_fields/_color.html.erb
+++ b/app/views/records/edit_fields/_color.html.erb
@@ -4,9 +4,9 @@
   <input id="color" type="hidden" name="numismatics_issue[color]" value="<%= f.object.model.color&.first %>" />
 
   <select class="form-control select2" id="numismatics_issue_color" data-hidden="#color">
-    <option <% f.object.model.color.blank? ? 'selected' : '' %></option>
+    <option <% f.object.model.color.blank? ? 'selected' : '' %>></option>
     <% f.object.model.decorate.colors.each do |color| %>
-      <option <% f.object.model.color == color ? 'selected' : '' %> ><%= color %></option>
+      <option <%= f.object.model.color&.first == color ? 'selected' : '' %> ><%= color %></option>
     <% end %>
   </select>
 </div>

--- a/app/views/records/edit_fields/_color.html.erb
+++ b/app/views/records/edit_fields/_color.html.erb
@@ -1,0 +1,12 @@
+<div class="form-group">
+
+  <label for="numismatics_issue_color" class="control-label select optional">Color</label>
+  <input id="color" type="hidden" name="numismatics_issue[color]" value="<%= f.object.model.color&.first %>" />
+
+  <select class="form-control select2" id="numismatics_issue_color" data-hidden="#color">
+    <option <% f.object.model.color.blank? ? 'selected' : '' %></option>
+    <% f.object.model.decorate.colors.each do |color| %>
+      <option <% f.object.model.color == color ? 'selected' : '' %> ><%= color %></option>
+    <% end %>
+  </select>
+</div>

--- a/app/views/records/edit_fields/_denomination.html.erb
+++ b/app/views/records/edit_fields/_denomination.html.erb
@@ -1,0 +1,12 @@
+<div class="form-group">
+
+  <label for="numismatics_issue_denomination" class="control-label select optional">Denomination</label>
+  <input id="denomination" type="hidden" name="numismatics_issue[denomination]" value="<%= f.object.model.denomination&.first %>" />
+
+  <select class="form-control select2" id="numismatics_issue_denomination" data-hidden="#denomination">
+    <option <% f.object.model.denomination.blank? ? 'selected' : '' %></option>
+    <% f.object.model.decorate.denominations.each do |denomination| %>
+      <option <% f.object.model.denomination == denomination ? 'selected' : '' %> ><%= denomination %></option>
+    <% end %>
+  </select>
+</div>

--- a/app/views/records/edit_fields/_denomination.html.erb
+++ b/app/views/records/edit_fields/_denomination.html.erb
@@ -4,9 +4,9 @@
   <input id="denomination" type="hidden" name="numismatics_issue[denomination]" value="<%= f.object.model.denomination&.first %>" />
 
   <select class="form-control select2" id="numismatics_issue_denomination" data-hidden="#denomination">
-    <option <% f.object.model.denomination.blank? ? 'selected' : '' %></option>
+    <option <% f.object.model.denomination.blank? ? 'selected' : '' %>></option>
     <% f.object.model.decorate.denominations.each do |denomination| %>
-      <option <% f.object.model.denomination == denomination ? 'selected' : '' %> ><%= denomination %></option>
+      <option <%= f.object.model.denomination&.first == denomination ? 'selected' : '' %> ><%= denomination %></option>
     <% end %>
   </select>
 </div>

--- a/app/views/records/edit_fields/_edge.html.erb
+++ b/app/views/records/edit_fields/_edge.html.erb
@@ -4,9 +4,9 @@
   <input id="edge" type="hidden" name="numismatics_issue[edge]" value="<%= f.object.model.edge&.first %>" />
 
   <select class="form-control select2" id="numismatics_issue_edge" data-hidden="#edge">
-    <option <% f.object.model.edge.blank? ? 'selected' : '' %></option>
+    <option <% f.object.model.edge.blank? ? 'selected' : '' %>></option>
     <% f.object.model.decorate.edges.each do |edge| %>
-      <option <% f.object.model.edge == edge ? 'selected' : '' %> ><%= edge %></option>
+      <option <%= f.object.model.edge&.first == edge ? 'selected' : '' %> ><%= edge %></option>
     <% end %>
   </select>
 </div>

--- a/app/views/records/edit_fields/_edge.html.erb
+++ b/app/views/records/edit_fields/_edge.html.erb
@@ -1,0 +1,12 @@
+<div class="form-group">
+
+  <label for="numismatics_issue_edge" class="control-label select optional">Edge</label>
+  <input id="edge" type="hidden" name="numismatics_issue[edge]" value="<%= f.object.model.edge&.first %>" />
+
+  <select class="form-control select2" id="numismatics_issue_edge" data-hidden="#edge">
+    <option <% f.object.model.edge.blank? ? 'selected' : '' %></option>
+    <% f.object.model.decorate.edges.each do |edge| %>
+      <option <% f.object.model.edge == edge ? 'selected' : '' %> ><%= edge %></option>
+    <% end %>
+  </select>
+</div>

--- a/app/views/records/edit_fields/_metal.html.erb
+++ b/app/views/records/edit_fields/_metal.html.erb
@@ -1,0 +1,12 @@
+<div class="form-group">
+
+  <label for="numismatics_issue_metal" class="control-label select optional">Metal</label>
+  <input id="metal" type="hidden" name="numismatics_issue[metal]" value="<%= f.object.model.metal&.first %>" />
+
+  <select class="form-control select2" id="numismatics_issue_metal" data-hidden="#metal">
+    <option <% f.object.model.metal.blank? ? 'selected' : '' %></option>
+    <% f.object.model.decorate.metals.each do |metal| %>
+      <option <% f.object.model.metal == metal ? 'selected' : '' %> ><%= metal %></option>
+    <% end %>
+  </select>
+</div>

--- a/app/views/records/edit_fields/_metal.html.erb
+++ b/app/views/records/edit_fields/_metal.html.erb
@@ -4,9 +4,9 @@
   <input id="metal" type="hidden" name="numismatics_issue[metal]" value="<%= f.object.model.metal&.first %>" />
 
   <select class="form-control select2" id="numismatics_issue_metal" data-hidden="#metal">
-    <option <% f.object.model.metal.blank? ? 'selected' : '' %></option>
+    <option <% f.object.model.metal.blank? ? 'selected' : '' %>></option>
     <% f.object.model.decorate.metals.each do |metal| %>
-      <option <% f.object.model.metal == metal ? 'selected' : '' %> ><%= metal %></option>
+      <option <%= f.object.model.metal&.first == metal ? 'selected' : '' %> ><%= metal %></option>
     <% end %>
   </select>
 </div>

--- a/app/views/records/edit_fields/_object_type.html.erb
+++ b/app/views/records/edit_fields/_object_type.html.erb
@@ -1,0 +1,12 @@
+<div class="form-group">
+
+  <label for="numismatics_issue_object_type" class="control-label select optional">Object type</label>
+  <input id="object_type" type="hidden" name="numismatics_issue[object_type]" value="<%= f.object.model.object_type&.first %>" />
+
+  <select class="form-control select2" id="numismatics_issue_object_type" data-hidden="#object_type">
+    <option <% f.object.model.object_type.blank? ? 'selected' : '' %></option>
+    <% f.object.model.decorate.object_types.each do |object_type| %>
+      <option <% f.object.model.object_type == object_type ? 'selected' : '' %> ><%= object_type %></option>
+    <% end %>
+  </select>
+</div>

--- a/app/views/records/edit_fields/_object_type.html.erb
+++ b/app/views/records/edit_fields/_object_type.html.erb
@@ -4,9 +4,9 @@
   <input id="object_type" type="hidden" name="numismatics_issue[object_type]" value="<%= f.object.model.object_type&.first %>" />
 
   <select class="form-control select2" id="numismatics_issue_object_type" data-hidden="#object_type">
-    <option <% f.object.model.object_type.blank? ? 'selected' : '' %></option>
+    <option <% f.object.model.object_type.blank? ? 'selected' : '' %>></option>
     <% f.object.model.decorate.object_types.each do |object_type| %>
-      <option <% f.object.model.object_type == object_type ? 'selected' : '' %> ><%= object_type %></option>
+      <option <%= f.object.model.object_type&.first == object_type ? 'selected' : '' %> ><%= object_type %></option>
     <% end %>
   </select>
 </div>

--- a/app/views/records/edit_fields/_shape.html.erb
+++ b/app/views/records/edit_fields/_shape.html.erb
@@ -1,0 +1,12 @@
+<div class="form-group">
+
+  <label for="numismatics_issue_shape" class="control-label select optional">Shape</label>
+  <input id="shape" type="hidden" name="numismatics_issue[shape]" value="<%= f.object.model.shape&.first %>" />
+
+  <select class="form-control select2" id="numismatics_issue_shape" data-hidden="#shape">
+    <option <% f.object.model.shape.blank? ? 'selected' : '' %></option>
+    <% f.object.model.decorate.shapes.each do |shape| %>
+      <option <% f.object.model.shape == shape ? 'selected' : '' %> ><%= shape %></option>
+    <% end %>
+  </select>
+</div>

--- a/spec/features/numismatic_issue_spec.rb
+++ b/spec/features/numismatic_issue_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "Numismatics::Issue", js: true do
+  let(:user) { FactoryBot.create(:admin) }
+  let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
+  let(:issue) do
+    FactoryBot.build(:numismatic_issue,
+                     object_type: "coin",
+                     denomination: "1/2 Penny",
+                     metal: "copper",
+                     shape: "round",
+                     color: "green",
+                     edge: "test value")
+  end
+  let(:change_set_persister) { ChangeSetPersister.new(metadata_adapter: adapter, storage_adapter: Valkyrie.config.storage_adapter) }
+
+  before do
+    sign_in user
+  end
+
+  describe "form editing" do
+    it "permits users to save a new object types" do
+      visit new_numismatics_issue_path
+
+      expect(page).to have_css("#select2-numismatics_issue_object_type-container")
+      expect(page).to have_css("#select2-numismatics_issue_denomination-container")
+      expect(page).to have_css("#select2-numismatics_issue_metal-container")
+      expect(page).to have_css("#select2-numismatics_issue_shape-container")
+      expect(page).to have_css("#select2-numismatics_issue_color-container")
+      expect(page).to have_css("#select2-numismatics_issue_edge-container")
+
+      page.find("#select2-numismatics_issue_object_type-container").click
+      page.find(".select2-search__field", visible: false).send_keys("coin2", :enter)
+      page.find(".save").click
+
+      expect(page).to have_css(".attribute.object_type", text: "coin2")
+    end
+
+    context "when Issues have been saved" do
+      let(:persisted) do
+        change_set = Numismatics::IssueChangeSet.new(issue)
+        change_set_persister.save(change_set: change_set)
+      end
+
+      it "permits users to select from existing object types" do
+        visit edit_numismatics_issue_path(id: persisted.id)
+
+        hidden = page.find("body #main form.edit_numismatics_issue input[type='hidden']#object_type", visible: false)
+        expect(hidden["value"]).to eq("coin")
+        hidden = page.find("body #main form.edit_numismatics_issue input[type='hidden']#denomination", visible: false)
+        expect(hidden["value"]).to eq("1/2 Penny")
+        hidden = page.find("body #main form.edit_numismatics_issue input[type='hidden']#metal", visible: false)
+        expect(hidden["value"]).to eq("copper")
+        hidden = page.find("body #main form.edit_numismatics_issue input[type='hidden']#shape", visible: false)
+        expect(hidden["value"]).to eq("round")
+        hidden = page.find("body #main form.edit_numismatics_issue input[type='hidden']#color", visible: false)
+        expect(hidden["value"]).to eq("green")
+        hidden = page.find("body #main form.edit_numismatics_issue input[type='hidden']#edge", visible: false)
+        expect(hidden["value"]).to eq("test value")
+
+        page.find("#select2-numismatics_issue_object_type-container").click
+        page.find(".select2-search__field", visible: false).send_keys("coin3", :enter)
+        page.find(".save").click
+
+        expect(page).to have_css(".attribute.object_type", text: "coin3")
+      end
+
+      it "persists already saved denominations" do
+        visit edit_numismatics_issue_path(id: persisted.id)
+
+        hidden = page.find("body #main form.edit_numismatics_issue input[type='hidden']#denomination", visible: false)
+        expect(hidden["value"]).to eq("1/2 Penny")
+      end
+    end
+  end
+end

--- a/spec/resources/numismatics/issues/numismatics/issue_wayfinder_spec.rb
+++ b/spec/resources/numismatics/issues/numismatics/issue_wayfinder_spec.rb
@@ -18,4 +18,11 @@ describe Numismatics::IssueWayfinder do
       expect(numismatic_issue_wayfinder.issues_count).to eq 1
     end
   end
+
+  describe "#issues" do
+    it "returns the all issues" do
+      expect(numismatic_issue_wayfinder.issues).not_to be_empty
+      expect(numismatic_issue_wayfinder.issues.first).to be_a Numismatics::Issue
+    end
+  end
 end

--- a/spec/resources/numismatics/issues/numismatics/issues_feature_spec.rb
+++ b/spec/resources/numismatics/issues/numismatics/issues_feature_spec.rb
@@ -72,10 +72,10 @@ RSpec.feature "Numismatics::Issues" do
     expect(page).to have_field "Type"
     expect(page).to have_field "Workshop"
 
-    fill_in "Object type", with: "ancient coin"
+    fill_in "Era", with: "test era"
     click_button "Save"
 
-    expect(page).to have_content "ancient coin"
+    expect(page).to have_content "test era"
   end
 
   context "when a user creates a new numismatic issue" do


### PR DESCRIPTION
Resolves #3618 by addressing the following:

- Integrating the select2 widget as a combobox for the Numismatic::Issue form
- Ensuring that the select2 can be used to select the fields "Object type", "Denomination", "Metal", "Shape", "Color", and "Edge"