### PR TITLE
Fix generation of WMS and WFS references for geo resources

### DIFF
--- a/app/services/geo_discovery/document_builder/wxs.rb
+++ b/app/services/geo_discovery/document_builder/wxs.rb
@@ -11,7 +11,7 @@ module GeoDiscovery
       # Returns the identifier to use with WMS/WFS/WCS services.
       # @return [String] wxs indentifier
       def identifier
-        return resource_decorator.layer_name if resource_decorator.layer_name
+        return resource_decorator.layer_name if resource_decorator.layer_name.present?
         return unless file_set
         return file_set.id.to_s unless @config && visibility
         "#{@config[visibility][:workspace]}:p-#{file_set.id}" if @config[visibility][:workspace]
@@ -20,7 +20,7 @@ module GeoDiscovery
       # Returns the wms server url.
       # @return [String] wms server url
       def wms_path
-        return resource_decorator.wms_url if resource_decorator.wms_url
+        return resource_decorator.wms_url if resource_decorator.wms_url.present?
         return unless generate_wms_path?
         "#{path}/#{@config[visibility][:workspace]}/wms"
       end
@@ -28,7 +28,7 @@ module GeoDiscovery
       # Returns the wfs server url.
       # @return [String] wfs server url
       def wfs_path
-        return resource_decorator.wfs_url if resource_decorator.wfs_url
+        return resource_decorator.wfs_url if resource_decorator.wfs_url.present?
         return unless @config && visibility && file_set && vector_file_set?
         "#{path}/#{@config[visibility][:workspace]}/wfs"
       end

--- a/spec/services/geo_discovery/document_builder/wxs_spec.rb
+++ b/spec/services/geo_discovery/document_builder/wxs_spec.rb
@@ -5,7 +5,7 @@ describe GeoDiscovery::DocumentBuilder::Wxs do
   with_queue_adapter :inline
   subject(:wxs_builder) { described_class.new(decorator) }
 
-  let(:geo_work) { FactoryBot.create_for_repository(:vector_resource, visibility: visibility) }
+  let(:geo_work) { FactoryBot.create_for_repository(:vector_resource, visibility: visibility, wms_url: "", wfs_url: "", layer_name: "") }
   let(:decorator) { query_service.find_by(id: geo_work.id).decorate }
   let(:visibility) { Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
   let(:change_set) { VectorResourceChangeSet.new(geo_work, files: [file]) }


### PR DESCRIPTION
Closes #5043 

- Occasionally, blank strings are saved in geo resource `layer_name`,` wms_url`, and `wfs_url` properties which causes an issue with GeoBlacklight document references. Use a better test for blank values.