### PR TITLE
remove obverse fields from reverse_description decorator

### DIFF
--- a/app/resources/numismatics/issues/numismatics/issue_decorator.rb
+++ b/app/resources/numismatics/issues/numismatics/issue_decorator.rb
@@ -164,7 +164,7 @@ module Numismatics
     end
 
     def reverse_description
-      [initial_capital(reverse_figure), reverse_part, obverse_orientation, obverse_figure_description].select(&:present?).join(", ")
+      [initial_capital(reverse_figure), reverse_part, reverse_orientation, reverse_figure_description].select(&:present?).join(", ")
     end
   end
 end

--- a/spec/services/orangelight_document_spec.rb
+++ b/spec/services/orangelight_document_spec.rb
@@ -168,7 +168,7 @@ describe OrangelightDocument do
         expect(output[:issue_obverse_legend_s]).to eq ["GEORGIUS•DEI•GRATIA•REX•"]
         expect(output[:issue_obverse_attributes_s]).to eq ["attribute name, attribute description"]
         expect(output[:issue_reverse_symbol_s]).to eq ["goat head"]
-        expect(output[:issue_reverse_description_s]).to eq "Emperor and Virgin, seated, right, Harp at left side, 5 strings."
+        expect(output[:issue_reverse_description_s]).to eq "Emperor and Virgin, seated, left, Harp at right side, 11 strings. Right arm holding up a palm-branch"
         expect(output[:issue_reverse_part_s]).to eq ["seated"]
         expect(output[:issue_reverse_orientation_s]).to eq ["left"]
         expect(output[:issue_reverse_figure_description_s]).to eq ["Harp at right side, 11 strings. Right arm holding up a palm-branch"]


### PR DESCRIPTION
When indexing coins via bibdata, we noticed that the reverse_description decorator refers to some obverse fields, when it should refer to their reverse field counterparts.