### PR TITLE
Remove memoization of GeoResourceIndexer event generator

### DIFF
--- a/app/services/geo_resource_reindexer.rb
+++ b/app/services/geo_resource_reindexer.rb
@@ -108,7 +108,7 @@ class GeoResourceReindexer
     end
 
     def messenger
-      @messenger ||= EventGenerator.new
+      EventGenerator.new
     end
 
     def query_service


### PR DESCRIPTION
Fixes bug where many copies of the first resource updated message is sent when reindexing Pulmap.