### PR TITLE
Look for the cdl field that bibdata-on-alma will return

### DIFF
--- a/app/resources/cdl/eligible_item_service.rb
+++ b/app/resources/cdl/eligible_item_service.rb
@@ -4,6 +4,7 @@ module CDL
   class EligibleItemService
     # EligibleItemService will return from Voyager items eligible for Controlled Digital Lending (Cdl)
     # patron_group_charged == "CDL"
+    # with alma the field will be "cdl": true
     class << self
       def item_ids(source_metadata_identifier:)
         return [] unless RemoteRecord.bibdata?(source_metadata_identifier)
@@ -15,13 +16,17 @@ module CDL
           end
         end
         items = items.select do |item|
-          item && item["patron_group_charged"] == "CDL"
+          item && cdl?(item)
         end
         items.map { |x| x["id"] }
       end
 
       def bibdata_base
         "https://bibdata.princeton.edu/"
+      end
+
+      def cdl?(item)
+        item["patron_group_charged"] == "CDL" || item["cdl"]
       end
     end
   end

--- a/spec/fixtures/files/bibdata/9965126093506421.json
+++ b/spec/fixtures/files/bibdata/9965126093506421.json
@@ -1,0 +1,17 @@
+{
+  "firestone$stacks": [
+    {
+      "holding_id": "22202918790006421",
+      "call_number": "PS3558.A62424 B43 2010",
+      "items": [
+        {
+          "pid": "23202918780006421",
+          "id": "23202918780006421",
+          "temp_location": null,
+          "perm_location": "firestone$stacks",
+          "cdl": true
+        }
+      ]
+    }
+  ]
+}

--- a/spec/fixtures/files/bibdata/9968643943506421.json
+++ b/spec/fixtures/files/bibdata/9968643943506421.json
@@ -1,0 +1,17 @@
+{
+  "recap$pa": [
+    {
+      "holding_id": "22258767470006421",
+      "call_number": "KKT1504 .B748 2009",
+      "items": [
+        {
+          "pid": "23258767460006421",
+          "id": "23258767460006421",
+          "temp_location": null,
+          "perm_location": "recap$pa",
+          "cdl": false
+        }
+      ]
+    }
+  ]
+}

--- a/spec/resources/cdl/eligible_item_service_spec.rb
+++ b/spec/resources/cdl/eligible_item_service_spec.rb
@@ -95,5 +95,31 @@ RSpec.describe CDL::EligibleItemService do
         expect(described_class.item_ids(source_metadata_identifier: "922720")).not_to be_blank
       end
     end
+
+    context "patron_group_charged is missing and cdl is true" do
+      before do
+        stub_request(:get, "https://bibdata.princeton.edu/bibliographic/#{bib_id}/items")
+          .to_return(status: 200,
+                     body: file_fixture("bibdata/#{bib_id}.json").read, headers: { "Content-Type" => "application/json" })
+      end
+      let(:bib_id) { "9965126093506421" }
+
+      it "returns the item pid" do
+        expect(described_class.item_ids(source_metadata_identifier: bib_id)).to eq ["23202918780006421"]
+      end
+    end
+
+    context "patron_group_charged is missing and cdl is false" do
+      before do
+        stub_request(:get, "https://bibdata.princeton.edu/bibliographic/#{bib_id}/items")
+          .to_return(status: 200,
+                     body: file_fixture("bibdata/#{bib_id}.json").read, headers: { "Content-Type" => "application/json" })
+      end
+      let(:bib_id) { "9968643943506421" }
+
+      it "will return an empty array" do
+        expect(described_class.item_ids(source_metadata_identifier: bib_id)).to eq []
+      end
+    end
   end
 end


### PR DESCRIPTION
I'm not sure why the item id was previous an int, or whether it will be a
problem for it to be a string here.

fixes pulibrary/bibdata#903