### PR TITLE
Don't process CDL Timer code if status check fails.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,12 @@ Release notes template:
 ## Removed
 
 -->
+# 2020-08-25
+
+## Fixed
+
+* Return this item button doesn't appear for non-CDL items now.
+
 # 2020-08-24
 
 ## Changed

--- a/app/javascript/test/viewer/cdl_timer.spec.js
+++ b/app/javascript/test/viewer/cdl_timer.spec.js
@@ -27,7 +27,8 @@ describe('CDLTimer', () => {
         'available': false
       }
       const mockFetchPromise = Promise.resolve({ // 3
-        json: () => json
+        json: () => json,
+        ok: true
       })
       global.fetch = jest.fn().mockImplementation(() => mockFetchPromise)
       const timer = new CDLTimer('b627a6ce-6717-4dd0-a16a-7a0c0b8a5788')
@@ -44,12 +45,34 @@ describe('CDLTimer', () => {
         'expires_at': Math.round(Date.now() / 1000) + 300
       }
       const mockFetchPromise = Promise.resolve({ // 3
-        json: () => json
+        json: () => json,
+        ok: true
       })
       global.fetch = jest.fn().mockImplementation(() => mockFetchPromise)
       const timer = new CDLTimer('b627a6ce-6717-4dd0-a16a-7a0c0b8a5788')
       await timer.initializeTimer()
       expect(document.getElementById('remaining-time').innerHTML).toMatch(/Remaining Checkout Time: \d\d:\d\d:\d\d/)
+    })
+
+    it("doesn't add a return button on error", async () => {
+      document.body.innerHTML = initialHTML
+
+      const json = {
+        'status': 500,
+        'error': 'Internal Server Error'
+      }
+
+      const mockFetchPromise = Promise.resolve({
+        json: () => json,
+        ok: false
+      })
+      global.fetch = jest.fn().mockImplementation(() => mockFetchPromise)
+
+      const timer = new CDLTimer('b627a6ce-6717-4dd0-a16a-7a0c0b8a5788')
+      await timer.initializeTimer()
+
+      let buttonElement = document.getElementById('return-early-button')
+      expect(buttonElement).toBe(null)
     })
 
     it('displays an expiration time if > 5 minutes left', async () => {
@@ -62,7 +85,8 @@ describe('CDLTimer', () => {
         'expires_at': expireTime
       }
       const mockFetchPromise = Promise.resolve({ // 3
-        json: () => json
+        json: () => json,
+        ok: true
       })
       global.fetch = jest.fn().mockImplementation(() => mockFetchPromise)
       const timer = new CDLTimer('b627a6ce-6717-4dd0-a16a-7a0c0b8a5788')
@@ -83,7 +107,8 @@ describe('CDLTimer', () => {
         'expires_at': expireTime
       }
       const mockFetchPromise = Promise.resolve({
-        json: () => json
+        json: () => json,
+        ok: true
       })
       global.fetch = jest.fn().mockImplementation(() => mockFetchPromise)
 
@@ -104,7 +129,8 @@ describe('CDLTimer', () => {
         'expires_at': expireTime
       }
       const mockFetchPromise = Promise.resolve({
-        json: () => json
+        json: () => json,
+        ok: true
       })
       global.fetch = jest.fn().mockImplementation(() => mockFetchPromise)
       const id = 'b627a6ce-6717-4dd0-a16a-7a0c0b8a5788'
@@ -125,7 +151,8 @@ describe('CDLTimer', () => {
         'expires_at': Math.round(Date.now() / 1000) - 1
       }
       const mockFetchPromise = Promise.resolve({ // 3
-        json: () => json
+        json: () => json,
+        ok: true
       })
       global.fetch = jest.fn().mockImplementation(() => mockFetchPromise)
 

--- a/app/javascript/viewer/cdl_timer.js
+++ b/app/javascript/viewer/cdl_timer.js
@@ -5,15 +5,18 @@ export default class CDLTimer {
 
   // Check time every second.
   async initializeTimer () {
-    this.status = await this.fetchStatus()
-    // If item isn't charged we're seeing it some other way - don't spin up a
-    // timer.
-    if (this.status.charged === false) { return }
-    this.setupReturnForm()
-    const uvPane = document.getElementById('uv').firstChild
-    uvPane.insertBefore(this.returnButton(), uvPane.firstChild)
-    await this.checkTime()
-    window.setInterval(() => { this.checkTime() }, 1000)
+    try {
+      this.status = await this.fetchStatus()
+      // If item isn't charged we're seeing it some other way - don't spin up a
+      // timer.
+      if (this.status.charged === false) { return }
+      this.setupReturnForm()
+      const uvPane = document.getElementById('uv').firstChild
+      uvPane.insertBefore(this.returnButton(), uvPane.firstChild)
+      await this.checkTime()
+      window.setInterval(() => { this.checkTime() }, 1000)
+    } catch (e) {
+    }
   }
 
   // We don't know the id when this form is set up in rails
@@ -84,7 +87,12 @@ export default class CDLTimer {
     return Math.round(Date.now() / 1000)
   }
 
+  okCheck (response) {
+    if (response.ok === true) { return response }
+    return Promise.reject(response)
+  }
+
   async fetchStatus () {
-    return fetch(`/cdl/${this.figgyId}/status`).then(response => response.json())
+    return fetch(`/cdl/${this.figgyId}/status`).then(this.okCheck).then(response => response.json())
   }
 }


### PR DESCRIPTION
This prevents attempting to parse a timer that doesn't exist as well as
displaying the return button on error.

Closes #4214