### PR TITLE
Attach numismatic monograms as members

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,14 @@ Release notes template:
 ## Removed
 
 -->
+# 2020-05-18
+
+## Changed
+
+* Numismatic Monograms are now attached to Numismatic Issue resources as members. Instead
+  of linking monograms on the edit page, monograms are created and linked
+  on the Issue show page.
+
 # 2020-05-15
 
 ## Changed

--- a/app/resources/numismatics/issues/numismatics/issue.rb
+++ b/app/resources/numismatics/issues/numismatics/issue.rb
@@ -9,7 +9,7 @@ module Numismatics
     # resources linked by ID
     attribute :member_ids, Valkyrie::Types::Array
     attribute :member_of_collection_ids
-    attribute :numismatic_monogram_ids
+    attribute :numismatic_monogram_ids # DEPRECATED. Will remove once values are migrated to member_ids
     attribute :numismatic_place_id
     attribute :ruler_id
     attribute :master_id

--- a/app/resources/numismatics/issues/numismatics/issue_change_set.rb
+++ b/app/resources/numismatics/issues/numismatics/issue_change_set.rb
@@ -46,7 +46,6 @@ module Numismatics
     property :master_id, multiple: false, required: false, type: Valkyrie::Types::ID
     property :member_ids, multiple: true, required: false, type: Types::Strict::Array.of(Valkyrie::Types::ID)
     property :member_of_collection_ids, multiple: true, required: false, type: Types::Strict::Array.of(Valkyrie::Types::ID)
-    property :numismatic_monogram_ids, multiple: true, required: false, type: Types::Strict::Array.of(Valkyrie::Types::ID)
     property :numismatic_place_id, multiple: false, required: false, type: Valkyrie::Types::ID
     property :ruler_id, multiple: true, required: false, type: Valkyrie::Types::ID
     property :pending_uploads, multiple: true, required: false
@@ -131,9 +130,6 @@ module Numismatics
         ],
         "Subject" => [
           :numismatic_subject
-        ],
-        "Monograms" => [
-          :numismatic_monogram_ids
         ]
       }
     end

--- a/app/resources/numismatics/issues/numismatics/issue_decorator.rb
+++ b/app/resources/numismatics/issues/numismatics/issue_decorator.rb
@@ -32,7 +32,6 @@ module Numismatics
             :reverse_symbol,
             :reverse_attributes,
             :reverse_legend,
-            :decorated_numismatic_monograms,
             :artists,
             :citations,
             :notes,
@@ -70,7 +69,13 @@ module Numismatics
     end
 
     def attachable_objects
-      [Numismatics::Coin]
+      [Numismatics::Coin, Numismatics::Monogram]
+    end
+
+    # Attached Numismatics::Coin resources with FileSets
+    # @return [Numismatics::CoinDecorator]
+    def coins_with_filesets
+      decorated_coins.select { |c| c.member_ids.present? }
     end
 
     def citations

--- a/app/resources/numismatics/issues/numismatics/issue_wayfinder.rb
+++ b/app/resources/numismatics/issues/numismatics/issue_wayfinder.rb
@@ -5,7 +5,7 @@ module Numismatics
     relationship_by_property :members, property: :member_ids
     relationship_by_property :numismatic_places, property: :numismatic_place_id, singular: true
     relationship_by_property :rulers, property: :ruler_id
-    relationship_by_property :numismatic_monograms, property: :numismatic_monogram_ids
+    relationship_by_property :numismatic_monograms, property: :member_ids, model: Numismatics::Monogram
     relationship_by_property :file_sets, property: :member_ids, model: FileSet
     relationship_by_property :coins, property: :member_ids, model: Numismatics::Coin
     relationship_by_property :collections, property: :member_of_collection_ids

--- a/app/resources/numismatics/issues/numismatics/issues_controller.rb
+++ b/app/resources/numismatics/issues/numismatics/issues_controller.rb
@@ -13,8 +13,6 @@ module Numismatics
     before_action :load_denominations, only: [:new, :edit]
     before_action :load_edges, only: [:new, :edit]
     before_action :load_metals, only: [:new, :edit]
-    before_action :load_monograms, only: [:new, :edit]
-    before_action :load_monogram_attributes, only: [:new, :edit]
     before_action :load_object_types, only: [:new, :edit]
     before_action :load_obverse_figures, only: [:new, :edit]
     before_action :load_obverse_orientations, only: [:new, :edit]
