### PR TITLE
Run CDL a lot more often.

### DIFF
--- a/app/resources/cdl/automatic_ingester.rb
+++ b/app/resources/cdl/automatic_ingester.rb
@@ -16,6 +16,7 @@ module CDL
       Dir.glob(root_path.join("*.pdf")).each do |file|
         file = Pathname.new(file)
         next unless RemoteRecord.bibdata?(file.basename(".*").to_s)
+        next unless Time.current - File.mtime(file.to_s) > 1.hour
         FileUtils.mv(file, root_path.join("ingesting", file.basename))
         CDL::PDFIngestJob.perform_later(file_name: file.basename.to_s)
       end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -28,7 +28,7 @@ every 10.minutes, roles: [:db] do
   rake "cdl:bulk_hold_process"
 end
 
-every :day, at: "2:00 AM", roles: [:db] do
+every 1.hour, roles: [:db] do
   rake "cdl:automatic_ingest"
 end
 

--- a/spec/resources/cdl/automatic_ingester_spec.rb
+++ b/spec/resources/cdl/automatic_ingester_spec.rb
@@ -4,10 +4,15 @@ require "rails_helper"
 
 RSpec.describe CDL::AutomaticIngester do
   context "when given multiple files, some of which are PDFs" do
-    it "queues a background job to ingest each of the PDFs with a valid source metadata identifier" do
+    it "queues a background job to ingest each of the PDFs with a valid source metadata identifier that are older than 1 hour" do
+      allow(File).to receive(:mtime).and_call_original
       file_path = Pathname.new(Figgy.config["cdl_in_path"])
       FileUtils.mkdir_p(file_path.join("ingesting")) unless File.exist?(file_path.join("ingesting"))
       FileUtils.cp(Rails.root.join("spec", "fixtures", "files", "sample.pdf"), file_path.join("123456.pdf"))
+      allow(File).to receive(:mtime).with(file_path.join("123456.pdf").to_s).and_return(1.hour.ago)
+      # Recently copied file - don't ingest.
+      FileUtils.cp(Rails.root.join("spec", "fixtures", "files", "sample.pdf"), file_path.join("56789.pdf"))
+      # Not a bib - don't ingest.
       FileUtils.cp(Rails.root.join("spec", "fixtures", "files", "sample.pdf"), file_path.join("notabib.pdf"))
       # Ensure already ingesting files aren't ingested again.
       FileUtils.cp(Rails.root.join("spec", "fixtures", "files", "sample.pdf"), file_path.join("ingesting", "45678.pdf"))


### PR DESCRIPTION
This will ingest any CDL file that hasn't been modified in the last
hour. Should decrease maximum time between copy and ingest to two hours.

An unfortunate side effect of this is they'll get emails a lot more often, probably, and throughout the day.