### PR TITLE
Update properties in Orangelight coin document builder

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,6 +14,12 @@ Release notes template:
 
 -->
 
+# 2020-02-17
+
+## Fixed
+
+ * Fixed title and location for Coin documents ingested into Orangelight
+
 # 2020-02-14
 
 ## Added

--- a/app/resources/numismatics/coins/numismatics/coin_decorator.rb
+++ b/app/resources/numismatics/coins/numismatics/coin_decorator.rb
@@ -39,7 +39,7 @@ module Numismatics
     delegate :id, :label, to: :accession, prefix: true
 
     def call_number
-      "Numismatics::Coin #{coin_number}"
+      "Coin #{coin_number}"
     end
 
     def citations

--- a/app/resources/numismatics/coins/orangelight_coin_builder.rb
+++ b/app/resources/numismatics/coins/orangelight_coin_builder.rb
@@ -37,7 +37,7 @@ class OrangelightCoinBuilder
     def document_coin_hash
       {
         id: decorator.orangelight_id,
-        title_display: "Numismatics::Coin: #{decorator.coin_number}",
+        title_display: "Coin: #{decorator.coin_number}",
         pub_created_display: decorator.pub_created_display,
         access_facet: ["Online", "In the Library"],
         call_number_display: [decorator.call_number],
@@ -45,7 +45,7 @@ class OrangelightCoinBuilder
         location_code_s: [coin_location_code],
         location: [coin_library_location],
         location_display: [coin_full_location],
-        format: ["Numismatics::Coin"],
+        format: ["Coin"],
         advanced_location_s: [coin_location_code],
         counter_stamp_s: decorator.counter_stamp,
         analysis_s: decorator.analysis,
@@ -135,11 +135,11 @@ class OrangelightCoinBuilder
     end
 
     def coin_library_location
-      "Rare Books and Special Collections"
+      "Special Collections"
     end
 
     def coin_full_location
-      "Rare Books and Special Collections - Numismatics Collection"
+      "Special Collections - Numismatics Collection"
     end
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/AbcSize

--- a/spec/services/orangelight_document_spec.rb
+++ b/spec/services/orangelight_document_spec.rb
@@ -92,21 +92,21 @@ describe OrangelightDocument do
         output = MultiJson.load(builder.to_json, symbolize_keys: true)
         holding = JSON.parse(output[:holdings_1display]).first.last
         expect(output[:id]).to eq coin.decorate.orangelight_id
-        expect(output[:title_display]).to eq "Numismatics::Coin: #{coin.coin_number}"
+        expect(output[:title_display]).to eq "Coin: #{coin.coin_number}"
         expect(output[:pub_created_display]).to eq "name1 name2 epithet (1868 - 1963), 1/2 Penny, city"
-        expect(output[:call_number_display]).to eq ["Numismatics::Coin #{coin.coin_number}"]
-        expect(output[:call_number_browse_s]).to eq ["Numismatics::Coin #{coin.coin_number}"]
+        expect(output[:call_number_display]).to eq ["Coin #{coin.coin_number}"]
+        expect(output[:call_number_browse_s]).to eq ["Coin #{coin.coin_number}"]
         expect(output[:access_facet]).to eq ["Online", "In the Library"]
-        expect(output[:location]).to eq ["Rare Books and Special Collections"]
-        expect(output[:location_display]).to eq ["Rare Books and Special Collections - Numismatics Collection"]
-        expect(output[:format]).to eq ["Numismatics::Coin"]
+        expect(output[:location]).to eq ["Special Collections"]
+        expect(output[:location_display]).to eq ["Special Collections - Numismatics Collection"]
+        expect(output[:format]).to eq ["Coin"]
         expect(output[:advanced_location_s]).to eq ["num"]
         expect(output[:location_code_s]).to eq ["num"]
-        expect(holding["call_number"]).to eq "Numismatics::Coin #{coin.coin_number}"
-        expect(holding["call_number_browse"]).to eq "Numismatics::Coin #{coin.coin_number}"
+        expect(holding["call_number"]).to eq "Coin #{coin.coin_number}"
+        expect(holding["call_number_browse"]).to eq "Coin #{coin.coin_number}"
         expect(holding["location_code"]).to eq "num"
-        expect(holding["location"]).to eq "Rare Books and Special Collections - Numismatics Collection"
-        expect(holding["library"]).to eq "Rare Books and Special Collections"
+        expect(holding["location"]).to eq "Special Collections - Numismatics Collection"
+        expect(holding["library"]).to eq "Special Collections"
         expect(output[:counter_stamp_s]).to eq ["two small counter-stamps visible as small circles on reverse, without known parallel"]
         expect(output[:analysis_s]).to eq ["holed at 12 o'clock, 16.73 grams"]
         expect(output[:notes_display]).to eq ["Abraham Usher| John Field| Charles Meredith.", "Black and red ink.", "Visible flecks of mica."]


### PR DESCRIPTION
- Updates title and format to "Coin" instead of "Numismatics::Coin"
- Updates "Rare Books and Special Collections" to "Special Collections"

Closes #3687 