### PR TITLE
Use Lando for Postgres.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -12,6 +12,9 @@ services:
     core: figgy-core-dev
     config:
       dir: solr/config
+  figgy_database:
+    type: postgres:10
+    portforward: true
 proxy:
   figgy_test_solr:
     - figgy.test.solr.lndo.site:8983

--- a/README.md
+++ b/README.md
@@ -71,7 +71,31 @@ Remember you'll need to run `bundle install` and `yarn install` on an ongoing ba
 
 ## Setup server
 
-### Manual Setup
+You can either run Solr/Postgres locally or spin them up in Docker containers
+with Lando.
+
+### Lando
+
+Lando will automatically set up docker images for Solr and Postgres which match
+the versions we use in Production. The ports will not collide with any other
+projects you're using Solr/Postgres for, and you can easily clean up with `lando
+destroy` or turn off all services with `lando spindown`.
+
+1. Install Lando DMG from [[https://github.com/lando/lando/releases]]
+1. `lando start`
+
+1. For test:
+   - `RAILS_ENV=test rake db:setup`
+   - In a separate terminal: `bundle exec rspec`
+   - Run jest tests: `yarn test`
+1. For development:
+   - ``export SECRET_KEY_BASE=`rake secret` ``
+   - `rake db:setup`
+   - In a separate terminal: `foreman start` (you can close the one launching solr)
+     - Or run services separately as shown in [[https://github.com/pulibrary/figgy/blob/master/Procfile]]
+   - Access Figgy at http://localhost:3000/
+
+### Manual Local Setup (Deprecated)
 
 1. For test:
    - `RAILS_ENV=test rake db:setup`
@@ -84,23 +108,6 @@ Remember you'll need to run `bundle install` and `yarn install` on an ongoing ba
    - In a separate terminal: `foreman start`
      - Or run services separately as shown in [[https://github.com/pulibrary/figgy/blob/master/Procfile]]
      - If you run into problems with `solr_wrapper`, you can also start Solr with `rake figgy:development`
-   - Access Figgy at http://localhost:3000/
-
-### Lando
-
-1. Uninstall Docker
-2. Install Lando v3.0.0-rrc.4 or later DMG from [[https://github.com/lando/lando/releases]]
-3. `lando start`
-
-1. For test:
-   - `RAILS_ENV=test rake db:setup`
-   - In a separate terminal: `bundle exec rspec`
-   - Run jest tests: `yarn test`
-2. For development:
-   - ``export SECRET_KEY_BASE=`rake secret` ``
-   - `rake db:setup`
-   - In a separate terminal: `foreman start` (you can close the one launching solr)
-     - Or run services separately as shown in [[https://github.com/pulibrary/figgy/blob/master/Procfile]]
    - Access Figgy at http://localhost:3000/
 
 ## Load sample development data

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ with Lando.
 Lando will automatically set up docker images for Solr and Postgres which match
 the versions we use in Production. The ports will not collide with any other
 projects you're using Solr/Postgres for, and you can easily clean up with `lando