@@ -60,12 +58,6 @@ module Numismatics
 
     def load_metals
       @metals = @facet_values[:metal_ssim]
-    end
-
-    def load_monograms
-      @numismatic_monograms = query_service.find_all_of_model(model: Numismatics::Monogram).map(&:decorate)
-
-      return [] if @numismatic_monograms.to_a.blank?
     end
 
     def load_object_types
@@ -136,43 +128,5 @@ module Numismatics
         resource_class.new
       end
     end
-
-    private
-
-      def build_monogram_thumbnail_url(resource)
-        file_sets = resource.decorate.decorated_file_sets.reject { |fs| fs.thumbnail_id.nil? }
-
-        if file_sets.empty?
-          helpers.asset_url("default.png")
-        else
-          ManifestBuilder::ManifestHelper.new.manifest_image_thumbnail_path(file_sets.first)
-        end
-      end
-
-      # Generates the Vue JSON for the Numismatic Monogram membership component
-      # @return [Array<Hash>]
-      def load_monogram_attributes
-        numismatic_monogram_attributes = @numismatic_monograms.map do |monogram|
-          member_thumbnail_url = build_monogram_thumbnail_url(monogram)
-          member_url = solr_document_path(id: monogram.id)
-          member_monogram_ids = params[:id] ? resource.decorate.decorated_numismatic_monograms.map(&:id) : []
-
-          {
-            id: monogram.id.to_s,
-            url: member_url,
-            thumbnail: member_thumbnail_url,
-            title: monogram.decorate.first_title,
-            attached: member_monogram_ids.include?(monogram.id)
-          }
-        end
-
-        @numismatic_monogram_attributes = numismatic_monogram_attributes.sort do |u, v|
-          if u[:attached] <=> v[:attached]
-            0
-          else
-            v[:attached] && !u[:attached] ? 1 : -1
-          end
-        end
-      end
   end
 end

--- a/app/resources/numismatics/monograms/numismatics/monogram_change_set.rb
+++ b/app/resources/numismatics/monograms/numismatics/monogram_change_set.rb
@@ -13,10 +13,13 @@ module Numismatics
     property :viewing_direction, required: false
     property :viewing_hint, multiple: false, required: false, default: "individuals"
     property :depositor, multiple: false, required: false
+    property :append_id, virtual: true, multiple: false, required: true
+    property :thumbnail_id, multiple: false, required: false, type: Valkyrie::Types::ID.optional
 
     def primary_terms
       [
-        :title
+        :title,
+        :append_id
       ]
     end
   end

--- a/app/resources/numismatics/monograms/numismatics/monograms_controller.rb
+++ b/app/resources/numismatics/monograms/numismatics/monograms_controller.rb
@@ -14,11 +14,11 @@ module Numismatics
     end
 
     def after_create_success(_obj, _change_set)
-      redirect_to numismatics_monograms_path
-    end
-
-    def after_update_success(_obj, _change_set)
-      redirect_to numismatics_monograms_path
+      if append_id.blank?
+        redirect_to numismatics_monograms_path
+      else
+        redirect_to solr_document_path(append_id)
+      end
     end
 
     def manifest
@@ -34,6 +34,10 @@ module Numismatics
     end
 
     private
+
+      def append_id
+        params[:numismatics_monogram][:append_id]
+      end
 
       def load_numismatic_monograms
         @numismatic_monograms = query_service.find_all_of_model(model: Numismatics::Monogram).map(&:decorate)

--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -460,10 +460,15 @@ class ManifestBuilder
   end
 
   class Numismatics::IssueNode < CollectionNode
-    # Only include coins which have file sets;
+    # Only include Coin resources which have file sets;
     # otherwise there is no image for the viewer.
     def members
-      @members ||= super.select { |coin| coin.member_ids.present? }
+      @members ||=
+        begin
+          decorate.coins_with_filesets.select do |member|
+            !current_ability || current_ability.can?(:read, member)
+          end
+        end
     end
   end
 

