### PR TITLE
Add SourceMetadataIdentifier Tests

### DIFF
--- a/app/services/bulk_cloud_ingester.rb
+++ b/app/services/bulk_cloud_ingester.rb
@@ -109,6 +109,10 @@ class BulkCloudIngester
       end
 
       def build_change_set(attrs)
+        if attrs[:title] && RemoteRecord.valid?(attrs[:title])
+          attrs[:source_metadata_identifier] = attrs[:title]
+          attrs[:title] = nil
+        end
         change_set = DynamicChangeSet.new(build_resource)
         change_set.validate(**attrs)
         change_set


### PR DESCRIPTION
This also makes source metadata identifier work for the bulk cloud
ingester.