### PR TITLE
Update Valkyrie to 2.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem "sprockets", ">= 3.7.2"
 gem "sqlite3"
 gem "title"
 gem "uglifier"
-gem "valkyrie", "~> 2.1.0"
+gem "valkyrie", "~> 2.1.1"
 gem "valkyrie-derivatives", git: "https://github.com/samvera-labs/valkyrie-derivatives.git"
 gem "webpacker", "~> 4.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,9 +292,10 @@ GEM
     dropbox_api (0.1.18)
       faraday (<= 1.0)
       oauth2 (~> 1.1)
-    dry-configurable (0.9.0)
+    dry-configurable (0.11.3)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.4, >= 0.4.7)
+      dry-equalizer (~> 0.2)
     dry-container (0.7.2)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.1, >= 0.1.3)
@@ -311,7 +312,7 @@ GEM
       dry-equalizer (~> 0.3)
       dry-types (~> 1.3)
       ice_nine (~> 0.11)
-    dry-types (1.3.0)
+    dry-types (1.4.0)
       concurrent-ruby (~> 1.0)
       dry-container (~> 0.3)
       dry-core (~> 0.4, >= 0.4.4)
@@ -835,7 +836,7 @@ GEM
     unf_ext (0.0.7.5)
     unicode-display_width (1.4.1)
     validatable (1.6.7)
-    valkyrie (2.1.0)
+    valkyrie (2.1.1)
       activemodel
       activesupport
       disposable (~> 0.4.5)
@@ -993,7 +994,7 @@ DEPENDENCIES
   tiny_tds
   title
   uglifier
-  valkyrie (~> 2.1.0)
+  valkyrie (~> 2.1.1)
   valkyrie-derivatives!
   valkyrie-sequel (~> 2.1.0)
   valkyrie-shrine!


### PR DESCRIPTION
Fixes a bunch of deprecation warnings regarding ID comparisons.