### PR TITLE
Reindexing Performance Optimizations

### DIFF
--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 class Resource < Valkyrie::Resource
   def self.human_readable_type
-    default = @_human_readable_type || name.demodulize.titleize
-    I18n.translate("models.#{new.model_name.i18n_key}", default: default)
+    @human_readable_type ||=
+      begin
+        default = @_human_readable_type || name.demodulize.titleize
+        I18n.translate("models.#{new.model_name.i18n_key}", default: default)
+      end
   end
 
   def self.can_have_manifests?

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -18,13 +18,21 @@ class Resource < Valkyrie::Resource
   end
 
   def self.model_name
-    ::ActiveModel::Name.new(self)
+    @model_name ||= ::ActiveModel::Name.new(self)
   end
 
   # Determines whether or not the "Save and Duplicate Metadata" is supported for this Resource
   # @return [Boolean]
   def self.supports_save_and_duplicate?
     false
+  end
+
+  def decorate
+    @decorated_resource ||= super
+  end
+
+  def model_name
+    @model_name ||= super
   end
 
   # Determines if this is an image resource

--- a/lib/tasks/performance.rake
+++ b/lib/tasks/performance.rake
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative "../../spec/support/create_for_repository"
+namespace :performance do
+  desc "Performance test persisting."
+  task reindex_profile: :environment do
+    require "ruby-prof"
+    raise unless Rails.env.test?
+    DataSeeder.new.wipe_metadata!
+    Array.new(30) do
+      FactoryBot.create_for_repository(:file_set)
+    end
+    Reindexer.reindex_all
+    result = RubyProf.profile do
+      Reindexer.reindex_all
+    end
+    printer = RubyProf::CallStackPrinter.new(result)
+    printer.print(File.open("tmp/output.html", "w"))
+  end
+  task reindex_benchmark: :environment do
+    require "benchmark/ips"
+    raise unless Rails.env.test?
+    DataSeeder.new.wipe_metadata!
+    Array.new(30) do
+      FactoryBot.create_for_repository(:file_set)
+    end
+    Reindexer.reindex_all
+    Benchmark.ips do |x|
+      x.report("reindex_all") do
+        Reindexer.reindex_all(logger: Logger.new(IO::NULL))
+      end
+    end
+  end
+end

--- a/lib/tasks/performance.rake
+++ b/lib/tasks/performance.rake
@@ -7,7 +7,7 @@ namespace :performance do
     require "ruby-prof"
     raise unless Rails.env.test?
     DataSeeder.new.wipe_metadata!
-    Array.new(30) do
+    Array.new(600) do
       FactoryBot.create_for_repository(:file_set)
     end
     Reindexer.reindex_all

--- a/spec/jobs/update_fgdc_onlink_job_spec.rb
+++ b/spec/jobs/update_fgdc_onlink_job_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe UpdateFgdcOnlinkJob do
     change_set_persister.save(change_set: VectorResourceChangeSet.new(VectorResource.new, files: [fgdc_file], member_ids: [vector_file_set.id]))
   end
   let(:fgdc_file) { fixture_file_upload("files/geo_metadata/fgdc-no-onlink.xml", "application/xml") }
-  let(:fgdc_file_set) { parent_resource.decorate.geo_metadata_members.first }
+  let(:fgdc_file_set) { Wayfinder.for(parent_resource).geo_metadata_members.first }
   let(:vector_file_set) { FactoryBot.create_for_repository(:file_set, file_metadata: vector_file_metadata) }
   let(:vector_file_id) { "1234567" }
   let(:vector_file_metadata) do

--- a/spec/services/add_ephemera_to_collection_spec.rb
+++ b/spec/services/add_ephemera_to_collection_spec.rb
@@ -27,11 +27,11 @@ describe AddEphemeraToCollection do
     let(:logger) { Logger.new(nil) }
 
     it "adds folder to collection" do
-      expect(collection.decorate.members.count).to eq(0)
+      expect(Wayfinder.for(collection).members.count).to eq(0)
       service.add_ephemera
-      expect(collection.decorate.members.count).to eq(1)
-      expect(collection.decorate.members.first).to be_a_kind_of(EphemeraFolder)
-      expect(collection.decorate.members.first.id).to eq(folder.id)
+      expect(Wayfinder.for(collection).members.count).to eq(1)
+      expect(Wayfinder.for(collection).members.first).to be_a_kind_of(EphemeraFolder)
+      expect(Wayfinder.for(collection).members.first.id).to eq(folder.id)
     end
   end
 
@@ -54,11 +54,11 @@ describe AddEphemeraToCollection do
     let(:logger) { Logger.new(nil) }
 
     it "adds folder to collection" do
-      expect(collection.decorate.members.count).to eq(0)
+      expect(Wayfinder.for(collection).members.count).to eq(0)
       service.add_ephemera
-      expect(collection.decorate.members.count).to eq(1)
-      expect(collection.decorate.members.first).to be_a_kind_of(EphemeraFolder)
-      expect(collection.decorate.members.first.id).to eq(folder.id)
+      expect(Wayfinder.for(collection).members.count).to eq(1)
+      expect(Wayfinder.for(collection).members.first).to be_a_kind_of(EphemeraFolder)
+      expect(Wayfinder.for(collection).members.first.id).to eq(folder.id)
     end
   end
 end


### PR DESCRIPTION
Adds a rake task to benchmark/profile reindexing and adds a few easy fixes.

The next fix is to have the solr persister not convert from the solr document to a `Valkyrie::Resource`, which is much harder.