### PR TITLE
Allow download of original pdf from viewer

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -215,12 +215,14 @@ class CatalogController < ApplicationController
     end
   end
 
+  # This endpoint redirects to download an original pdf if present,
+  # or redirects to the resource pdf endpoint if one needs to be generated
   def pdf
     _, @document = fetch(params[:solr_document_id])
 
     source_pdf = Wayfinder.for(resource).source_pdf
-    if source_pdf && can?(:download, source_pdf)
-      redirect_to "#{request.base_url}#{helpers.fileset_download_path(source_pdf)}"
+    if source_pdf
+      redirect_to "#{request.base_url}#{helpers.fileset_download_path(source_pdf, auth_token_param)}"
     elsif helpers.pdf_allowed?(resource) && can?(:pdf, resource)
       redirect_to "#{request.base_url}#{polymorphic_path([:pdf, resource], auth_token_param)}"
     else

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -222,9 +222,16 @@ class CatalogController < ApplicationController
     if source_pdf && can?(:download, source_pdf)
       redirect_to "#{request.base_url}#{helpers.fileset_download_path(source_pdf)}"
     elsif helpers.pdf_allowed?(resource) && can?(:pdf, resource)
-      redirect_to "#{request.base_url}#{polymorphic_path([:pdf, resource])}"
+      redirect_to "#{request.base_url}#{polymorphic_path([:pdf, resource], auth_token_param)}"
     else
       redirect_to solr_document_url(resource), notice: "No PDF available for this item"
     end
   end
+
+  private
+
+    def auth_token_param
+      return {} unless params[:auth_token]
+      { auth_token: params[:auth_token] }
+    end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -180,8 +180,11 @@ module ApplicationHelper
     "/viewer#?manifest=#{manifest_url(resource)}"
   end
 
-  def fileset_download_path(fileset)
-    download_path(fileset.id, fileset.file_metadata.first.id)
+  # Convenience method for a fileset download path
+  # @param [FileSet] the fileset to provide a download link to
+  # @param [Hash] querystring options, for example an auth token to pass through
+  def fileset_download_path(fileset, opts = {})
+    download_path(fileset.id, fileset.file_metadata.first.id, opts)
   end
 
   def figgy_pdf_path(resource)

--- a/app/resources/scanned_resources/scanned_resource.rb
+++ b/app/resources/scanned_resources/scanned_resource.rb
@@ -39,6 +39,7 @@ class ScannedResource < Resource
     Array.wrap(imported_metadata).first || ImportedMetadata.new
   end
 
+  # This retrieves a generated pdf file (not an original pdf file)
   def pdf_file
     file_metadata.find do |file|
       file.mime_type == ["application/pdf"]

--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -715,7 +715,7 @@ class ManifestBuilder
     end
 
     def pdf_url(resource)
-      url = manifest_url(resource).gsub("manifest", "pdf")
+      url = Rails.application.routes.url_helpers.pdf_url(resource)
       return url + "?auth_token=#{resource.auth_token}" if token_authorizable?(resource)
       url
     end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -971,40 +971,4 @@ RSpec.describe CatalogController do
       end
     end
   end
-
-  describe "#pdf" do
-    let(:resources) { [resource] }
-    before do
-      persister.save_all(resources: resources)
-    end
-
-    context "when the resource was ingested from a pdf" do
-      let(:resource) { FactoryBot.create_for_repository(:complete_scanned_resource, member_ids: [file_set.id]) }
-      let(:file_set) { FactoryBot.create_for_repository(:file_set, file_metadata: [file_meta]) }
-      let(:file_meta) { FileMetadata.new(id: "1234", use: Valkyrie::Vocab::PCDMUse.OriginalFile, mime_type: "application/pdf") }
-      let(:resources) { [resource, file_set] }
-
-      it "downloads the original pdf" do
-        get :pdf, params: { solr_document_id: resource.id }
-        expect(response).to redirect_to "http://test.host/downloads/#{file_set.id}/file/1234"
-      end
-    end
-
-    context "when the resource can generate a pdf" do
-      let(:resource) { FactoryBot.create_for_repository(:complete_scanned_resource) }
-
-      it "redirects to the pdf" do
-        get :pdf, params: { solr_document_id: resource.id }
-        expect(response).to redirect_to "http://test.host/concern/scanned_resources/#{resource.id}/pdf"
-      end
-    end
-    context "when the resource can't generate a pdf" do
-      let(:resource) { FactoryBot.create_for_repository(:collection) }
-
-      it "redirects to the show page" do
-        get :pdf, params: { solr_document_id: resource.id.to_s }
-        expect(response).to redirect_to "http://test.host/catalog/#{resource.id}"
-      end
-    end
-  end
 end

