### PR TITLE
Adds ResourceChargeList#hold_queue

### DIFF
--- a/app/resources/cdl/charge_manager.rb
+++ b/app/resources/cdl/charge_manager.rb
@@ -53,7 +53,10 @@ module CDL
       raise CDL::UnavailableForCharge unless available_for_charge?(netid: netid)
       charge = CDL::ChargedItem.new(item_id: available_item_id, netid: netid, expiration_time: Time.current + 3.hours)
       change_set = CDL::ResourceChargeListChangeSet.new(resource_charge_list)
-      change_set.validate(charged_items: resource_charge_list.charged_items + [charge])
+      updated_hold_queue = resource_charge_list.hold_queue.reject do |hold|
+        hold.netid == netid
+      end
+      change_set.validate(charged_items: resource_charge_list.charged_items + [charge], hold_queue: updated_hold_queue)
       change_set_persister.save(change_set: change_set)
       charge
     end

--- a/app/resources/cdl/charge_manager.rb
+++ b/app/resources/cdl/charge_manager.rb
@@ -25,7 +25,22 @@ module CDL
 
     def available_for_charge?(netid: nil)
       return false unless eligible?
-      resource_charge_list.charged_items.count < item_ids.count
+      return true if charged_item_count < item_ids.count && active_hold?(netid: netid)
+      (charged_item_count + held_item_count) < item_ids.count
+    end
+
+    def active_hold?(netid:)
+      resource_charge_list.hold_queue.find do |hold|
+        hold.active? && !hold.expired? && hold.netid == netid
+      end.present?
+    end
+
+    def charged_item_count
+      resource_charge_list.charged_items.count
+    end
+
+    def held_item_count
+      resource_charge_list.pending_or_active_holds.count
     end
 
     def estimated_wait_time

--- a/app/resources/cdl/charge_manager.rb
+++ b/app/resources/cdl/charge_manager.rb
@@ -23,7 +23,7 @@ module CDL
       resource_charge_list.charged_items = resource_charge_list.charged_items.reject(&:expired?)
     end
 
-    def available_for_charge?
+    def available_for_charge?(netid: nil)
       return false unless eligible?
       resource_charge_list.charged_items.count < item_ids.count
     end
@@ -35,7 +35,7 @@ module CDL
     end
 
     def create_charge(netid:)
-      raise CDL::UnavailableForCharge unless available_for_charge?
+      raise CDL::UnavailableForCharge unless available_for_charge?(netid: netid)
       charge = CDL::ChargedItem.new(item_id: available_item_id, netid: netid, expiration_time: Time.current + 3.hours)
       change_set = CDL::ResourceChargeListChangeSet.new(resource_charge_list)
       change_set.validate(charged_items: resource_charge_list.charged_items + [charge])

--- a/app/resources/cdl/hold.rb
+++ b/app/resources/cdl/hold.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module CDL
+  class Hold < Valkyrie::Resource
+    attribute :netid, Valkyrie::Types::String
+    attribute :expiration_time, Valkyrie::Types::Time.optional
+    attribute :notification_time, Valkyrie::Types::Time.optional
+
+    def active?
+      expiration_time.present?
+    end
+
+    def expired?
+      expiration_time <= Time.current
+    end
+  end
+end

--- a/app/resources/cdl/resource_charge_list.rb
+++ b/app/resources/cdl/resource_charge_list.rb
@@ -5,5 +5,6 @@ module CDL
   class ResourceChargeList < Valkyrie::Resource
     attribute :resource_id, Valkyrie::Types::ID
     attribute :charged_items, Valkyrie::Types::Set.of(CDL::ChargedItem)
+    attribute :hold_queue, Valkyrie::Types::Set.of(CDL::Hold)
   end
 end

--- a/app/resources/cdl/resource_charge_list.rb
+++ b/app/resources/cdl/resource_charge_list.rb
@@ -6,5 +6,11 @@ module CDL
     attribute :resource_id, Valkyrie::Types::ID
     attribute :charged_items, Valkyrie::Types::Set.of(CDL::ChargedItem)
     attribute :hold_queue, Valkyrie::Types::Set.of(CDL::Hold)
+
+    def pending_or_active_holds
+      hold_queue.reject do |hold|
+        hold.active? && hold.expired?
+      end
+    end
   end
 end

--- a/app/resources/cdl/resource_charge_list_change_set.rb
+++ b/app/resources/cdl/resource_charge_list_change_set.rb
@@ -3,5 +3,6 @@
 module CDL
   class ResourceChargeListChangeSet < Valkyrie::ChangeSet
     property :charged_items
+    property :hold_queue
   end
 end

