### PR TITLE
Add a multi-value geom types field to gbl document

### DIFF
--- a/app/services/geo_discovery/abstract_document.rb
+++ b/app/services/geo_discovery/abstract_document.rb
@@ -4,7 +4,7 @@ module GeoDiscovery
   class AbstractDocument
     attr_accessor :access_rights, :all_subject, :call_number, :creator,
                   :dct_references, :description, :download, :fgdc, :format,
-                  :geom_type, :identifier, :iiif, :iiif_manifest, :iso19139,
+                  :geom_types, :identifier, :iiif, :iiif_manifest, :iso19139,
                   :issued, :language, :layer_modified, :layer_year, :mods,
                   :held_by, :publisher, :resource_type, :rendered_rights_statement,
                   :slug, :solr_coverage, :source, :spatial, :subject,

--- a/app/services/geo_discovery/geoblacklight_document.rb
+++ b/app/services/geo_discovery/geoblacklight_document.rb
@@ -57,7 +57,8 @@ module GeoDiscovery
           layer_modified_dt: layer_modified,
           layer_id_s: layer_id,
           dct_references_s: clean_document(references).to_json.to_s,
-          layer_geom_type_s: geom_type,
+          layer_geom_type_s: geom_types.first,
+          layer_geom_type_sm: geom_types,
           dc_format_s: format,
           dct_issued_dt: issued,
           suppressed_b: suppressed,
@@ -177,7 +178,7 @@ module GeoDiscovery
       end
 
       def build_private_document?
-        return true if geom_type == "Image" && access_rights == restricted_visibility
+        return true if geom_types.include?("Image") && access_rights == restricted_visibility
         return true if access_rights == private_visibility
         false
       end

--- a/spec/services/geo_discovery/document_builder/layer_info_builder_spec.rb
+++ b/spec/services/geo_discovery/document_builder/layer_info_builder_spec.rb
@@ -32,7 +32,7 @@ describe GeoDiscovery::DocumentBuilder::LayerInfoBuilder do
     context "with a geometry value of None" do
       it "returns a value of Mixed" do
         builder.build(document)
-        expect(document.geom_type).to eq("Mixed")
+        expect(document.geom_types).to eq(["Mixed"])
       end
     end
 
@@ -41,7 +41,7 @@ describe GeoDiscovery::DocumentBuilder::LayerInfoBuilder do
 
       it "returns a value of Point" do
         builder.build(document)
-        expect(document.geom_type).to eq("Point")
+        expect(document.geom_types).to eq(["Point"])
       end
     end
 
@@ -50,7 +50,7 @@ describe GeoDiscovery::DocumentBuilder::LayerInfoBuilder do
 
       it "returns a value of Line" do
         builder.build(document)
-        expect(document.geom_type).to eq("Line")
+        expect(document.geom_types).to eq(["Line"])
       end
     end
 
@@ -59,7 +59,7 @@ describe GeoDiscovery::DocumentBuilder::LayerInfoBuilder do
 
       it "returns a value of Line" do
         builder.build(document)
-        expect(document.geom_type).to eq("Line")
+        expect(document.geom_types).to eq(["Line"])
       end
     end
   end

--- a/spec/services/geo_discovery/document_builder_spec.rb
+++ b/spec/services/geo_discovery/document_builder_spec.rb
@@ -75,6 +75,7 @@ describe GeoDiscovery::DocumentBuilder, skip_fixity: true do
 
       # layer info fields
       expect(document["layer_geom_type_s"]).to eq("Polygon")
+      expect(document["layer_geom_type_sm"]).to eq(["Polygon"])
       expect(document["dc_format_s"]).to eq("Shapefile")
 
       # references
@@ -185,6 +186,7 @@ describe GeoDiscovery::DocumentBuilder, skip_fixity: true do
 
       it "has layer info fields" do
         expect(document["layer_geom_type_s"]).to eq("Image")
+        expect(document["layer_geom_type_sm"]).to eq(["Image"])
         expect(document["dc_format_s"]).to eq("TIFF")
       end
     end
@@ -373,9 +375,10 @@ describe GeoDiscovery::DocumentBuilder, skip_fixity: true do
         metadata_adapter.persister.save(resource: file_set)
       end
 
-      it "returns document wmts reference" do
+      it "returns document wmts reference and both formats" do
         refs = JSON.parse(document["dct_references_s"])
         expect(refs["http://www.opengis.net/def/serviceType/ogc/wmts"]).to match(/WMTSCapabilities/)
+        expect(document["layer_geom_type_sm"]).to contain_exactly("Image", "Raster")
       end
     end
   end
@@ -403,6 +406,7 @@ describe GeoDiscovery::DocumentBuilder, skip_fixity: true do
     it "has metadata" do
       # Layer info fields
       expect(document["layer_geom_type_s"]).to eq("Raster")
+      expect(document["layer_geom_type_sm"]).to eq(["Raster"])
       expect(document["dc_format_s"]).to eq("GeoTIFF")
       expect(document["all_subject_sm"]).to eq(["Human settlements", "Society"])
 


### PR DESCRIPTION
refs pulibrary/pulmap#1028

see also pulibrary/pulmap#1075 -- since that copies from the old single-value field to the new one we will also want to remove the old field as part of this PR.