### PR TITLE
Continuable Cached Parent ID Migration

### DIFF
--- a/app/change_set_persisters/change_set_persister/cache_parent_id.rb
+++ b/app/change_set_persisters/change_set_persister/cache_parent_id.rb
@@ -10,8 +10,8 @@ class ChangeSetPersister
 
     def run
       return unless change_set.resource.respond_to?(:cached_parent_id)
-      return unless append_id || existing_parent
-      change_set.resource.cached_parent_id = append_id || existing_parent.id
+      return unless append_id || existing_parent || change_set.resource.cached_parent_id.present?
+      change_set.resource.cached_parent_id = append_id || existing_parent&.id
     end
 
     def existing_parent

--- a/app/models/schema/common.rb
+++ b/app/models/schema/common.rb
@@ -88,7 +88,7 @@ module Schema
         attribute common_attribute
       end
       attribute :claimed_by, Valkyrie::Types::String
-      attribute :cached_parent_id, Valkyrie::Types::ID
+      attribute :cached_parent_id, Valkyrie::Types::ID.optional
     end
   end
 end

--- a/app/models/schema/geo.rb
+++ b/app/models/schema/geo.rb
@@ -23,7 +23,7 @@ module Schema
       # Can be used to override business logic about whether a record is discoverable in GeoBlacklight
       attribute :gbl_suppressed_override, Valkyrie::Types::Bool
       attribute :claimed_by, Valkyrie::Types::String
-      attribute :cached_parent_id, Valkyrie::Types::ID
+      attribute :cached_parent_id, Valkyrie::Types::ID.optional
     end
   end
 end

--- a/app/resources/ephemera_boxes/ephemera_box.rb
+++ b/app/resources/ephemera_boxes/ephemera_box.rb
@@ -17,7 +17,7 @@ class EphemeraBox < Resource
   attribute :workflow_note, Valkyrie::Types::Array.of(WorkflowNote).optional
   attribute :thumbnail_id
   attribute :local_identifier
-  attribute :cached_parent_id, Valkyrie::Types::ID
+  attribute :cached_parent_id, Valkyrie::Types::ID.optional
 
   def title
     ["Ephemera Box"]

--- a/app/resources/ephemera_folders/ephemera_folder.rb
+++ b/app/resources/ephemera_folders/ephemera_folder.rb
@@ -50,7 +50,7 @@ class EphemeraFolder < Resource
   attribute :workflow_note, Valkyrie::Types::Array.of(WorkflowNote).optional
   attribute :holding_location
   attribute :claimed_by, Valkyrie::Types::String
-  attribute :cached_parent_id, Valkyrie::Types::ID
+  attribute :cached_parent_id, Valkyrie::Types::ID.optional
 
   def self.can_have_manifests?
     true

--- a/app/resources/file_sets/file_set.rb
+++ b/app/resources/file_sets/file_set.rb
@@ -14,7 +14,7 @@ class FileSet < Resource
   attribute :part, Valkyrie::Types::Set
   attribute :transfer_notes
   attribute :processing_status, Valkyrie::Types::String.optional
-  attribute :cached_parent_id, Valkyrie::Types::ID
+  attribute :cached_parent_id, Valkyrie::Types::ID.optional
 
   delegate :width,
            :height,

--- a/app/resources/numismatics/coins/numismatics/coin.rb
+++ b/app/resources/numismatics/coins/numismatics/coin.rb
@@ -49,7 +49,7 @@ module Numismatics
     attribute :file_metadata, Valkyrie::Types::Set.of(FileMetadata.optional)
     attribute :identifier
     attribute :claimed_by, Valkyrie::Types::String
-    attribute :cached_parent_id, Valkyrie::Types::ID
+    attribute :cached_parent_id, Valkyrie::Types::ID.optional
 
     # manifest metadata
     attribute :start_canvas

--- a/app/resources/numismatics/issues/numismatics/issue.rb
+++ b/app/resources/numismatics/issues/numismatics/issue.rb
@@ -63,7 +63,7 @@ module Numismatics
     attribute :workflow_note, Valkyrie::Types::Array.of(WorkflowNote).optional
     attribute :pending_uploads, Valkyrie::Types::Array.of(PendingUpload)
     attribute :claimed_by, Valkyrie::Types::String
-    attribute :cached_parent_id, Valkyrie::Types::ID
+    attribute :cached_parent_id, Valkyrie::Types::ID.optional
 
     # manifest metadata
     attribute :start_canvas

--- a/spec/models/scanned_resource_spec.rb
+++ b/spec/models/scanned_resource_spec.rb
@@ -37,4 +37,13 @@ RSpec.describe ScannedResource do
       expect(scanned_resource).not_to be_a_media_resource
     end
   end
+
+  describe "#cached_parent_id" do
+    it "accepts a nil value" do
+      scanned_resource = FactoryBot.build(:scanned_resource)
+      scanned_resource.cached_parent_id = nil
+
+      expect(scanned_resource.cached_parent_id).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
1. Enables cached_parent_id to be a nil value.
2. Makes the migration only migrate those objects which haven't been
migrated yet.
3. Only migrates top-level members. Ignore some known models that don't
have cached parents, as well as FileSets. All FileSets have parents, and
if we end up needing it later we can handle it then.