### PR TITLE
Add guard against appending a resource as its own member

### DIFF
--- a/app/change_set_persisters/change_set_persister/append_to_parent.rb
+++ b/app/change_set_persisters/change_set_persister/append_to_parent.rb
@@ -11,6 +11,7 @@ class ChangeSetPersister
 
     def run
       return unless append_id.present?
+      return if post_save_resource.id == append_id
       remove_from_old_parent
       add_to_new_parent
       # Re-save to solr unless it's going to be done by save_all

--- a/spec/change_set_persisters/change_set_persister_spec.rb
+++ b/spec/change_set_persisters/change_set_persister_spec.rb
@@ -1320,6 +1320,15 @@ RSpec.describe ChangeSetPersister do
       solr_record = Blacklight.default_index.connection.get("select", params: { qt: "document", q: "id:#{output.id}" })["response"]["docs"][0]
       expect(solr_record["member_of_ssim"]).to eq ["id-#{new_parent.id}"]
     end
+
+    it "will not append a resource as a child of itself" do
+      resource = FactoryBot.create_for_repository(:scanned_resource)
+      change_set = change_set_class.new(resource)
+      change_set.validate(append_id: resource.id.to_s)
+
+      output = change_set_persister.save(change_set: change_set)
+      expect(output.member_ids).to eq []
+    end
   end
 
   context "setting visibility from remote metadata" do


### PR DESCRIPTION
This test was never red, but it did go through a lot more of the code than seemed necessary, including at one point saving the "parent" with the new member id list. which got overridden by another save later in the code path.

closes #4701