### PR TITLE
Fix display of fixity checks from deleted resources.

### DIFF
--- a/app/views/fixity_dashboard/_cloud_fixity_table.html.erb
+++ b/app/views/fixity_dashboard/_cloud_fixity_table.html.erb
@@ -10,8 +10,18 @@
   <tbody>
     <% resources.each do |event| %>
       <tr>
-        <td><%= link_to(event.affected_resource.preserved_resource.title.first, solr_document_path(id: event.affected_resource.preserved_resource.id)) %></td>
-        <td><%= link_to(event.affected_child.label.first, solr_document_path(id: event.affected_resource.preserved_resource.id)) %></td>
+        <td>
+          <% if event.affected_resource&.preserved_resource.present? %>
+            <%= link_to(event.affected_resource.preserved_resource.title.first, solr_document_path(id: event.affected_resource.preserved_resource.id)) %>
+          <% else %>
+            Preservation Object: <%= event.resource_id %> (Deleted)
+          <% end %>
+        </td>
+        <td>
+          <% if event.affected_child.present? && event.affected_resource.preserved_resource.present? %>
+            <%= link_to(event.affected_child.label.first, solr_document_path(id: event.affected_resource.preserved_resource.id)) %>
+          <% end %>
+        </td>
         <td><%= event.status %></td>
         <td><%= event.updated_at %></td>
       </tr>

--- a/spec/features/fixity_dashboard_spec.rb
+++ b/spec/features/fixity_dashboard_spec.rb
@@ -32,6 +32,22 @@ RSpec.feature "Fixity dashboard" do
     end
   end
 
+  context "the fixity check for a resource by a cloud service provider is for a deleted resource" do
+    it "displays that the event was a success and that the preservation object was deleted" do
+      cloud_fixity_event
+      file_set
+      preservation_object
+      metadata_adapter.persister.delete(resource: file_set)
+      metadata_adapter.persister.delete(resource: preservation_object)
+      metadata_adapter.persister.delete(resource: scanned_resource)
+
+      visit fixity_dashboard_path
+
+      expect(page).to have_css "#cloud-fixity-checks table tr td", text: "Preservation Object: #{preservation_object.id} (Deleted)"
+      expect(page).to have_css "#cloud-fixity-checks table tr td", text: "SUCCESS"
+    end
+  end
+
   context "the fixity check for a resource by a cloud service provider has failed" do
     scenario "it displays that the event was a failure and links to the resource" do
       failed_cloud_fixity_event


### PR DESCRIPTION
Makes fixity dashboard display again.

Closes #3814 