### PR TITLE
Index a unique numismatic reference title into Solr

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,13 @@ Release notes template:
 -->
 # 2020-02-28
 
+## Added
+
+* Indexes a unique numismatic reference title into Solr.
+* Drop-down menus for references will display this title.
+
+# 2020-02-28
+
 ## Changed
 
 * Sort numismatics drop down values alphabetically.

--- a/app/indexers/title_indexer.rb
+++ b/app/indexers/title_indexer.rb
@@ -16,6 +16,14 @@ class TitleIndexer
   end
 
   def title_strings
-    @title_strings ||= Array.wrap(resource.decorate.title).map(&:to_s)
+    @title_strings ||= begin
+      # Some resources need a different title to be indexed into Solr.
+      # NumismaticReference is an example. Needed for user requested drop down values.
+      if resource.decorate.respond_to?(:indexed_title) && resource.decorate.indexed_title.present?
+        Array.wrap(resource.decorate.indexed_title).map(&:to_s)
+      else
+        Array.wrap(resource.decorate.title).map(&:to_s)
+      end
+    end
   end
 end

--- a/app/resources/numismatics/references/numismatics/reference_decorator.rb
+++ b/app/resources/numismatics/references/numismatics/reference_decorator.rb
@@ -18,6 +18,10 @@ module Numismatics
       decorated_authors.map(&:title)
     end
 
+    def indexed_title
+      [short_title, authors.first, year].compact.join(", ")
+    end
+
     def manageable_files?
       false
     end

--- a/spec/indexers/title_indexer_spec.rb
+++ b/spec/indexers/title_indexer_spec.rb
@@ -48,5 +48,17 @@ RSpec.describe TitleIndexer do
         expect(output[:figgy_title_ssi]).to eq title
       end
     end
+    context "with a distinct indexed title" do
+      it "properly indexes the indexed title values" do
+        resource = FactoryBot.build(:numismatic_reference, year: 2020)
+        title = "short-title, 2020"
+
+        output = described_class.new(resource: resource).to_solr
+        expect(output[:figgy_title_tesim]).to contain_exactly(title)
+        expect(output[:figgy_title_tesi]).to eq title
+        expect(output[:figgy_title_ssim]).to contain_exactly(title)
+        expect(output[:figgy_title_ssi]).to eq title
+      end
+    end
   end
 end


### PR DESCRIPTION
- Allows unique values (different from the actual resource title) to be indexed into Solr.
- Creates an indexed title for NumismaticReference that is displayed in the ajax drop down.

Closes #3714 

<img width="610" alt="Screenshot 2020-02-28 12 07 22" src="https://user-images.githubusercontent.com/784196/75574210-b5487000-5a23-11ea-8110-29598311ca92.png">
