### PR TITLE
Implements component_creators

### DIFF
--- a/app/services/pul_metadata_services/pulfa_record.rb
+++ b/app/services/pul_metadata_services/pulfa_record.rb
@@ -143,7 +143,7 @@ module PulMetadataServices
 
         def component_creators
           creators = data.xpath("#{data_root}/did/origination/*")
-          creators.map(&:content).map(&:strip)
+          creators.map { |node| node.text.gsub(/\s+/, " ") }
         end
 
         def collection_date
@@ -168,7 +168,7 @@ module PulMetadataServices
           # @param result [Nokogiri::XML::Node]
           # @return [Array<String>]
           def text(result)
-            [result.text] if result
+            [result.text.gsub(/\s+/, " ")] if result
           end
 
           # Generate a description of the parent container for the item (using an encoded ID)

--- a/app/services/pul_metadata_services/pulfa_record.rb
+++ b/app/services/pul_metadata_services/pulfa_record.rb
@@ -65,7 +65,7 @@ module PulMetadataServices
             extent: extent,
             container: container,
             heldBy: location_code,
-            creator: collection_creators,
+            creator: creators,
             publisher: collection_creators,
             memberOf: collections
           }
@@ -116,6 +116,14 @@ module PulMetadataServices
           text(data.at_xpath("#{data_root}/did/physloc"))
         end
 
+        def creators
+          if data.at_xpath("#{data_root}/did/origination/*")
+            component_creators
+          else
+            collection_creators
+          end
+        end
+
         # Retrieve the creator information encoded for the collection in which the item is stored
         # @return [Array<String>]
         def collection_creators
@@ -134,7 +142,8 @@ module PulMetadataServices
         end
 
         def component_creators
-          # TODO
+          creators = data.xpath("#{data_root}/did/origination/*")
+          creators.map(&:content).map(&:strip)
         end
 
         def collection_date

