### PR TITLE
Run GC between pages to keep file handle usage low.

### DIFF
--- a/app/derivative_services/pdf_derivative_service.rb
+++ b/app/derivative_services/pdf_derivative_service.rb
@@ -28,7 +28,7 @@ class PDFDerivativeService
     tiffs = convert_pages
     add_file_sets(tiffs)
   ensure
-    FileUtils.remove_entry(tmpdir) if File.exist?(tmpdir)
+    FileUtils.remove_entry(tmpdir, true) if File.exist?(tmpdir)
   end
 
   def add_file_sets(files)

--- a/app/derivative_services/pdf_derivative_service.rb
+++ b/app/derivative_services/pdf_derivative_service.rb
@@ -97,7 +97,8 @@ class PDFDerivativeService
       original_filename: "converted_from_pdf_page_#{page}.tiff",
       container_attributes: {
         title: pad_with_zeroes(page)
-      }
+      },
+      copyable: true
     )
   end
 

--- a/app/derivative_services/pdf_derivative_service.rb
+++ b/app/derivative_services/pdf_derivative_service.rb
@@ -69,14 +69,21 @@ class PDFDerivativeService
   end
 
   def convert_pages
-    files = []
-    page = 0
-    loop do
-      image = convert_page(page: page)
-      break unless image
-      page += 1
-      files << build_file(page, image)
+    image = Vips::Image.pdfload(filename, access: :sequential, memory: true)
+    pages = image.get_value("pdf-n_pages")
+    files = Array.new(pages).each_with_index.map do |_, page|
+      # Ruby's set to mark and sweep for GC, and we can't explicitly close VIPS
+      # references. The file handles aren't freed up until the garbage collector
+      # runs, but it's 4 handles per VIPS access. So force a GC to keep the
+      # handles low.
+      # See https://github.com/libvips/ruby-vips/issues/67
+      GC.start
+      page_image = Vips::Image.new_from_file(filename, access: :sequential, memory: true, page: page)
+      location = temporary_output(page)
+      page_image.tiffsave(location.path.to_s)
+      build_file(page + 1, location)
     end
+    GC.start
     files
   end
 
@@ -94,17 +101,6 @@ class PDFDerivativeService
 
   def pad_with_zeroes(n)
     format("%08d", n)
-  end
-
-  def convert_page(page:)
-    vips_image = Vips::Image.pdfload(filename, page: page)
-    location = temporary_output(page).path.to_s
-    vips_image.tiffsave(location)
-    location
-  rescue Vips::Error => error
-    return nil if error.message.strip == "pdfload: pages out of range"
-    update_error_message(message: error.message)
-    raise error
   end
 
   def temporary_output(page)

--- a/app/derivative_services/pdf_derivative_service.rb
+++ b/app/derivative_services/pdf_derivative_service.rb
@@ -27,6 +27,9 @@ class PDFDerivativeService
     update_pdf_use
     tiffs = convert_pages
     add_file_sets(tiffs)
+  rescue StandardError => e
+    update_error_message(message: e.message)
+    raise e
   ensure
     FileUtils.remove_entry(tmpdir, true) if File.exist?(tmpdir)
   end


### PR DESCRIPTION
This also refactors things a bit to use a known page count and makes it so the `IngestableFile`s are `copyable: true`, so that it's `mv`'d instead of copied, which results in a bunch of file handles being held open.

I can confirm that this branch results in both example PDFs ingesting.