### PR TITLE
Move geo member and parent labels into placeholder text

### DIFF
--- a/app/views/catalog/_member_resources_raster_resource.html.erb
+++ b/app/views/catalog/_member_resources_raster_resource.html.erb
@@ -62,8 +62,8 @@
           </div>
           <div class="col-md-4">
             <%= f.input :member_ids,
-                        placeholder: 'Enter existing raster resource id...',
-                        label: "Child raster resource identifier",
+                        placeholder: 'Child raster resource identifier...',
+                        label: false,
                         required: false,
                         input_html: {
                           id: "child_raster_resource_id_input",

--- a/app/views/catalog/_member_resources_scanned_map.html.erb
+++ b/app/views/catalog/_member_resources_scanned_map.html.erb
@@ -62,8 +62,8 @@
           </div>
           <div class="col-md-4">
             <%= f.input :member_ids,
-                        placeholder: 'Enter existing scanned map resource id...',
-                        label: "Child scanned map resource identifier",
+                        placeholder: 'Child scanned map resource identifier...',
+                        label: false,
                         required: false,
                         input_html: {
                           id: "child_scanned_map_resource_id_input",

--- a/app/views/catalog/_member_resources_vector_resource.html.erb
+++ b/app/views/catalog/_member_resources_vector_resource.html.erb
@@ -62,8 +62,8 @@
           </div>
           <div class="col-md-4">
             <%= f.input :member_ids,
-                        placeholder: 'Enter existing vector resource id...',
-                        label: "Child vector resource identifier",
+                        placeholder: 'Child vector resource identifier...',
+                        label: false,
                         required: false,
                         input_html: {
                           id: "child_vector_resource_id_input",

--- a/app/views/catalog/_parent_resources_raster_resource.html.erb
+++ b/app/views/catalog/_parent_resources_raster_resource.html.erb
@@ -63,8 +63,8 @@
           </div>
           <div class="col-md-4">
             <%= f.input :member_ids,
-                        placeholder: 'Enter existing vector resource id...',
-                        label: "Parent raster resource identifier",
+                        placeholder: 'Parent raster resource identifier...',
+                        label: false,
                         required: false,
                         input_html: {
                           id: "parent_raster_resource_id_input",

--- a/app/views/catalog/_parent_resources_scanned_map.html.erb
+++ b/app/views/catalog/_parent_resources_scanned_map.html.erb
@@ -63,8 +63,8 @@
           </div>
           <div class="col-md-4">
             <%= f.input :member_ids,
-                        placeholder: 'Enter existing scanned map resource id...',
-                        label: "Parent scanned map resource identifier",
+                        placeholder: 'Parent scanned map resource identifier...',
+                        label: false,
                         required: false,
                         input_html: {
                           id: "parent_scanned_map_resource_id_input",

--- a/app/views/catalog/_parent_resources_vector_resource.html.erb
+++ b/app/views/catalog/_parent_resources_vector_resource.html.erb
@@ -63,8 +63,8 @@
           </div>
           <div class="col-md-4">
             <%= f.input :member_ids,
-                        placeholder: 'Enter existing vector resource id...',
-                        label: "Parent vector resource identifier",
+                        placeholder: 'Parent vector resource identifier...',
+                        label: false,
                         required: false,
                         input_html: {
                           id: "parent_vector_resource_id_input",


### PR DESCRIPTION
Move geo member and parent labels into placeholder text to fix attach button alignment while preserving clarity.

Closes #4756 
![Screen Shot 2021-11-18 at 2 42 27 PM](https://user-images.githubusercontent.com/784196/142494243-34d38ef2-5d20-4a1d-a290-3d1f564a8e8c.png)


