### PR TITLE
Add rake task to report LAE subjects to CSV

### DIFF
--- a/app/utils/data_seeder.rb
+++ b/app/utils/data_seeder.rb
@@ -296,8 +296,8 @@ class DataSeeder
           columns: { label: "label", category: nil } },
         { file: File.join("spec", "fixtures", "lae_genres.csv"), name: "LAE Genres",
           columns: { label: "pul_label", category: nil } },
-        { file: File.join("spec", "fixtures", "lae_subjects.csv"), name: "LAE Subjects",
-          columns: { label: "subject", category: "category" } }
+        { file: File.join("config", "vocab", "lae_subjects.csv"), name: "LAE Subjects",
+          columns: { label: "label", code: "code", uri: "uri", category: "category" } }
       ]
       to_load.each do |vocab|
         change_set_persister.buffer_into_index do |buffered_change_set_persister|

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require "csv"
+
+namespace :report do
+  desc "Write a CSV of LAE Subject terms"
+  task lae_subjects: :environment do
+    output = ENV["OUTPUT"]
+    abort "usage: OUTPUT=output_path rake report:lae_subjects" unless output
+
+    metadata_adapter = Valkyrie::MetadataAdapter.find(:indexing_persister)
+    query_service = metadata_adapter.query_service
+
+    vocab = query_service.custom_queries.find_ephemera_vocabulary_by_label(label: "LAE Subjects")
+    terms = collect_terms(vocab)
+    fields = %w[label code uri category]
+    CSV.open(output, "w") do |csv|
+      csv << fields
+      terms.each do |term|
+        csv << [
+          term.label,
+          term.code,
+          JSON.parse(term.decorate.uri).first,
+          term.decorate.vocabulary.label
+        ]
+      end
+    end
+  end
+end
+
+def collect_terms(vocab)
+  arr = []
+  arr += vocab.decorate.terms
+  vocab.decorate.categories.each do |category|
+    arr += collect_terms(category)
+  end
+  arr
+end


### PR DESCRIPTION
advances #4639

- Update the data seeder to use the lae_subjects from production
- Add a task to report lae subjects to CSV

It would be better to put this in a service and test it, but since this is
urgently needed and doesn't update any data I thought I would inquire whether we
might just go ahead and merge it this way.
