### PR TITLE
Add language to oai_dc; use ISO-639-2

### DIFF
--- a/app/models/oai/figgy/oai_wrapper.rb
+++ b/app/models/oai/figgy/oai_wrapper.rb
@@ -21,6 +21,12 @@ module OAI::Figgy
       ControlledVocabulary.for(:rights_statement).find(decorated_resource.rights_statement.first).label
     end
 
+    def language
+      english_names = decorated_resource.language || decorated_resource.imported_language
+      return unless english_names.present?
+      ISO_639.find_by_english_name(english_names.first).alpha3
+    end
+
     def formats
       mime_types + extents
     end

--- a/spec/controllers/oai_controller_spec.rb
+++ b/spec/controllers/oai_controller_spec.rb
@@ -138,6 +138,7 @@ RSpec.describe OaiController do
           expect(result.xpath("//rights").text).to eq "No Known Copyright"
           expect(result.xpath("//format").map(&:text)).to eq ["image/tiff", "1 item; 33 x 29 cm"]
           expect(result.xpath("//source").text).to eq "Princeton University Library, C0022_c0145"
+          expect(result.xpath("//language").text).to eq "eng"
         end
       end
 


### PR DESCRIPTION
refs #3975