### PR TITLE
Issues should be valid if earliest/latest date are the same number.

### DIFF
--- a/app/resources/numismatics/issues/numismatics/issue_change_set.rb
+++ b/app/resources/numismatics/issues/numismatics/issue_change_set.rb
@@ -166,7 +166,7 @@ module Numismatics
 
     def earliest_date_before_latest_date
       return if earliest_date.blank? && latest_date.blank?
-      return if earliest_date.to_i < latest_date.to_i
+      return if earliest_date.to_i <= latest_date.to_i
       errors.add(:earliest_date, "must be a date before Latest Date")
     end
 

--- a/spec/resources/numismatics/issues/numismatics/issue_change_set_spec.rb
+++ b/spec/resources/numismatics/issues/numismatics/issue_change_set_spec.rb
@@ -83,6 +83,12 @@ RSpec.describe Numismatics::IssueChangeSet do
         expect(change_set).not_to be_valid
       end
     end
+    context "when earliest_date is the same year as latest_date" do
+      it "is valid" do
+        change_set.validate(earliest_date: "2020", latest_date: "2020")
+        expect(change_set).to be_valid
+      end
+    end
   end
 
   describe "#downloadable" do


### PR DESCRIPTION
Closes #4668

The user request was to be able to leave the latest date blank, but this is much easier to implement, is something they automatically tried, and is less likely to negatively impact upstream indexers. I've told Alan about this compromise.