### PR TITLE
Refactor download permissions to act on the FileMetadata

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -41,7 +41,14 @@ class DownloadsController < ApplicationController
 
   def load_file
     return unless binary_file && file_desc
-    @load_file ||= FileWithMetadata.new(id: params[:id], file: binary_file, mime_type: file_desc.mime_type, original_name: file_desc.original_filename.first, file_set_id: resource.id, file_metadata: file_desc)
+    @load_file ||= FileWithMetadata.new(
+      id: params[:id],
+      file: binary_file,
+      mime_type: file_desc.mime_type,
+      original_name: file_desc.original_filename.first,
+      file_set_id: resource.id,
+      file_metadata: file_desc
+    )
   rescue Valkyrie::StorageAdapter::FileNotFound
     nil
   end

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -41,7 +41,7 @@ class DownloadsController < ApplicationController
 
   def load_file
     return unless binary_file && file_desc
-    @load_file ||= FileWithMetadata.new(id: params[:id], file: binary_file, mime_type: file_desc.mime_type, original_name: file_desc.original_filename.first, file_set_id: resource.id)
+    @load_file ||= FileWithMetadata.new(id: params[:id], file: binary_file, mime_type: file_desc.mime_type, original_name: file_desc.original_filename.first, file_set_id: resource.id, file_metadata: file_desc)
   rescue Valkyrie::StorageAdapter::FileNotFound
     nil
   end
@@ -56,17 +56,17 @@ class DownloadsController < ApplicationController
     @binary_file ||= storage_adapter.find_by(id: file_desc.file_identifiers.first)
   end
 
-  class FileWithMetadata < Dry::Struct
+  class FileWithMetadata < Valkyrie::Resource
     delegate :size, :read, :stream, to: :file
     attribute :file, Valkyrie::Types::Any
     attribute :mime_type, Valkyrie::Types::SingleValuedString
     attribute :original_name, Valkyrie::Types::SingleValuedString
     attribute :file_set_id, Valkyrie::Types::Any
+    attribute :file_metadata, Valkyrie::Types::Any
   end
 
   # Customize the :download ability in your Ability class, or override this method
   def authorize_download!
-    authorize! :download, resource
     authorize! :download, load_file
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -88,7 +88,6 @@ class Ability
   end
 
   def download_file_with_metadata?(resource)
-    return true if token_readable_for_file_metadata?(resource)
     # Geo thumbnails/metadata are always downloadable no matter what.
     return true if geo_thumbnail?(resource) || geo_metadata?(resource)
     file_set = query_service.find_by(id: resource.file_set_id)
@@ -339,20 +338,5 @@ class Ability
     # @return [Boolean]
     def can_read_parent?(resource)
       can?(:read, resource.decorate.parent&.object)
-    end
-
-    # Determines whether or not an auth token grants access to the parent of a given resource
-    # @param obj [Resource]
-    # @return [Boolean]
-    def token_readable_for_file_metadata?(obj)
-      return false unless auth_token && obj.respond_to?(:file_set_id)
-      # This is not always a FileSet, as PDFs are attached directly to ScannedResources
-      attaching_resource = find_by(id: obj.file_set_id)
-
-      return if attaching_resource.nil?
-      return token_readable?(attaching_resource) unless attaching_resource.is_a?(FileSet)
-
-      # Retrieve the Playlist
-      authorized_by_token?(attaching_resource)
     end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -59,7 +59,7 @@ class Ability
     anonymous_permissions
 
     can :download, DownloadsController::FileWithMetadata do |resource|
-      download_file_with_metadata?(resource) || geo_campus_file?(resource)
+      download_file_with_metadata?(resource)
     end
   end
 
@@ -101,21 +101,6 @@ class Ability
   # Geo metadata is always downloadable
   def geo_metadata?(resource)
     ControlledVocabulary::GeoMetadataFormat.new.include?(resource.mime_type)
-  end
-
-  # Find visibility of parent geo resource and return true if it's authenticated
-  def geo_campus_file?(resource)
-    file_set = query_service.find_by(id: resource.file_set_id)
-    parent = file_set.decorate.parent
-    return unless parent.try(:geo_resource?)
-    visibility = parent.model.visibility
-    visibility.include?(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED)
-  end
-
-  def geo_file_set?(resource)
-    return false unless resource.is_a?(FileSet)
-    parent = resource.decorate.parent
-    parent.try(:geo_resource?)
   end
 
   # Geo thumbnails are always downloadable

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -457,7 +457,7 @@ describe Ability do
       let(:vector_resource_members) { query_service.find_members(resource: vector_resource) }
       let(:file_set) { vector_resource_members.first }
       let(:vector_file) do
-        DownloadsController::FileWithMetadata.new(id: "1234", file: "", mime_type: "application/vnd.geo+json", original_name: "file.geosjon", file_set_id: file_set.id)
+        DownloadsController::FileWithMetadata.new(id: "1234", file: "", mime_type: "application/vnd.geo+json", original_name: "file.geosjon", file_set_id: file_set.id, file_metadata: file_set.file_metadata.first)
       end
       let(:vector_resource) do
         change_set_persister.save(change_set: VectorResourceChangeSet.new(campus_only_vector_resource, files: [file]))
@@ -522,13 +522,13 @@ describe Ability do
     let(:vector_resource_members) { query_service.find_members(resource: vector_resource) }
     let(:file_set) { vector_resource_members.first }
     let(:vector_file) do