--- a/app/services/numismatics_import_service.rb
+++ b/app/services/numismatics_import_service.rb
@@ -391,7 +391,6 @@ class NumismaticsImportService
       attributes[:numismatic_place_id] = valkyrie_id(value: attributes[:numismatic_place_id], model: Numismatics::Place)
       attributes[:ruler_id] = valkyrie_id(value: attributes[:ruler_id], model: Numismatics::Person)
       attributes[:master_id] = valkyrie_id(value: attributes[:master_id], model: Numismatics::Person)
-      attributes[:numismatic_monogram_ids] = issue_monogram_ids(issue_id: attributes[:issue_number])
 
       # Add nested properties
       attributes[:numismatic_artist] = artist_attributes(issue_id: attributes[:issue_number])
@@ -403,10 +402,11 @@ class NumismaticsImportService
 
       resource = new_resource(klass: Numismatics::Issue, **attributes)
 
-      # Add child coins
+      # Add child coins and monograms
       change_set_persister.buffer_into_index do |buffered_change_set_persister|
         change_set = DynamicChangeSet.new(resource)
-        change_set.member_ids = coin_ids
+        monogram_ids = issue_monogram_ids(issue_id: attributes[:issue_number])
+        change_set.member_ids = coin_ids + monogram_ids
         buffered_change_set_persister.save(change_set: change_set)
       end
     end

--- a/app/views/catalog/_members_issue.html.erb
+++ b/app/views/catalog/_members_issue.html.erb
@@ -1,6 +1,6 @@
 <table class="table table-striped coin-datatable">
   <thead>
-    <tr><h3>Numismatics::Coins</h3><tr>
+    <tr><h3>Coins</h3><tr>
     <tr>
       <th>Thumbnail</th>
       <th>Title</th>
@@ -27,6 +27,41 @@
     <% else %>
       <tr>
         <td>This work has no coins attached. Click the "Attach Coin" button to create a new coin.</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<table class="table table-striped monogram-datatable">
+  <thead>
+    <tr><h3>Monograms</h3><tr>
+    <tr>
+      <th>Thumbnail</th>
+      <th>Title</th>
+      <th>Date Uploaded</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% unless decorated_resource.decorated_numismatic_monograms.empty? %>
+      <% decorated_resource.decorated_numismatic_monograms.each do |monogram| %>
+        <% monogram_url = parent_solr_document_path(parent_id: resource.id, id: monogram.id) %>
+        <tr>
+          <td style="width: 30%"><%= link_to figgy_thumbnail_path(monogram, { class: 'thumbnail-inner', onerror: default_icon_fallback }), monogram_url %></td>
+          <td><%= monogram.first_title %></td>
+          <td><%= monogram.created_at %></td>
+          <td>
+              <%= link_to 'View', monogram_url, class: 'btn btn-default' %>
+          </td>
+        </tr>
+      <% end %>  
+    <% else %>
+      <tr>
+        <td>This work has no monograms attached. Click the "Attach Child" button to create a new monogram.</td>
         <td></td>
         <td></td>
         <td></td>

--- a/app/views/numismatics/monograms/index.html.erb
+++ b/app/views/numismatics/monograms/index.html.erb
@@ -23,6 +23,4 @@
       <% end %>
   </tbody>
 </table>
-<br>
-  <%= link_to 'New Numismatic Monogram', new_numismatics_monogram_path, class: 'btn btn-primary' %>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -160,6 +160,7 @@ Rails.application.routes.draw do
     end
 
     get "/numismatics/issues/:parent_id/coin" => "numismatics/coins#new", as: :parent_new_numismatics_coin
+    get "/numismatics/issues/:parent_id/monogram" => "numismatics/monograms#new", as: :parent_new_numismatics_monogram
     get "/numismatics/references/:parent_id/new", to: "numismatics/references#new", as: :parent_new_numismatics_reference
 
     resources :ephemera_projects do

--- a/spec/jobs/numismatic_import_job_spec.rb
+++ b/spec/jobs/numismatic_import_job_spec.rb
@@ -140,8 +140,8 @@ RSpec.describe NumismaticImportJob do
       # issues
       issue = query_service.find_all_of_model(model: Numismatics::Issue).first
       expect(issue.member_of_collection_ids.first.to_s).to eq collection_id
-      expect(issue.member_ids).to eq [coin.id]
-      expect(issue.numismatic_monogram_ids).to eq [monogram.id]
+      expect(issue.member_ids).to include coin.id
+      expect(issue.member_ids).to include monogram.id
       expect(issue.numismatic_place_id).to eq [place.id]
       expect(issue.ruler_id).to eq [ruler.id]
       expect(issue.master_id).to eq [person.id]