-destroy` or turn off all services with `lando spindown`.
+destroy` or turn off all services with `lando poweroff`.
 
 1. Install Lando DMG from [[https://github.com/lando/lando/releases]]
 1. `lando start`

--- a/README.md
+++ b/README.md
@@ -91,11 +91,13 @@ destroy` or turn off all services with `lando poweroff`.
 1. For development:
    - ``export SECRET_KEY_BASE=`rake secret` ``
    - `rake db:setup`
-   - In a separate terminal: `foreman start` (you can close the one launching solr)
+   - In a separate terminal: `foreman start`
      - Or run services separately as shown in [[https://github.com/pulibrary/figgy/blob/master/Procfile]]
    - Access Figgy at http://localhost:3000/
 
 ### Manual Local Setup (Deprecated)
+
+The following steps will not work if you have Lando installed on your machine.
 
 1. For test:
    - `RAILS_ENV=test rake db:setup`
@@ -105,9 +107,9 @@ destroy` or turn off all services with `lando poweroff`.
 2. For development:
    - ``export SECRET_KEY_BASE=`rake secret` ``
    - `rake db:setup`
+   - `rake figgy:development`
    - In a separate terminal: `foreman start`
      - Or run services separately as shown in [[https://github.com/pulibrary/figgy/blob/master/Procfile]]
-     - If you run into problems with `solr_wrapper`, you can also start Solr with `rake figgy:development`
    - Access Figgy at http://localhost:3000/
 
 ## Load sample development data

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,12 +6,18 @@ development: &default
   pool: <%= Integer(ENV.fetch("DB_POOL", 30)) %>
   reaping_frequency: <%= Integer(ENV.fetch("DB_REAPING_FREQUENCY", 20)) %>
   timeout: 5000
+  host: <%= ENV["lando_figgy_database_conn_host"] %>
+  port: <%= ENV["lando_figgy_database_conn_port"] %>
+  username: <%= ENV["lando_figgy_database_creds_user"] %>
+  password: <%= ENV["lando_figgy_database_creds_password"] %>
 
 test:
   <<: *default
   host: <%= ENV["FIGGY_DB_HOST"] %>
-  username: <%= Figgy.read_only_mode ? ENV["FIGGY_DB_RO_USERNAME"] : ENV["FIGGY_DB_USERNAME"] %>
-  password: <%= Figgy.read_only_mode ? ENV["FIGGY_DB_RO_PASSWORD"] : ENV["FIGGY_DB_PASSWORD"] %>
+  username: <%= (Figgy.read_only_mode ? ENV["FIGGY_DB_RO_USERNAME"] : ENV["FIGGY_DB_USERNAME"]) || ENV["lando_figgy_database_creds_user"] %>
+  password: <%= (Figgy.read_only_mode ? ENV["FIGGY_DB_RO_PASSWORD"] : ENV["FIGGY_DB_PASSWORD"]) || ENV["lando_figgy_database_creds_password"] %>
+  host: <%= ENV["lando_figgy_database_conn_host"] %>
+  port: <%= ENV["lando_figgy_database_conn_port"] %>
   database: figgy_test
 
 production: &deploy

--- a/config/database.yml
+++ b/config/database.yml
@@ -16,8 +16,8 @@ test:
   host: <%= ENV["FIGGY_DB_HOST"] %>
   username: <%= (Figgy.read_only_mode ? ENV["FIGGY_DB_RO_USERNAME"] : ENV["FIGGY_DB_USERNAME"]) || ENV["lando_figgy_database_creds_user"] %>
   password: <%= (Figgy.read_only_mode ? ENV["FIGGY_DB_RO_PASSWORD"] : ENV["FIGGY_DB_PASSWORD"]) || ENV["lando_figgy_database_creds_password"] %>
-  host: <%= ENV["lando_figgy_database_conn_host"] %>
-  port: <%= ENV["lando_figgy_database_conn_port"] %>
+  host: <%= ENV["FIGGY_DB_HOST"] || ENV["lando_figgy_database_conn_host"] %>
+  port: <%= ENV["FIGGY_DB_HOST"] ? nil : ENV["lando_figgy_database_conn_port"] %>
   database: figgy_test
 
 production: &deploy

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -2,6 +2,7 @@
 require_relative "figgy"
 
 Rails.application.config.to_prepare do
+  begin
   # Registers a storage adapter for a *NIX file system
   # Binaries are persisted by invoking "mv" with access limited to read/write for owning users, and read-only for all others
   # NOTE: "mv" may preserve the inode for the file system
@@ -419,6 +420,7 @@ Rails.application.config.to_prepare do
 
   # Ensure that the logger used for Valkyrie is the same used by Rails
   Valkyrie.logger = Rails.logger
-rescue Sequel::DatabaseConnectionError
-  Rails.logger.info "Unable to connect to database - skipping Valkyrie initialization."
+  rescue Sequel::DatabaseConnectionError
+    Rails.logger.info "Unable to connect to database - skipping Valkyrie initialization."
+end
 end

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -419,4 +419,6 @@ Rails.application.config.to_prepare do
 
   # Ensure that the logger used for Valkyrie is the same used by Rails
   Valkyrie.logger = Rails.logger
+rescue Sequel::DatabaseConnectionError
+  Rails.logger.info "Unable to connect to database - skipping Valkyrie initialization."
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -10,6 +10,20 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+
+
+--
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+
+
+--
 -- Name: uuid-ossp; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -1006,11 +1020,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200225213135'),
 ('20200422192849'),
 ('20200423183539'),
-('20200605213204'),
-('20200605214148'),
-('20200605215751'),
-('20200608044923'),
-('20200608055833'),
 ('20200608160046');
 
 


### PR DESCRIPTION
This keeps us locked to the Postgres version we're running in
production, and keeps all the developers on the same version for this
project as well, resulting in a consistent schema file on rake
db:migrate.

Closes #4212 