--- a/spec/fixtures/files/pulfa/WC064_c1630.xml
+++ b/spec/fixtures/files/pulfa/WC064_c1630.xml
@@ -1,0 +1,1122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<c xmlns="urn:isbn:1-931666-22-9" xmlns:pulfa="http://library.princeton.edu/pulfa"
+    xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    level="item" id="WC064_c1630">
+    <pulfa:context>
+        <pulfa:uri>https://findingaids.princeton.edu/collections/WC064/c1630</pulfa:uri>
+        <pulfa:collectionInfo>
+            <pulfa:ARK>http://arks.princeton.edu/ark:/88435/pn89d9197</pulfa:ARK>
+            <pulfa:uri>https://findingaids.princeton.edu/collections/WC064</pulfa:uri>
+            <pulfa:collection-creators>
+                <corpname source="viaf" authfilenumber="http://viaf.org/viaf/168350386" role="cre"
+                    >Princeton University Library. Special Collections.</corpname>
+            </pulfa:collection-creators>
+            <eadid url="http://arks.princeton.edu/ark:/88435/pn89d9197" urn="ark:/88435/pn89d9197"
+                countrycode="US" mainagencycode="US-NjP">WC064</eadid>
+            <unittitle>Princeton University Library Collection of Western Americana
+                Photographs</unittitle>
+            <unitid countrycode="US" repositorycode="US-NjP" type="collection">WC064</unitid>
+            <unitdate normal="1870/1915" type="bulk">1870-1915</unitdate>
+            <unitdate normal="1840/1998" type="inclusive">1840-1998</unitdate>
+            <extent unit="footage">123 linear feet</extent>
+            <extent>143 boxes</extent>
+        </pulfa:collectionInfo>
+        <pulfa:request type="single">WC064 folder M1089</pulfa:request>
+    </pulfa:context>
+    <did>
+        <unittitle>Picnic west of Syracuse about 1885</unittitle>
+        <origination><persname source="viaf" role="cre"
+                authfilenumber="http://viaf.org/viaf/15075395">Savage, C. R. (Charles Roscoe),
+                1832-1909</persname></origination>
+        <unitdate type="inclusive" normal="1885-01-01T00:00:00Z/1885-12-31T23:59:59Z">circa
+            1885</unitdate>
+        <langmaterial><language langcode="eng"/></langmaterial>
+        <physloc type="code">mss</physloc>
+        <physloc type="code">hsvm</physloc>
+        <physloc type="text">Boxes H4 and H5 (Lummis glass plate negatives) and H6 (California Gold
+            Rush daguerreotype) are stored in special vault facilities.</physloc>
+        <repository id="mss"><corpname source="viaf" authfilenumber="http://viaf.org/viaf/168350386"
+                >Princeton University Library. Special Collections.</corpname><subarea>Manuscripts
+                Division</subarea><address>
+                <addressline>One Washington Road</addressline>
+                <addressline>Princeton, New Jersey 08544 USA</addressline>
+            </address></repository>
+        <unitid type="accessionnumber">WA 1984-724</unitid>
+        <container type="folder" parent="WC064_i74">M1089</container>
+        <physdesc><dimensions>10 x 22 cm.</dimensions><extent type="computed">1
+            item</extent></physdesc>
+        <dao xmlns:xlin="http://www.w3.org/1999/xlink"
+            xlin:href="http://arks.princeton.edu/ark:/88435/j098zb37d" xlin:type="simple"/>
+    </did>
+    <scopecontent>
+        <p>Written on verso: "Picnic west of Syracuse about 1885."</p>
+    </scopecontent>
+    <accessrestrict type="open">
+        <p>This collection is open to researchers.</p>
+    </accessrestrict>
+    <controlaccess>
+        <subject source="lcsh">Food</subject>
+        <subject source="lcsh">Manners and customs</subject>
+        <subject source="lcsh">Women</subject>
+        <geogname source="lcsh">Syracuse (Utah)</geogname>
+        <genreform source="aat">Albumen prints</genreform>
+        <genreform source="aat">Vintage prints</genreform>
+    </controlaccess>
+    <dsc type="othertype" othertype="physicalholdings">
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i1">
+            <did>
+                <container type="box">H1</container>
+                <unitid type="barcode">32101047360068</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i2">
+            <did>
+                <container type="box">H2</container>
+                <unitid type="barcode">32101047360134</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">C, glass slides</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i3">
+            <did>
+                <container type="box">H3</container>
+                <unitid type="barcode">32101080827932</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i4">
+            <did>
+                <container type="box">H4</container>
+                <unitid type="barcode">32101080827908</unitid>
+                <physloc type="code">hsvm</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i5">
+            <did>
+                <container type="box">H5</container>
+                <unitid type="barcode">32101080827916</unitid>
+                <physloc type="code">hsvm</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i6">
+            <did>
+                <container type="box">L1</container>
+                <unitid type="barcode">32101037658547</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i7">
+            <did>
+                <container type="box">L2</container>
+                <unitid type="barcode">32101037658539</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i8">
+            <did>
+                <container type="box">L3</container>
+                <unitid type="barcode">32101037658521</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i9">
+            <did>
+                <container type="box">L4</container>
+                <unitid type="barcode">32101037658513</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i10">
+            <did>
+                <container type="box">L5</container>
+                <unitid type="barcode">32101037658505</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i11">
+            <did>
+                <container type="box">L6</container>
+                <unitid type="barcode">32101036922399</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i12">
+            <did>
+                <container type="box">L7</container>
+                <unitid type="barcode">32101036922381</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i13">
+            <did>
+                <container type="box">L8</container>
+                <unitid type="barcode">32101036922373</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i14">
+            <did>
+                <container type="box">L9</container>
+                <unitid type="barcode">32101036922365</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i15">
+            <did>
+                <container type="box">L10</container>
+                <unitid type="barcode">32101036922357</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i16">
+            <did>
+                <container type="box">L11</container>
+                <unitid type="barcode">32101036922340</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i17">
+            <did>
+                <container type="box">L12</container>
+                <unitid type="barcode">32101036922332</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i18">
+            <did>
+                <container type="box">L13</container>
+                <unitid type="barcode">32101036922324</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i19">
+            <did>
+                <container type="box">L14</container>
+                <unitid type="barcode">32101036922316</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i20">
+            <did>
+                <container type="box">L15</container>
+                <unitid type="barcode">32101036922308</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i21">
+            <did>
+                <container type="box">L16</container>
+                <unitid type="barcode">32101036922290</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i22">
+            <did>
+                <container type="box">L17</container>
+                <unitid type="barcode">32101036922282</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i23">
+            <did>
+                <container type="box">L18</container>
+                <unitid type="barcode">32101036922274</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i24">
+            <did>
+                <container type="box">L19</container>
+                <unitid type="barcode">32101036922266</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i25">
+            <did>
+                <container type="box">L20</container>
+                <unitid type="barcode">32101036922258</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i26">
+            <did>
+                <container type="box">L21</container>
+                <unitid type="barcode">32101036922241</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i27">
+            <did>
+                <container type="box">L22</container>
+                <unitid type="barcode">32101036922233</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i28">
+            <did>
+                <container type="box">L23</container>
+                <unitid type="barcode">32101036922225</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i29">
+            <did>
+                <container type="box">L24</container>
+                <unitid type="barcode">32101036922217</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i30">
+            <did>
+                <container type="box">L25</container>
+                <unitid type="barcode">32101036922209</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i31">
+            <did>
+                <container type="box">L26</container>
+                <unitid type="barcode">32101036922191</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i32">
+            <did>
+                <container type="box">L27</container>
+                <unitid type="barcode">32101036922183</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i33">
+            <did>
+                <container type="box">L28</container>
+                <unitid type="barcode">32101036922175</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i34">
+            <did>
+                <container type="box">L29</container>
+                <unitid type="barcode">32101036922167</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i35">
+            <did>
+                <container type="box">L30</container>
+                <unitid type="barcode">32101036922159</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i36">
+            <did>
+                <container type="box">L31</container>
+                <unitid type="barcode">32101036922142</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i37">
+            <did>
+                <container type="box">L32</container>
+                <unitid type="barcode">32101136922134</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i38">
+            <did>
+                <container type="box">L33</container>
+                <unitid type="barcode">32101036922126</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i39">
+            <did>
+                <container type="box">L34</container>
+                <unitid type="barcode">32101036922118</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i40">
+            <did>
+                <container type="box">L35</container>
+                <unitid type="barcode">32101036922100</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i41">
+            <did>
+                <container type="box">L36</container>
+                <unitid type="barcode">32101036922092</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i42">
+            <did>
+                <container type="box">L37</container>
+                <unitid type="barcode">32101036922084</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i43">
+            <did>
+                <container type="box">M1</container>
+                <unitid type="barcode">32101037434576</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i44">
+            <did>
+                <container type="box">M2</container>
+                <unitid type="barcode">32101037434741</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i45">
+            <did>
+                <container type="box">M3</container>
+                <unitid type="barcode">32101037434758</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i46">
+            <did>
+                <container type="box">M4</container>
+                <unitid type="barcode">32101037434766</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i47">
+            <did>
+                <container type="box">M5</container>
+                <unitid type="barcode">32101037434790</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i48">
+            <did>
+                <container type="box">M6</container>
+                <unitid type="barcode">32101037434816</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i49">
+            <did>
+                <container type="box">M7</container>
+                <unitid type="barcode">32101037434774</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i50">
+            <did>
+                <container type="box">M8</container>
+                <unitid type="barcode">32101037434782</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i51">
+            <did>
+                <container type="box">M9</container>
+                <unitid type="barcode">32101037434808</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i52">
+            <did>
+                <container type="box">M10</container>
+                <unitid type="barcode">32101037434840</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i53">
+            <did>
+                <container type="box">M11</container>
+                <unitid type="barcode">32101037434832</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i54">
+            <did>
+                <container type="box">M12</container>
+                <unitid type="barcode">32101037434824</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i55">
+            <did>
+                <container type="box">M13</container>
+                <unitid type="barcode">32101037434857</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i56">
+            <did>
+                <container type="box">M14</container>
+                <unitid type="barcode">32101037434865</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i57">
+            <did>
+                <container type="box">M15</container>
+                <unitid type="barcode">32101037434873</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i58">
+            <did>
+                <container type="box">M16</container>
+                <unitid type="barcode">32101037434881</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i59">
+            <did>
+                <container type="box">M17</container>
+                <unitid type="barcode">32101037434899</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i60">
+            <did>
+                <container type="box">M18</container>
+                <unitid type="barcode">32101037434907</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i61">
+            <did>
+                <container type="box">M19</container>
+                <unitid type="barcode">32101037434915</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i62">
+            <did>
+                <container type="box">M20</container>
+                <unitid type="barcode">32101037434923</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i63">
+            <did>
+                <container type="box">M21</container>
+                <unitid type="barcode">32101037434931</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i64">
+            <did>
+                <container type="box">M22</container>
+                <unitid type="barcode">32101037434949</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i65">
+            <did>
+                <container type="box">M23</container>
+                <unitid type="barcode">32101037434956</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i66">
+            <did>
+                <container type="box">M24</container>
+                <unitid type="barcode">32101037434964</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i67">
+            <did>
+                <container type="box">M25</container>
+                <unitid type="barcode">32101037434972</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i68">
+            <did>
+                <container type="box">M26</container>
+                <unitid type="barcode">32101037434980</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i69">
+            <did>
+                <container type="box">M27</container>
+                <unitid type="barcode">32101037435003</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i70">
+            <did>
+                <container type="box">M28</container>
+                <unitid type="barcode">32101037435144</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i71">
+            <did>
+                <container type="box">M29</container>
+                <unitid type="barcode">32101037435037</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i72">
+            <did>
+                <container type="box">M30</container>
+                <unitid type="barcode">32101037434998</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i73">
+            <did>
+                <container type="box">M31</container>
+                <unitid type="barcode">32101037435011</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i74">
+            <did>
+                <container type="box">M32</container>
+                <unitid type="barcode">32101037435029</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i75">
+            <did>
+                <container type="box">M33</container>
+                <unitid type="barcode">32101037435086</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i76">
+            <did>
+                <container type="box">M34</container>
+                <unitid type="barcode">32101037435078</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i77">
+            <did>
+                <container type="box">M35</container>
+                <unitid type="barcode">32101037435060</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i78">
+            <did>
+                <container type="box">M36</container>
+                <unitid type="barcode">32101037435052</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i79">
+            <did>
+                <container type="box">M37</container>
+                <unitid type="barcode">32101037435045</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i80">
+            <did>
+                <container type="box">M38</container>
+                <unitid type="barcode">32101037435094</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i81">
+            <did>
+                <container type="box">M39</container>
+                <unitid type="barcode">32101037435102</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i82">
+            <did>
+                <container type="box">M40</container>
+                <unitid type="barcode">32101037435110</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i83">
+            <did>
+                <container type="box">M41</container>
+                <unitid type="barcode">32101037435128</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i84">
+            <did>
+                <container type="box">M42</container>
+                <unitid type="barcode">32101037435136</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i85">
+            <did>
+                <container type="box">M43</container>
+                <unitid type="barcode">32101037435243</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i86">
+            <did>
+                <container type="box">M44</container>
+                <unitid type="barcode">32101037435235</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i87">
+            <did>
+                <container type="box">M45</container>
+                <unitid type="barcode">32101037435227</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i88">
+            <did>
+                <container type="box">M46</container>
+                <unitid type="barcode">32101037435201</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i89">
+            <did>
+                <container type="box">M47</container>
+                <unitid type="barcode">32101037435219</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i90">
+            <did>
+                <container type="box">M48</container>
+                <unitid type="barcode">32101037435193</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i91">
+            <did>
+                <container type="box">M49</container>
+                <unitid type="barcode">32101037435185</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i92">
+            <did>
+                <container type="box">M50</container>
+                <unitid type="barcode">32101037435177</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i93">
+            <did>
+                <container type="box">M51</container>
+                <unitid type="barcode">32101037435169</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i94">
+            <did>
+                <container type="box">M52</container>
+                <unitid type="barcode">32101037435151</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i95">
+            <did>
+                <container type="box">M53</container>
+                <unitid type="barcode">32101037435292</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i96">
+            <did>
+                <container type="box">M54</container>
+                <unitid type="barcode">32101037435300</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i97">
+            <did>
+                <container type="box">M55</container>
+                <unitid type="barcode">32101037435318</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i98">
+            <did>
+                <container type="box">M56</container>
+                <unitid type="barcode">32101037435326</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i99">
+            <did>
+                <container type="box">M57</container>
+                <unitid type="barcode">32101037435334</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i100">
+            <did>
+                <container type="box">M58</container>
+                <unitid type="barcode">32101037435284</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i101">
+            <did>
+                <container type="box">M59</container>
+                <unitid type="barcode">32101037435276</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i102">
+            <did>
+                <container type="box">M60</container>
+                <unitid type="barcode">32101037435268</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i103">
+            <did>
+                <container type="box">M61</container>
+                <unitid type="barcode">32101037435250</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i104">
+            <did>
+                <container type="box">M62</container>
+                <unitid type="barcode">32101036941043</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i105">
+            <did>
+                <container type="box">M63</container>
+                <unitid type="barcode">32101037435359</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i106">
+            <did>
+                <container type="box">M64</container>
+                <unitid type="barcode">32101037435342</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i107">
+            <did>
+                <container type="box">M65</container>
+                <unitid type="barcode">32101037435367</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i108">
+            <did>
+                <container type="box">M66</container>
+                <unitid type="barcode">32101037435375</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i109">
+            <did>
+                <container type="box">M67</container>
+                <unitid type="barcode">32101037435383</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i110">
+            <did>
+                <container type="box">M68</container>
+                <unitid type="barcode">32101037435391</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i111">
+            <did>
+                <container type="box">M69</container>
+                <unitid type="barcode">32101037435409</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i112">
+            <did>
+                <container type="box">M70</container>
+                <unitid type="barcode">32101036941274</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i113">
+            <did>
+                <container type="box">M71</container>
+                <unitid type="barcode">32101037675145</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i114">
+            <did>
+                <container type="box">M72</container>
+                <unitid type="barcode">32101037675152</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i115">
+            <did>
+                <container type="box">M73</container>
+                <unitid type="barcode">32101036965588</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i116">
+            <did>
+                <container type="box">M74</container>
+                <unitid type="barcode">32101038580922</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i117">
+            <did>
+                <container type="box">S1</container>
+                <unitid type="barcode">32101037434568</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i118">
+            <did>
+                <container type="box">S2</container>
+                <unitid type="barcode">32101037434584</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i119">
+            <did>
+                <container type="box">S3</container>
+                <unitid type="barcode">32101037434592</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i120">
+            <did>
+                <container type="box">S4</container>
+                <unitid type="barcode">32101037434600</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i121">
+            <did>
+                <container type="box">S5</container>
+                <unitid type="barcode">32101037434618</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i122">
+            <did>
+                <container type="box">S6</container>
+                <unitid type="barcode">32101037434659</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i123">
+            <did>
+                <container type="box">S7</container>
+                <unitid type="barcode">32101037434634</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i124">
+            <did>
+                <container type="box">S8</container>
+                <unitid type="barcode">32101037434667</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i125">
+            <did>
+                <container type="box">S9</container>
+                <unitid type="barcode">32101037434642</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i126">
+            <did>
+                <container type="box">S10</container>
+                <unitid type="barcode">32101037434683</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i127">
+            <did>
+                <container type="box">S11</container>
+                <unitid type="barcode">32101037434675</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i128">
+            <did>
+                <container type="box">S12</container>
+                <unitid type="barcode">32101037434691</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i129">
+            <did>
+                <container type="box">S13</container>
+                <unitid type="barcode">32101037434717</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i130">
+            <did>
+                <container type="box">S14</container>
+                <unitid type="barcode">32101037434725</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i131">
+            <did>
+                <container type="box">X3</container>
+                <unitid type="barcode">32101038580112</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">Z</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i132">
+            <did>
+                <container type="box">X4</container>
+                <unitid type="barcode">32101038580906</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">Z</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i133">
+            <did>
+                <container type="box">X5</container>
+                <unitid type="barcode">32101038580914</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">Z</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i134">
+            <did>
+                <container type="box">X1</container>
+                <unitid type="barcode">32101038580096</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i135">
+            <did>
+                <container type="box">X2</container>
+                <unitid type="barcode">32101038580104</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i136">
+            <did>
+                <container type="box">X6</container>
+                <unitid type="barcode">32101080827924</unitid>
+                <physloc type="code">mss</physloc>
+                <physloc type="text">L</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i139">
+            <did>
+                <container type="box">X7</container>
+                <unitid type="barcode">32101080848664</unitid>
+                <physloc type="code">hsvm</physloc>
+                <physloc type="text">North 5</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i140">
+            <did>
+                <container type="box">X8</container>
+                <unitid type="barcode">32101080848672</unitid>
+                <physloc type="code">hsvm</physloc>
+                <physloc type="text">North 5</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i141">
+            <did>
+                <container type="box">B-000834</container>
+                <unitid type="barcode">32101080848672</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i142">
+            <did>
+                <container type="box">P-000076</container>
+                <unitid type="barcode">32101080516733</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i143">
+            <did>
+                <container type="box">P-000082</container>
+                <unitid type="barcode">32101078581210</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i144">
+            <did>
+                <container type="box">H6</container>
+                <unitid type="barcode">32101086133236</unitid>
+                <physloc type="code">hsvm</physloc>
+                <physloc type="text">South Wall 15</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i145">
+            <did>
+                <container type="box">P-000113</container>
+                <unitid type="barcode">32101086135959</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+        <c level="otherlevel" otherlevel="physicalitem" id="WC064_i146">
+            <did>
+                <container type="box">B-001455</container>
+                <unitid type="barcode">32101103190847</unitid>
+                <physloc type="code">mss</physloc>
+            </did>
+        </c>
+    </dsc>
+</c>