--- a/spec/resources/numismatics/issues/numismatics/issue_change_set_spec.rb
+++ b/spec/resources/numismatics/issues/numismatics/issue_change_set_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Numismatics::IssueChangeSet do
   describe "#primary_terms" do
     it "includes displayed fields" do
       expect(change_set.primary_terms).to be_a(Hash)
-      expect(change_set.primary_terms.keys).to eq(["", "Obverse", "Obverse Attributes", "Reverse", "Reverse Attributes", "Artist", "Citation", "Note", "Subject", "Monograms"])
+      expect(change_set.primary_terms.keys).to eq(["", "Obverse", "Obverse Attributes", "Reverse", "Reverse Attributes", "Artist", "Citation", "Note", "Subject"])
       expect(change_set.primary_terms[""]).to include(:object_type, :denomination, :metal, :workshop)
       expect(change_set.primary_terms.values.flatten).not_to include(:issue_number)
     end

--- a/spec/resources/numismatics/issues/numismatics/issue_decorator_spec.rb
+++ b/spec/resources/numismatics/issues/numismatics/issue_decorator_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Numismatics::IssueDecorator do
 
   describe "#attachable_objects" do
     it "allows attaching coins" do
-      expect(decorator.attachable_objects).to eq([Numismatics::Coin])
+      expect(decorator.attachable_objects).to eq([Numismatics::Coin, Numismatics::Monogram])
     end
   end
 

--- a/spec/resources/numismatics/issues/numismatics/issues_controller_spec.rb
+++ b/spec/resources/numismatics/issues/numismatics/issues_controller_spec.rb
@@ -36,25 +36,10 @@ RSpec.describe Numismatics::IssuesController, type: :controller do
   end
   describe "edit" do
     let(:user) { FactoryBot.create(:admin) }
+    let(:resource) { FactoryBot.create_for_repository(:numismatic_issue) }
     context "access control" do
       let(:factory) { :numismatic_issue }
       it_behaves_like "an access controlled edit request"
-    end
-    let(:resource) { FactoryBot.create_for_repository(:numismatic_issue) }
-    it "retrieves all of the persisted numismatic monograms" do
-      monogram1 = FactoryBot.create_for_repository(:numismatic_monogram)
-      monogram2 = FactoryBot.create_for_repository(:numismatic_monogram)
-
-      get :edit, params: { id: resource.id.to_s }
-      numismatic_monograms = assigns(:numismatic_monograms)
-      expect(numismatic_monograms.map(&:id)).to include(monogram1.id)
-      expect(numismatic_monograms.map(&:id)).to include(monogram2.id)
-    end
-    context "when no numismatic monograms have been persisted" do
-      it "retrieves an empty array" do
-        get :edit, params: { id: resource.id.to_s }
-        expect(assigns(:numismatic_monograms)).to eq([])
-      end
     end
     it "retrieves an array of facet values to for use in populating select boxes" do
       metadata_adapter = Valkyrie::MetadataAdapter.find(:index_solr)

--- a/spec/resources/numismatics/monograms/numismatics/monogram_change_set_spec.rb
+++ b/spec/resources/numismatics/monograms/numismatics/monogram_change_set_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Numismatics::MonogramChangeSet do
 
   describe "#primary_terms" do
     it "includes displayed fields" do
-      expect(change_set.primary_terms).to include(:title)
+      expect(change_set.primary_terms).to include(:title, :append_id)
     end
   end
 end

--- a/spec/resources/numismatics/monograms/numismatics/monogram_feature_spec.rb
+++ b/spec/resources/numismatics/monograms/numismatics/monogram_feature_spec.rb
@@ -14,9 +14,20 @@ RSpec.feature "Monogram" do
       monogram
       sign_in(user)
     end
-    it "does not display the Order Manager button" do
+    it "does not display the Order Manager button or a button to create a new monogram" do
       visit solr_document_path(monogram)
       expect(page).not_to have_link "Order Manager"
+    end
+  end
+
+  describe "index page" do
+    before do
+      sign_in(user)
+    end
+
+    it "does not have a link for creating a new monogram" do
+      visit numismatics_monograms_path
+      expect(page).not_to have_css("a[href='#{new_numismatics_monogram_path}']")
     end
   end
 end

