### PR TITLE
Allow simple resources to be edited.

### DIFF
--- a/app/resources/scanned_resources/scanned_resources_controller.rb
+++ b/app/resources/scanned_resources/scanned_resources_controller.rb
@@ -7,15 +7,6 @@ class ScannedResourcesController < BaseResourceController
     storage_adapter: Valkyrie.config.storage_adapter
   )
 
-  def edit
-    if change_set.class == SimpleChangeSet
-      flash[:alert] = "Editing resources without imported metadata has been disabled while features are being added to support metadata from PUDL. Please contact us on Slack if you need help."
-      redirect_to solr_document_path(params[:id])
-    else
-      super
-    end
-  end
-
   def after_create_success(obj, change_set)
     super
     handle_save_and_ingest(obj)

--- a/app/resources/scanned_resources/simple_change_set.rb
+++ b/app/resources/scanned_resources/simple_change_set.rb
@@ -8,7 +8,6 @@ class SimpleChangeSet < ChangeSet
   include VisibilityProperty
   include DateRangeProperty
   property :title, multiple: true, required: true, default: []
-  property :sort_title, multiple: true, required: true, default: []
   property :downloadable, multiple: false, require: true, default: "public"
   property :rights_statement, multiple: false, required: true, default: RightsStatements.no_known_copyright, type: ::Types::URI
   property :rights_note, multiple: false, required: false
@@ -26,6 +25,9 @@ class SimpleChangeSet < ChangeSet
   property :file_metadata, multiple: true, required: false, default: []
   property :depositor, multiple: false, require: false
 
+  # The following are editable through automated ingest, but will not show up in
+  # the form until we have support for the data types in them in production.
+  property :sort_title, multiple: true, required: true, default: []
   property :abstract, multiple: true, required: false, default: []
   property :alternative, multiple: true, required: false, default: []
   property :alternative_title, multiple: true, required: false, default: []
@@ -56,6 +58,7 @@ class SimpleChangeSet < ChangeSet
   property :date_copyright, multiple: true, required: false, default: []
   property :source, multiple: true, required: false, default: []
   property :subject, multiple: true, required: false, default: []
+
   property :ocr_language, multiple: true, require: false, default: []
   property :logical_structure, multiple: true, required: false, type: Types::Strict::Array.of(Structure), default: [Structure.new(label: "Logical", nodes: [])]
   property :holding_location, multiple: false, required: false, type: ::Types::URI
@@ -80,7 +83,6 @@ class SimpleChangeSet < ChangeSet
   def primary_terms
     [
       :title,
-      :sort_title,
       :rights_statement,
       :rights_note,
       :local_identifier,
@@ -91,34 +93,37 @@ class SimpleChangeSet < ChangeSet
       :nav_date,
       :member_of_collection_ids,
       :append_id,
-      :abstract,
-      :alternative,
-      :alternative_title,
-      :bibliographic_citation,
-      :contents,
-      :extent,
-      :genre,
-      :geo_subject,
-      :license,
-      :part_of,
-      :replaces,
-      :type,
-      :contributor,
-      :coverage,
-      :creator,
-      :date,
-      :description,
-      :keyword,
-      :language,
-      :publisher,
-      :date_published,
-      :date_issued,
-      :date_copyright,
-      :date_range_form,
-      :source,
-      :subject,
       :holding_location,
       :change_set
+      # The following were disabled until we have support for already-ingested
+      # content that have complicated values in these fields. See #1714 and #1713
+      # :sort_title,
+      # :abstract,
+      # :alternative,
+      # :alternative_title,
+      # :bibliographic_citation,
+      # :contents,
+      # :extent,
+      # :genre,
+      # :geo_subject,
+      # :license,
+      # :part_of,
+      # :replaces,
+      # :type,
+      # :contributor,
+      # :coverage,
+      # :creator,
+      # :date,
+      # :description,
+      # :keyword,
+      # :language,
+      # :publisher,
+      # :date_published,
+      # :date_issued,
+      # :date_copyright,
+      # :date_range_form,
+      # :source,
+      # :subject,
     ]
   end
 end

