### PR TITLE
Store Raster Derivatives in the Cloud

### DIFF
--- a/app/derivative_services/raster_resource_derivative_service.rb
+++ b/app/derivative_services/raster_resource_derivative_service.rb
@@ -13,16 +13,6 @@ class RasterResourceDerivativeService
     end
   end
 
-  class IoDecorator < SimpleDelegator
-    attr_reader :original_filename, :content_type, :use
-    def initialize(io, original_filename, content_type, use)
-      @original_filename = original_filename
-      @content_type = content_type
-      @use = use
-      super(io)
-    end
-  end
-
   attr_reader :id, :change_set_persister
   delegate :mime_type, to: :original_file
   delegate :query_service, to: :change_set_persister
@@ -41,11 +31,11 @@ class RasterResourceDerivativeService
   end
 
   def build_display_file
-    IoDecorator.new(temporary_display_output, "display_raster.tif", "image/tiff; gdal-format=GTiff", use_display)
+    IngestableFile.new(file_path: temporary_display_output.path, mime_type: "image/tiff; gdal-format=GTiff", original_filename: "display_raster.tif", use: use_display, copyable: true)
   end
 
   def build_thumbnail_file
-    IoDecorator.new(temporary_thumbnail_output, "thumbnail.png", "image/png", use_thumbnail)
+    IngestableFile.new(file_path: temporary_thumbnail_output.path, mime_type: "image/png", use: use_thumbnail, original_filename: "thumbnail.png", copyable: true)
   end
 
   # Removes Valkyrie::StorageAdapter::File member Objects for any given Resource (usually a FileSet)
@@ -78,7 +68,7 @@ class RasterResourceDerivativeService
   end
 
   def filename
-    return Pathname.new(file_object.io.path) if file_object.io.respond_to?(:path) && File.exist?(file_object.io.path)
+    return Pathname.new(file_object.disk_path) if file_object.respond_to?(:disk_path) && File.exist?(file_object.disk_path)
   end
 
   def instructions_for_display

--- a/app/services/geoserver_message_generator.rb
+++ b/app/services/geoserver_message_generator.rb
@@ -31,7 +31,10 @@ class GeoserverMessageGenerator
     # Generate the file path for the first derivative appended to the resource
     # @return [String]
     def derivative_file_path
-      derivative_id = resource.derivative_file.file_identifiers.first
+      local_derivative = resource.derivative_files.find do |derivative_file|
+        derivative_file.file_identifiers.first.to_s.include?(Figgy.config["geoserver"]["derivatives_path"])
+      end
+      derivative_id = local_derivative.file_identifiers.first
       Valkyrie::StorageAdapter.find_by(id: derivative_id).io.path
     rescue Valkyrie::StorageAdapter::FileNotFound
       ""

--- a/config/config.yml
+++ b/config/config.yml
@@ -12,7 +12,7 @@ defaults: &defaults
   aws_access_key_id: <%= ENV["FIGGY_AWS_ACCESS_KEY_ID"] %>
   aws_secret_access_key: <%= ENV["FIGGY_AWS_SECRET_ACCESS_KEY"] %>
   cloud_geo_region: "us-east-1"
-  cloud_geo_bucket: "figgy-geo-staging"
+  cloud_geo_bucket: <%= ENV["FIGGY_CLOUD_GEO_BUCKET"] %>
   test_cloud_geo_derivative_path: <%= Rails.root.join("tmp", "cloud_geo_derivatives") %>
   preservation_bucket: "figgy-staging-preservation"
   fixity_status_topic: "figgy-staging-fixity-status"
@@ -297,6 +297,7 @@ staging:
   index_read_only: false # set to true if doing a long reindex process.
   repository_path: "/opt/repository/files"
   derivative_path: "/opt/repository/derivatives"
+  cloud_geo_bucket: "figgy-geo-staging"
   pyramidal_derivative_path: "/opt/repository/derivatives/pyramidals"
   geo_derivative_path: "/opt/repository/geo_derivatives"
   stream_derivatives_path: "/opt/repository/stream_derivatives"

--- a/config/config.yml
+++ b/config/config.yml
@@ -282,6 +282,7 @@ production:
   fixity_status_topic: "figgy-production-fixity-status"
   fixity_request_topic: "figgy-production-fixity-request"
   pyramidals_bucket: "iiif-image-production"
+  cloud_geo_bucket: "figgy-geo-production"
   enable_pyramidal_access: <%= ENV["FIGGY_PYRAMIDAL_ACCESS"].present? || false %>
   events:
     server: <%= ENV['FIGGY_RABBIT_SERVER'] || 'amqp://localhost:5672' %>

--- a/config/config.yml
+++ b/config/config.yml
@@ -13,6 +13,7 @@ defaults: &defaults
   aws_secret_access_key: <%= ENV["FIGGY_AWS_SECRET_ACCESS_KEY"] %>
   cloud_geo_region: "us-east-1"
   cloud_geo_bucket: "figgy-geo-staging"
