### PR TITLE
Adds from_csv task

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,10 @@ Release notes template:
 ## Removed
 
 -->
+# 2020-10-09
+## Added
+* bulk.rake now includes a task to ingest resources and metadata from a csv file.
+
 # 2020-09-21
 
 # Added

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -139,6 +139,7 @@ class CatalogController < ApplicationController
     config.add_index_field "state_ssim", label: "State"
     config.add_index_field "call_number_tsim", label: "Call Number"
     config.add_index_field "part_of_ssim", label: "Part Of"
+    config.add_index_field "imported_date_created_tesim", label: "Date"
   end
 
   # Determine whether or not a user can edit the resource in the current context

--- a/app/derivative_services/hocr_derivative_service.rb
+++ b/app/derivative_services/hocr_derivative_service.rb
@@ -15,11 +15,11 @@ class HocrDerivativeService
   end
 
   attr_reader :change_set_persister, :processor, :id
-  delegate :mime_type, to: :original_file
+  delegate :mime_type, to: :primary_file
   delegate :resource, to: :change_set
   delegate :metadata_adapter, :storage_adapter, to: :change_set_persister
   delegate :query_service, to: :metadata_adapter
-  delegate :original_file, to: :resource
+  delegate :primary_file, to: :resource
   def initialize(change_set_persister:, processor_factory:, id:)
     @change_set_persister = change_set_persister
     @id = id
@@ -57,7 +57,7 @@ class HocrDerivativeService
   end
 
   def file_object
-    @file_object ||= Valkyrie::StorageAdapter.find_by(id: original_file.file_identifiers[0])
+    @file_object ||= Valkyrie::StorageAdapter.find_by(id: primary_file.file_identifiers[0])
   end
 
   class TesseractProcessor

--- a/lib/tasks/bulk.rake
+++ b/lib/tasks/bulk.rake
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require "csv"
 
-
 namespace :bulk do
   desc "Migrates directory of METS files"
   task ingest_mets: :environment do
@@ -335,7 +334,7 @@ namespace :bulk do
     coll = ENV["COLL"]
     csvfile = ENV["CSV"]
 
-    abort "usage: COLL=collection_id BASEDIR=directory CSV=csvfile rake bulk:from_csv" unless coll && basedir 
+    abort "usage: COLL=collection_id BASEDIR=directory CSV=csvfile rake bulk:from_csv" unless coll && basedir
     abort "no such file #{csvfile}" unless File.file?(csvfile)
 
     user = User.find_by_user_key(ENV["USER"]) if ENV["USER"]
@@ -366,8 +365,7 @@ namespace :bulk do
         member_of_collection_ids: [coll],
         file_filters: filters,
         attributes: attrs
-        )
-      
+      )
     end
   end
 end

--- a/lib/tasks/bulk.rake
+++ b/lib/tasks/bulk.rake
@@ -336,9 +336,6 @@ namespace :bulk do
 
     abort "usage: COLL=collection_id BASEDIR=directory CSV=csvfile rake bulk:from_csv" unless coll && basedir
     abort "no such file #{csvfile}" unless File.file?(csvfile)
-
-    user = User.find_by_user_key(ENV["USER"]) if ENV["USER"]
-    user = User.all.select(&:admin?).first unless user
     class_name = "ScannedResource"
     @logger = Logger.new(STDOUT)
 
@@ -352,10 +349,7 @@ namespace :bulk do
     logger.info "processing #{csv.length} rows"
     csv.each do |row|
       logger.info "processing #{row}"
-      attrs = {}
-      row.to_h.keys.each do |k|
-        attrs[k.to_sym] = row[k]
-      end
+      attrs = row.map { |k, v| [k.to_sym, v] }.to_h
       dir = File.join(basedir, attrs.delete(:path))
       filters = [".jpg", ".png"]
       @logger.info "dir: #{dir}; class_name: #{class_name}; file_filters: #{filters}; attributes: #{attrs}"

--- a/spec/change_set_persisters/change_set_persister_spec.rb
+++ b/spec/change_set_persisters/change_set_persister_spec.rb
@@ -1949,6 +1949,13 @@ RSpec.describe ChangeSetPersister do
 
       expect(file_set.primary_file.checksum).to be_present
     end
+    it "creates resources which can be OCR'd" do
+      file = fixture_file_upload("files/sample.pdf", "application/pdf")
+      resource = FactoryBot.create_for_repository(:scanned_resource, files: [file], ocr_language: "eng")
+      file_set = Wayfinder.for(resource).members.last
+
+      expect(file_set.ocr_content).to be_present
+    end
   end
 
   context "when telling an archival_media_collection to reorganize" do


### PR DESCRIPTION
I'm opening this PR to start a discussion about how to do this properly.  The rake task from_csv is a placeholder; it should be replaced with a service/job pair. But my primary question has to do with how to handle the mapping of csv headers to resource attributes: as implemented here it is a casual hack.  Some sort of mapping table is one possibility.  Another (or an extension of the mapping-table idea) is to create an Ingestible class that can take something like a CSV row (or a hash, or whatever) and create a valid set of parameters for ingestion: class of resource, path to resource (validated to exist), required attributes, additional attributes. Many of these bulk rake tasks could then be refactored to work with Ingestibles.

Or perhaps I'm missing something entirely; perhaps this is already implemented in some way; perhaps you have better ideas?