### PR TITLE
Adds identifier property to ScannedResourceChangeSet

### DIFF
--- a/app/resources/scanned_resources/scanned_resource_change_set.rb
+++ b/app/resources/scanned_resources/scanned_resource_change_set.rb
@@ -28,6 +28,7 @@ class ScannedResourceChangeSet < ChangeSet
   property :depositor, multiple: false, require: false
   property :ocr_language, multiple: true, require: false, default: []
   property :replaces, multiple: true, require: false
+  property :identifier, multiple: false, require: false
 
   # Virtual Attributes
   property :files, virtual: true, multiple: true, required: false

--- a/lib/tasks/bulk.rake
+++ b/lib/tasks/bulk.rake
@@ -39,6 +39,7 @@ namespace :bulk do
     @logger.info "filtering to files ending with #{filter}" if filter
     @logger.info "ingesting as: #{user.user_key} (override with USER=foo)"
     @logger.info "adding item to collection #{coll}" if coll
+    @logger.info "passing identifier |#{identifier}|"
     if model
       begin
         model.constantize

--- a/spec/jobs/ingest_mets_job_spec.rb
+++ b/spec/jobs/ingest_mets_job_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe IngestMETSJob do
       book = adapter.query_service.find_all_of_model(model: ScannedResource).first
       expect(book).not_to be_nil
       expect(book.source_metadata_identifier).to eq ["4612596"]
-      expect(book.identifier.first).to eq "ark:/88435/5m60qr98htest"
+      expect(book.identifier.first).to eq "ark:/88435/5m60qr98h"
       expect(book.logical_structure[0].nodes.length).to eq 1
       expect(book.logical_structure[0].nodes[0].label).to contain_exactly "leaf 1"
       expect(book.logical_structure[0].nodes[0].nodes[0].label).to contain_exactly "leaf 1. recto"


### PR DESCRIPTION
Required so that identifier can be passed in to IngestFolderJob