### PR TITLE
Don't build child thumbnails for collection manifests.

### DIFF
--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -799,6 +799,9 @@ class ManifestBuilder
       @manifest ||= begin
         if audio_collection? || recording?
           IIIFManifest::V3::ManifestFactory.new(@resource, manifest_service_locator: ManifestServiceLocatorV3).to_h
+        # If not multi-part and a collection, it's not a MVW
+        elsif @resource.viewing_hint.blank? && @resource.collection?
+          IIIFManifest::ManifestFactory.new(@resource, manifest_service_locator: CollectionManifestServiceLocator).to_h
         else
           # note this assumes audio resources use flat modeling
           IIIFManifest::ManifestFactory.new(@resource, manifest_service_locator: ManifestServiceLocator).to_h

--- a/app/services/manifest_builder/collection_manifest_service_locator.rb
+++ b/app/services/manifest_builder/collection_manifest_service_locator.rb
@@ -4,8 +4,9 @@ class ManifestBuilder
   # performance.
   class CollectionManifestServiceLocator < ManifestBuilder::ManifestServiceLocator
     class << self
-      ##
       # Builder for a manifest which is a sub-item in a collection.
+      # @note This is the same as in ManifestServiceLocator, but there's no
+      #   thumbnail builder, to improve render time.
       def real_child_manifest_builder
         IIIFManifest::ManifestServiceLocator::InjectedFactory.new(
           IIIFManifest::ManifestBuilder,

--- a/app/services/manifest_builder/collection_manifest_service_locator.rb
+++ b/app/services/manifest_builder/collection_manifest_service_locator.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+class ManifestBuilder
+  # Collections have fewer builders (notably the thumbnail builder) to improve
+  # performance.
+  class CollectionManifestServiceLocator < ManifestBuilder::ManifestServiceLocator
+    class << self
+      ##
+      # Builder for a manifest which is a sub-item in a collection.
+      def real_child_manifest_builder
+        IIIFManifest::ManifestServiceLocator::InjectedFactory.new(
+          IIIFManifest::ManifestBuilder,
+          builders:
+          composite_builder_factory.new(
+            child_record_property_builder,
+            composite_builder: composite_builder
+          ),
+          top_record_factory: iiif_manifest_factory
+        )
+      end
+    end
+  end
+end

--- a/spec/services/manifest_builder/thumbnail_builder_spec.rb
+++ b/spec/services/manifest_builder/thumbnail_builder_spec.rb
@@ -70,9 +70,9 @@ describe ManifestBuilder::ThumbnailBuilder do
 
     context "when viewing a Multi-Volume Work" do
       let(:persisted_volume) do
-        change_set_persister.save(change_set: change_set)
+        FactoryBot.create_for_repository(:scanned_resource, files: [file])
       end
-      let(:parent_change_set) { ScannedResourceChangeSet.new(scanned_resource, member_ids: [persisted_volume.id]) }
+      let(:parent_change_set) { ScannedResourceChangeSet.new(scanned_resource, member_ids: [persisted_volume.id], thumbnail_id: persisted_volume.id) }
       let(:persisted) do
         change_set_persister.save(change_set: parent_change_set)
       end


### PR DESCRIPTION
We need MVWs to have them for sync to DPUL, but we don't need it for
collection manifests and it adds a ton of extra queries.

Work towards #1656