### PR TITLE
Add CDL::ChargeManager

### DIFF
--- a/app/resources/cdl/charge_manager.rb
+++ b/app/resources/cdl/charge_manager.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Controlled Digital Lending
+module CDL
+  class UnavailableForCharge < StandardError; end
+  class ChargeManager
+    attr_reader :resource_id, :eligible_item_service, :change_set_persister
+    # TODO: default eligible_item_service from #4033
+    def initialize(resource_id:, eligible_item_service:, change_set_persister:)
+      @resource_id = resource_id
+      @eligible_item_service = eligible_item_service
+      @change_set_persister = change_set_persister
+    end
+
+    def available_for_charge?
+      return false unless item_ids.present?
+      resource_charge_list.charged_items.count < item_ids.count
+    end
+
+    def create_charge(netid:)
+      raise CDL::UnavailableForCharge unless available_for_charge?
+      charge = CDL::ChargedItem.new(item_id: available_item_id, netid: netid, expiration_time: Time.current + 3.hours)
+      change_set = CDL::ResourceChargeListChangeSet.new(resource_charge_list)
+      change_set.validate(charged_items: resource_charge_list.charged_items + [charge])
+      change_set_persister.save(change_set: change_set)
+      charge
+    end
+
+    def available_item_id
+      (item_ids - resource_charge_list.charged_items.map(&:item_id)).first
+    end
+
+    def item_ids
+      eligible_item_service.item_ids(source_metadata_identifier: resource.source_metadata_identifier&.first)
+    end
+
+    def resource_charge_list
+      @resource_charge_list ||= Wayfinder.for(resource).resource_charge_list || build_resource_charge
+    end
+
+    def build_resource_charge
+      CDL::ResourceChargeList.new(
+        resource_id: resource.id
+      )
+    end
+
+    def resource
+      @resource ||= query_service.find_by(id: resource_id)
+    end
+
+    def query_service
+      change_set_persister.metadata_adapter.query_service
+    end
+  end
+end

--- a/app/resources/cdl/charged_item.rb
+++ b/app/resources/cdl/charged_item.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module CDL
+  class ChargedItem < Valkyrie::Resource
+    attribute :item_id, Valkyrie::Types::String
+    attribute :netid, Valkyrie::Types::String
+    attribute :expiration_time, Valkyrie::Types::Time
+  end
+end

--- a/app/resources/cdl/resource_charge_list.rb
+++ b/app/resources/cdl/resource_charge_list.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Controlled Digital Lending
+module CDL
+  class ResourceChargeList < Valkyrie::Resource
+    attribute :resource_id, Valkyrie::Types::ID
+    attribute :charged_items, Valkyrie::Types::Set.of(CDL::ChargedItem)
+  end
+end

--- a/app/resources/cdl/resource_charge_list_change_set.rb
+++ b/app/resources/cdl/resource_charge_list_change_set.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CDL
+  class ResourceChargeListChangeSet < Valkyrie::ChangeSet
+    property :charged_items
+  end
+end

--- a/app/wayfinders/base_wayfinder.rb
+++ b/app/wayfinders/base_wayfinder.rb
@@ -100,6 +100,10 @@ class BaseWayfinder
   # Define a preservation_objects relationship for all resources
   inverse_relationship_by_property :preservation_objects, property: :preserved_object_id, singular: true, model: PreservationObject
 
+  def resource_charge_list
+    @resource_charge_list ||= query_service.custom_queries.find_by_property(property: :resource_id, value: resource.id, model: CDL::ResourceChargeList).first
+  end
+
   def metadata_adapter
     @metadata_adapter ||= Valkyrie::MetadataAdapter.find(:indexing_persister)
   end

--- a/spec/factories/cdl/resource_charge_list.rb
+++ b/spec/factories/cdl/resource_charge_list.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :resource_charge_list, class: CDL::ResourceChargeList do
+    to_create do |instance|
+      Valkyrie.config.metadata_adapter.persister.save(resource: instance)
+    end
+  end
+end

