### PR TITLE
Coerce numismatics numbers to integers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -346,3 +346,6 @@ Style/IfUnlessModifier:
 Lint/HandleExceptions:
   Exclude:
     - 'lib/tasks/performance.rake'
+Naming/ConstantName:
+  Exclude:
+    - 'app/types/types.rb'

--- a/app/resources/numismatics/accessions/numismatics/accession.rb
+++ b/app/resources/numismatics/accessions/numismatics/accession.rb
@@ -11,7 +11,7 @@ module Numismatics
     attribute :numismatic_citation, Valkyrie::Types::Array.of(Numismatics::Citation).meta(ordered: true)
 
     # descriptive metadata
-    attribute :accession_number, Valkyrie::Types::Integer
+    attribute :accession_number, Valkyrie::Types::Coercible::Integer.optional
     attribute :account
     attribute :cost
     attribute :date

--- a/app/resources/numismatics/coins/numismatics/coin.rb
+++ b/app/resources/numismatics/coins/numismatics/coin.rb
@@ -17,7 +17,7 @@ module Numismatics
     attribute :provenance, Valkyrie::Types::Array.of(Numismatics::Provenance).meta(ordered: true)
 
     # descriptive metadata
-    attribute :coin_number, Valkyrie::Types::Anything
+    attribute :coin_number, Valkyrie::Types::Coercible::Integer.optional
     attribute :number_in_accession, Valkyrie::Types::Integer
     attribute :counter_stamp
     attribute :analysis
@@ -32,7 +32,7 @@ module Numismatics
     attribute :size
     attribute :technique
     attribute :weight
-    attribute :find_number
+    attribute :find_number, Valkyrie::Types::Coercible::Integer.optional
     attribute :numismatic_collection
     attribute :rights_statement
 

--- a/app/resources/numismatics/coins/numismatics/coin_change_set.rb
+++ b/app/resources/numismatics/coins/numismatics/coin_change_set.rb
@@ -18,6 +18,8 @@ module Numismatics
     property :find_date, multiple: false, required: false
     property :find_feature, multiple: false, required: false
     property :find_locus, multiple: false, required: false
+    # We could use a validator if we get values that fail even here, such as
+    # string characters
     property :find_number, multiple: false, required: false, type: ::Types::BetterParamsInteger
     property :find_description, multiple: false, required: false
     property :die_axis, multiple: false, required: false

--- a/app/resources/numismatics/coins/numismatics/coin_change_set.rb
+++ b/app/resources/numismatics/coins/numismatics/coin_change_set.rb
@@ -18,7 +18,7 @@ module Numismatics
     property :find_date, multiple: false, required: false
     property :find_feature, multiple: false, required: false
     property :find_locus, multiple: false, required: false
-    property :find_number, multiple: false, required: false
+    property :find_number, multiple: false, required: false, type: ::Types::BetterParamsInteger
     property :find_description, multiple: false, required: false
     property :die_axis, multiple: false, required: false
     property :size, multiple: false, required: false

--- a/app/resources/numismatics/coins/numismatics/coin_decorator.rb
+++ b/app/resources/numismatics/coins/numismatics/coin_decorator.rb
@@ -37,6 +37,10 @@ module Numismatics
 
     delegate :id, :label, to: :accession, prefix: true
 
+    def find_number
+      Array.wrap(super.to_s)
+    end
+
     def call_number
       "Coin #{coin_number}"
     end

--- a/app/resources/numismatics/issues/numismatics/issue.rb
+++ b/app/resources/numismatics/issues/numismatics/issue.rb
@@ -29,7 +29,7 @@ module Numismatics
     attribute :denomination
     attribute :edge
     attribute :era
-    attribute :issue_number, Valkyrie::Types::Anything
+    attribute :issue_number, Valkyrie::Types::Coercible::Integer.optional
     attribute :metal
     attribute :object_date
     attribute :object_type

--- a/app/services/migrations/cast_numismatics_integers_migrator.rb
+++ b/app/services/migrations/cast_numismatics_integers_migrator.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Migrations
+  class CastNumismaticsIntegersMigrator
+    def self.run; end
+  end
+end

--- a/app/services/migrations/cast_numismatics_integers_migrator.rb
+++ b/app/services/migrations/cast_numismatics_integers_migrator.rb
@@ -2,6 +2,13 @@
 
 module Migrations
   class CastNumismaticsIntegersMigrator
-    def self.run; end
+    def self.run
+      csp = ChangeSetPersister.default
+      [Numismatics::Accession, Numismatics::Issue, Numismatics::Coin].each do |klass|
+        csp.query_service.find_all_of_model(model: klass).each do |resource|
+          csp.save(change_set: ChangeSet.for(resource))
+        end
+      end
+    end
   end
 end

--- a/app/types/types.rb
+++ b/app/types/types.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Types
-  include Dry.Types(default: :nominal)
+  include Dry.Types()
   URI = Dry::Types::Definition
         .new(RDF::URI)
         .constructor do |input|
@@ -10,4 +10,6 @@ module Types
       input
     end
   end
+
+  BetterParamsInteger = (Types::Params::Nil | Types::Params::Integer.optional)
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -931,7 +931,7 @@ RSpec.describe CatalogController do
         find_description: "coin-find-description",
         find_feature: "coin-find-feature",
         find_locus: "coin-find-locus",
-        find_number: "coin-find-number",
+        find_number: "101",
         private_note: "coin-private-note",
         replaces: "coin-replaces",
         size: "coin-size",

