### PR TITLE
Adding explicit Chrome dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A digital repository application in use at Princeton University Library for stor
 * Ruby
 * Node v.8.2.1
 * Java (to run Solr server)
+* [Google Chrome](https://google.com/chrome/) (for feature tests)
 * Postgres (for OSX dev systems, install via homebrew)
 * [Redis](http://redis.io/)
     * Start Redis with `redis-server` or if you're on certain Linuxes, you can do this via `sudo service redis-server start`.


### PR DESCRIPTION
When I run the tests, about 30 feature tests fail because it can't find Chrome. Installing Chrome fixes this.