### PR TITLE
Deploy 'main' when we asked to deploy 'master'

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -4,10 +4,6 @@
 set :application, 'figgy'
 set :repo_url, 'https://github.com/pulibrary/figgy.git'
 
-# Default branch is :master
-# ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
-set :branch, ENV['BRANCH'] || 'master'
-
 # Default deploy_to directory is /var/www/my_app_name
 # set :deploy_to, '/var/www/my_app_name'
 set :deploy_to, '/opt/figgy'
@@ -36,6 +32,14 @@ set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/derivatives', 'tmp/up
 # Default value for keep_releases is 5
 # set :keep_releases, 5
 set :passenger_restart_with_touch, true
+
+# this will keep deploys from hubot-deploy working as expected
+def set_branch
+  branch = ENV['BRANCH'] || 'main'
+  return branch unless branch == 'master'
+  return 'main'
+end
+set :branch, set_branch
 
 desc "Write the current version to public/version.txt"
 task :write_version do


### PR DESCRIPTION
fixes #4195

excerpts from dry-run before:
```
00:00 git:create_release
      01 mkdir -p /opt/figgy/releases/20200818124448
      02 git archive master | /usr/bin/env tar -x -f - -C /opt/figgy/releases/202008181244…
```
```
00:00 deploy:log_revision
      01 echo "Branch master (at ) deployed as release 20200818124448 by hackmastera" >> /opt…
```

dry-run after:
```
00:00 git:create_release
      01 mkdir -p /opt/figgy/releases/20200818124526
      02 git archive main | /usr/bin/env tar -x -f - -C /opt/figgy/releases/20200818124526
```
```
00:00 deploy:log_revision
      01 echo "Branch main (at ) deployed as release 20200818124526 by hackmastera" >> /opt/f…
```