### PR TITLE
Restoring location to the IIIF manifest metadata hash

### DIFF
--- a/app/decorators/valkyrie/resource_decorator.rb
+++ b/app/decorators/valkyrie/resource_decorator.rb
@@ -167,7 +167,6 @@ class Valkyrie::ResourceDecorator < ApplicationDecorator
       :created_at,
       :depositor,
       :description, # this is included in the manifest builder
-      :location,
       :pdf_type,
       :references,
       :updated_at

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -445,7 +445,7 @@ RSpec.describe ManifestBuilder do
       expect(output).to include "metadata"
       metadata = output["metadata"]
       expect(metadata).to be_kind_of Array
-      expect(metadata.length).to eq(7)
+      expect(metadata.length).to eq(8)
 
       metadata_object = metadata.find { |h| h["label"] == "Portion Note" }
       metadata_values = metadata_object["value"]

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -451,7 +451,9 @@ RSpec.describe ManifestBuilder do
       metadata_values = metadata_object["value"]
       expect(metadata_values).to be_kind_of Array
       expect(metadata_values).to include "test value1"
-      expect(metadata_values).to include "RCPPA BL980.G7 B66 1982"
+
+      location = metadata.find { |h| h["label"] == "Location" }
+      expect(location["value"]).to include "RCPPA BL980.G7 B66 1982"
     end
 
     context "when the resource has linked vocabulary terms" do

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -451,6 +451,7 @@ RSpec.describe ManifestBuilder do
       metadata_values = metadata_object["value"]
       expect(metadata_values).to be_kind_of Array
       expect(metadata_values).to include "test value1"
+      expect(metadata_values).to include "RCPPA BL980.G7 B66 1982"
     end
 
     context "when the resource has linked vocabulary terms" do


### PR DESCRIPTION
Location was removed from the IIIF manifest metadata hash in a broader cleanup guided by feedback from the Cicognara project (#2358). But there was no substantive discussion of that field in particular, and that project no longer uses the metadata hash for its displays.

The Grounds and Buildings collection has item-level location information for thousands of photographs, and displaying this field will allow researchers to request viewing the original photographs.