### PR TITLE
Viewer#auth should not check eligibility twice.

### DIFF
--- a/app/controllers/viewer_controller.rb
+++ b/app/controllers/viewer_controller.rb
@@ -52,6 +52,10 @@ class ViewerController < ApplicationController
 
   private
 
+    def current_ability
+      Ability.new(current_user, charge_manager: @charge_manager)
+    end
+
     def allow_iframe
       response.headers.except! "X-Frame-Options"
     end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -169,7 +169,21 @@ class Ability
   def cdl_eligible?(obj)
     return false unless obj.persisted?
     return false unless obj.decorate.public_readable_state?
-    CDL::ChargeManager.new(resource_id: obj.id, eligible_item_service: eligible_item_service, change_set_persister: change_set_persister).eligible?
+    charge_manager(obj).eligible?
+  end
+
+  def charge_manager(obj)
+    if cached_charge_manager&.resource_id&.to_s == obj.id.to_s
+      cached_charge_manager
+    else
+      CDL::ChargeManager.new(resource_id: obj.id, eligible_item_service: eligible_item_service, change_set_persister: change_set_persister)
+    end
+  end
+
+  # Sometimes a charge manager is passed through from viewer auth to reduce the
+  # calls to bibdata.
+  def cached_charge_manager
+    @cached_charge_manager ||= options.fetch(:charge_manager, nil)
   end
 
   def eligible_item_service

--- a/app/resources/cdl/charge_manager.rb
+++ b/app/resources/cdl/charge_manager.rb
@@ -19,7 +19,7 @@ module CDL
     end
 
     def eligible?
-      item_ids.present?
+      @eligible ||= item_ids.present?
     end
 
     def available_for_charge?(netid: nil)

--- a/spec/controllers/viewer_controller_spec.rb
+++ b/spec/controllers/viewer_controller_spec.rb
@@ -65,6 +65,7 @@ RSpec.describe ViewerController do
 
           expect(response).to be_successful
           expect(response.body).to have_link "Princeton Users: Log in to check out a digital copy"
+          expect(CDL::EligibleItemService).to have_received(:item_ids).exactly(1).times
         end
       end
     end


### PR DESCRIPTION
Improves performance now that checking items in bibdata is so much
slower.

Closes #4596