### PR TITLE
Check restricted collection membership of parents if there is one.

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -198,7 +198,7 @@ class Ability
   def restricted_collection_viewer?(obj)
     return false unless current_user && obj.decorate.public_readable_state?
     return false if private?(obj)
-    collections = Wayfinder.for(obj).try(:collections) || []
+    collections = Wayfinder.for(obj).try(:self_or_parent_collections) || []
     collections.flat_map(&:restricted_viewers).include?(current_user.uid)
   end
 

--- a/app/wayfinders/base_wayfinder.rb
+++ b/app/wayfinders/base_wayfinder.rb
@@ -97,6 +97,17 @@ class BaseWayfinder
     @resource = resource
   end
 
+  # Collections are only assigned at the MVW level, but permissions for volumes
+  # need to see if a user has permission for a restricted collection. To do that
+  # it needs its parents collections if it has one.
+  def self_or_parent_collections
+    if try(:parent).present?
+      Wayfinder.for(parent).try(:collections)
+    else
+      try(:collections) || []
+    end
+  end
+
   # Define a preservation_objects relationship for all resources
   inverse_relationship_by_property :preservation_objects, property: :preserved_object_id, singular: true, model: PreservationObject
 


### PR DESCRIPTION
This fixes OARSC downloading of audio files. Audio resources are parent
resources that are a member of the collection with a child per
resource. Without this it wasn't finding that the child resource was a
member of a collection.

Closes #4562