### PR TITLE
Use primary_file in NullCharacterizationService

### DIFF
--- a/app/characterization_services/null_characterization_service.rb
+++ b/app/characterization_services/null_characterization_service.rb
@@ -21,6 +21,6 @@ class NullCharacterizationService
   end
 
   def target_file
-    @file_set.original_file || @file_set.intermediate_files.first
+    @file_set.primary_file
   end
 end

--- a/spec/characterization_services/null_characterization_service_spec.rb
+++ b/spec/characterization_services/null_characterization_service_spec.rb
@@ -34,4 +34,20 @@ RSpec.describe NullCharacterizationService do
       end
     end
   end
+
+  context "with a pdf preservation file" do
+    let(:pdf_file) { fixture_file_upload("files/sample.pdf", "application/pdf") }
+    describe "#valid?" do
+      it "returns false" do
+        resource = FactoryBot.create_for_repository(:scanned_resource, files: [pdf_file])
+        file_set = resource.decorate.members.first
+        pdf_file_metadata = file_set.file_metadata.first
+        pdf_file_metadata.use = [Valkyrie::Vocab::PCDMUse.PreservationMasterFile]
+        file_set.file_metadata = [pdf_file_metadata]
+        file_set = adapter.persister.save(resource: file_set)
+
+        expect(described_class.new(file_set: file_set, persister: persister).valid?).to be false
+      end
+    end
+  end
 end

--- a/spec/characterization_services/null_characterization_service_spec.rb
+++ b/spec/characterization_services/null_characterization_service_spec.rb
@@ -4,43 +4,33 @@ require "rails_helper"
 
 RSpec.describe NullCharacterizationService do
   let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
-  let(:storage_adapter) { Valkyrie.config.storage_adapter }
   let(:persister) { adapter.persister }
-  let(:query_service) { adapter.query_service }
-  let(:file) { fixture_file_upload("mets/pudl0001-4612596.mets", "application/xml; schema=mets") }
-  let(:change_set_persister) { ChangeSetPersister.new(metadata_adapter: adapter, storage_adapter: storage_adapter) }
-  let(:sr) do
-    change_set_persister.save(change_set: ScannedResourceChangeSet.new(ScannedResource.new, files: [file]))
-  end
-  let(:mets_members) { query_service.find_members(resource: sr) }
-  let(:valid_file_set) { mets_members.first }
 
-  it "properly no-ops on a mets metadata file" do
-    file_set = valid_file_set
-    new_file_set = described_class.new(file_set: file_set, persister: persister).characterize(save: false)
-    expect(new_file_set.original_file.mime_type).to eq ["application/xml; schema=mets"]
-  end
-
-  describe "#valid?" do
-    let(:file_set) { instance_double("FileSet") }
-    let(:original_file) { instance_double("FileMetadata") }
-    context "with a tiff" do
-      before do
-        allow(file_set).to receive(:original_file).and_return(original_file)
-        allow(original_file).to receive(:mime_type).and_return(["image/tiff"])
-      end
-
-      it "returns false" do
-        expect(described_class.new(file_set: file_set, persister: persister).valid?).to be false
+  context "with a mets file" do
+    let(:mets_file) { fixture_file_upload("mets/pudl0001-4612596.mets", "application/xml; schema=mets") }
+    describe "#valid?" do
+      it "is valid" do
+        resource = FactoryBot.create_for_repository(:scanned_resource, files: [mets_file])
+        file_set = resource.decorate.members.first
+        expect(described_class.new(file_set: file_set, persister: persister).valid?).to be true
       end
     end
-    context "with a mets file" do
-      before do
-        allow(file_set).to receive(:original_file).and_return(original_file)
-        allow(original_file).to receive(:mime_type).and_return(["application/xml; schema=mets"])
-      end
-      it "returns true" do
-        expect(described_class.new(file_set: file_set, persister: persister).valid?).to be true
+
+    it "properly no-ops on a mets metadata file" do
+      resource = FactoryBot.create_for_repository(:scanned_resource, files: [mets_file])
+      file_set = resource.decorate.members.first
+      new_file_set = described_class.new(file_set: file_set, persister: persister).characterize(save: false)
+      expect(new_file_set.original_file.mime_type).to eq ["application/xml; schema=mets"]
+    end
+  end
+
+  context "with a tiff" do
+    let(:tiff_file) { fixture_file_upload("files/example.tif", "image/tiff") }
+    describe "#valid?" do
+      it "returns false" do
+        resource = FactoryBot.create_for_repository(:scanned_resource, files: [tiff_file])
+        file_set = resource.decorate.members.first
+        expect(described_class.new(file_set: file_set, persister: persister).valid?).to be false
       end
     end
   end


### PR DESCRIPTION
- Use real objects instead of mocks in null_characterization_service_spec
- Use primary_file in NullCharacterizationService

refs #4846 

note to reviewer: it may be helpful to look at the commits separately. The first refactors the specs and the second adds the new test / updates the code.