### PR TITLE
Activate holds based on a cron job

### DIFF
--- a/app/resources/cdl/bulk_hold_processor.rb
+++ b/app/resources/cdl/bulk_hold_processor.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module CDL
+  class BulkHoldProcessor
+    attr_reader :change_set_persister
+    delegate :metadata_adapter, to: :change_set_persister
+    delegate :query_service, to: :metadata_adapter
+    def initialize(change_set_persister:)
+      @change_set_persister = change_set_persister
+    end
+
+    def process!
+      held_resources.each do |held_resource|
+        charge_manager_for(resource_charge_list: held_resource).activate_holds!
+      end
+    end
+
+    private
+
+      def charge_manager_for(resource_charge_list:)
+        CDL::ChargeManager.new(
+          resource_id: resource_charge_list.resource_id,
+          eligible_item_service: EligibleItemService,
+          change_set_persister: change_set_persister
+        )
+      end
+
+      def held_resources
+        @held_resources ||= query_service.custom_queries.find_by_property(property: :hold_queue, value: [{}], model: CDL::ResourceChargeList)
+      end
+  end
+end

--- a/app/resources/cdl/bulk_hold_processor.rb
+++ b/app/resources/cdl/bulk_hold_processor.rb
@@ -2,6 +2,19 @@
 
 module CDL
   class BulkHoldProcessor
+    def self.process!
+      change_set_persister.buffer_into_index do |buffered_change_set_persister|
+        new(change_set_persister: buffered_change_set_persister).process!
+      end
+    end
+
+    def self.change_set_persister
+      ::ChangeSetPersister.new(
+        metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister),
+        storage_adapter: Valkyrie.config.storage_adapter
+      )
+    end
+
     attr_reader :change_set_persister
     delegate :metadata_adapter, to: :change_set_persister
     delegate :query_service, to: :metadata_adapter

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -24,6 +24,10 @@ every :day, at: "9:00 PM", roles: [:db] do
   rake "fixity:request_daily_cloud_fixity"
 end
 
+every 10.minutes, roles: [:db] do
+  rake "cdl:bulk_hold_process"
+end
+
 # Example:
 #
 # set :output, "/path/to/my/cron_log.log"

--- a/lib/tasks/cdl.rake
+++ b/lib/tasks/cdl.rake
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+namespace :cdl do
+  desc "Active/Expire all CDL Holds"
+  task bulk_hold_process: :environment do
+    CDL::BulkHoldProcessor.process!
+  end
+end

--- a/spec/resources/cdl/bulk_hold_processor_spec.rb
+++ b/spec/resources/cdl/bulk_hold_processor_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe CDL::BulkHoldProcessor do
     )
     resource_charge_list2 = FactoryBot.create_for_repository(:resource_charge_list, resource_id: FactoryBot.create_for_repository(:complete_private_scanned_resource).id)
 
-    described_class.new(change_set_persister: ScannedResourcesController.change_set_persister).process!
+    described_class.process!
 
     reloaded_resource_charge_list1 = query_service.find_by(id: resource_charge_list1.id)
     expect(reloaded_resource_charge_list1.updated_at).not_to eq resource_charge_list1.updated_at
@@ -33,7 +33,7 @@ RSpec.describe CDL::BulkHoldProcessor do
     )
     resource_charge_list2 = FactoryBot.create_for_repository(:resource_charge_list, resource_id: FactoryBot.create_for_repository(:complete_private_scanned_resource).id)
 
-    described_class.new(change_set_persister: ScannedResourcesController.change_set_persister).process!
+    described_class.process!
 
     reloaded_resource_charge_list1 = query_service.find_by(id: resource_charge_list1.id)
     expect(reloaded_resource_charge_list1.updated_at).not_to eq resource_charge_list1.updated_at

--- a/spec/resources/cdl/bulk_hold_processor_spec.rb
+++ b/spec/resources/cdl/bulk_hold_processor_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe CDL::BulkHoldProcessor do
       inactive_hold_netids: ["one", "two"]
     )
     resource_charge_list2 = FactoryBot.create_for_repository(:resource_charge_list, resource_id: FactoryBot.create_for_repository(:complete_private_scanned_resource).id)
+    resource_charge_list3 = FactoryBot.create_for_repository(:resource_charge_list, resource_id: FactoryBot.create_for_repository(:complete_private_scanned_resource).id, inactive_hold_netids: ["one"])
 
     described_class.process!
 
@@ -40,6 +41,12 @@ RSpec.describe CDL::BulkHoldProcessor do
     expect(reloaded_resource_charge_list1.hold_queue.size).to eq 2
     expect(reloaded_resource_charge_list1.active_holds.size).to eq 1
     expect(reloaded_resource_charge_list1.active_holds[0].netid).to eq "one"
+
     expect(query_service.find_by(id: resource_charge_list2.id).updated_at).to eq resource_charge_list2.updated_at
+
+    # Ensure all resources are activated.
+    reloaded_resource_charge_list3 = query_service.find_by(id: resource_charge_list3.id)
+    expect(reloaded_resource_charge_list3.hold_queue.size).to eq 1
+    expect(reloaded_resource_charge_list3.active_holds.size).to eq 1
   end
 end

