### PR TITLE
Update Honeybadger syntax for v4

### DIFF
--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -2,6 +2,11 @@
 
 # Errors for honeybadger to ignore.
 # https://docs.honeybadger.io/ruby/getting-started/ignoring-errors.html#ignore-programmatically
-Honeybadger.exception_filter do |notice|
-  notice[:error_message] =~ /ogr2ogr -q -nln/ # Shapefile encoding errors.
+Honeybadger.configure do |config|
+  config.before_notify do |notice|
+    # Ignore Shapefile encoding errors.
+    if notice.error_message =~ /ogr2ogr -q -nln/
+      notice.halt!
+    end
+  end
 end


### PR DESCRIPTION
See
https://docs.honeybadger.io/lib/ruby/support/v4-upgrade.html#removal-of-the-notice-accessor.

This might close #4539, and may be an issue for #4531 