### PR TITLE
Expand fields included in ephemera metadata export

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -137,6 +137,7 @@ Metrics/LineLength:
     - 'spec/helpers/application_helper_spec.rb'
     - 'spec/resources/collections/collections_controller_spec.rb'
     - 'spec/models/oai/figgy/valkyrie_provider_model_spec.rb'
+    - 'spec/controllers/reports_controller_spec.rb'
 Metrics/MethodLength:
   Exclude:
     - 'db/migrate/**/*'
@@ -172,6 +173,7 @@ Metrics/MethodLength:
     - 'app/services/manifest_builder.rb'
     - 'app/indexers/imported_metadata_indexer.rb'
     - 'app/controllers/concerns/resource_controller.rb'
+    - 'app/controllers/reports_controller.rb'
     - 'app/models/search_builder.rb'
     - 'app/helpers/application_helper.rb'
     - 'app/change_sets/change_set.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -137,7 +137,6 @@ Metrics/LineLength:
     - 'spec/helpers/application_helper_spec.rb'
     - 'spec/resources/collections/collections_controller_spec.rb'
     - 'spec/models/oai/figgy/valkyrie_provider_model_spec.rb'
-    - 'spec/controllers/reports_controller_spec.rb'
 Metrics/MethodLength:
   Exclude:
     - 'db/migrate/**/*'
@@ -307,6 +306,9 @@ Lint/Void:
   Enabled: true
   Exclude:
     - 'app/derivative_services/jp2_derivative_service.rb'
+Style/LineEndConcatenation:
+  Exclude:
+    - 'spec/controllers/reports_controller_spec.rb'
 Style/MethodMissingSuper:
   Exclude:
     - 'app/decorators/media_info_tracks_decorator.rb'

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,11 @@ Release notes template:
 ## Removed
 
 -->
+# 2021-03-05
+
+## Changed
+* Expanding fields included in ephemera metadata export
+
 # 2021-01-27
 
 ## Changed

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -5,7 +5,7 @@ class ReportsController < ApplicationController
     authorize! :show, Report
     if params[:project_id]
       @ephemera_project = find_resource(params[:project_id]).decorate
-      @resources = @ephemera_project.boxes.map(&:folders).flatten
+      @resources = @ephemera_project.boxes.map(&:folders).flatten + @ephemera_project.folders
     end
     @ephemera_projects = query_service.find_all_of_model(model: EphemeraProject).map(&:decorate) unless @ephemera_project
 

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ReportsController, type: :controller do
   let(:user) { FactoryBot.create(:admin) }
 
   describe "GET #ephemera_data" do
-    let(:project) { FactoryBot.create_for_repository(:ephemera_project, member_ids: box.id) }
+    let(:project) { FactoryBot.create_for_repository(:ephemera_project, member_ids: [box.id, boxless.id]) }
     let(:box) { FactoryBot.create_for_repository(:ephemera_box, member_ids: folder.id) }
     let(:folder) do
       FactoryBot.create_for_repository(:ephemera_folder, contributor: ["contributor 1", "contributor 2"],
@@ -15,12 +15,26 @@ RSpec.describe ReportsController, type: :controller do
                                                          geographic_origin: geo_origin,
                                                          transliterated_title: "test transliterated title")
     end
+    let(:boxless) { FactoryBot.create_for_repository(:ephemera_folder, title: "boxless folder") }
     let(:language) { EphemeraTerm.new label: "test language" }
     let(:genre) { EphemeraTerm.new label: "test genre" }
     let(:subject) { EphemeraTerm.new label: "test subject" }
     let(:geo_subject) { EphemeraTerm.new label: "test geo subject" }
     let(:geo_origin) { EphemeraTerm.new label: "test geo origin" }
