### PR TITLE
Dramatically improve speed of indexing records with imported metadata.

### DIFF
--- a/app/indexers/facet_indexer.rb
+++ b/app/indexers/facet_indexer.rb
@@ -6,9 +6,9 @@ class FacetIndexer
   end
 
   def to_solr
-    if resource.try(:primary_imported_metadata)
+    if resource.try(:imported_metadata)&.first
       {
-        display_subject_ssim: resource.primary_imported_metadata.subject,
+        display_subject_ssim: resource.imported_metadata.first.subject,
         display_language_ssim: imported_language,
         has_structure_bsi: structure?,
         pub_date_start_itsi: pub_date_start
@@ -50,7 +50,7 @@ class FacetIndexer
   end
 
   def pub_date_start
-    date = resource.primary_imported_metadata.created
+    date = resource.imported_metadata&.first&.created
     return unless date.present?
     date = parse_date(date.first)
     return unless date

--- a/app/indexers/imported_metadata_indexer.rb
+++ b/app/indexers/imported_metadata_indexer.rb
@@ -6,7 +6,7 @@ class ImportedMetadataIndexer
   end
 
   def to_solr
-    return {} unless resource.try(:primary_imported_metadata)
+    return {} unless resource.imported_metadata&.first.present?
     identifier_properties.merge(primary_imported_properties)
   end
 

--- a/app/indexers/imported_metadata_indexer.rb
+++ b/app/indexers/imported_metadata_indexer.rb
@@ -25,7 +25,7 @@ class ImportedMetadataIndexer
     end
 
     def primary_imported_properties
-      resource.primary_imported_metadata.to_h.except(*suppressed_keys).map do |k, v|
+      resource.primary_imported_metadata.__attributes__.except(*suppressed_keys).map do |k, v|
         ["imported_#{k}_tesim", format_values(v)]
       end.to_h
     end

--- a/app/indexers/imported_metadata_indexer.rb
+++ b/app/indexers/imported_metadata_indexer.rb
@@ -21,7 +21,8 @@ class ImportedMetadataIndexer
     end
 
     def imported_or_existing(attribute:)
-      resource.primary_imported_metadata.send(attribute) ? resource.primary_imported_metadata.send(attribute) : resource.try(attribute)
+      return resource[attribute] if resource.imported_metadata.blank?
+      resource.imported_metadata.first[attribute] || resource[attribute]
     end
 
     def primary_imported_properties

--- a/app/indexers/imported_metadata_indexer.rb
+++ b/app/indexers/imported_metadata_indexer.rb
@@ -6,7 +6,7 @@ class ImportedMetadataIndexer
   end
 
   def to_solr
-    return {} unless resource.imported_metadata&.first.present?
+    return {} unless resource.try(:imported_metadata)&.first.present?
     identifier_properties.merge(primary_imported_properties)
   end
 

--- a/app/resources/scanned_resources/scanned_resource.rb
+++ b/app/resources/scanned_resources/scanned_resource.rb
@@ -37,7 +37,7 @@ class ScannedResource < Resource
   end
 
   def title
-    primary_imported_metadata.title.present? ? primary_imported_metadata.title : attributes[:title]
+    imported_metadata&.first&.title.present? ? imported_metadata&.first&.title : __attributes__[:title]
   end
 
   # Determines if this is an image resource

--- a/app/resources/scanned_resources/scanned_resource_decorator.rb
+++ b/app/resources/scanned_resources/scanned_resource_decorator.rb
@@ -142,8 +142,7 @@ class ScannedResourceDecorator < Valkyrie::ResourceDecorator
   end
 
   def imported_attribute(attribute_key)
-    return primary_imported_metadata.send(attribute_key) if primary_imported_metadata.try(attribute_key)
-    Array.wrap(primary_imported_metadata.attributes.fetch(attribute_key, []))
+    imported_metadata&.first.try(attribute_key) || []
   end
 
   def imported_language

--- a/lib/tasks/performance.rake
+++ b/lib/tasks/performance.rake
@@ -10,7 +10,7 @@ namespace :performance do
       raise unless Rails.env.test?
       DataSeeder.new.wipe_metadata!
       Array.new(600) do
-        FactoryBot.create_for_repository(:file_set)
+        FactoryBot.create_for_repository(:scanned_resource)
       end
       Reindexer.reindex_all
       result = RubyProf.profile do

--- a/spec/indexers/imported_metadata_indexer_spec.rb
+++ b/spec/indexers/imported_metadata_indexer_spec.rb
@@ -30,5 +30,12 @@ RSpec.describe ImportedMetadataIndexer do
       output = described_class.new(resource: resource).to_solr
       expect(output["imported_creator_tesim"]).to eq ["Test Literal"]
     end
+
+    it "indexes string imported metadata" do
+      resource = FactoryBot.build(:scanned_resource)
+      resource.imported_metadata = [ImportedMetadata.new(layer_name: "layer")]
+      output = described_class.new(resource: resource).to_solr
+      expect(output["imported_layer_name_tesim"]).to eq "layer"
+    end
   end
 end


### PR DESCRIPTION
Accessing this pre-built hash is about 5x faster than calling to_h (resulting in being able to convert 120 ScannedResource records/second vs 30 records/second).

Also, avoiding `primary_imported_metadata` repeatedly creating an `ImportedMetadata` object results in being able to convert 180 ScannedResource records/second.