+  test_cloud_geo_derivative_path: <%= Rails.root.join("tmp", "cloud_geo_derivatives") %>
   preservation_bucket: "figgy-staging-preservation"
   fixity_status_topic: "figgy-staging-fixity-status"
   fixity_request_topic: "figgy-staging-fixity-request"

--- a/config/config.yml
+++ b/config/config.yml
@@ -11,6 +11,8 @@ defaults: &defaults
   pyramidals_region: "us-east-1"
   aws_access_key_id: <%= ENV["FIGGY_AWS_ACCESS_KEY_ID"] %>
   aws_secret_access_key: <%= ENV["FIGGY_AWS_SECRET_ACCESS_KEY"] %>
+  cloud_geo_region: "us-east-1"
+  cloud_geo_bucket: "figgy-geo-staging"
   preservation_bucket: "figgy-staging-preservation"
   fixity_status_topic: "figgy-staging-fixity-status"
   fixity_request_topic: "figgy-staging-fixity-request"

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -180,6 +180,27 @@ Rails.application.config.to_prepare do
     :geo_derivatives
   )
 
+  if Figgy.config["cloud_geo_bucket"].present? && !Rails.env.test?
+    require "shrine/storage/s3"
+    Shrine.storages = (Shrine.storages || {}).merge(
+      cloud_geo_storage: Shrine::Storage::S3.new(
+        bucket: Figgy.config["cloud_geo_bucket"],
+        region: Figgy.config["cloud_geo_region"],
+        access_key_id: Figgy.config["aws_access_key_id"],
+        secret_access_key: Figgy.config["aws_secret_access_key"]
+      )
+    )
+    Valkyrie::StorageAdapter.register(
+      Valkyrie::Storage::Shrine.new(
+        Shrine.storages[:cloud_geo_storage],
+        Shrine::NullVerifier,
+        Valkyrie::Storage::Disk::BucketedStorage,
+        identifier_prefix: "cloud-geo-derivatives"
+      ),
+      :cloud_geo_derivatives
+    )
+  end
+
   # Registers a storage adapter for storing a Bag on a *NIX file system
   # @see https://tools.ietf.org/html/draft-kunze-bagit-14
   Valkyrie::StorageAdapter.register(

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -199,6 +199,22 @@ Rails.application.config.to_prepare do
       ),
       :cloud_geo_derivatives
     )
+  else
+    # Fall back to disk storage for development/test or if S3 is not
+    # configured.
+    Valkyrie::StorageAdapter.register(
+      InstrumentedStorageAdapter.new(
+        storage_adapter: Valkyrie::Storage::Disk.new(
+          base_path: Figgy.config["test_cloud_geo_derivative_path"],
+          file_mover: lambda { |old_path, new_path|
+            FileUtils.mv(old_path, new_path)
+            FileUtils.chmod(0o644, new_path)
+          }
+        ),
+        tracer: Datadog.tracer
+      ),
+      :cloud_geo_derivatives
+    )
   end
 
   # Registers a storage adapter for storing a Bag on a *NIX file system

--- a/spec/resources/raster_resources/raster_resource_derivative_service_spec.rb
+++ b/spec/resources/raster_resources/raster_resource_derivative_service_spec.rb
@@ -36,14 +36,16 @@ RSpec.describe RasterResourceDerivativeService do
   end
 
   context "with a valid geotiff" do
-    it "creates a display raster intermediate file and a thumbnail in the geo derivatives directory" do
+    it "creates a display raster intermediate file and a thumbnail in the geo derivatives directory, and also stores to the cloud" do
       resource = query_service.find_by(id: valid_resource.id)
       rasters = resource.file_metadata.find_all { |f| f.label == ["display_raster.tif"] }
       thumbnails = resource.file_metadata.find_all { |f| f.label == ["thumbnail.png"] }
       raster_file = Valkyrie::StorageAdapter.find_by(id: rasters.first.file_identifiers.first)
       thumbnail_file = Valkyrie::StorageAdapter.find_by(id: thumbnails.first.file_identifiers.first)
+      cloud_raster_file = Valkyrie::StorageAdapter.find_by(id: rasters.last.file_identifiers.first)
       expect(raster_file.io.path).to start_with(Rails.root.join("tmp", Figgy.config["geo_derivative_path"]).to_s)
       expect(thumbnail_file.io.path).to start_with(Rails.root.join("tmp", Figgy.config["geo_derivative_path"]).to_s)
+      expect(cloud_raster_file.io.path).to start_with(Rails.root.join("tmp", Figgy.config["test_cloud_geo_derivative_path"]).to_s)
     end
   end
 


### PR DESCRIPTION
This doesn't make it so you can hit "Download" in the list of files, but it does upload a second copy of the display_raster.tif to S3 in staging.

Closes #4769 