### PR TITLE
Test FacetIndexer from Solr directly

### DIFF
--- a/app/indexers/facet_indexer.rb
+++ b/app/indexers/facet_indexer.rb
@@ -52,15 +52,16 @@ class FacetIndexer
   def pub_date_start
     date = resource.primary_imported_metadata.created
     return unless date.present?
-    date = date.first
-    date =
-      begin
-        Time.zone.parse(date) unless date.is_a?(Time)
-      rescue TypeError, ArgumentError
-        nil
-      end
+    date = parse_date(date.first)
     return unless date
     date.year
+  end
+
+  def parse_date(date)
+    return date if date.is_a?(Time)
+    Time.zone.parse(date)
+  rescue TypeError, ArgumentError
+    nil
   end
 
   def decorated_resource

--- a/spec/indexers/facet_indexer_spec.rb
+++ b/spec/indexers/facet_indexer_spec.rb
@@ -7,6 +7,16 @@ RSpec.describe FacetIndexer do
       it "indexes relevant facets" do
         stub_bibdata(bib_id: "123456")
         scanned_resource = FactoryBot.create(:pending_scanned_resource, source_metadata_identifier: "123456", import_metadata: true)
+        solr_record = Blacklight.default_index.connection.get("select", params: { qt: "document", q: "*:*" })["response"]["docs"][0]
+
+        expect(solr_record["display_subject_ssim"]).to eq scanned_resource.imported_metadata.first.subject
+        expect(solr_record["display_language_ssim"]).to eq ["English"]
+        expect(solr_record["pub_date_start_itsi"]).to eq 1982
+      end
+
+      it "reindexes relevant facets" do
+        stub_bibdata(bib_id: "123456")
+        scanned_resource = FactoryBot.create(:pending_scanned_resource, source_metadata_identifier: "123456", import_metadata: true)
         output = described_class.new(resource: scanned_resource).to_solr
 
         expect(output[:display_subject_ssim]).to eq scanned_resource.imported_metadata.first.subject


### PR DESCRIPTION
The tests for this class actually hit the class twice, once when the
record is created (and the metadata is pulled), and then again when
`described_class.to_solr` is called. The first time dates come through
as Time objects. The second time they come through as strings. There was
a bug in the code giving a nil value when the date was a Time object,
which the tests didn't catch because they were only checking values via
`described_class`. Adding a test that looks at the index directly gave a
failing test from which to resolve the bug.