### PR TITLE
Prevent indexing certain models

### DIFF
--- a/app/adapters/indexing_adapter.rb
+++ b/app/adapters/indexing_adapter.rb
@@ -11,7 +11,8 @@ class IndexingAdapter
     [
       Event,
       ProcessedEvent,
-      PreservationObject
+      PreservationObject,
+      Tombstone
     ]
   end
   attr_reader :metadata_adapter, :index_adapter

--- a/app/services/reindexer.rb
+++ b/app/services/reindexer.rb
@@ -77,10 +77,7 @@ class Reindexer
   end
 
   def excluded_models
-    [
-      ProcessedEvent,
-      Event
-    ]
+    IndexingAdapter.no_index_models
   end
 
   def progress_bar

--- a/spec/adapters/indexing_adapter_spec.rb
+++ b/spec/adapters/indexing_adapter_spec.rb
@@ -56,4 +56,17 @@ RSpec.describe IndexingAdapter do
 
     expect(adapter.index_adapter.persister).not_to have_received(:save_all)
   end
+
+  it "doesn't index certain models" do
+    resource = FactoryBot.create_for_repository(:event)
+    allow(adapter.index_adapter.persister).to receive(:save_all)
+    allow(adapter.index_adapter.persister).to receive(:save)
+    persister.buffer_into_index do |buffered_adapter|
+      buffered_adapter.persister.save(resource: resource)
+    end
+    persister.save(resource: resource)
+
+    expect(adapter.index_adapter.persister).not_to have_received(:save_all)
+    expect(adapter.index_adapter.persister).not_to have_received(:save)
+  end
 end


### PR DESCRIPTION
This doesn't actually improve reindexing speed or anything, but
preventing these from indexing makes our unit tests able to tell us if
we need to index PreservationObjects and Tombstones, and makes it so we don't accidentally end up with these in the index.

Closes #4601 