### PR TITLE
Add varchar-casted ID as an index.

### DIFF
--- a/db/migrate/20211025213822_add_varchar_id_index_to_orm_resources.rb
+++ b/db/migrate/20211025213822_add_varchar_id_index_to_orm_resources.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddVarcharIdIndexToOrmResources < ActiveRecord::Migration[5.2]
+  def change
+    add_index :orm_resources, "(id::varchar)"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -834,6 +834,13 @@ CREATE INDEX index_ocr_requests_on_user_id ON public.ocr_requests USING btree (u
 
 
 --
+-- Name: index_orm_resources_on_id_varchar; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_orm_resources_on_id_varchar ON public.orm_resources USING btree (((id)::character varying));
+
+
+--
 -- Name: index_orm_resources_on_internal_resource; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1004,6 +1011,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200225213135'),
 ('20200422192849'),
 ('20200423183539'),
-('20200608160046');
+('20200608160046'),
+('20211025213822');
 
 


### PR DESCRIPTION
Significantly speeds up find_many_by_id query (60s to 2ms).