--- a/spec/resources/numismatics/accessions/numismatics/accession_spec.rb
+++ b/spec/resources/numismatics/accessions/numismatics/accession_spec.rb
@@ -9,4 +9,12 @@ describe Numismatics::Accession do
     expect(accession.type).to eq(["purchase"])
     expect(accession.items_number).to eq(102)
   end
+
+  it "stores accession_number as an integer" do
+    change_set = ChangeSet.for(accession)
+    change_set.validate(accession_number: "105")
+    csp = ChangeSetPersister.default
+    accession = csp.save(change_set: change_set)
+    expect(accession.accession_number).to eq 105
+  end
 end

--- a/spec/resources/numismatics/coins/numismatics/coin_feature_spec.rb
+++ b/spec/resources/numismatics/coins/numismatics/coin_feature_spec.rb
@@ -106,7 +106,7 @@ RSpec.feature "Numismatics::Coins" do
         find_description: "test value",
         find_feature: "test value",
         find_locus: "test value",
-        find_number: "test value",
+        find_number: "101",
         find_place_id: find_place.id,
         loan: loan,
         private_note: "test value",
@@ -132,7 +132,7 @@ RSpec.feature "Numismatics::Coins" do
       expect(page).to have_css ".attribute.find_description", text: "test value"
       expect(page).to have_css ".attribute.find_feature", text: "test value"
       expect(page).to have_css ".attribute.find_locus", text: "test value"
-      expect(page).to have_css ".attribute.find_number", text: "test value"
+      expect(page).to have_css ".attribute.find_number", text: "101"
       expect(page).to have_css ".attribute.find_place", text: "city, state, region"
       expect(page).to have_css ".attribute.loan", text: "type, exhibit, note"
       expect(page).to have_css ".attribute.numismatic_collection", text: "test value"

--- a/spec/resources/numismatics/coins/numismatics/coin_spec.rb
+++ b/spec/resources/numismatics/coins/numismatics/coin_spec.rb
@@ -25,6 +25,15 @@ RSpec.describe Numismatics::Coin do
     expect(coin.identifier).to eq ["ark:/99999/fk4"]
   end
 
+  it "stores find_number and coin_number as integers" do
+    change_set = ChangeSet.for(coin)
+    change_set.validate(find_number: "105", coin_number: "200")
+    csp = ChangeSetPersister.default
+    coin = csp.save(change_set: change_set)
+    expect(coin.find_number).to eq 105
+    expect(coin.coin_number).to eq 200
+  end
+
   describe "#pdf_file" do
     let(:file_metadata) { FileMetadata.new mime_type: ["application/pdf"], use: [Valkyrie::Vocab::PCDMUse.OriginalFile] }
     it "retrieves only PDF FileSets" do

--- a/spec/resources/numismatics/issues/numismatics/issue_spec.rb
+++ b/spec/resources/numismatics/issues/numismatics/issue_spec.rb
@@ -21,4 +21,12 @@ describe Numismatics::Issue do
     issue.downloadable = ["public"]
     expect(issue.downloadable).to eq ["public"]
   end
+
+  it "stores issue_number as an integer" do
+    change_set = ChangeSet.for(issue)
+    change_set.validate(issue_number: "105")
+    csp = ChangeSetPersister.default
+    issue = csp.save(change_set: change_set)
+    expect(issue.issue_number).to eq 105
+  end
 end

--- a/spec/services/migrations/cast_numismatics_integers_migrator_spec.rb
+++ b/spec/services/migrations/cast_numismatics_integers_migrator_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Migrations::CastNumismaticsIntegersMigrator do
+  describe ".run" do
+    it "migrates number fields from strings to integers" do
+      accession = FactoryBot.create_for_repository(:numismatic_accession, accession_number: 100)
+      coin = FactoryBot.create_for_repository(:coin, coin_number: 200, find_number: 300)
+      issue = FactoryBot.create_for_repository(:numismatic_issue, issue_number: 400, member_ids: [coin.id])
+
+      adapter = Valkyrie::MetadataAdapter.find(:postgres)
+
+      # save them as strings
+      accession_resource = adapter.resources.where(id: accession.id.to_s)
+      accession_attributes = accession_resource.first
+      accession_attributes[:metadata]["accession_number"] = ["100"]
+      accession_resource.returning.update(accession_attributes)
+
+      coin_resource = adapter.resources.where(id: coin.id.to_s)
+      coin_attributes = coin_resource.first
+      coin_attributes[:metadata]["coin_number"] = ["200"]
+      coin_attributes[:metadata]["find_number"] = ["300"]
+      coin_resource.returning.update(coin_attributes)
+
+      issue_resource = adapter.resources.where(id: issue.id.to_s)
+      issue_attributes = issue_resource.first
+      issue_attributes[:metadata]["issue_number"] = ["400"]
+      issue_resource.returning.update(issue_attributes)
+
+      described_class.run
+
+      accession_attributes = adapter.resources.where(id: accession.id.to_s).first
+      coin_attributes = adapter.resources.where(id: coin.id.to_s).first
+      issue_attributes = adapter.resources.where(id: issue.id.to_s).first
+
+      expect(accession_attributes[:metadata]["accession_number"]).to eq [100]
+      expect(coin_attributes[:metadata]["coin_number"]).to eq [200]
+      expect(coin_attributes[:metadata]["find_number"]).to eq [300]
+      expect(issue_attributes[:metadata]["issue_number"]).to eq [400]
+    end
+  end
+end


### PR DESCRIPTION
Make them optional because in at least one case there was a nil value
that raised an error.

refs #4728