--- a/spec/requests/catalog_spec.rb
+++ b/spec/requests/catalog_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "Catalog requests", type: :request do
+  with_queue_adapter :inline
+
+  describe "#pdf" do
+    context "when the resource was ingested from a pdf" do
+      let(:sample_file) { fixture_file_upload("files/sample.pdf", "application/pdf") }
+      let(:scanned_resource) { FactoryBot.create_for_repository(:complete_scanned_resource, files: [sample_file]) }
+
+      before do
+        stub_bibdata(bib_id: "123456")
+        stub_ezid(shoulder: "99999/fk4", blade: "123456")
+      end
+
+      it "downloads the original pdf" do
+        file_set = Wayfinder.for(scanned_resource).source_pdf
+        get "/catalog/#{scanned_resource.id}/pdf"
+        expect(response).to redirect_to "/downloads/#{file_set.id}/file/#{file_set.file_metadata.first.id}"
+
+        follow_redirect!
+        expect(response.status).to be 200
+      end
+
+      context "when the resource is private" do
+        let(:scanned_resource) { FactoryBot.create_for_repository(:complete_private_scanned_resource, files: [sample_file]) }
+
+        it "redirects the client to be authenticated" do
+          wayfinder = Wayfinder.for(scanned_resource)
+
+          # TODO
+          # it's generating the pdf page images -- we don't want it to do this.
+          wayfinder.file_sets.each do |fs|
+            stub_request(:any, "http://www.example.com/image-service/#{fs.id}/full/200,/0/gray.jpg")
+              .to_return(body: File.open(Rails.root.join("spec", "fixtures", "files", "derivatives", "grey-pdf.jpg")), status: 200)
+          end
+          get "/catalog/#{scanned_resource.id}/pdf"
+
+          # TODO: it's sending client to omniauth via concerns route
+          # expect(response).to redirect_to "/downloads/#{file_set.id}/file/1234"
+
+          # first it goes to the concerns route
+          follow_redirect!
+
+          # then it goes to the downloads route
+          follow_redirect!
+
+          # then it wants to auth
+          expect(response).to redirect_to user_cas_omniauth_authorize_path
+        end
+
+        # TODO: write this spec and make it pass
+        it "can download the original with a token" do
+        end
+      end
+    end
+
+    context "when the resource can generate a pdf" do
+      let(:sample_file) { fixture_file_upload("files/example.tif", "image/tiff") }
+      let(:scanned_resource) { FactoryBot.create_for_repository(:complete_scanned_resource, files: [sample_file]) }
+
+      before do
+        stub_bibdata(bib_id: "123456")
+        stub_ezid(shoulder: "99999/fk4", blade: "123456")
+        # used in pdf generation
+        stub_request(:any, "http://www.example.com/image-service/#{scanned_resource.member_ids.first}/full/200,/0/gray.jpg")
+          .to_return(body: File.open(Rails.root.join("spec", "fixtures", "files", "derivatives", "grey-pdf.jpg")), status: 200)
+      end
+
+      it "redirects to pdf generation" do
+        get "/catalog/#{scanned_resource.id}/pdf"
+        expect(response).to redirect_to "/concern/scanned_resources/#{scanned_resource.id}/pdf"
+      end
+
+      context "when the resource is private" do
+        let(:scanned_resource) { FactoryBot.create_for_repository(:complete_private_scanned_resource, files: [sample_file]) }
+
+        it "redirects the client to be authenticated" do
+          get "/catalog/#{scanned_resource.id}/pdf"
+
+          expect(response).to redirect_to "/concern/scanned_resources/#{scanned_resource.id}/pdf"
+
+          follow_redirect! # actually generates the pdf
+
+          adapter = Valkyrie::MetadataAdapter.find(:indexing_persister)
+          reloaded = adapter.query_service.find_by(id: scanned_resource.id)
+          expect(response).to redirect_to "/downloads/#{scanned_resource.id}/file/#{reloaded.pdf_file.id}"
+
+          follow_redirect!
+          expect(response).to redirect_to user_cas_omniauth_authorize_path
+        end
+
+        it "can download the generated pdf with a token" do
+          auth_token = AuthToken.create!(group: ["admin"], label: "Admin Token").token
+          get "/catalog/#{scanned_resource.id}/pdf?auth_token=#{auth_token}"
+
+          expect(response.status).to eq 302 # Redirects to the concerns pdf route
+
+          follow_redirect!
+          expect(response.status).to eq 302 # This redirects to the downloads controller
+          follow_redirect!
+          expect(response.status).to eq 200
+        end
+      end
+    end
+
+    context "when the resource can't generate a pdf" do
+      let(:resource) { FactoryBot.create_for_repository(:collection) }
+      let(:persister) { Valkyrie::MetadataAdapter.find(:indexing_persister).persister }
+
+      it "redirects to the show page" do
+        persister.save(resource: resource)
+        get "/catalog/#{resource.id}/pdf"
+        expect(response).to redirect_to "/catalog/#{resource.id}"
+      end
+    end
+  end
+end

