### PR TITLE
Remove JPEG2000 derivative generation functionality

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,12 @@ Release notes template:
 ## Removed
 
 -->
+# 2020-04-24
+
+## Removed
+
+* Removed support for ingesting JPEG2000 files.
+
 # 2020-04-23
 
 ## Fixed

--- a/app/derivative_services/default_derivative_service.rb
+++ b/app/derivative_services/default_derivative_service.rb
@@ -32,7 +32,7 @@ class DefaultDerivativeService
 
   def valid?
     return false unless original_file
-    ["image/tiff", "image/jpeg", "image/png", "image/jp2"].include?(mime_type.first) && !parent.is_a?(ScannedMap)
+    ["image/tiff", "image/jpeg", "image/png"].include?(mime_type.first) && !parent.is_a?(ScannedMap)
   end
 
   def parent

--- a/app/derivative_services/jp2_derivative_service.rb
+++ b/app/derivative_services/jp2_derivative_service.rb
@@ -55,7 +55,7 @@ class Jp2DerivativeService
   end
 
   def valid_mime_types
-    ["image/tiff", "image/jpeg", "image/png", "image/jp2"]
+    ["image/tiff", "image/jpeg", "image/png"]
   end
 
   def create_derivatives
@@ -79,11 +79,7 @@ class Jp2DerivativeService
   end
 
   def run_tiff_derivatives
-    if mime_type.first == "image/jp2"
-      copy_file(filename)
-    else
-      create_tiff_derivative(filename)
-    end
+    create_tiff_derivative(filename)
   end
 
   def create_tiff_derivative(filename)
@@ -91,10 +87,6 @@ class Jp2DerivativeService
     _stdout, stderr, status =
       Open3.capture3("opj_compress", "-i", color_corrected_tiff.path.to_s, "-o", temporary_output.path.to_s, "-t", "1024,1024", "-p", "RPCL", "-n", "8", "-r", "10")
     raise stderr unless status.success?
-  end
-
-  def copy_file(filename)
-    FileUtils.cp(filename.to_s, temporary_output.path.to_s)
   end
 
   def correct_color(filename)

--- a/app/derivative_services/scanned_map_derivative_service.rb
+++ b/app/derivative_services/scanned_map_derivative_service.rb
@@ -36,7 +36,7 @@ class ScannedMapDerivativeService
   end
 
   def valid_mime_types
-    ["image/tiff", "image/jpeg", "image/png", "image/jp2"]
+    ["image/tiff", "image/jpeg", "image/png"]
   end
 
   def parent

--- a/app/derivative_services/thumbnail_derivative_service.rb
+++ b/app/derivative_services/thumbnail_derivative_service.rb
@@ -71,7 +71,7 @@ class ThumbnailDerivativeService
   end
 
   def valid_mime_types
-    ["image/tiff", "image/jpeg", "image/png", "image/jp2"]
+    ["image/tiff", "image/jpeg", "image/png"]
   end
 
   def create_derivatives
@@ -98,24 +98,11 @@ class ThumbnailDerivativeService
     raise "Unable to store thunbnail for #{filename}!" unless File.exist?(temporary_output.path)
   end
 
-  def convert_jp2
-    temp_file = Tempfile.new(["tempfile", ".tif"])
-    _stdout, stderr, status =
-      Open3.capture3("opj_decompress", "-i", filename.to_s, "-o", temp_file.path)
-    raise stderr unless status.success?
-    temp_file
-  end
-
   def vips_image
     @vips_image ||=
       begin
-        path = if mime_type.first == "image/jp2"
-                 convert_jp2.path
-               else
-                 filename
-               end
         Vips::Image.thumbnail(
-          path.to_s,
+          filename.to_s,
           width,
           height: height
         )

--- a/app/derivative_services/vips_derivative_service.rb
+++ b/app/derivative_services/vips_derivative_service.rb
@@ -59,7 +59,7 @@ class VIPSDerivativeService
   end
 
   def valid_mime_types
-    ["image/tiff", "image/jpeg", "image/png", "image/jp2"]
+    ["image/tiff", "image/jpeg", "image/png"]
   end
 
   def create_derivatives
@@ -93,23 +93,10 @@ class VIPSDerivativeService
     raise "Unable to store pyramidal TIFF for #{filename}!" unless File.exist?(temporary_output.path)
   end
 
-  def convert_jp2
-    temp_file = Tempfile.new(["tempfile", ".tif"])
-    _stdout, stderr, status =
-      Open3.capture3("opj_decompress", "-i", filename.to_s, "-o", temp_file.path)
-    raise stderr unless status.success?
-    temp_file
-  end
-
   def vips_image
     @vips_image ||=
       begin
-        path = if mime_type.first == "image/jp2"
-                 convert_jp2.path
-               else
-                 filename
-               end
-        image = Vips::Image.new_from_file(path.to_s)
+        image = Vips::Image.new_from_file(filename.to_s)
         if image.height >= REDUCTION_THRESHOLD || image.width >= REDUCTION_THRESHOLD
           image.resize(0.5)
         else

