### PR TITLE
Numismatic Issue form: update the label Numismatic Place to Minting Location & Move the Numismatic Place field under the Ruler field.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,6 +17,13 @@ Release notes template:
 
 ## Added
 
+* Update on the 'Numismatic Issue' form the label 'Numismatic Place' to 'Minting Location'.
+* Move the 'Numismatic Place' field under the 'Ruler' field.  
+
+# 2020-02-27
+
+## Added
+
 * Update layout/Move in one line Earliest Date and Latest Date fields.
 * Update layout/Move in one line Era and Date of the Object fields.
 

--- a/app/resources/numismatics/issues/numismatics/issue_change_set.rb
+++ b/app/resources/numismatics/issues/numismatics/issue_change_set.rb
@@ -90,10 +90,10 @@ module Numismatics
             :object_date
           ],
           :ruler_id,
+          :numismatic_place_id,
           :master_id,
           :workshop,
-          :series,
-          :numismatic_place_id
+          :series
         ],
         "Obverse" => [
           :obverse_figure,

--- a/app/views/numismatics/issues/edit_fields/_numismatic_place_id.html.erb
+++ b/app/views/numismatics/issues/edit_fields/_numismatic_place_id.html.erb
@@ -1,5 +1,5 @@
 <div class="form-group string optional">
-  <%= f.label :numismatic_place_id, required: f.object.required?(:numismatic_place_id) %>
+  <%= f.label :numismatic_place_id, required: f.object.required?(:numismatic_place_id), label: "Minting Location" %>
   <%= link_to 'New Place', new_numismatics_place_path, class: 'btn btn-sm btn-primary new-link', target: '_blank'%>
   <%= f.hidden_field :numismatic_place_id, ajax_select_type: "Place" %>
 </div>

--- a/spec/resources/numismatics/issues/numismatics/issues_feature_spec.rb
+++ b/spec/resources/numismatics/issues/numismatics/issues_feature_spec.rb
@@ -45,7 +45,7 @@ RSpec.feature "Numismatics::Issues" do
     expect(page).to have_selector("label", text: "Numismatic reference")
     expect(page).to have_field "Part"
     expect(page).to have_selector("label", text: "Person")
-    expect(page).to have_selector("label", text: "Numismatic place")
+    expect(page).to have_selector("label", text: "Minting Location")
     expect(page).to have_field "Object type"
     expect(page).to have_field "Obverse figure"
     expect(page).to have_field "Obverse figure description"


### PR DESCRIPTION
* Update on the 'Numismatic Issue' form the label 'Numismatic Place' to 'Minting Location'.
* Move the 'Numismatic Place' field under the 'Ruler' field.

closes #3707 