### PR TITLE
Prevent checking for range if a range hasn't started yet.

### DIFF
--- a/public/uv/lib/AVComponent.js
+++ b/public/uv/lib/AVComponent.js
@@ -537,7 +537,7 @@ var IIIFComponents;
             this._checkMediaSynchronization();
             var range = this._getRangeForCurrentTime();
             if (range && !this._data.limitToRange && (!this._data.range || (this._data.range && range.id !== this._data.range.id))) {
-                if(this._canvasClockTime <= this._data.range.getDuration().end && this._canvasClockTime >= this._data.range.getDuration().start) {
+                if(this._data.range && this._canvasClockTime <= this._data.range.getDuration().end && this._canvasClockTime >= this._data.range.getDuration().start) {
                   return
                 }
                 this.set({


### PR DESCRIPTION
Closes #4914 

Confirmed in staging this works. This will require a hard refresh from users to get this file out of their cache, unfortunately.