### PR TITLE
Json ingest task

### DIFF
--- a/app/services/json_ingester.rb
+++ b/app/services/json_ingester.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+class JsonIngester
+  attr_reader :json_path, :logger
+  def initialize(json_path:, logger: Rails.logger)
+    @json_path = json_path
+    @logger = logger
+  end
+
+  def ingest!
+    logger.info "ingesting #{data[:records].length} records"
+    data[:records].each do |attrs|
+      dir = attrs.delete(:path)
+      logger.info "ingesting #{attrs[:title]}"
+      IngestFolderJob.perform_now(
+        directory: dir,
+        class_name: class_name,
+        file_filters: filters,
+        change_set_param: "Simple",
+        **attrs
+      )
+      logger.info "done ingesting #{attrs[:title]}"
+    end
+  end
+
+  def data
+    @params ||= JSON.parse(File.read(json_path), symbolize_names: true)
+  end
+
+  def class_name
+    "ScannedResource"
+  end
+
+  def filters
+    [".pdf", ".jpg", ".png", ".tif", ".TIF", ".tiff", ".TIFF"]
+  end
+end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -24,5 +24,37 @@ namespace :figgy do
 
       IngestMETSJob.set(queue: :low).perform_later(file, user, import_mods)
     end
+
+    desc "Ingest a JSON file."
+    task json: :environment do
+      file_path = ENV["FILE"]
+      user = User.find_by_user_key(ENV["USER"]) if ENV["USER"]
+      user = User.all.find(&:admin?) unless user
+
+      abort "usage: rake import:json FILE=/path/to/file.json [USER=person]" unless file && File.file?(file)
+
+      @logger = Logger.new(STDOUT)
+      @logger.info "ingesting #{file_path} as: #{user.user_key} (override with USER=foo)"
+
+      class_name = "ScannedResource"
+      filters = [".pdf", ".jpg", ".png", ".tif", ".TIF", ".tiff", ".TIFF"]
+
+      data = JSON.parse(File.read(file))
+      logger.info "ingesting #{data['records'].length} records"
+      data["records"].each do |record|
+        attrs = record.map { |k, v| [k.to_sym, v] }.to_h
+        dir = attrs.delete(:path)
+        colls = Array(attrs.delete(:member_of_collection_ids))
+        logger.info "ingesting #{attrs[:title]}"
+        IngestFolderJob.perform_now(
+          directory: dir,
+          class_name: class_name,
+          member_of_collection_ids: colls,
+          file_filters: filters,
+          **attrs
+        )
+        logger.info "done ingesting #{attrs[:title]}"
+      end
+    end
   end
 end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -31,7 +31,7 @@ namespace :figgy do
       user = User.find_by_user_key(ENV["USER"]) if ENV["USER"]
       user = User.all.find(&:admin?) unless user
 
-      abort "usage: rake import:json FILE=/path/to/file.json [USER=person]" unless file && File.file?(file)
+      abort "usage: rake import:json FILE=/path/to/file.json [USER=person]" unless file_path && File.file?(file_path)
 
       @logger = Logger.new(STDOUT)
       @logger.info "ingesting #{file_path} as: #{user.user_key} (override with USER=foo)"
@@ -39,7 +39,7 @@ namespace :figgy do
       class_name = "ScannedResource"
       filters = [".pdf", ".jpg", ".png", ".tif", ".TIF", ".tiff", ".TIFF"]
 
-      data = JSON.parse(File.read(file))
+      data = JSON.parse(File.read(file_path))
       logger.info "ingesting #{data['records'].length} records"
       data["records"].each do |record|
         attrs = record.map { |k, v| [k.to_sym, v] }.to_h

--- a/spec/fixtures/json_ingest.json
+++ b/spec/fixtures/json_ingest.json
@@ -1,0 +1,28 @@
+{
+  "records": [
+    {
+      "title": "Princeton Plasma Physics Laboratory Highlights for Fiscal Year 2007",
+      "local_identifier": "07Highlights",
+      "path": "/mnt/hydra_sources/ingest_scratch/pppl_technical_reports/staged/07Highlights",
+      "creator": [
+        ""
+      ],
+      "member_of_collection_ids": [
+        "e6080f72-4ba5-4e35-a87d-9a4eb826d0e3"
+      ]
+    },
+    {
+      "title": "Annual Site Environmental Report - 2018",
+      "local_identifier": "PPPL-2019_191",
+      "path": "/mnt/hydra_sources/ingest_scratch/pppl_technical_reports/staged/PPPL-2019_191",
+      "creator": [
+        "M. Hughes",
+        "R. Sheneman",
+        "J. Levine"
+      ],
+      "member_of_collection_ids": [
+        "e6080f72-4ba5-4e35-a87d-9a4eb826d0e3"
+      ]
+    }
+  ]
+}

--- a/spec/services/json_ingester_spec.rb
+++ b/spec/services/json_ingester_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe JsonIngester do
+  context "when given a JSON hash" do
+    it "ingests records according to it" do
+      collection = FactoryBot.create_for_repository(:collection)
+      json_file = generate_fixture_json(collection: collection)
+      ingester = described_class.new(json_path: json_file.path)
+      allow(IngestFolderJob).to receive(:perform_now).and_call_original
+
+      ingester.ingest!
+      resources = ChangeSetPersister.default.query_service.find_all_of_model(model: ScannedResource)
+
+      expect(resources.to_a.length).to eq 2
+      resource1 = resources.find { |r| r.title.include?("Princeton Plasma Physics Laboratory Highlights for Fiscal Year 2007") }
+      resource2 = resources.find { |r| r != resource1 }
+      # Ingesting metadata, needs to be a simple resource.
+      expect(ChangeSet.for(resource1)).to be_a SimpleChangeSet
+      expect(resource1.member_of_collection_ids).to eq [collection.id]
+      # Ensure an empty creator doesn't create blank creators.
+      expect(resource1.creator).to eq []
+      expect(resource2.creator).to eq ["M. Hughes", "R. Sheneman", "J. Levine"]
+      expect(resource1.local_identifier).to eq ["07Highlights"]
+      # Ensure files ingested.
+      expect(resource1.member_ids.length).to eq 1
+      # Ensure ingest is called synchronously - for some reason. Feedback?
+      expect(IngestFolderJob).to have_received(:perform_now).exactly(2).times
+    end
+  end
+
+  # Creates fixture JSON and puts it in a file.
+  def generate_fixture_json(collection:)
+    json = JSON.parse(File.read(Rails.root.join("spec", "fixtures", "json_ingest.json")), symbolize_names: true)
+    json[:records][0][:path] = Rails.root.join("spec", "fixtures", "bulk_ingest", "123456", "vol1").to_s
+    json[:records][1][:path] = Rails.root.join("spec", "fixtures", "bulk_ingest", "123456", "vol2").to_s
+    json[:records][0][:member_of_collection_ids] = [collection.id.to_s]
+    json[:records][1][:member_of_collection_ids] = [collection.id.to_s]
+    file = Tempfile.new(["ingest_test", ".json"])
+    file.puts(json.to_json)
+    file.rewind
+    file
+  end
+end


### PR DESCRIPTION
Adds a task called **json** to _import.rake_; ingests resources from the Isilon server with metadata formatted as JSON.  This should be a general-purpose ingest task, but it has been created specifically for #5023 