-    let(:data) { "id,local_identifier,barcode,folder_number,title,alternative_title,transliterated_title,language,creator,contributor,publisher,genre,width,height,page_count,series,keywords,subject,geo_subject,geographic_origin,description,date_created,provenance,source_url,dspace_url,rights_statement\n#{folder.id},xyz1,12345678901234,one,test folder,test alternative title,test transliterated title,test language,test creator,contributor 1;contributor 2,test publisher,test genre,10,20,30,test series,keyword1;keyword2,test subject,test geo subject,test geo origin,test description,1970/01/01,Donated by the Mario Bros.,http://example.com,http://example.com,http://rightsstatements.org/vocab/NKC/1.0/\n" }
+    let(:data) do
+      "id,local_identifier,barcode,folder_number,title,alternative_title,transliterated_title,language," +
+        "creator,contributor,publisher,genre,width,height,page_count,series,keywords,subject,geo_subject," +
+        "geographic_origin,description,date_created,provenance,source_url,dspace_url,rights_statement\n" +
+        "#{folder.id},xyz1,12345678901234,one,test folder,test alternative title,test transliterated title," +
+        "test language,test creator,contributor 1;contributor 2,test publisher,test genre,10,20,30," +
+        "test series,keyword1;keyword2,test subject,test geo subject,test geo origin,test description," +
+        "1970/01/01,Donated by the Mario Bros.,http://example.com,http://example.com," +
+        "http://rightsstatements.org/vocab/NKC/1.0/\n" +
+        "#{boxless.id},xyz1,12345678901234,one,boxless folder,test alternative title,\"\",test language," +
+        "test creator,test contributor,test publisher,test genre,10,20,30,test series,\"\",test subject," +
+        "\"\",\"\",test description,1970/01/01,Donated by the Mario Bros.," +
+        "http://example.com,http://example.com,http://rightsstatements.org/vocab/NKC/1.0/\n"
+    end
 
     before do
       sign_in user

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -7,8 +7,20 @@ RSpec.describe ReportsController, type: :controller do
   describe "GET #ephemera_data" do
     let(:project) { FactoryBot.create_for_repository(:ephemera_project, member_ids: box.id) }
     let(:box) { FactoryBot.create_for_repository(:ephemera_box, member_ids: folder.id) }
-    let(:folder) { FactoryBot.create_for_repository(:ephemera_folder, contributor: ["contributor 1", "contributor 2"]) }
-    let(:data) { "id,title,creator,contributor,publisher\n#{folder.id},test folder,test creator,contributor 1;contributor 2,test publisher\n" }
+    let(:folder) do
+      FactoryBot.create_for_repository(:ephemera_folder, contributor: ["contributor 1", "contributor 2"],
+                                                         language: language, genre: genre, subject: subject,
+                                                         keywords: ["keyword1", "keyword2"],
+                                                         geo_subject: geo_subject,
+                                                         geographic_origin: geo_origin,
+                                                         transliterated_title: "test transliterated title")
+    end
+    let(:language) { EphemeraTerm.new label: "test language" }
+    let(:genre) { EphemeraTerm.new label: "test genre" }
+    let(:subject) { EphemeraTerm.new label: "test subject" }
+    let(:geo_subject) { EphemeraTerm.new label: "test geo subject" }
+    let(:geo_origin) { EphemeraTerm.new label: "test geo origin" }
+    let(:data) { "id,local_identifier,barcode,folder_number,title,alternative_title,transliterated_title,language,creator,contributor,publisher,genre,width,height,page_count,series,keywords,subject,geo_subject,geographic_origin,description,date_created,provenance,source_url,dspace_url,rights_statement\n#{folder.id},xyz1,12345678901234,one,test folder,test alternative title,test transliterated title,test language,test creator,contributor 1;contributor 2,test publisher,test genre,10,20,30,test series,keyword1;keyword2,test subject,test geo subject,test geo origin,test description,1970/01/01,Donated by the Mario Bros.,http://example.com,http://example.com,http://rightsstatements.org/vocab/NKC/1.0/\n" }
 
     before do
       sign_in user


### PR DESCRIPTION
* Adds support for all of the metadata fields in the ephemera forms
* Include boxless folders in the reports

Fixes #4431 