### PR TITLE
Require bootsnap/setup after bundler/setup

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
-require "bootsnap/setup"
 require "bundler/setup" # Set up gems listed in the Gemfile.
+require "bootsnap/setup"


### PR DESCRIPTION
as specified in the bootsnap README:
https://github.com/Shopify/bootsnap#usage

closes #4211