--- a/spec/resources/cdl/charge_manager_spec.rb
+++ b/spec/resources/cdl/charge_manager_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe CDL::ChargeManager do
+  before do
+    class EligibleItemService
+      attr_reader :cached_item_ids
+      def initialize(item_ids:)
+        @cached_item_ids = item_ids
+      end
+
+      def item_ids(source_metadata_identifier:)
+        cached_item_ids
+      end
+    end
+  end
+
+  after do
+    Object.send(:remove_const, :EligibleItemService)
+  end
+
+  let(:change_set_persister) { ScannedResourcesController.change_set_persister }
+
+  describe "#create_charge" do
+    context "it is available for charge" do
+      context "there is a ResourceChargeList" do
+        it "creates a charge" do
+          eligible_item_service = EligibleItemService.new(item_ids: ["1234"])
+          stub_bibdata(bib_id: "123456")
+          resource = FactoryBot.create_for_repository(:scanned_resource, source_metadata_identifier: "123456")
+
+          resource_charge_list = FactoryBot.create_for_repository(:resource_charge_list, resource_id: resource.id)
+          charge_manager = described_class.new(resource_id: resource.id, eligible_item_service: eligible_item_service, change_set_persister: change_set_persister)
+
+          charged_item = charge_manager.create_charge(netid: "skye")
+          expect(charged_item).to be_a CDL::ChargedItem
+          reloaded_charges = Valkyrie.config.metadata_adapter.query_service.find_by(id: resource_charge_list.id)
+          expect(reloaded_charges.charged_items).to be_present
+        end
+      end
+
+      context "there is no ResourceChargeList" do
+        it "creates a ResourceChargeList and places a Charge in it" do
+          eligible_item_service = EligibleItemService.new(item_ids: ["1234"])
+          stub_bibdata(bib_id: "123456")
+          resource = FactoryBot.create_for_repository(:scanned_resource, source_metadata_identifier: "123456")
+
+          charge_manager = described_class.new(resource_id: resource.id, eligible_item_service: eligible_item_service, change_set_persister: change_set_persister)
+
+          charged_item = charge_manager.create_charge(netid: "skye")
+          expect(charged_item).to be_a CDL::ChargedItem
+          reloaded_charges = Wayfinder.for(resource).resource_charge_list
+          expect(reloaded_charges.charged_items).to be_present
+        end
+      end
+    end
+
+    context "it is not available for charge" do
+      it "raises a CDL::UnavailableForCharge" do
+        eligible_item_service = EligibleItemService.new(item_ids: [])
+        stub_bibdata(bib_id: "123456")
+        resource = FactoryBot.create_for_repository(:scanned_resource, source_metadata_identifier: "123456")
+
+        charge_manager = described_class.new(resource_id: resource.id, eligible_item_service: eligible_item_service, change_set_persister: change_set_persister)
+
+        expect { charge_manager.create_charge(netid: "zelda") }.to raise_error CDL::UnavailableForCharge
+      end
+    end
+    # (netid:) (checks bibdata for items, compares with current charged items, if possible creates a charge.)
+  end
+
+  describe "#available_for_charge?" do
+    context "when there are no items" do
+      it "returns false" do
+        eligible_item_service = EligibleItemService.new(item_ids: [])
+        stub_bibdata(bib_id: "123456")
+        resource = FactoryBot.create_for_repository(:scanned_resource, source_metadata_identifier: "123456")
+
+        charge_manager = described_class.new(resource_id: resource.id, eligible_item_service: eligible_item_service, change_set_persister: change_set_persister)
+
+        expect(charge_manager.available_for_charge?).to eq false
+      end
+    end
+
+    context "when there are items and nothing has ever been charged" do
+      it "returns true" do
+        eligible_item_service = EligibleItemService.new(item_ids: ["1234"])
+        stub_bibdata(bib_id: "123456")
+        resource = FactoryBot.create_for_repository(:scanned_resource, source_metadata_identifier: "123456")
+
+        charge_manager = described_class.new(resource_id: resource.id, eligible_item_service: eligible_item_service, change_set_persister: change_set_persister)
+
+        expect(charge_manager.available_for_charge?).to eq true
+      end
+    end
+
+    context "when one item is not currently charged" do
+      it "returns true" do
+        charged_items = [
+          CDL::ChargedItem.new(item_id: "1234", netid: "skye", expiration_time: Time.current + 3.hours)
+        ]
+        eligible_item_service = EligibleItemService.new(item_ids: ["1234", "5678"])
+        stub_bibdata(bib_id: "123456")
+        resource = FactoryBot.create_for_repository(:scanned_resource, source_metadata_identifier: "123456")
+
+        FactoryBot.create_for_repository(:resource_charge_list, resource_id: resource.id, charged_items: charged_items)
+
+        charge_manager = described_class.new(resource_id: resource.id, eligible_item_service: eligible_item_service, change_set_persister: change_set_persister)
+        expect(charge_manager.available_for_charge?).to eq true
+      end
+    end
+
+    context "when all items are currently charged" do
+      it "returns false" do
+        charged_items = [
+          CDL::ChargedItem.new(item_id: "1234", netid: "skye", expiration_time: Time.current + 3.hours),
+          CDL::ChargedItem.new(item_id: "5678", netid: "zelda", expiration_time: Time.current + 3.hours)
+        ]
+        eligible_item_service = EligibleItemService.new(item_ids: ["1234", "5678"])
+        stub_bibdata(bib_id: "123456")
+        resource = FactoryBot.create_for_repository(:scanned_resource, source_metadata_identifier: "123456")
+
+        FactoryBot.create_for_repository(:resource_charge_list, resource_id: resource.id, charged_items: charged_items)
+
+        charge_manager = described_class.new(resource_id: resource.id, eligible_item_service: eligible_item_service, change_set_persister: change_set_persister)
+        expect(charge_manager.available_for_charge?).to eq false
+      end
+    end
+  end
+end

--- a/spec/resources/cdl/charged_item_spec.rb
+++ b/spec/resources/cdl/charged_item_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CDL::ChargedItem do
+  describe "#expiration_time" do
+    it "returns a time" do
+      resource = described_class.new
+      resource.expiration_time = Time.zone.at(0)
+      expect(resource.expiration_time).to eq Time.zone.at(0)
+    end
+  end
+end

--- a/spec/resources/cdl/resource_charge_list_spec.rb
+++ b/spec/resources/cdl/resource_charge_list_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe CDL::ResourceChargeList do
+  describe "#resource_id" do
+    it "returns the figgy id of the resource it manages charges for" do
+      resource = FactoryBot.create_for_repository(:scanned_resource)
+      charge_manager = described_class.new(resource_id: resource.id)
+      expect(charge_manager.resource_id).to eq resource.id
+    end
+  end
+
+  describe "#charged_items" do
+    it "stores an array of ChargedItems" do
+      charge_manager = described_class.new
+
+      charged_item = CDL::ChargedItem.new(item_id: "1", netid: "skye", expiration_time: Time.zone.at(0))
+      charge_manager.charged_items = [charged_item]
+
+      expect(charge_manager.charged_items[0]).to eq charged_item
+    end
+  end
+end


### PR DESCRIPTION
The `CDL::ChargeManager` is a business logic object which creates and
manages `CDL::ResourceChargeList` and its `CDL::ChargeItem`s.

The implementation currently stubs the EligibleItemService, but after
 #4033 it will pull from bibdata.

Closes #4026