### PR TITLE
Reload resource for Alma migration of resources.

### DIFF
--- a/app/services/bibid_updater.rb
+++ b/app/services/bibid_updater.rb
@@ -9,6 +9,8 @@ class BibidUpdater
   def update
     progress_bar
     resources.each do |resource|
+      # Reload resource to get a new version.
+      resource = query_service.find_by(id: resource.id)
       change_set = ChangeSet.for(resource)
       change_set.source_metadata_identifier = transform_id(change_set.source_metadata_identifier)
       change_set_persister.save(change_set: change_set)


### PR DESCRIPTION
Reduces the diff time between read/persist.

Closes #4597 