--- a/app/resources/cdl/status.rb
+++ b/app/resources/cdl/status.rb
@@ -37,7 +37,7 @@ module CDL
     end
 
     def available_status
-      charge_manager.available_for_charge?
+      charge_manager.available_for_charge?(netid: user.uid)
     end
   end
 end

--- a/app/views/viewer/cdl_checkout.html.erb
+++ b/app/views/viewer/cdl_checkout.html.erb
@@ -12,8 +12,8 @@
   <p>Under certain conditions specified in the law, libraries and archives are authorized to furnish a photocopy or other reproduction. One of these specific conditions is that the photocopy or reproduction is not to be “used for any purpose other than private study, scholarship, or research.” If a user makes a request for, or later uses, a photocopy or reproduction for purposes in excess of “fair use,” that user may be liable for copyright infringement.</p>
 
   <p>This institution reserves the right to refuse to accept a copying order if, in its judgment, fulfillment of the order would involve violation of copyright law.</p>
-  <%= button_to "Check Out for 3 Hours", { action: "charge", controller: "cdl/cdl" }, class: "btn btn-primary", disabled: !@charge_manager.available_for_charge?, params: { id: params[:id] } %>
-  <% if !@charge_manager.available_for_charge? %>
+  <%= button_to "Check Out for 3 Hours", { action: "charge", controller: "cdl/cdl" }, class: "btn btn-primary", disabled: !@charge_manager.available_for_charge?(netid: current_user&.uid), params: { id: params[:id] } %>
+  <% if !@charge_manager.available_for_charge?(netid: current_user&.uid) %>
     <b>This item is currently checked out. The estimated wait time is <%= @charge_manager.estimated_wait_time %>.</b>
   <% end %>
 </div>

--- a/spec/resources/cdl/charge_manager_spec.rb
+++ b/spec/resources/cdl/charge_manager_spec.rb
@@ -102,7 +102,7 @@ describe CDL::ChargeManager do
         charge_manager = described_class.new(resource_id: resource.id, eligible_item_service: eligible_item_service, change_set_persister: change_set_persister)
 
         expect(charge_manager.eligible?).to eq false
-        expect(charge_manager.available_for_charge?).to eq false
+        expect(charge_manager.available_for_charge?(netid: "miku")).to eq false
       end
     end
 
@@ -115,7 +115,7 @@ describe CDL::ChargeManager do
         charge_manager = described_class.new(resource_id: resource.id, eligible_item_service: eligible_item_service, change_set_persister: change_set_persister)
 
         expect(charge_manager.eligible?).to eq true
-        expect(charge_manager.available_for_charge?).to eq true
+        expect(charge_manager.available_for_charge?(netid: "miku")).to eq true
       end
     end
 
@@ -132,7 +132,7 @@ describe CDL::ChargeManager do
 
         charge_manager = described_class.new(resource_id: resource.id, eligible_item_service: eligible_item_service, change_set_persister: change_set_persister)
         expect(charge_manager.eligible?).to eq true
-        expect(charge_manager.available_for_charge?).to eq true
+        expect(charge_manager.available_for_charge?(netid: "miku")).to eq true
       end
     end
 
@@ -150,7 +150,7 @@ describe CDL::ChargeManager do
 
         charge_manager = described_class.new(resource_id: resource.id, eligible_item_service: eligible_item_service, change_set_persister: change_set_persister)
         expect(charge_manager.eligible?).to eq true
-        expect(charge_manager.available_for_charge?).to eq false
+        expect(charge_manager.available_for_charge?(netid: "miku")).to eq false
       end
     end
   end

--- a/spec/resources/cdl/charge_manager_spec.rb
+++ b/spec/resources/cdl/charge_manager_spec.rb
@@ -89,7 +89,6 @@ describe CDL::ChargeManager do
         expect { charge_manager.create_charge(netid: "zelda") }.to raise_error CDL::UnavailableForCharge
       end
     end
-    # (netid:) (checks bibdata for items, compares with current charged items, if possible creates a charge.)
   end
 
   describe "#available_for_charge?" do
@@ -147,6 +146,68 @@ describe CDL::ChargeManager do
         resource = FactoryBot.create_for_repository(:scanned_resource, source_metadata_identifier: "123456")
 
         FactoryBot.create_for_repository(:resource_charge_list, resource_id: resource.id, charged_items: charged_items)
