### PR TITLE
Don't reindex PreservationObjects.

### DIFF
--- a/app/services/reindexer.rb
+++ b/app/services/reindexer.rb
@@ -47,7 +47,7 @@ class Reindexer
   end
 
   def reindex_works
-    reindex_all(except_models: excluded_models + ["FileSet"])
+    reindex_all(except_models: excluded_models + ["FileSet", "PreservationObject"])
   end
 
   def run_individual_retries(records, progress_bar)

--- a/spec/services/reindexer_spec.rb
+++ b/spec/services/reindexer_spec.rb
@@ -104,10 +104,11 @@ RSpec.describe Reindexer do
   end
 
   describe ".reindex_works" do
-    context "when there are FileSets" do
+    context "when there are disallowed models" do
       it "doesn't index them" do
         postgres_adapter.persister.save(resource: FactoryBot.build(:file_set))
         scanned_resource = postgres_adapter.persister.save(resource: FactoryBot.build(:scanned_resource))
+        postgres_adapter.persister.save(resource: FactoryBot.build(:preservation_object))
         described_class.reindex_works(logger: logger, wipe: true)
         expect(solr_adapter.query_service.find_all.map(&:id)).to eq([scanned_resource.id])
       end


### PR DESCRIPTION
There's millions, most of them point to FileSets, and we don't really
use their Solr records.