### PR TITLE
Provide raster visibility in mosaic endpoint response

### DIFF
--- a/app/resources/raster_resources/raster_resources_controller.rb
+++ b/app/resources/raster_resources/raster_resources_controller.rb
@@ -19,12 +19,14 @@ class RasterResourcesController < ResourceController
       mosaic_path = MosaicService.new(resource: resource).path
       respond_to do |f|
         f.json do
-          render json: { uri: mosaic_path }
+          render json: { uri: mosaic_path, visibility: resource.visibility&.first }
         end
       end
     else
       respond_to do |f|
-        f.json { head :not_found }
+        f.json do
+          render json: { visibility: resource.visibility&.first }
+        end
       end
     end
   end

--- a/app/resources/raster_resources/raster_resources_controller.rb
+++ b/app/resources/raster_resources/raster_resources_controller.rb
@@ -14,7 +14,7 @@ class RasterResourcesController < ResourceController
     @thumbnail_members = resource.decorate.thumbnail_members
   end
 
-  def mosaic
+  def titiler
     if resource.decorate.raster_set?
       mosaic_path = MosaicService.new(resource: resource).path
       respond_to do |f|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -239,7 +239,7 @@ Rails.application.routes.draw do
       member do
         get :file_manager
         get :geoblacklight, defaults: { format: :json }
-        get :mosaic, defaults: { format: :json }
+        get :titiler, defaults: { format: :json }
         post :browse_everything_files
       end
     end

--- a/spec/resources/raster_resources/raster_resources_controller_spec.rb
+++ b/spec/resources/raster_resources/raster_resources_controller_spec.rb
@@ -300,16 +300,20 @@ RSpec.describe RasterResourcesController, type: :controller do
         raster_set = FactoryBot.create_for_repository(:raster_set_with_files, id: "331d70a5-4bd9-4a65-80e4-763c8f6b34fd")
         get :mosaic, params: { id: raster_set.id, format: :json }
 
-        expect(JSON.parse(response.body)["uri"]).to end_with("tmp/cloud_geo_derivatives/33/1d/70/331d70a54bd94a6580e4763c8f6b34fd/mosaic.json")
+        doc = JSON.parse(response.body)
+        expect(doc["uri"]).to end_with("tmp/cloud_geo_derivatives/33/1d/70/331d70a54bd94a6580e4763c8f6b34fd/mosaic.json")
+        expect(doc["visibility"]).to eq "open"
       end
     end
 
     context "with a Raster Resource that's not a Set" do
-      it "returns a 404" do
-        raster_resource = FactoryBot.create_for_repository(:raster_resource)
+      it "returns json with only the visibility" do
+        raster_resource = FactoryBot.create_for_repository(:raster_resource, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED)
         get :mosaic, params: { id: raster_resource.id, format: :json }
 
-        expect(response.status).to eq 404
+        doc = JSON.parse(response.body)
+        expect(doc["uri"]).to be_nil
+        expect(doc["visibility"]).to eq "authenticated"
       end
     end
 

--- a/spec/resources/raster_resources/raster_resources_controller_spec.rb
+++ b/spec/resources/raster_resources/raster_resources_controller_spec.rb
@@ -289,7 +289,7 @@ RSpec.describe RasterResourcesController, type: :controller do
     end
   end
 
-  describe "#mosaic" do
+  describe "#titiler" do
     context "with a RasterSet" do
       with_queue_adapter :inline
 
@@ -298,7 +298,7 @@ RSpec.describe RasterResourcesController, type: :controller do
         allow(mosaic_generator).to receive(:run).and_return(true)
         allow(MosaicGenerator).to receive(:new).and_return(mosaic_generator)
         raster_set = FactoryBot.create_for_repository(:raster_set_with_files, id: "331d70a5-4bd9-4a65-80e4-763c8f6b34fd")
-        get :mosaic, params: { id: raster_set.id, format: :json }
+        get :titiler, params: { id: raster_set.id, format: :json }
 
         doc = JSON.parse(response.body)
         expect(doc["uri"]).to end_with("tmp/cloud_geo_derivatives/33/1d/70/331d70a54bd94a6580e4763c8f6b34fd/mosaic.json")
@@ -309,7 +309,7 @@ RSpec.describe RasterResourcesController, type: :controller do
     context "with a Raster Resource that's not a Set" do
       it "returns json with only the visibility" do
         raster_resource = FactoryBot.create_for_repository(:raster_resource, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED)
-        get :mosaic, params: { id: raster_resource.id, format: :json }
+        get :titiler, params: { id: raster_resource.id, format: :json }
 
         doc = JSON.parse(response.body)
         expect(doc["uri"]).to be_nil
@@ -319,7 +319,7 @@ RSpec.describe RasterResourcesController, type: :controller do
 
     context "when there's no such resource" do
       it "returns a 404" do
-        get :mosaic, params: { id: "331d70a5-4bd9-4a65-80e4-763c8f6b34fd", format: :json }
+        get :titiler, params: { id: "331d70a5-4bd9-4a65-80e4-763c8f6b34fd", format: :json }
 
         expect(response.status).to eq 404
       end


### PR DESCRIPTION
- Adds visibility to rasterset and raster documents
- Updates the routes to the more generic `titiler`. Non-set rasters need a visibility value as well and renaming avoids confusion.