### PR TITLE
RunOCRJob should not error if the FileSet or its parent are gone.

### DIFF
--- a/app/derivative_services/hocr_derivative_service.rb
+++ b/app/derivative_services/hocr_derivative_service.rb
@@ -49,7 +49,7 @@ class HocrDerivativeService
   def cleanup_derivatives; end
 
   def parent
-    @parent ||= query_service.find_inverse_references_by(id: id, property: :member_ids).first
+    @parent ||= Wayfinder.for(resource).parent
   end
 
   def filename

--- a/app/jobs/run_ocr_job.rb
+++ b/app/jobs/run_ocr_job.rb
@@ -5,6 +5,8 @@ class RunOCRJob < ApplicationJob
 
   def perform(file_set_id)
     derivative_service_factory.new(id: file_set_id).create_derivatives
+  rescue Valkyrie::Persistence::ObjectNotFoundError => error
+    Valkyrie.logger.warn "#{self.class}: #{error}: Failed to find the resource #{file_set_id}"
   end
 
   private

--- a/spec/jobs/run_ocr_job_spec.rb
+++ b/spec/jobs/run_ocr_job_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe RunOCRJob do
+  context "when given a file set that doesn't exist" do
+    it "doesn't raise an error" do
+      expect { described_class.perform_now("bla") }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
Just ignore if this happens - the file's gone.

Closes #2835
Closes #4696