--- a/architecture-decisions/0008-jpeg2000-ingest.md
+++ b/architecture-decisions/0008-jpeg2000-ingest.md
@@ -1,0 +1,26 @@
+# 7. JPEG2000 Ingest
+
+Date: 2020-04-24
+
+## Status
+
+Accepted
+
+## Context
+
+Support for ingestion of JPEG2000 images was added to accommodate
+scanned map records for which we cannot find original TIFFs. The VIPS library,
+used to generate pyramidal tiffs and thumbnails, can't read JP2s
+directly, so a temporary intermediate TIFF was generated using the OpenJPEG `opj_decompress`
+command. This command uses a large amount of memory and will eventually
+crash the host server if several JP2s are decompressed simultaneously.
+
+## Decisions
+
+1. Derivative generation functionality for JPEG2000 images was removed.
+
+## Consequences
+
+1. Figgy can no longer generate derivaties for ingested JPEG2000 images.
+1. If this functionality is needed in the future, a better performing
+   intermediate step is required.

--- a/spec/derivative_services/default_derivative_service_spec.rb
+++ b/spec/derivative_services/default_derivative_service_spec.rb
@@ -41,12 +41,6 @@ RSpec.describe DefaultDerivativeService do
 
       it { is_expected.to be_valid }
     end
-
-    context "when given mime_type image/jp2" do
-      let(:file) { fixture_file_upload("files/example.jp2", "image/jp2") }
-
-      it { is_expected.to be_valid }
-    end
   end
 
   it "creates a JP2 and attaches it to the fileset" do

--- a/spec/derivative_services/jp2_derivative_service_spec.rb
+++ b/spec/derivative_services/jp2_derivative_service_spec.rb
@@ -48,15 +48,6 @@ RSpec.describe Jp2DerivativeService do
       end
     end
 
-    context "when given a JPEG2000 mime_type" do
-      it "is valid" do
-        # rubocop:disable RSpec/SubjectStub
-        allow(valid_file).to receive(:mime_type).and_return(["image/jp2"])
-        # rubocop:enable RSpec/SubjectStub
-        is_expected.to be_valid
-      end
-    end
-
     context "when given an invalid mime_type" do
       it "does not validate" do
         # rubocop:disable RSpec/SubjectStub
@@ -160,20 +151,6 @@ RSpec.describe Jp2DerivativeService do
   context "png source", run_real_derivatives: true do
     let(:file) { fixture_file_upload("files/abstract.png", "image/png") }
     it "creates a JP2 and attaches it to the fileset" do
-      derivative_service.new(id: valid_change_set.id).create_derivatives
-
-      reloaded = query_service.find_by(id: valid_resource.id)
-      derivative = reloaded.derivative_file
-
-      expect(derivative).to be_present
-      derivative_file = Valkyrie::StorageAdapter.find_by(id: derivative.file_identifiers.first)
-      expect(derivative_file.read).not_to be_blank
-    end
-  end
-
-  context "JPEG2000 source", run_real_derivatives: true do
-    let(:file) { fixture_file_upload("files/example.jp2", "image/jp2") }
-    it "creates a derivative JP2 and attaches it to the fileset" do
       derivative_service.new(id: valid_change_set.id).create_derivatives
 
       reloaded = query_service.find_by(id: valid_resource.id)

--- a/spec/derivative_services/scanned_map_derivative_service_spec.rb
+++ b/spec/derivative_services/scanned_map_derivative_service_spec.rb
@@ -48,15 +48,6 @@ RSpec.describe ScannedMapDerivativeService do
       end
     end
 
-    context "when given a JPEG2000 mime_type" do
-      it "is valid" do
-        # rubocop:disable RSpec/SubjectStub
-        allow(valid_file).to receive(:mime_type).and_return(["image/jp2"])
-        # rubocop:enable RSpec/SubjectStub
-        is_expected.to be_valid
-      end
-    end
-
     context "when given an invalid mime_type" do
       it "does not validate" do
         # rubocop:disable RSpec/SubjectStub

--- a/spec/derivative_services/vips_derivative_service_spec.rb
+++ b/spec/derivative_services/vips_derivative_service_spec.rb
@@ -48,15 +48,6 @@ RSpec.describe VIPSDerivativeService do
       end
     end
 
-    context "when given a JPEG2000 mime_type" do
-      it "is valid" do
-        # rubocop:disable RSpec/SubjectStub
-        allow(valid_file).to receive(:mime_type).and_return(["image/jp2"])
-        # rubocop:enable RSpec/SubjectStub
-        is_expected.to be_valid
-      end
-    end
-
     context "when given an invalid mime_type" do
       it "does not validate" do
         # rubocop:disable RSpec/SubjectStub
@@ -134,20 +125,6 @@ RSpec.describe VIPSDerivativeService do
 
   context "png source", run_real_derivatives: true do
     let(:file) { fixture_file_upload("files/abstract.png", "image/png") }
-    it "creates a tiff and attaches it to the fileset" do
-      derivative_service.new(id: valid_change_set.id).create_derivatives
-
-      reloaded = query_service.find_by(id: valid_resource.id)
-      derivative = reloaded.derivative_file
-
-      expect(derivative).to be_present
-      derivative_file = Valkyrie::StorageAdapter.find_by(id: derivative.file_identifiers.first)
-      expect(derivative_file.read).not_to be_blank
-    end
-  end
-
-  context "JPEG2000 source", run_real_derivatives: true do
-    let(:file) { fixture_file_upload("files/example.jp2", "image/jp2") }
     it "creates a tiff and attaches it to the fileset" do
       derivative_service.new(id: valid_change_set.id).create_derivatives
 


### PR DESCRIPTION
- Removes functionality for generating derivatives from JPEG2000 images.
- Adds ADR explaining decision.
- Leaves the VIPS thumbnail derivative service intact.