--- a/spec/services/pul_metadata_services/pulfa_record_spec.rb
+++ b/spec/services/pul_metadata_services/pulfa_record_spec.rb
@@ -8,20 +8,41 @@ describe PulMetadataServices::PulfaRecord do
   let(:source) { file_fixture("pulfa/#{pulfa_id}.xml").read }
 
   describe "#attributes" do
-    it "works" do
-      expected = {
-        title: ["19th Century Catalog and Correspondence, Pre-Vinton, 1811-"],
-        created: ["1865-01-01T00:00:00Z/1865-12-31T23:59:59Z"],
-        creator: ["Princeton University. Library. Dept. of Rare Books and Special Collections"],
-        publisher: ["Princeton University. Library. Dept. of Rare Books and Special Collections"],
-        memberOf: [{ title: "Princeton University Library Records", identifier: "AC123" }],
-        date_created: ["circa 1865"],
-        container: ["Box 1, Folder 2"],
-        extent: ["1 folder"],
-        heldBy: ["mudd"],
-        language: ["eng"]
-      }
-      expect(pulfa_record.attributes).to eq expected
+    context "with a component without orgination" do
+      it "works" do
+        expected = {
+          title: ["19th Century Catalog and Correspondence, Pre-Vinton, 1811-"],
+          created: ["1865-01-01T00:00:00Z/1865-12-31T23:59:59Z"],
+          creator: ["Princeton University. Library. Dept. of Rare Books and Special Collections"],
+          publisher: ["Princeton University. Library. Dept. of Rare Books and Special Collections"],
+          memberOf: [{ title: "Princeton University Library Records", identifier: "AC123" }],
+          date_created: ["circa 1865"],
+          container: ["Box 1, Folder 2"],
+          extent: ["1 folder"],
+          heldBy: ["mudd"],
+          language: ["eng"]
+        }
+        expect(pulfa_record.attributes).to eq expected
+      end
+    end
+
+    context "with a component that has origination" do
+      let(:pulfa_id) { "WC064_c1630" }
+      it "works" do
+        expected = {
+          title: ["Picnic west of Syracuse about 1885"],
+          created: ["1885-01-01T00:00:00Z/1885-12-31T23:59:59Z"],
+          creator: ["Savage, C. R. (Charles Roscoe),\n                1832-1909"],
+          publisher: ["Princeton University Library. Special Collections."],
+          memberOf: [{ identifier: "WC064", title: "Princeton University Library Collection of Western Americana\n                Photographs" }],
+          date_created: ["circa\n            1885"],
+          container: ["Box M32, Folder M1089"],
+          extent: ["1\n            item"],
+          heldBy: ["mss"],
+          language: ["eng"]
+        }
+        expect(pulfa_record.attributes).to eq expected
+      end
     end
   end
 

