### PR TITLE
Pass host roles to Whenever.

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -91,9 +91,9 @@ namespace :deploy do
 
   desc "Generate the crontab tasks using Whenever"
   task :whenever do
-    on roles(:db) do
+    on roles(:db) do |host|
       within release_path do
-        execute("cd #{release_path} && bundle exec whenever --update-crontab #{fetch :application} --set environment=#{fetch :rails_env, fetch(:stage, 'production')} --user deploy")
+        execute("cd #{release_path} && bundle exec whenever --update-crontab #{fetch :application} --set environment=#{fetch :rails_env, fetch(:stage, 'production')} --user=deploy --roles=#{host.roles_array.join(",")}")
       end
     end
   end


### PR DESCRIPTION
Prevents the export:pulfa job from running in staging.

This is how Whenever's built in task works: https://github.com/javan/whenever/blob/master/lib/whenever/capistrano/v3/tasks/whenever.rake#L27-L28

I tried to use the built in task and couldn't get it to use the release_path correctly for some reason, so adjusting our custom task seemed easiest.

Closes #3462