### PR TITLE
Make complete the default state on numismatic Issues

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,6 +16,14 @@ Release notes template:
 
 # 2020-02-14
 
+## Changed
+
+ * Sets default state of Numismatics Issues to "complete".
+ * Prevents propagation of Issue state to Coin members.
+ * Stops minting ARKs for Issues.
+
+# 2020-02-14
+
 ## Added
 
  * Integrated the "Save and Duplicate Metadata" feature for Numismatic Issues and

--- a/app/change_set_persisters/change_set_persister/propagate_visibility_and_state.rb
+++ b/app/change_set_persisters/change_set_persister/propagate_visibility_and_state.rb
@@ -18,6 +18,7 @@ class ChangeSetPersister
     # Execute the handler
     def run
       return if new_collection_record
+      return if numismatics_issue
       members.each do |member|
         resource_change_set = DynamicChangeSet.new(member)
         resource_change_set = propagate_visibility(resource_change_set)
@@ -105,6 +106,10 @@ class ChangeSetPersister
       # it doesn't have members yet if it is just now being created
       def new_collection_record
         change_set.model.is_a?(Collection) && change_set.model.id.nil?
+      end
+
+      def numismatics_issue
+        change_set.model.is_a?(Numismatics::Issue)
       end
   end
 end

--- a/app/resources/numismatics/issues/numismatics/issue_change_set.rb
+++ b/app/resources/numismatics/issues/numismatics/issue_change_set.rb
@@ -57,6 +57,7 @@ module Numismatics
     property :downloadable, multiple: false, require: true, default: "public"
     property :rights_statement, multiple: false, required: true, default: RightsStatements.no_known_copyright, type: ::Types::URI
     property :rights_note, multiple: false, required: false
+    property :state, multiple: false, required: true, default: "complete"
 
     # Virtual Attributes
     property :files, virtual: true, multiple: true, required: false

--- a/app/resources/numismatics/issues/numismatics/issue_decorator.rb
+++ b/app/resources/numismatics/issues/numismatics/issue_decorator.rb
@@ -60,6 +60,11 @@ module Numismatics
              :members,
              to: :wayfinder
 
+    # Don't mink ARKs for Numismatics::Issues
+    def ark_mintable_state?
+      false
+    end
+
     def artists
       numismatic_artist.map { |a| a.decorate.title }
     end

--- a/spec/change_set_persisters/change_set_persister_spec.rb
+++ b/spec/change_set_persisters/change_set_persister_spec.rb
@@ -1205,23 +1205,6 @@ RSpec.describe ChangeSetPersister do
         expect(rabbit_connection).to have_received(:publish).twice.with(expected_result.to_json)
       end
     end
-    context "with a numismatic issue and coin member" do
-      let(:issue) { FactoryBot.create_for_repository(:numismatic_issue, member_ids: [coin.id], state: "draft") }
-      let(:coin) { FactoryBot.create_for_repository(:coin, state: "draft") }
-
-      it "does not propagate the workflow state" do
-        members = Wayfinder.for(issue).members
-        expect(members.first.state).to eq ["draft"]
-
-        change_set = DynamicChangeSet.new(issue)
-        change_set.validate(state: "complete")
-        output = change_set_persister.save(change_set: change_set)
-        expect(output.identifier.first).to eq "ark:/#{shoulder}#{blade}"
-
-        members = Wayfinder.for(output).members
-        expect(members.first.state).to eq ["draft"]
-      end
-    end
   end
 
   describe "appending" do

--- a/spec/change_set_persisters/change_set_persister_spec.rb
+++ b/spec/change_set_persisters/change_set_persister_spec.rb
@@ -1205,6 +1205,23 @@ RSpec.describe ChangeSetPersister do
         expect(rabbit_connection).to have_received(:publish).twice.with(expected_result.to_json)
       end
     end
+    context "with a numismatic issue and coin member" do
+      let(:issue) { FactoryBot.create_for_repository(:numismatic_issue, member_ids: [coin.id], state: "draft") }
+      let(:coin) { FactoryBot.create_for_repository(:coin, state: "draft") }
+
+      it "does not propagate the workflow state" do
+        members = Wayfinder.for(issue).members
+        expect(members.first.state).to eq ["draft"]
+
+        change_set = DynamicChangeSet.new(issue)
+        change_set.validate(state: "complete")
+        output = change_set_persister.save(change_set: change_set)
+        expect(output.identifier.first).to eq "ark:/#{shoulder}#{blade}"
+
+        members = Wayfinder.for(output).members
+        expect(members.first.state).to eq ["draft"]
+      end
+    end
   end
 
   describe "appending" do

--- a/spec/resources/numismatics/issues/numismatics/issue_change_set_spec.rb
+++ b/spec/resources/numismatics/issues/numismatics/issue_change_set_spec.rb
@@ -32,19 +32,16 @@ RSpec.describe Numismatics::IssueChangeSet do
     context "when an issue has coin members" do
       subject(:change_set) { described_class.new(issue) }
       let(:coin) { FactoryBot.create_for_repository(:coin) }
-      let(:issue) { FactoryBot.create_for_repository(:numismatic_issue, member_ids: [coin.id]) }
+      let(:issue) { FactoryBot.create_for_repository(:numismatic_issue, member_ids: [coin.id], state: ["draft"]) }
       let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
       let(:storage_adapter) { Valkyrie.config.storage_adapter }
       let(:change_set_persister) { ChangeSetPersister.new(metadata_adapter: adapter, storage_adapter: storage_adapter) }
 
-      before do
-        stub_ezid(shoulder: "99999/fk4", blade: "123456")
-      end
-      it "propagates the state to member resources" do
+      it "does not propagate the state to member resources" do
         change_set.state = "complete"
         persisted = change_set_persister.save(change_set: change_set)
         coins = persisted.decorate.decorated_coins
-        expect(coins.first.state).to eq "complete"
+        expect(coins.first.state).to eq "draft"
       end
     end
   end

--- a/spec/resources/numismatics/issues/numismatics/issue_change_set_spec.rb
+++ b/spec/resources/numismatics/issues/numismatics/issue_change_set_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Numismatics::IssueChangeSet do
 
   describe "#state" do
     it "pre-populates" do
-      expect(change_set.state).to eq "draft"
+      expect(change_set.state).to eq "complete"
     end
 
     context "when an issue has coin members" do


### PR DESCRIPTION
I wrote up a detailed ticket describing why this PR might be desirable, but it didn't save for some reason and I don't feel up to recreating it in full. Long story short, I think that we should set Numismatic Issue states to "complete" by default and not propagate state changes to Coin members.

- Issues are like containers that hold metadata but no files. Users will add coins as they are acquired and cataloged.
- Focusing on getting the numismatics lab users to use workflow functionality for Coin resources seems much more important.