### PR TITLE
updates GNIB MODS ingest to include more fields, check for empty imag…

### DIFF
--- a/app/models/mets_document/mods_document.rb
+++ b/app/models/mets_document/mods_document.rb
@@ -226,6 +226,10 @@ class METSDocument
       value_from(xpath: "mods:identifier[@type=\"localAccession\"]") + value_from(xpath: "mods:identifier[@type=\"local\"]")
     end
 
+    def record_identifier
+      value_from(xpath: "//mods:recordIdentifier").first
+    end
+
     private
 
       def find_elements(xpath, element: @element)

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -60,12 +60,12 @@ namespace :migrate do
   end
 
   desc "Migrates directory of Moscow Election records"
-  task gnib_directory: :environment do
+  task pudl0125: :environment do
     project = ENV["PROJECT"]
     md_root = ENV["METADATA"]
     image_root = ENV["IMAGES"]
 
-    usage = "usage: rake migrate:gnib_directory PROJECT=project_id METADATA=/path/to/mods_records IMAGES=/path/to/images"
+    usage = "usage: rake migrate:pudl0125 PROJECT=project_id METADATA=/path/to/mods_records IMAGES=/path/to/images"
     abort usage unless project && image_root && md_root && Dir.exist?(image_root) && Dir.exist?(md_root)
     logger.info "Ingesting Moscow election records from #{md_root}"
     change_set_persister = ChangeSetPersister.new(

--- a/spec/services/ingest_ephemera_mods_spec.rb
+++ b/spec/services/ingest_ephemera_mods_spec.rb
@@ -15,6 +15,8 @@ describe IngestEphemeraMODS do
   before do
     languages = FactoryBot.create_for_repository(:ephemera_vocabulary, label: "LAE Languages")
     FactoryBot.create_for_repository(:ephemera_term, label: ["Russian"], code: ["rus"], member_of_vocabulary_id: languages.id)
+    FactoryBot.create_for_repository(:ephemera_term, label: ["English"], code: ["eng"], member_of_vocabulary_id: languages.id)
+    FactoryBot.create_for_repository(:ephemera_term, label: ["Spanish"], code: ["spa"], member_of_vocabulary_id: languages.id)
 
     areas = FactoryBot.create_for_repository(:ephemera_vocabulary, label: "LAE Areas")
     FactoryBot.create_for_repository(:ephemera_term, label: ["Ukraine"], member_of_vocabulary_id: areas.id)
@@ -68,6 +70,26 @@ describe IngestEphemeraMODS do
       expect(output.decorate.genre).to eq "ephemera"
       expect(output.decorate.members.map(&:title).flatten).to eq ["00223.tif", "00224.tif", "00223.mods"]
       expect(output.decorate.subject).to include "Free trade"
+      expect(output.decorate.language.first.label).to eq "English"
+      expect(output.decorate.barcode).to eq "00000000"
+      expect(output.decorate.folder_number).to eq "E_0_3"
+      expect(output.decorate.local_identifier.first).to eq "E_0_3_00223"
+    end
+
+    it "gets ocr" do
+      output = service.ingest
+      expect(output.ocr_language.first).to eq "eng"
+    end
+  end
+
+  context "GNIB object has no image files" do
+    subject(:service) { IngestEphemeraMODS::IngestGnibMODS.new(project.id, mods, dir, change_set_persister, logger) }
+    let(:mods) { Rails.root.join("spec", "fixtures", "files", "GNIB", "00223.mods") }
+    let(:dir) { Rails.root.join("spec", "fixtures", "GNIB", "empty") }
+
+    it "does not ingest the object" do
+      output = service.ingest
+      expect(output).to be_nil
     end
   end
 


### PR DESCRIPTION
Adds methods to include barcode, folder_number, local_identifier, and ocr_language to the attributes committed to Figgy.  Also checks to see if the directory of images is empty and skips validation and persistence if so.