### PR TITLE
Allow Numismatic edit form select box values to be cleared

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,12 @@ Release notes template:
 
 ## Changed
 
+* Allow Numismatic resource edit form select box values to be cleared.
+
+# 2020-02-12
+
+## Changed
+
 * Increased the load speed of numismatics issue edit pages by using
 * Solr queries to populate select boxes.
 

--- a/app/assets/javascripts/figgy_boot.es6
+++ b/app/assets/javascripts/figgy_boot.es6
@@ -83,7 +83,8 @@ export default class Initializer {
 
     $('select.select2').select2({
       tags: true,
-      placeholder: "Nothing selected"
+      placeholder: "Nothing selected",
+      allowClear: true
     }).on('select2:select', (event) => {
       const $target = $(event.target)
       const selected = $target.select2('data')

--- a/app/assets/stylesheets/components/form.scss
+++ b/app/assets/stylesheets/components/form.scss
@@ -199,6 +199,10 @@ form {
     .select2-selection__arrow {
       margin-right: 6px;
     }
+
+    .select2-selection__clear {
+      margin: 0 4px 0 0;
+    }
   }
 }
 


### PR DESCRIPTION
Users can clear select box values by clicking the "x" on the right of the dropdown element.

<img width="795" alt="Screenshot 2020-02-12 15 28 46" src="https://user-images.githubusercontent.com/784196/74379307-298cdd80-4dad-11ea-852d-63d109695c30.png">

Closes #3662

