### PR TITLE
Setting a password explicitly for the postgres Docker image for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,12 +9,12 @@ jobs:
           RAILS_ENV: test
           FIGGY_DB_HOST: localhost
           FIGGY_DB_USERNAME: figgy
-          FIGGY_DB_PASSWORD:  ""
+          FIGGY_DB_PASSWORD:  "secret"
       - image: postgres:10.6-alpine
         environment:
           POSTGRES_USER: figgy
           POSTGRES_DB: figgy_test
-          POSTGRES_PASSWORD: ""
+          POSTGRES_PASSWORD: "secret"
     steps:
       - checkout
       - run: sudo sh bin/ci_mediainfo_install.sh
@@ -78,13 +78,13 @@ jobs:
           RAILS_ENV: test
           FIGGY_DB_HOST: localhost
           FIGGY_DB_USERNAME: figgy
-          FIGGY_DB_PASSWORD:  ""
+          FIGGY_DB_PASSWORD:  "secret"
           MEDIAINFO_PATH: /usr/bin/mediainfo
       - image: postgres:9.6-alpine
         environment:
           POSTGRES_USER: figgy
           POSTGRES_DB: figgy_test
-          POSTGRES_PASSWORD: ""
+          POSTGRES_PASSWORD: "secret"
       - image: solr:7.7-alpine
         command: bin/solr -cloud -noprompt -f -p 8984
     parallelism: 4
@@ -180,7 +180,7 @@ jobs:
           RAILS_ENV: test
           FIGGY_DB_HOST: localhost
           FIGGY_DB_USERNAME: figgy
-          FIGGY_DB_PASSWORD:  ""
+          FIGGY_DB_PASSWORD:  "secret"
     steps:
       - attach_workspace:
           at: '~/figgy'
@@ -218,7 +218,7 @@ jobs:
           RAILS_ENV: test
           FIGGY_DB_HOST: localhost
           FIGGY_DB_USERNAME: figgy
-          FIGGY_DB_PASSWORD:  ""
+          FIGGY_DB_PASSWORD:  "secret"
     steps:
       - checkout
       - run: bin/ci_check_release_notes.sh


### PR DESCRIPTION
This is necessary after the Docker Image for PostgreSQL was updated for CircleCI builds: https://hub.docker.com/layers/postgres/library/postgres/9.6-alpine/images/sha256-07e2b0c89d90a2656c012fd06b9f167ce78b02e5631aae0f06123354d4d119eb?context=explore