--- a/spec/services/pul_metadata_services/pulfa_record_spec.rb
+++ b/spec/services/pul_metadata_services/pulfa_record_spec.rb
@@ -32,12 +32,12 @@ describe PulMetadataServices::PulfaRecord do
         expected = {
           title: ["Picnic west of Syracuse about 1885"],
           created: ["1885-01-01T00:00:00Z/1885-12-31T23:59:59Z"],
-          creator: ["Savage, C. R. (Charles Roscoe),\n                1832-1909"],
+          creator: ["Savage, C. R. (Charles Roscoe), 1832-1909"],
           publisher: ["Princeton University Library. Special Collections."],
           memberOf: [{ identifier: "WC064", title: "Princeton University Library Collection of Western Americana\n                Photographs" }],
-          date_created: ["circa\n            1885"],
+          date_created: ["circa 1885"],
           container: ["Box M32, Folder M1089"],
-          extent: ["1\n            item"],
+          extent: ["1 item"],
           heldBy: ["mss"],
           language: ["eng"]
         }


### PR DESCRIPTION
For the creator of any pulfa record, the previous version always returned the collection_creators (as expressed in the `pulfa:context` element added to the EAD at pulfa ingest). Gabrielle Swift (#3839) asked that the creator of individual components be drawn from the component's `ead:origination` element, if it exists.