--- a/spec/resources/cdl/bulk_hold_processor_spec.rb
+++ b/spec/resources/cdl/bulk_hold_processor_spec.rb
@@ -8,13 +8,38 @@ RSpec.describe CDL::BulkHoldProcessor do
     allow(CDL::EligibleItemService).to receive(:item_ids).and_return(["1"])
     User.create!(uid: "one", email: "one@princeton.edu")
     User.create!(uid: "two", email: "two@princeton.edu")
-    hold1 = FactoryBot.create_for_repository(:resource_charge_list, resource_id: FactoryBot.create_for_repository(:complete_private_scanned_resource).id, expired_hold_netids: ["one", "two"])
-    hold2 = FactoryBot.create_for_repository(:resource_charge_list, resource_id: FactoryBot.create_for_repository(:complete_private_scanned_resource).id)
+    resource_charge_list1 = FactoryBot.create_for_repository(
+      :resource_charge_list,
+      resource_id: FactoryBot.create_for_repository(:complete_private_scanned_resource).id,
+      expired_hold_netids: ["one", "two"]
+    )
+    resource_charge_list2 = FactoryBot.create_for_repository(:resource_charge_list, resource_id: FactoryBot.create_for_repository(:complete_private_scanned_resource).id)
 
     described_class.new(change_set_persister: ScannedResourcesController.change_set_persister).process!
 
-    reloaded_hold1 = query_service.find_by(id: hold1.id)
-    expect(reloaded_hold1.updated_at).not_to eq hold1.updated_at
-    expect(query_service.find_by(id: hold2.id).updated_at).to eq hold2.updated_at
+    reloaded_resource_charge_list1 = query_service.find_by(id: resource_charge_list1.id)
+    expect(reloaded_resource_charge_list1.updated_at).not_to eq resource_charge_list1.updated_at
+    expect(reloaded_resource_charge_list1.hold_queue).to be_empty
+    expect(query_service.find_by(id: resource_charge_list2.id).updated_at).to eq resource_charge_list2.updated_at
+  end
+  it "activates any eligible holds" do
+    allow(CDL::EligibleItemService).to receive(:item_ids).and_return(["1"])
+    User.create!(uid: "one", email: "one@princeton.edu")
+    User.create!(uid: "two", email: "two@princeton.edu")
+    resource_charge_list1 = FactoryBot.create_for_repository(
+      :resource_charge_list,
+      resource_id: FactoryBot.create_for_repository(:complete_private_scanned_resource).id,
+      inactive_hold_netids: ["one", "two"]
+    )
+    resource_charge_list2 = FactoryBot.create_for_repository(:resource_charge_list, resource_id: FactoryBot.create_for_repository(:complete_private_scanned_resource).id)
+
+    described_class.new(change_set_persister: ScannedResourcesController.change_set_persister).process!
+
+    reloaded_resource_charge_list1 = query_service.find_by(id: resource_charge_list1.id)
+    expect(reloaded_resource_charge_list1.updated_at).not_to eq resource_charge_list1.updated_at
+    expect(reloaded_resource_charge_list1.hold_queue.size).to eq 2
+    expect(reloaded_resource_charge_list1.active_holds.size).to eq 1
+    expect(reloaded_resource_charge_list1.active_holds[0].netid).to eq "one"
+    expect(query_service.find_by(id: resource_charge_list2.id).updated_at).to eq resource_charge_list2.updated_at
   end
 end

--- a/spec/resources/cdl/bulk_hold_processor_spec.rb
+++ b/spec/resources/cdl/bulk_hold_processor_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CDL::BulkHoldProcessor do
+  let(:query_service) { Valkyrie.config.metadata_adapter.query_service }
+  it "expires all expired holds" do
+    allow(CDL::EligibleItemService).to receive(:item_ids).and_return(["1"])
+    User.create!(uid: "one", email: "one@princeton.edu")
+    User.create!(uid: "two", email: "two@princeton.edu")
+    hold1 = FactoryBot.create_for_repository(:resource_charge_list, resource_id: FactoryBot.create_for_repository(:complete_private_scanned_resource).id, expired_hold_netids: ["one", "two"])
+    hold2 = FactoryBot.create_for_repository(:resource_charge_list, resource_id: FactoryBot.create_for_repository(:complete_private_scanned_resource).id)
+
+    described_class.new(change_set_persister: ScannedResourcesController.change_set_persister).process!
+
+    reloaded_hold1 = query_service.find_by(id: hold1.id)
+    expect(reloaded_hold1.updated_at).not_to eq hold1.updated_at
+    expect(query_service.find_by(id: hold2.id).updated_at).to eq hold2.updated_at
+  end
+end


### PR DESCRIPTION
This runs a cron which activates all possible holds every 10 minutes, sending the appropriate emails.

There's a possible alternate implementation which would use scheduled jobs, but it'd be significantly more complex (although likely require less processing power than this solution.)

Closes #4123 