--- a/spec/requests/scanned_resource_spec.rb
+++ b/spec/requests/scanned_resource_spec.rb
@@ -80,8 +80,10 @@ RSpec.describe "ScannedResource requests", type: :request do
     it "redirects the client to be authenticated" do
       get "/concern/scanned_resources/#{scanned_resource.id}/pdf"
 
+      # it has to be reloaded to get the pdf_file because hitting this route
+      # generates the file
       reloaded = adapter.query_service.find_by(id: scanned_resource.id)
-      expect(response).to redirect_to Rails.application.routes.url_helpers.download_path(resource_id: scanned_resource.id.to_s, id: reloaded.pdf_file.id.to_s)
+      expect(response).to redirect_to "/downloads/#{scanned_resource.id}/file/#{reloaded.pdf_file.id}"
 
       follow_redirect!
       expect(response).to redirect_to user_cas_omniauth_authorize_path
@@ -107,7 +109,7 @@ RSpec.describe "ScannedResource requests", type: :request do
         sequences = manifest_values["sequences"]
         renderings = sequences.first["rendering"]
 
-        expect(renderings.first).to include("@id" => "http://www.example.com/concern/scanned_resources/#{scanned_resource.id}/pdf")
+        expect(renderings.first).to include("@id" => "http://www.example.com/catalog/#{scanned_resource.id}/pdf")
 
         canvases = sequences.first["canvases"]
         canvas_renderings = canvases.first["rendering"]

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe ManifestBuilder do
       expect(output["viewingDirection"]).to eq "right-to-left"
       expect(output["rendering"]).to include "@id" => "http://arks.princeton.edu/ark:/88435/abc1234de", "format" => "text/html"
       expect(output["sequences"].length).to eq 1
-      expect(output["sequences"][0]["rendering"][0]["@id"]).to eq "http://www.example.com/concern/scanned_resources/#{change_set.id}/pdf"
+      expect(output["sequences"][0]["rendering"][0]["@id"]).to eq "http://www.example.com/catalog/#{change_set.id}/pdf"
       expect(output["sequences"][0]["rendering"][0]["format"]).to eq "application/pdf"
       expect(output["sequences"][0]["viewingHint"]).to eq "individuals"
       canvas_id = output["sequences"][0]["canvases"][0]["@id"]


### PR DESCRIPTION
- Use catalog pdf route in manifest
- Fix path in scanned resource request spec
- Pass auth token through from catalog pdf route to concerns pdf route
- Allow original pdf download with token or auth

closes #5020 