### PR TITLE
Adds MARCRelator attributes to ScannedResourceChangeSet

### DIFF
--- a/app/resources/scanned_resources/scanned_resource_change_set.rb
+++ b/app/resources/scanned_resources/scanned_resource_change_set.rb
@@ -31,6 +31,9 @@ class ScannedResourceChangeSet < ChangeSet
   property :replaces, multiple: true, require: false
   property :identifier, multiple: false, require: false
 
+  # MARCRelator attributes
+  Schema::MARCRelators.attributes.each { |field| property field }
+
   # Virtual Attributes
   property :files, virtual: true, multiple: true, required: false
   property :pending_uploads, multiple: true, required: false

--- a/spec/resources/scanned_resources/scanned_resource_change_set_spec.rb
+++ b/spec/resources/scanned_resources/scanned_resource_change_set_spec.rb
@@ -143,4 +143,10 @@ RSpec.describe ScannedResourceChangeSet do
       expect(change_set.resource.claimed_by).to eq "tpend"
     end
   end
+
+  describe "MARCRelators" do
+    it "has MARCRelator properties" do
+      expect(change_set).to respond_to(:complainant_appellant)
+    end
+  end
 end


### PR DESCRIPTION
Adds the MARCRelator fields to the ScannedResourceChangeSet so that it can validate metadata fields requested by clients.