--- a/spec/features/simple_resource_spec.rb
+++ b/spec/features/simple_resource_spec.rb
@@ -35,35 +35,36 @@ RSpec.feature "SimpleChangeSets" do
     expect(page).to have_field "Navigation Date"
     expect(page).to have_css '.select[for="scanned_resource_member_of_collection_ids"]', text: "Collections"
 
-    expect(page).to have_field "Abstract"
-    expect(page).to have_field "Alternative"
-    expect(page).to have_field "Alternative title"
-    expect(page).to have_field "Bibliographic citation"
-    expect(page).to have_field "Contents"
-    expect(page).to have_field "Extent"
-    expect(page).to have_field "Genre"
-    expect(page).to have_field "Geo subject"
-    expect(page).to have_field "License"
-    expect(page).to have_field "Part of"
-    expect(page).to have_field "Replaces"
-    expect(page).to have_field "Type"
-    expect(page).to have_field "Contributor"
-    expect(page).to have_css '.control-label[for="scanned_resource_coverage"]', text: "Coverage"
-    expect(page).to have_field "Creator"
-    expect(page).to have_field "Date"
-    expect(page).to have_field "Description"
-    expect(page).to have_field "Keyword"
-    expect(page).to have_field "Language"
-    expect(page).to have_field "Publisher"
-    expect(page).to have_field "Source"
-    expect(page).to have_field "Subject"
+    # The following were disabled until we have support for all these fields.
+    # expect(page).to have_field "Abstract"
+    # expect(page).to have_field "Alternative"
+    # expect(page).to have_field "Alternative title"
+    # expect(page).to have_field "Bibliographic citation"
+    # expect(page).to have_field "Contents"
+    # expect(page).to have_field "Extent"
+    # expect(page).to have_field "Genre"
+    # expect(page).to have_field "Geo subject"
+    # expect(page).to have_field "License"
+    # expect(page).to have_field "Part of"
+    # expect(page).to have_field "Replaces"
+    # expect(page).to have_field "Type"
+    # expect(page).to have_field "Contributor"
+    # expect(page).to have_css '.control-label[for="scanned_resource_coverage"]', text: "Coverage"
+    # expect(page).to have_field "Creator"
+    # expect(page).to have_field "Date"
+    # expect(page).to have_field "Description"
+    # expect(page).to have_field "Keyword"
+    # expect(page).to have_field "Language"
+    # expect(page).to have_field "Publisher"
+    # expect(page).to have_field "Source"
+    # expect(page).to have_field "Subject"
     expect(page.find("#scanned_resource_change_set", visible: false).value).to eq "simple"
 
-    fill_in "Title", with: "Test"
-    fill_in "Contributor", with: "Test Contributor"
+    fill_in "Title", with: "Test Title"
+    # fill_in "Contributor", with: "Test Contributor"
     click_button "Save"
 
-    expect(page).to have_content "Test Contributor"
+    expect(page).to have_content "Test Title"
   end
 
   scenario "creating an invalid resource" do
@@ -115,10 +116,14 @@ RSpec.feature "SimpleChangeSets" do
     scenario "editing a resource" do
       visit edit_scanned_resource_path(simple_resource)
 
-      expect(page).to have_content "Editing resources without imported metadata has been disabled while features are being added to support metadata from PUDL. " \
-        "Please contact us on Slack if you need help."
-
-      expect(current_path).to eq "/catalog/#{simple_resource.id}"
+      expect(page).to have_field "Title"
+      expect(page).to have_css '.select[for="scanned_resource_rights_statement"]', text: "Rights Statement"
+      expect(page).to have_field "Rights Note"
+      expect(page).to have_field "Local identifier"
+      expect(page).to have_css '.select[for="scanned_resource_pdf_type"]', text: "PDF Type"
+      expect(page).to have_field "Portion Note"
+      expect(page).to have_field "Navigation Date"
+      expect(page).to have_css '.select[for="scanned_resource_member_of_collection_ids"]', text: "Collections"
     end
 
     scenario "viewing a resource" do


### PR DESCRIPTION
This lets simple resources be edited, but only allows a very minimal
amount of metadata to be changed - basically just those fields that
Figgy uses for curation such as collection ID, append_id, title, etc.