### PR TITLE
Filtering resources included in OAI endpoint based on rights statement

### DIFF
--- a/app/models/oai/figgy/valkyrie_provider_model.rb
+++ b/app/models/oai/figgy/valkyrie_provider_model.rb
@@ -79,7 +79,8 @@ module OAI::Figgy
         marc_only: options.marc?,
         from: options.from,
         until_time: options.until,
-        requirements: oai_object_requirements
+        requirements: oai_object_requirements,
+        exclude_rights: suppress_rights_statements
       ).to_a.compact.map { |r| OAIWrapper.new(r) }
       wrap_results(result, options)
     end
@@ -92,6 +93,12 @@ module OAI::Figgy
         state: ["complete"],
         read_groups: [Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC]
       }
+    end
+
+    def suppress_rights_statements
+      [
+        RightsStatements.no_copyright_contractual_restrictions
+      ]
     end
 
     def wrap_results(result, options)

--- a/spec/models/oai/figgy/valkyrie_provider_model_spec.rb
+++ b/spec/models/oai/figgy/valkyrie_provider_model_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe OAI::Figgy::ValkyrieProviderModel do
         create_scanned_resource(source_metadata_identifier: "8543429", collection_id: nil)
         create_scanned_resource(source_metadata_identifier: "8543429", collection_id: nil, state: "pending", visibility: ::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_ON_CAMPUS)
         create_scanned_resource(source_metadata_identifier: "8543429", collection_id: nil, state: "complete", visibility: ::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_ON_CAMPUS)
+        create_scanned_resource(source_metadata_identifier: "8543429", collection_id: nil, state: "complete", rights_statement: RightsStatements.no_copyright_contractual_restrictions)
 
         output = described_class.new.find_all(metadata_prefix: "marc21")
 
@@ -96,7 +97,7 @@ RSpec.describe OAI::Figgy::ValkyrieProviderModel do
     end
   end
 
-  def create_scanned_resource(source_metadata_identifier:, collection_id:, member_ids: [], append_id: nil, state: "complete", visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
+  def create_scanned_resource(source_metadata_identifier:, collection_id:, member_ids: [], append_id: nil, state: "complete", visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, rights_statement: RightsStatements.no_known_copyright)
     stub_bibdata(bib_id: source_metadata_identifier)
     stub_bibdata(bib_id: source_metadata_identifier, content_type: "application/marcxml+xml") if File.exist?(bibdata_fixture_path(source_metadata_identifier, BibdataStubbing::CONTENT_TYPE_MARC_XML))
     stub_ezid(shoulder: "99999/fk4", blade: source_metadata_identifier)
@@ -107,6 +108,7 @@ RSpec.describe OAI::Figgy::ValkyrieProviderModel do
       import_metadata: true,
       member_ids: member_ids,
       append_id: append_id,
+      rights_statement: rights_statement,
       state: state,
       visibility: visibility
     )


### PR DESCRIPTION
Fixes #4463 

This would suppress items from the OAI endpoint based on rights statement. For now, the list of rights statements to suppress is just the No Copyright/Contractual Restrictions which seems like a reasonably good fit for this scenario.