### PR TITLE
Ensure we don't update DAOs for non-readable items.

### DIFF
--- a/app/services/dao_updater.rb
+++ b/app/services/dao_updater.rb
@@ -8,6 +8,7 @@ class DaoUpdater
   end
 
   def update!
+    return unless change_set.resource.decorate.public_readable_state?
     archival_object = aspace_client.find_archival_object_by_component_id(component_id: change_set.source_metadata_identifier)
 
     # Create digital object.

--- a/spec/services/dao_updater_spec.rb
+++ b/spec/services/dao_updater_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DaoUpdater do
+  describe "#update!" do
+    context "when the resource is not complete" do
+      it "does nothing" do
+        resource = FactoryBot.create_for_repository(:scanned_resource, state: "pending")
+        change_set_persister = instance_double(ChangeSetPersister)
+
+        updater = described_class.new(change_set: ChangeSet.for(resource), change_set_persister: change_set_persister)
+
+        # We haven't stubbed ASpace, so webmock will error if it tries to do
+        # something.
+        updater.update!
+      end
+    end
+  end
+end


### PR DESCRIPTION
Protects us from adding DAOs from private items when bulk updating DAOs

Closes #4568