+
+        charge_manager = described_class.new(resource_id: resource.id, eligible_item_service: eligible_item_service, change_set_persister: change_set_persister)
+        expect(charge_manager.eligible?).to eq true
+        expect(charge_manager.available_for_charge?(netid: "miku")).to eq false
+      end
+    end
+    context "when an item isn't charged but there's a hold queue" do
+      it "returns false" do
+        eligible_item_service = EligibleItemService.new(item_ids: ["1234"])
+        stub_bibdata(bib_id: "123456")
+        resource = FactoryBot.create_for_repository(:scanned_resource, source_metadata_identifier: "123456")
+
+        FactoryBot.create_for_repository(:resource_charge_list, resource_id: resource.id, hold_queue: CDL::Hold.new(netid: "tiberius"))
+
+        charge_manager = described_class.new(resource_id: resource.id, eligible_item_service: eligible_item_service, change_set_persister: change_set_persister)
+        expect(charge_manager.eligible?).to eq true
+        expect(charge_manager.available_for_charge?(netid: "miku")).to eq false
+      end
+    end
+    context "when an item isn't charged and there's an active hold for that user" do
+      it "returns true" do
+        eligible_item_service = EligibleItemService.new(item_ids: ["1234"])
+        stub_bibdata(bib_id: "123456")
+        resource = FactoryBot.create_for_repository(:scanned_resource, source_metadata_identifier: "123456")
+
+        FactoryBot.create_for_repository(:resource_charge_list, resource_id: resource.id, hold_queue: CDL::Hold.new(netid: "miku", expiration_time: Time.current + 1.hour))
+
+        charge_manager = described_class.new(resource_id: resource.id, eligible_item_service: eligible_item_service, change_set_persister: change_set_persister)
+        expect(charge_manager.eligible?).to eq true
+        expect(charge_manager.available_for_charge?(netid: "miku")).to eq true
+      end
+    end
+    # When and under what circumstances a hold is activated should be left to
+    # the create_hold method. Don't worry about those logistics for checking
+    # availability - if it's not an active hold, then don't let them charge.
+    context "when an item isn't charged and there's an inactive hold for that user" do
+      it "returns false" do
+        eligible_item_service = EligibleItemService.new(item_ids: ["1234"])
+        stub_bibdata(bib_id: "123456")
+        resource = FactoryBot.create_for_repository(:scanned_resource, source_metadata_identifier: "123456")
+
+        FactoryBot.create_for_repository(:resource_charge_list, resource_id: resource.id, hold_queue: CDL::Hold.new(netid: "miku"))
+
+        charge_manager = described_class.new(resource_id: resource.id, eligible_item_service: eligible_item_service, change_set_persister: change_set_persister)
+        expect(charge_manager.eligible?).to eq true
+        expect(charge_manager.available_for_charge?(netid: "miku")).to eq false
+      end
+    end
+    context "when an item isn't charged and there's an expired hold for that user" do
+      it "returns false" do
+        eligible_item_service = EligibleItemService.new(item_ids: ["1234"])
+        stub_bibdata(bib_id: "123456")
+        resource = FactoryBot.create_for_repository(:scanned_resource, source_metadata_identifier: "123456")
+
+        FactoryBot.create_for_repository(
+          :resource_charge_list,
+          resource_id: resource.id,
+          hold_queue: [
+            CDL::Hold.new(netid: "miku", expiration_time: Time.current - 1.hour),
+            CDL::Hold.new(netid: "tiberius")
+          ]
+        )
 
         charge_manager = described_class.new(resource_id: resource.id, eligible_item_service: eligible_item_service, change_set_persister: change_set_persister)
         expect(charge_manager.eligible?).to eq true

--- a/spec/resources/cdl/hold_spec.rb
+++ b/spec/resources/cdl/hold_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CDL::Hold do
+  describe "#active?" do
+    context "when the expiration_time is set" do
+      it "returns true" do
+        hold = described_class.new(netid: "miku", expiration_time: Time.current + 1.hour)
+        expect(hold).to be_active
+      end
+    end
+    context "when expiration_time is not set" do
+      it "returns false" do
+        hold = described_class.new(netid: "miku")
+        expect(hold).not_to be_active
+      end
+    end
+  end
+  describe "#expired?" do
+    context "when the expiration_time is in the past" do
+      it "returns true" do
+        hold = described_class.new(netid: "miku", expiration_time: Time.current - 1.hour)
+        expect(hold).to be_expired
+      end
+    end
+    context "when expiration_time is in the future" do
+      it "returns false" do
+        hold = described_class.new(netid: "miku", expiration_time: Time.current + 1.hour)
+        expect(hold).not_to be_expired
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #4088

* Adds a CDL::Hold to store a hold.
* Adds a `hold_queue` to `CDL::ResourceChargeList`
* Adds `netid:` to `available_for_charge` so it can take into account existing active holds.
* Takes the `hold_queue` into account for `available_for_charge?`
* Clear out `hold_queue` when charging an item.