-      DownloadsController::FileWithMetadata.new(id: "1234", file: "", mime_type: "application/vnd.geo+json", original_name: "file.geosjon", file_set_id: file_set.id)
+      DownloadsController::FileWithMetadata.new(id: "1234", file: "", mime_type: "application/vnd.geo+json", original_name: "file.geosjon", file_set_id: file_set.id, file_metadata: instance_double(FileMetadata, derivative?: false, derivative_partial?: false))
     end
     let(:metadata_file) do
-      DownloadsController::FileWithMetadata.new(id: "5768", file: "", mime_type: "application/xml; schema=fgdc", original_name: "fgdc.xml", file_set_id: file_set.id)
+      DownloadsController::FileWithMetadata.new(id: "5768", file: "", mime_type: "application/xml; schema=fgdc", original_name: "fgdc.xml", file_set_id: file_set.id, file_metadata: instance_double(FileMetadata, derivative?: false, derivative_partial?: false))
     end
     let(:thumbnail_file) do
-      DownloadsController::FileWithMetadata.new(id: "9abc", file: "", mime_type: "image/png", original_name: "thumbnail.png", file_set_id: file_set.id)
+      DownloadsController::FileWithMetadata.new(id: "9abc", file: "", mime_type: "image/png", original_name: "thumbnail.png", file_set_id: file_set.id, file_metadata: instance_double(FileMetadata, derivative?: true))
     end
 
     it {
@@ -640,7 +640,6 @@ describe Ability do
       end
 
       it {
-        is_expected.to be_able_to(:download, file_set)
         is_expected.to be_able_to(:download, thumbnail_file)
         is_expected.to be_able_to(:download, metadata_file)
         is_expected.to be_able_to(:download, vector_file)
@@ -658,7 +657,6 @@ describe Ability do
       end
 
       it {
-        is_expected.to be_able_to(:download, file_set)
         is_expected.to be_able_to(:download, thumbnail_file)
         is_expected.to be_able_to(:download, metadata_file)
         is_expected.not_to be_able_to(:download, vector_file)

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -457,7 +457,14 @@ describe Ability do
       let(:vector_resource_members) { query_service.find_members(resource: vector_resource) }
       let(:file_set) { vector_resource_members.first }
       let(:vector_file) do
-        DownloadsController::FileWithMetadata.new(id: "1234", file: "", mime_type: "application/vnd.geo+json", original_name: "file.geosjon", file_set_id: file_set.id, file_metadata: file_set.file_metadata.first)
+        DownloadsController::FileWithMetadata.new(
+          id: "1234",
+          file: "",
+          mime_type: "application/vnd.geo+json",
+          original_name: "file.geosjon",
+          file_set_id: file_set.id,
+          file_metadata: file_set.file_metadata.first
+        )
       end
       let(:vector_resource) do
         change_set_persister.save(change_set: VectorResourceChangeSet.new(campus_only_vector_resource, files: [file]))
@@ -522,13 +529,34 @@ describe Ability do
     let(:vector_resource_members) { query_service.find_members(resource: vector_resource) }
     let(:file_set) { vector_resource_members.first }
     let(:vector_file) do
-      DownloadsController::FileWithMetadata.new(id: "1234", file: "", mime_type: "application/vnd.geo+json", original_name: "file.geosjon", file_set_id: file_set.id, file_metadata: instance_double(FileMetadata, derivative?: false, derivative_partial?: false))
+      DownloadsController::FileWithMetadata.new(
+        id: "1234",
+        file: "",
+        mime_type: "application/vnd.geo+json",
+        original_name: "file.geosjon",
+        file_set_id: file_set.id,
+        file_metadata: instance_double(FileMetadata, derivative?: false, derivative_partial?: false)
+      )
     end
     let(:metadata_file) do
-      DownloadsController::FileWithMetadata.new(id: "5768", file: "", mime_type: "application/xml; schema=fgdc", original_name: "fgdc.xml", file_set_id: file_set.id, file_metadata: instance_double(FileMetadata, derivative?: false, derivative_partial?: false))
+      DownloadsController::FileWithMetadata.new(
+        id: "5768",
+        file: "",
+        mime_type: "application/xml; schema=fgdc",
+        original_name: "fgdc.xml",
+        file_set_id: file_set.id,
+        file_metadata: instance_double(FileMetadata, derivative?: false, derivative_partial?: false)
+      )
     end
     let(:thumbnail_file) do
-      DownloadsController::FileWithMetadata.new(id: "9abc", file: "", mime_type: "image/png", original_name: "thumbnail.png", file_set_id: file_set.id, file_metadata: instance_double(FileMetadata, derivative?: true))
+      DownloadsController::FileWithMetadata.new(
+        id: "9abc",
+        file: "",
+        mime_type: "image/png",
+        original_name: "thumbnail.png",
+        file_set_id: file_set.id,
+        file_metadata: instance_double(FileMetadata, derivative?: true)
+      )
     end
 
     it {


### PR DESCRIPTION
There's no point in checking for the FileSet, as the permissions for
streaming differ from the permissions for downloading the original file.
Instead, derivatives are allowed if the FileSet is readable (it's
complete and accessible by the user), and original files are downloadable if the
FileSet is configured to be so.

An exception is made for Geo Thumbnails/Metadata, which are set to
always be downloadable as per existing functionality.

Closes #3652