### PR TITLE
strips leading/trailing spaces from mods:language elements

### DIFF
--- a/app/services/ingest_ephemera_mods.rb
+++ b/app/services/ingest_ephemera_mods.rb
@@ -82,7 +82,7 @@ class IngestEphemeraMODS
     end
 
     def ocr_language
-      mods_doc.language
+      mods_doc.language.map(&:strip)
     end
 
     def local_identifier

--- a/spec/fixtures/files/GNIB/00223.mods
+++ b/spec/fixtures/files/GNIB/00223.mods
@@ -8,7 +8,7 @@
    <mods:typeOfResource>text</mods:typeOfResource>
    <mods:genre authority="aat">ephemera</mods:genre>
    <mods:language>
-      <mods:languageTerm type="code" authority="iso639-2b">eng</mods:languageTerm>
+      <mods:languageTerm type="code" authority="iso639-2b">eng </mods:languageTerm>
    </mods:language>
    <mods:note>Document extracted from:</mods:note>
    <mods:subject authority="lcsh">


### PR DESCRIPTION
Fixes glitch where ocr_language was being set to "eng " or "spa " because there were trailing spaces in the source data.