### PR TITLE
Uses ENV["OBJID"] to associate identifier with existing resource

### DIFF
--- a/app/jobs/delete_archival_collection_job.rb
+++ b/app/jobs/delete_archival_collection_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+class DeleteArchivalCollectionJob < ApplicationJob
+  def perform(id:)
+    qs = Valkyrie::MetadataAdapter.find(:indexing_persister).query_service
+    resources = qs.custom_queries.find_by_property(property: :archival_collection_code,
+                                                   value: id)
+    if resources.count.zero?
+      Rails.logger.info("Archival collection #{id} does not exist, can't delete members")
+    else
+      Rails.logger.info("removing #{resources.count} resources from collection #{id}.")
+      change_set_persister = ScannedResourcesController.change_set_persister
+      resources.each do |resource|
+        change_set = DynamicChangeSet.new(resource)
+        change_set_persister.delete(change_set: change_set)
+      end
+    end
+  end
+end

--- a/lib/tasks/bulk.rake
+++ b/lib/tasks/bulk.rake
@@ -29,6 +29,7 @@ namespace :bulk do
     background = ENV["BACKGROUND"]
     model = ENV["MODEL"]
     filter = ENV["FILTER"]
+    identifier = ENV["OBJID"] # will be the ark for the resource
 
     abort "usage: rake bulk:ingest DIR=/path/to/files BIB=1234567 COLL=collid LOCAL_ID=local_id REPLACES=replaces FILTER=file_filter MODEL=ResourceClass" unless dir && Dir.exist?(dir)
 
@@ -59,7 +60,8 @@ namespace :bulk do
           member_of_collection_ids: [coll],
           source_metadata_identifier: bib,
           local_identifier: local_id,
-          replaces: replaces
+          replaces: replaces,
+          identifier: identifier
         )
       else
         IngestFolderJob.perform_now(
@@ -69,7 +71,8 @@ namespace :bulk do
           member_of_collection_ids: [coll],
           source_metadata_identifier: bib,
           local_identifier: local_id,
-          replaces: replaces
+          replaces: replaces,
+          identifier: identifier
         )
       end
     rescue => e

--- a/lib/tasks/bulk.rake
+++ b/lib/tasks/bulk.rake
@@ -264,4 +264,25 @@ namespace :bulk do
       logger.error e.backtrace
     end
   end
+
+  desc "Remove all resources in an archival collection"
+  task remove: :environment do
+    abort "usage: rake bulk:remove CODE=archival_collection_code" unless ENV["CODE"]
+
+    archival_collection_code = ENV["CODE"]
+    background = ENV["BACKGROUND"]
+
+    @logger = Logger.new(STDOUT)
+    @logger.info "Removing archival collection #{archival_collection_code}"
+
+    begin
+      if background
+        DeleteArchivalCollectionJob.set(queue: :low).perform_later(id: archival_collection_code)
+      else
+        DeleteArchivalCollectionJob.perform_now(id: archival_collection_code)
+      end
+    rescue => e
+      @logger.error "Error: #{e.message}"
+    end
+  end
 end

--- a/spec/jobs/delete_archival_collection_job_spec.rb
+++ b/spec/jobs/delete_archival_collection_job_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DeleteArchivalCollectionJob do
+  with_queue_adapter :inline
+  context "when there are objects to remove" do
+    it "removes all of the objects" do
+      bib = "WC055_c0001"
+      FactoryBot.create_for_repository(:scanned_resource, archival_collection_code: bib)
+      qs = Valkyrie::MetadataAdapter.find(:indexing_persister).query_service
+      resources = qs.custom_queries.find_by_property(property: :archival_collection_code, value: bib)
+
+      expect(resources.count).not_to eq(0)
+      described_class.perform_now(id: bib)
+      resources = qs.custom_queries.find_by_property(property: :archival_collection_code, value: bib)
+      expect(resources.count).to eq(0)
+    end
+  end
+
+  describe ".perform" do
+    it "does not error when the collection does not exist" do
+      expect { described_class.perform_now(id: :nonexistent) }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
identifier is now passed into IngestFolderJob, so that images can be associated with already-created ScannedResources from EADs.