### PR TITLE
Add button for new numismatic reference to citation form

### DIFF
--- a/app/views/numismatics/coins/edit_fields/_numismatic_citation_fields.html.erb
+++ b/app/views/numismatics/coins/edit_fields/_numismatic_citation_fields.html.erb
@@ -2,6 +2,7 @@
   <div class="row">
     <div class="col-md-6">
       <%= f.label :numismatic_reference_id, required: f.object.required?(:numismatic_reference_id) %>
+      <%= link_to 'New Reference', new_numismatics_reference_path, class: 'btn btn-sm btn-primary new-link', target: '_blank'%>
       <%= f.hidden_field :numismatic_reference_id, ajax_select_type: "Reference"%>
     </div>
     <div class="col-md-6">

--- a/app/views/records/edit_fields/_numismatic_citation_fields.html.erb
+++ b/app/views/records/edit_fields/_numismatic_citation_fields.html.erb
@@ -2,6 +2,7 @@
   <div class="row">
     <div class="col-md-6">
       <%= f.label :numismatic_reference_id, required: f.object.required?(:numismatic_reference_id) %>
+      <%= link_to 'New Reference', new_numismatics_reference_path, class: 'btn btn-sm btn-primary new-link', target: '_blank'%>
       <%= f.hidden_field :numismatic_reference_id, ajax_select_type: "Reference"%>
     </div>
   </div>

--- a/spec/resources/numismatics/coins/numismatics/coin_feature_spec.rb
+++ b/spec/resources/numismatics/coins/numismatics/coin_feature_spec.rb
@@ -77,6 +77,8 @@ RSpec.feature "Numismatics::Coins" do
     expect(page).to have_field "Type"
     expect(page).to have_field "Weight (g)"
 
+    expect(page).to have_css "a.btn.btn-sm.btn-primary.new-link", text: "New Reference"
+
     fill_in "Size", with: "3 cm"
     click_button "Save"
 

--- a/spec/resources/numismatics/issues/numismatics/issues_feature_spec.rb
+++ b/spec/resources/numismatics/issues/numismatics/issues_feature_spec.rb
@@ -75,6 +75,7 @@ RSpec.feature "Numismatics::Issues" do
     expect(page).to have_css "a.btn.btn-sm.btn-primary.new-link", text: "New Person"
     expect(page).to have_css "a.btn.btn-sm.btn-primary.new-link", text: "New Monogram"
     expect(page).to have_css "a.btn.btn-sm.btn-primary.new-link", text: "New Master"
+    expect(page).to have_css "a.btn.btn-sm.btn-primary.new-link", text: "New Reference"
     expect(page).to have_css "a.btn.btn-sm.btn-primary.new-link", text: "New Ruler"
     expect(page).to have_css "div.panel.panel-default div.panel-body div.col-sm-6 div.form-group div.col-sm-6 div.form-group input#numismatics_issue_earliest_date"
     expect(page).to have_css "div.panel.panel-default div.panel-body div.col-sm-6 div.form-group div.col-sm-6 div.form-group input#numismatics_issue_latest_date"


### PR DESCRIPTION
Closes #3712 

<img width="1197" alt="Screenshot 2020-02-28 11 24 22" src="https://user-images.githubusercontent.com/784196/75570521-ebcebc80-5a1c-11ea-97d7-c5279748cb79.png">
