### PR TITLE
2586 bulk edit

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -724,6 +724,9 @@ skipping them.
 * Display title of a playlist at the top of the Playlist viewer. [#3203](https://github.com/pulibrary/figgy/issues/3203)
 * Add depositor facet [#3217](https://github.com/pulibrary/figgy/issues/3217)
 
+## Changed
+* Modified BulkEditService to enable users to add all items in one collection to another [#2586](https://github.com/pulibrary/figgy/issues/2586)
+
 ## Fixed
 
 * Don't ingest hidden files which start with a `.`

--- a/app/services/bulk_edit_service.rb
+++ b/app/services/bulk_edit_service.rb
@@ -20,8 +20,8 @@ class BulkEditService
     incorporated_attributes = {}
     proposed_attributes.each_key do |key|
       incorporated_attributes[key] = case key
-                                     when :member_of_collection_ids
-                                       existing_attributes[key] << proposed_attributes[key]
+                                     when :append_collection_ids
+                                       existing_attributes[:member_of_collection_ids] << proposed_attributes[key]
                                      else
                                        proposed_attributes[key]
                                      end

--- a/app/services/bulk_edit_service.rb
+++ b/app/services/bulk_edit_service.rb
@@ -8,7 +8,7 @@ class BulkEditService
     c.decorate.members.each do |member|
       logger.info "Updating attributes for #{member}"
       change_set = ChangeSet.for(member)
-      if change_set.validate(incorporate_proposed_attributes(member.attributes, attributes))
+      if change_set.validate(append_or_replace_attributes(member.attributes, attributes))
         change_set_persister.save(change_set: change_set)
       else
         logger.warn "  Failed validation: #{change_set.errors}"
@@ -16,7 +16,7 @@ class BulkEditService
     end
   end
 
-  def self.incorporate_proposed_attributes(existing_attributes, proposed_attributes)
+  def self.append_or_replace_attributes(existing_attributes, proposed_attributes)
     incorporated_attributes = {}
     proposed_attributes.each_key do |key|
       incorporated_attributes[key] = case key

--- a/app/services/bulk_edit_service.rb
+++ b/app/services/bulk_edit_service.rb
@@ -8,11 +8,24 @@ class BulkEditService
     c.decorate.members.each do |member|
       logger.info "Updating attributes for #{member}"
       change_set = ChangeSet.for(member)
-      if change_set.validate(attributes)
+      if change_set.validate(incorporate_proposed_attributes(member.attributes, attributes))
         change_set_persister.save(change_set: change_set)
       else
         logger.warn "  Failed validation: #{change_set.errors}"
       end
     end
+  end
+
+  def self.incorporate_proposed_attributes(existing_attributes, proposed_attributes)
+    incorporated_attributes = {}
+    proposed_attributes.each_key do |key|
+      incorporated_attributes[key] = case key
+                                     when :member_of_collection_ids
+                                       existing_attributes[key] << proposed_attributes[key]
+                                     else
+                                       proposed_attributes[key]
+                                     end
+    end
+    incorporated_attributes
   end
 end

--- a/lib/tasks/bulk.rake
+++ b/lib/tasks/bulk.rake
@@ -318,11 +318,11 @@ namespace :bulk do
   desc "Adds all members of a Collection to an additional collection"
   task update_attrs: :environment do
     coll = ENV["COLL"]
-    add_coll = ENV["ADD_COLL"]
+    append_coll = ENV["APPEND_COLL"]
 
-    abort "usage: rake bulk:update_attrs COLL=[collection id] ADD_COLL=[new collection id]" unless coll && add_coll
+    abort "usage: rake bulk:update_attrs COLL=[collection id] APPEND_COLL=[new collection id]" unless coll && append_coll
     logger = Logger.new(STDOUT)
-    attrs = { member_of_collection_ids: Valkyrie::ID.new(add_coll) }
+    attrs = { member_of_collection_ids: Valkyrie::ID.new(append_coll) }
     BulkEditService.perform(collection_id: Valkyrie::ID.new(coll), attributes: attrs, metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister), logger: logger)
   end
 end

--- a/lib/tasks/bulk.rake
+++ b/lib/tasks/bulk.rake
@@ -314,4 +314,15 @@ namespace :bulk do
       @logger.error "Error: #{e.message}"
     end
   end
+
+  desc "Adds all members of a Collection to an additional collection"
+  task update_attrs: :environment do
+    coll = ENV["COLL"]
+    add_coll = ENV["ADD_COLL"]
+
+    abort "usage: rake bulk:update_attrs COLL=[collection id] ADD_COLL=[new collection id]" unless coll && add_coll
+    logger = Logger.new(STDOUT)
+    attrs = { member_of_collection_ids: Valkyrie::ID.new(add_coll) }
+    BulkEditService.perform(collection_id: Valkyrie::ID.new(coll), attributes: attrs, metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister), logger: logger)
+  end
 end

--- a/lib/tasks/bulk.rake
+++ b/lib/tasks/bulk.rake
@@ -322,7 +322,7 @@ namespace :bulk do
 
     abort "usage: rake bulk:update_attrs COLL=[collection id] APPEND_COLL=[new collection id]" unless coll && append_coll
     logger = Logger.new(STDOUT)
-    attrs = { member_of_collection_ids: Valkyrie::ID.new(append_coll) }
+    attrs = { append_collection_ids: Valkyrie::ID.new(append_coll) }
     BulkEditService.perform(collection_id: Valkyrie::ID.new(coll), attributes: attrs, metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister), logger: logger)
   end
 end

