### PR TITLE
Add additional numismatics drop-downs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,13 @@ Release notes template:
 -->
 # 2020-02-26
 
+## Added
+
+* Added firm and person ajax drop downs to numismatics accessions.
+* Added buttons for new Numismatic Ruler and Master.
+
+# 2020-02-26
+
 ## Changed
 
 * Sort coins in members data table by date uploaded.

--- a/app/views/numismatics/accessions/edit_fields/_firm_id.html.erb
+++ b/app/views/numismatics/accessions/edit_fields/_firm_id.html.erb
@@ -1,0 +1,6 @@
+<div class="form-group string optional">
+  <%= f.label :firm_id, required: f.object.required?(:firm_id) %>
+  <%= link_to 'New Firm', new_numismatics_firm_path, class: 'btn btn-sm btn-primary new-link', target: '_blank'%>
+  <%= f.hidden_field :firm_id, ajax_select_type: "Firm" %>
+</div>
+

--- a/app/views/numismatics/accessions/edit_fields/_person_id.html.erb
+++ b/app/views/numismatics/accessions/edit_fields/_person_id.html.erb
@@ -1,0 +1,5 @@
+<div class="form-group string optional">
+  <%= f.label :person_id, required: f.object.required?(:person_id) %>
+  <%= link_to 'New Person', new_numismatics_person_path, class: 'btn btn-sm btn-primary new-link', target: '_blank'%>
+  <%= f.hidden_field :person_id, ajax_select_type: "Person" %>
+</div>

--- a/app/views/numismatics/issues/edit_fields/_master_id.html.erb
+++ b/app/views/numismatics/issues/edit_fields/_master_id.html.erb
@@ -1,4 +1,5 @@
 <div class="form-group string optional">
   <%= f.label :master_id, required: f.object.required?(:master_id) %>
+  <%= link_to 'New Master', new_numismatics_person_path, class: 'btn btn-sm btn-primary new-link', target: '_blank'%>
   <%= f.hidden_field :master_id, ajax_select_type: "Person" %>
 </div>

--- a/app/views/numismatics/issues/edit_fields/_ruler_id.html.erb
+++ b/app/views/numismatics/issues/edit_fields/_ruler_id.html.erb
@@ -1,4 +1,5 @@
 <div class="form-group string optional">
   <%= f.label :ruler_id, required: f.object.required?(:ruler_id) %>
+  <%= link_to 'New Ruler', new_numismatics_person_path, class: 'btn btn-sm btn-primary new-link', target: '_blank'%>
   <%= f.hidden_field :ruler_id, ajax_select_type: "Person" %>
 </div>

--- a/app/views/records/edit_fields/_person_id.html.erb
+++ b/app/views/records/edit_fields/_person_id.html.erb
@@ -1,8 +1,0 @@
-<%= f.input :person_id,
-            label: "Person",
-            collection: @numismatic_people&.sort_by(&:title),
-            label_method: :title,
-            value_method: :id,
-            input_html: { multiple: f.object.multiple?(key) },
-            include_blank: true,
-            required: f.object.required?(key) %>

--- a/spec/resources/numismatics/accessions/numismatics/accession_feature_spec.rb
+++ b/spec/resources/numismatics/accessions/numismatics/accession_feature_spec.rb
@@ -14,15 +14,17 @@ RSpec.feature "Numismatics::Accessions" do
     expect(page).to have_field "Account"
     expect(page).to have_field "Cost"
     expect(page).to have_field "Date"
-    expect(page).to have_field "Firm"
+    expect(page).to have_selector("label", text: "Firm")
     expect(page).to have_field "Note"
     expect(page).to have_field "Number"
     expect(page).to have_field "Number of items"
     expect(page).to have_selector("label", text: "Numismatic reference")
     expect(page).to have_field "Part"
-    expect(page).to have_field "Person"
+    expect(page).to have_selector("label", text: "Person")
     expect(page).to have_field "Private note"
     expect(page).to have_field "Type"
+    expect(page).to have_css "a.btn.btn-sm.btn-primary.new-link", text: "New Person"
+    expect(page).to have_css "a.btn.btn-sm.btn-primary.new-link", text: "New Firm"
 
     fill_in "Type", with: "purchase"
     click_button "Save"

--- a/spec/resources/numismatics/issues/numismatics/issues_feature_spec.rb
+++ b/spec/resources/numismatics/issues/numismatics/issues_feature_spec.rb
@@ -74,6 +74,8 @@ RSpec.feature "Numismatics::Issues" do
     expect(page).to have_css "a.btn.btn-sm.btn-primary.new-link", text: "New Place"
     expect(page).to have_css "a.btn.btn-sm.btn-primary.new-link", text: "New Person"
     expect(page).to have_css "a.btn.btn-sm.btn-primary.new-link", text: "New Monogram"
+    expect(page).to have_css "a.btn.btn-sm.btn-primary.new-link", text: "New Master"
+    expect(page).to have_css "a.btn.btn-sm.btn-primary.new-link", text: "New Ruler"
 
     fill_in "Era", with: "test era"
     click_button "Save"


### PR DESCRIPTION
- Adds firm and person ajax drop downs to numismatics accessions.
- Adds buttons for new numismatic ruler and master.

Closes #3619 