### PR TITLE
Don't use JS to handle viewer auth flow.

### DIFF
--- a/app/assets/javascripts/viewer.js
+++ b/app/assets/javascripts/viewer.js
@@ -1,8 +1,4 @@
 function loadUV () {
-  var urlDataProvider = new UV.URLDataProvider(false)
-  var manifest = urlDataProvider.get('manifest')
-  $('#loginContainer').hide()
-  $('#uv').hide()
   $('#login').click(function (e) {
     e.preventDefault()
     var child = window.open('/users/auth/cas?login_popup=true')
@@ -10,11 +6,14 @@ function loadUV () {
 
     function checkChild () {
       if (child.closed) {
-        loadUV()
         clearInterval(timer)
+        window.location.reload()
       }
     }
   })
+  var urlDataProvider = new UV.URLDataProvider(false)
+  var manifest = urlDataProvider.get('manifest')
+  $('#uv').hide()
   $.ajax(manifest, { type: 'HEAD' }).done(function (data, status, jqXHR) {
     var linkHeader = jqXHR.getResponseHeader('Link')
     if (linkHeader) {
@@ -29,9 +28,9 @@ function loadUV () {
       }
     }
     $('#uv').show()
-    manifestUri = urlDataProvider.get('manifest')
-    configUri = '/viewer/config/' + manifestUri.replace('/manifest', '').replace(/.*\//, '') + '.json'
-    uv = createUV('#uv', {
+    var manifestUri = urlDataProvider.get('manifest')
+    var configUri = '/viewer/config/' + manifestUri.replace('/manifest', '').replace(/.*\//, '') + '.json'
+    createUV('#uv', {
       root: 'uv',
       iiifResourceUri: manifestUri,
       configUri: configUri,
@@ -45,8 +44,13 @@ function loadUV () {
       embedded: true
     }, urlDataProvider)
   }).fail(function (data, status) {
-    if (data.status == 401) {
-      $('#loginContainer').show()
+    if (data.status === 401) {
+      var urlDataProvider = new UV.URLDataProvider(false)
+      var manifestUri = urlDataProvider.get('manifest')
+      if (manifestUri.includes(window.location.host)) {
+        var figgyId = manifestUri.replace('/manifest', '').replace(/.*\//, '')
+        window.location.href = '/viewer/' + figgyId + '/auth'
+      }
     }
   })
 }

--- a/app/controllers/viewer_controller.rb
+++ b/app/controllers/viewer_controller.rb
@@ -5,4 +5,26 @@ class ViewerController < ApplicationController
   def index
     render :index
   end
+
+  def auth
+    resource = query_service.find_by(id: params[:id])
+    return redirect_to_viewer(resource) if current_user
+    if can?(:discover, resource)
+      render :auth
+    else
+      redirect_to_viewer(resource)
+    end
+  end
+
+  def redirect_to_viewer(resource)
+    redirect_to viewer_index_path(anchor: "?manifest=#{manifest_helper.manifest_url(resource)}")
+  end
+
+  def manifest_helper
+    ManifestBuilder::ManifestHelper.new
+  end
+
+  def query_service
+    Valkyrie.config.metadata_adapter.query_service
+  end
 end

--- a/app/views/layouts/viewer_layout.html.erb
+++ b/app/views/layouts/viewer_layout.html.erb
@@ -3,13 +3,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <link rel="stylesheet" type="text/css" href="uv/uv.css">
     <%= stylesheet_link_tag 'viewer' %>
-    <script type="text/javascript" src="uv/lib/offline.js"></script>
-    <script type="text/javascript" src="uv/lib/offline.js"></script>
-    <script type="text/javascript" src="uv/helpers.js"></script>
+    <%= yield :head %>
+    <script type="text/javascript" src="/uv/lib/offline.js"></script>
+    <script type="text/javascript" src="/uv/lib/offline.js"></script>
+    <script type="text/javascript" src="/uv/helpers.js"></script>
   </head>
   <body>
     <%= yield %>
     <%= javascript_include_tag 'viewer' %>
-    <script type="text/javascript" src="uv/uv.js"></script>
+    <script type="text/javascript" src="/uv/uv.js"></script>
   </body>
 </html>

--- a/app/views/viewer/auth.html.erb
+++ b/app/views/viewer/auth.html.erb
@@ -1,0 +1,7 @@
+<% content_for :head do %>
+  <%= stylesheet_link_tag 'application' %>
+  <%= stylesheet_pack_tag 'application' %>
+<% end %>
+<div id="loginContainer">
+  <%= link_to 'Princeton Users: Log in to View', main_app.new_user_session_path, class: 'btn btn-primary', id: "login" %>
+</div>

--- a/app/views/viewer/index.html.erb
+++ b/app/views/viewer/index.html.erb
@@ -1,5 +1,2 @@
 <h1 id="title" class="lux-heading h1" style="display: none;"></h1>
-<div id="loginContainer" style="display: none;">
-  <button type="button" class="lux-button text medium" id="login">Princeton Users: Log in to View</button>
-</div>
 <div id="uv" class="uv"></div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -290,5 +290,9 @@ Rails.application.routes.draw do
   resources :ocr_requests, only: [:index, :destroy, :show]
   post "/ocr_requests/upload_file", to: "ocr_requests#upload_file", as: :upload_file
 
-  get "/viewer", to: "viewer#index"
+  resources :viewer, only: [:index] do
+    member do
+      get :auth
+    end
+  end
 end

--- a/spec/controllers/viewer_controller_spec.rb
+++ b/spec/controllers/viewer_controller_spec.rb
@@ -9,7 +9,38 @@ RSpec.describe ViewerController do
     it "generates a hidden login container" do
       get :index
 
-      expect(response.body).to have_selector "#login", text: "Princeton Users: Log in to View", visible: false
+      expect(response.body).to have_selector "h1#title", visible: false
+    end
+  end
+
+  describe "#auth" do
+    context "when the user is not logged in and could get access to the resource" do
+      it "displays a sign in button" do
+        resource = FactoryBot.create_for_repository(:complete_campus_only_scanned_resource)
+
+        get :auth, params: { id: resource.id.to_s }
+
+        expect(response.body).to have_link "Princeton Users: Log in to View"
+      end
+      context "and the resource is private" do
+        it "redirects the user back to the viewer" do
+          resource = FactoryBot.create_for_repository(:complete_private_scanned_resource)
+
+          get :auth, params: { id: resource.id.to_s }
+
+          expect(response).to redirect_to viewer_index_path(anchor: "?manifest=http://www.example.com/concern/scanned_resources/#{resource.id}/manifest")
+        end
+      end
+    end
+    context "when the user is logged in" do
+      it "redirects back to the viewer" do
+        sign_in FactoryBot.create(:user)
+        resource = FactoryBot.create_for_repository(:complete_campus_only_scanned_resource)
+
+        get :auth, params: { id: resource.id.to_s }
+
+        expect(response).to redirect_to viewer_index_path(anchor: "?manifest=http://www.example.com/concern/scanned_resources/#{resource.id}/manifest")
+      end
     end
   end
 end


### PR DESCRIPTION
This should make it easier for us to handle things like CDL auth flows without a bunch of complex javascript branching or stashing data in manifest bodies.

Closes #4043