--- a/spec/services/bulk_edit_service_spec.rb
+++ b/spec/services/bulk_edit_service_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe BulkEditService do
         obj = FactoryBot.create_for_repository(:scanned_resource,
                                                member_of_collection_ids: [collection.id],
                                                title: "original")
-        attrs = { member_of_collection_ids: collection2.id, title: "updated" }
+        attrs = { append_collection_ids: collection2.id, title: "updated" }
         described_class.perform(collection_id: collection.id, attributes: attrs, logger: logger)
 
         after = query_service.find_by(id: obj.id)

--- a/spec/services/bulk_edit_service_spec.rb
+++ b/spec/services/bulk_edit_service_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 RSpec.describe BulkEditService do
   let(:query_service) { Valkyrie.config.metadata_adapter.query_service }
   let(:collection) { FactoryBot.create_for_repository(:collection) }
+  let(:collection2) { FactoryBot.create_for_repository(:collection) }
   let(:logger) { Logger.new(nil) }
   let(:initial_rights) { RightsStatements.no_known_copyright }
   let(:new_rights) { RightsStatements.copyright_not_evaluated }
@@ -78,6 +79,21 @@ RSpec.describe BulkEditService do
         after = query_service.find_by(id: obj2.id)
         expect(after.rights_statement).to eq([new_rights])
         expect(after.state).to eq(["complete"])
+      end
+    end
+
+    context "when updating collection_ids" do
+      it "adds to the existing collection set" do
+        obj = FactoryBot.create_for_repository(:scanned_resource,
+                                               member_of_collection_ids: [collection.id],
+                                               title: "original")
+        attrs = { member_of_collection_ids: collection2.id, title: "updated" }
+        described_class.perform(collection_id: collection.id, attributes: attrs, logger: logger)
+
+        after = query_service.find_by(id: obj.id)
+        expect(after.member_of_collection_ids).to include(collection.id)
+        expect(after.member_of_collection_ids).to include(collection2.id)
+        expect(after.title).to eq(["updated"])
       end
     end
   end


### PR DESCRIPTION
addresses #2586, #2862, and #4185 

- Extends bulk_edit_service to enable all items of a collection to be added to another collection.
- Provides a rake task to support this extension.

The GUI form is not addressed in this PR.