### PR TITLE
PDF Derivative Service should extract/move files in batches.

### DIFF
--- a/app/derivative_services/pdf_derivative_service.rb
+++ b/app/derivative_services/pdf_derivative_service.rb
@@ -36,10 +36,12 @@ class PDFDerivativeService
 
   def add_file_sets(files)
     resource = parent
-    files.each_slice(200) do |file_slice|
-      change_set = ChangeSet.for(resource)
-      change_set.validate(files: file_slice)
-      resource = change_set_persister.save(change_set: change_set)
+    change_set_persister.buffer_into_index do |buffered_change_set_persister|
+      files.each_slice(200) do |file_slice|
+        change_set = ChangeSet.for(resource)
+        change_set.validate(files: file_slice)
+        resource = buffered_change_set_persister.save(change_set: change_set)
+      end
     end
   end
 

--- a/app/derivative_services/pdf_derivative_service.rb
+++ b/app/derivative_services/pdf_derivative_service.rb
@@ -35,13 +35,12 @@ class PDFDerivativeService
   end
 
   def add_file_sets(files)
-    change_set = parent_change_set
-    change_set.validate(files: files)
-    change_set_persister.save(change_set: change_set)
-  end
-
-  def parent_change_set
-    ChangeSet.for(parent)
+    resource = parent
+    files.each_slice(200) do |file_slice|
+      change_set = ChangeSet.for(resource)
+      change_set.validate(files: file_slice)
+      resource = change_set_persister.save(change_set: change_set)
+    end
   end
 
   def parent
@@ -76,7 +75,7 @@ class PDFDerivativeService
   def convert_pages
     image = Vips::Image.pdfload(filename, access: :sequential, memory: true)
     pages = image.get_value("pdf-n_pages")
-    files = Array.new(pages).each_with_index.map do |_, page|
+    files = Array.new(pages).lazy.each_with_index.map do |_, page|
       # Ruby's set to mark and sweep for GC, and we can't explicitly close VIPS
       # references. The file handles aren't freed up until the garbage collector
       # runs, but it's 4 handles per VIPS access. So force a GC to keep the
@@ -88,7 +87,6 @@ class PDFDerivativeService
       page_image.tiffsave(location)
       build_file(page + 1, location)
     end
-    GC.start
     files
   end
 

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -358,7 +358,7 @@ Rails.application.config.to_prepare do
   Valkyrie::Derivatives::DerivativeService.services << PDFDerivativeService::Factory.new(
     change_set_persister: ::ChangeSetPersister.new(
       metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister),
-      storage_adapter: Valkyrie::StorageAdapter.find(:disk_via_copy)
+      storage_adapter: Valkyrie::StorageAdapter.find(:disk)
     )
   )
 


### PR DESCRIPTION
The lazy array makes it extract groups of 200 files at a time, then adds
them to the parent (in a transaction), which moves the files off the tmp
location. This should take care of the issue where we run out of space,
but if the extraction fails we may end up with orphan files in
production.

Closes #4215 