### PR TITLE
Disable Finding Aids Refresh

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -9,7 +9,9 @@ job_type :logging_rake, "cd :path && :environment_variable=:environment bundle e
 
 every :day, at: "11:00 PM", roles: [:db] do
   logging_rake "figgy:update_bib_ids", output: "/tmp/figgy_update_bib_ids.log"
-  logging_rake "figgy:refresh:finding_aids:all", output: "/tmp/figgy_update_finding_aids.log"
+  # Disabled - it wasn't working and the requests from DPUL working to reindex
+  # from Figgy were crashing Figgy.
+  # logging_rake "figgy:refresh:finding_aids:all", output: "/tmp/figgy_update_finding_aids.log"
 end
 
 every :monday, at: "10am", roles: [:db] do


### PR DESCRIPTION
The task is broken (see https://github.com/pulibrary/figgy/issues/4149), when it's fixed this will be too slow to run every night, we're about to switch to ASpace, and refreshing everything is breaking Figgy at night.