--- a/spec/resources/numismatics/monograms/numismatics/monograms_controller_spec.rb
+++ b/spec/resources/numismatics/monograms/numismatics/monograms_controller_spec.rb
@@ -35,6 +35,22 @@ RSpec.describe Numismatics::MonogramsController, type: :controller do
       expect(response.location).to start_with "http://test.host/concern/numismatics/monograms"
       monogram = query_service.find_all_of_model(model: Numismatics::Monogram).select { |n| n["title"] == ["Monogram 1"] }.first
       expect(monogram.depositor).to eq [user.uid]
+      expect(response).to be_redirect
+      expect(response.location).to start_with "http://test.host/concern/numismatics/monograms"
+    end
+    context "when creating a monogram from a Numismatic Issue" do
+      let(:issue) { FactoryBot.create_for_repository(:numismatic_issue) }
+      let(:params) do
+        {
+          title: ["Monogram 1"],
+          append_id: issue.id
+        }
+      end
+      it "redirects to the parent Issue" do
+        post :create, params: { numismatics_monogram: params }
+        expect(response).to be_redirect
+        expect(response.location).to eq "http://test.host/catalog/#{issue.id}"
+      end
     end
   end
   describe "destroy" do
@@ -62,7 +78,7 @@ RSpec.describe Numismatics::MonogramsController, type: :controller do
       numismatic_monogram = FactoryBot.create_for_repository(:numismatic_monogram)
       patch :update, params: { id: numismatic_monogram.id.to_s, numismatics_monogram: { title: ["Monogram 45"] } }
       expect(response).to be_redirect
-      expect(response.location).to start_with "http://test.host/concern/numismatics/monograms"
+      expect(response.location).to start_with "http://test.host/catalog"
     end
   end
   describe "index" do

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -917,12 +917,14 @@ RSpec.describe ManifestBuilder do
     subject(:manifest_builder) { described_class.new(query_service.find_by(id: numismatic_issue.id)) }
     let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }
     let(:numismatic_issue) { FactoryBot.create_for_repository(:numismatic_issue) }
-    let(:change_set) { Numismatics::IssueChangeSet.new(numismatic_issue, member_ids: [coin1.id, coin2.id, coin3.id]) }
+    let(:change_set) { Numismatics::IssueChangeSet.new(numismatic_issue, member_ids: [coin1.id, coin2.id, coin3.id, monogram.id]) }
     let(:coin1) { FactoryBot.create_for_repository(:coin, files: [file1]) }
     let(:coin2) { FactoryBot.create_for_repository(:coin, files: [file2]) }
     let(:coin3) { FactoryBot.create_for_repository(:coin) }
+    let(:monogram) { FactoryBot.create_for_repository(:numismatic_monogram, files: [file3]) }
     let(:file1) { fixture_file_upload("files/abstract.tiff", "image/tiff") }
     let(:file2) { fixture_file_upload("files/abstract.tiff", "image/tiff") }
+    let(:file3) { fixture_file_upload("files/abstract.tiff", "image/tiff") }
     before do
       numismatic_issue
       change_set_persister.save(change_set: change_set)

--- a/spec/services/orangelight_document_spec.rb
+++ b/spec/services/orangelight_document_spec.rb
@@ -47,7 +47,7 @@ describe OrangelightDocument do
       end
       let(:issue) do
         FactoryBot.create_for_repository(:numismatic_issue,
-                                         member_ids: [coin.id],
+                                         member_ids: [coin.id, numismatic_monogram1.id, numismatic_monogram2.id],
                                          object_type: "coin",
                                          numismatic_artist: numismatic_artist,
                                          numismatic_citation: numismatic_citation,
@@ -58,7 +58,6 @@ describe OrangelightDocument do
                                          master_id: numismatic_person.id,
                                          earliest_date: "-91",
                                          latest_date: "-41",
-                                         numismatic_monogram_ids: [numismatic_monogram1.id, numismatic_monogram2.id],
                                          denomination: "1/2 Penny",
                                          metal: "copper",
                                          shape: "round",


### PR DESCRIPTION
- Monograms are now attached as members on the Numismatic Issue show page.

Closes #3449

![monogram](https://user-images.githubusercontent.com/784196/82251275-8222c800-9912-11ea-9963-db99a0e6a8ca.gif)
