### PR TITLE
Use Bootstrap 4 configuration for Simple Form.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -141,6 +141,7 @@ Layout/LineLength:
     - 'spec/controllers/collections_controller_spec.rb'
     - 'spec/models/oai/figgy/valkyrie_provider_model_spec.rb'
     - 'spec/decorators/numismatics/accession_decorator_spec.rb'
+    - 'config/initializers/simple_form_bootstrap.rb'
 Metrics/MethodLength:
   Exclude:
     - 'db/migrate/**/*'

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -1,154 +1,432 @@
 # frozen_string_literal: true
-# NOTE: This is a modified version of simple_form's default config file.
-#       The only changes were to move the inputs to after the hints and errors.
+
+# Please do not make direct changes to this file!
+# This generator is maintained by the community around simple_form-bootstrap:
+# https://github.com/rafaelfranca/simple_form-bootstrap
+# All future development, tests, and organization should happen there.
+# Background history: https://github.com/plataformatec/simple_form/issues/1561
+
+# Uncomment this and change the path if necessary to include your own
+# components.
+# See https://github.com/plataformatec/simple_form#custom-components
+# to know more about custom components.
+# Dir[Rails.root.join('lib/components/**/*.rb')].each { |f| require f }
 
 # Use this setup block to configure all options available in SimpleForm.
-
 SimpleForm.setup do |config|
+  # Default class for buttons
+  config.button_class = "btn"
+
+  # Define the default class of the input wrapper of the boolean input.
+  config.boolean_label_class = "form-check-label"
+
+  # How the label text should be generated altogether with the required text.
+  config.label_text = ->(label, required, _explicit_label) { "#{label} #{required}" }
+
+  # Define the way to render check boxes / radio buttons with labels.
+  config.boolean_style = :inline
+
+  # You can wrap each item in a collection of radio/check boxes with a tag
+  config.item_wrapper_tag = :div
+
+  # Defines if the default input wrapper class should be included in radio
+  # collection wrappers.
+  config.include_default_input_wrapper_class = false
+
+  # CSS class to add for error notification helper.
   config.error_notification_class = "alert alert-danger"
-  config.button_class = "btn btn-default"
-  config.boolean_label_class = nil
 
-  config.wrappers :vertical_form, tag: "div", class: "form-group", error_class: "has-error" do |b|
+  # Method used to tidy up errors. Specify any Rails Array method.
+  # :first lists the first message for each field.
+  # :to_sentence to list all errors for each field.
+  config.error_method = :to_sentence
+
+  # add validation classes to `input_field`
+  config.input_field_error_class = "is-invalid"
+  config.input_field_valid_class = ""
+
+  # vertical forms
+  #
+  # vertical default_wrapper
+  config.wrappers :vertical_form, tag: "div", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
+    b.optional :minlength
     b.optional :pattern
     b.optional :min_max
     b.optional :readonly
-    b.use :label, class: "control-label"
-    b.use :error, wrap_with: { tag: "span", class: "help-block" }
-    b.use :hint,  wrap_with: { tag: "p", class: "help-block" }
-    b.use :input, class: "form-control"
+    b.use :label, class: "form-control-label"
+    b.use :input, class: "form-control", error_class: "is-invalid", valid_class: ""
+    b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback" }
+    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
   end
 
-  config.wrappers :vertical_file_input, tag: "div", class: "form-group", error_class: "has-error" do |b|
-    b.use :html5
-    b.use :placeholder
-    b.optional :maxlength
-    b.optional :readonly
-    b.use :label, class: "control-label"
-    b.use :error, wrap_with: { tag: "span", class: "help-block" }
-    b.use :hint,  wrap_with: { tag: "p", class: "help-block" }
-    b.use :input
-  end
-
-  config.wrappers :vertical_boolean, tag: "div", class: "form-group", error_class: "has-error" do |b|
+  # vertical input for boolean
+  config.wrappers :vertical_boolean, tag: "fieldset", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.optional :readonly
-
-    b.wrapper tag: "div", class: "form-check" do |ba|
-      ba.use :input, class: "form-check-input"
-      ba.use :label, class: "form-check-label"
+    b.wrapper :form_check_wrapper, tag: "div", class: "form-check" do |bb|
+      bb.use :input, class: "form-check-input", error_class: "is-invalid", valid_class: ""
+      bb.use :label, class: "form-check-label"
+      bb.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback" }
+      bb.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
     end
-
-    b.use :error, wrap_with: { tag: "span", class: "help-block" }
-    b.use :hint,  wrap_with: { tag: "p", class: "help-block" }
   end
 
-  config.wrappers :vertical_radio_and_checkboxes, tag: "div", class: "form-group", error_class: "has-error" do |b|
+  # vertical input for radio buttons and check boxes
+  config.wrappers :vertical_collection, item_wrapper_class: "form-check", tag: "fieldset", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.optional :readonly
-    b.use :label, class: "control-label"
-    b.use :error, wrap_with: { tag: "span", class: "help-block" }
-    b.use :hint,  wrap_with: { tag: "p", class: "help-block" }
-    b.use :input
+    b.wrapper :legend_tag, tag: "legend", class: "col-form-label pt-0" do |ba|
+      ba.use :label_text
+    end
+    b.use :input, class: "form-check-input", error_class: "is-invalid", valid_class: ""
+    b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
   end
 
-  config.wrappers :horizontal_form, tag: "div", class: "form-group", error_class: "has-error" do |b|
+  # vertical input for inline radio buttons and check boxes
+  config.wrappers :vertical_collection_inline, item_wrapper_class: "form-check form-check-inline", tag: "fieldset", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
+    b.use :html5
+    b.optional :readonly
+    b.wrapper :legend_tag, tag: "legend", class: "col-form-label pt-0" do |ba|
+      ba.use :label_text
+    end
+    b.use :input, class: "form-check-input", error_class: "is-invalid", valid_class: ""
+    b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
+  end
+
+  # vertical file input
+  config.wrappers :vertical_file, tag: "div", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
+    b.optional :minlength
+    b.optional :readonly
+    b.use :label
+    b.use :input, class: "form-control-file", error_class: "is-invalid", valid_class: ""
+    b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
+  end
+
+  # vertical multi select
+  config.wrappers :vertical_multi_select, tag: "div", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :label, class: "form-control-label"
+    b.wrapper tag: "div", class: "d-flex flex-row justify-content-between align-items-center" do |ba|
+      ba.use :input, class: "form-control mx-1", error_class: "is-invalid", valid_class: ""
+    end
+    b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
+  end
+
+  # vertical range input
+  config.wrappers :vertical_range, tag: "div", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :readonly
+    b.optional :step
+    b.use :label
+    b.use :input, class: "form-control-range", error_class: "is-invalid", valid_class: ""
+    b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
+  end
+
+  # horizontal forms
+  #
+  # horizontal default_wrapper
+  config.wrappers :horizontal_form, tag: "div", class: "form-group row", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
     b.optional :pattern
     b.optional :min_max
     b.optional :readonly
-    b.use :label, class: "col-sm-3 control-label"
-
-    b.wrapper tag: "div", class: "col-sm-9" do |ba|
-      ba.use :error, wrap_with: { tag: "span", class: "help-block" }
-      ba.use :hint,  wrap_with: { tag: "p", class: "help-block" }
-      ba.use :input, class: "form-control"
+    b.use :label, class: "col-sm-3 col-form-label"
+    b.wrapper :grid_wrapper, tag: "div", class: "col-sm-9" do |ba|
+      ba.use :input, class: "form-control", error_class: "is-invalid", valid_class: " "
+      ba.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback" }
+      ba.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
     end
   end
 
-  config.wrappers :horizontal_file_input, tag: "div", class: "form-group", error_class: "has-error" do |b|
+  # horizontal input for boolean
+  config.wrappers :horizontal_boolean, tag: "div", class: "form-group row", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
-    b.use :placeholder
-    b.optional :maxlength
     b.optional :readonly
-    b.use :label, class: "col-sm-3 control-label"
-
-    b.wrapper tag: "div", class: "col-sm-9" do |ba|
-      ba.use :error, wrap_with: { tag: "span", class: "help-block" }
-      ba.use :hint,  wrap_with: { tag: "p", class: "help-block" }
-      ba.use :input
+    b.wrapper tag: "label", class: "col-sm-3" do |ba|
+      ba.use :label_text
     end
-  end
-
-  config.wrappers :horizontal_boolean, tag: "div", class: "form-group", error_class: "has-error" do |b|
-    b.use :html5
-    b.optional :readonly
-
-    b.wrapper tag: "div", class: "col-sm-offset-3 col-sm-9" do |wr|
-      wr.wrapper tag: "div", class: "checkbox" do |ba|
-        ba.use :label_input
+    b.wrapper :grid_wrapper, tag: "div", class: "col-sm-9" do |wr|
+      wr.wrapper :form_check_wrapper, tag: "div", class: "form-check" do |bb|
+        bb.use :input, class: "form-check-input", error_class: "is-invalid", valid_class: ""
+        bb.use :label, class: "form-check-label"
+        bb.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+        bb.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
       end
-
-      wr.use :error, wrap_with: { tag: "span", class: "help-block" }
-      wr.use :hint,  wrap_with: { tag: "p", class: "help-block" }
     end
   end
 
-  config.wrappers :horizontal_radio_and_checkboxes, tag: "div", class: "form-group", error_class: "has-error" do |b|
+  # horizontal input for radio buttons and check boxes
+  config.wrappers :horizontal_collection, item_wrapper_class: "form-check", tag: "div", class: "form-group row", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.optional :readonly
-
-    b.use :label, class: "col-sm-3 control-label"
-
-    b.wrapper tag: "div", class: "col-sm-9" do |ba|
-      ba.use :error, wrap_with: { tag: "span", class: "help-block" }
-      ba.use :hint,  wrap_with: { tag: "p", class: "help-block" }
-      ba.use :input
+    b.use :label, class: "col-sm-3 form-control-label"
+    b.wrapper :grid_wrapper, tag: "div", class: "col-sm-9" do |ba|
+      ba.use :input, class: "form-check-input", error_class: "is-invalid", valid_class: ""
+      ba.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+      ba.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
     end
   end
 
-  config.wrappers :inline_form, tag: "div", class: "form-group", error_class: "has-error" do |b|
+  # horizontal input for inline radio buttons and check boxes
+  config.wrappers :horizontal_collection_inline, item_wrapper_class: "form-check form-check-inline", tag: "div", class: "form-group row", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :label, class: "col-sm-3 form-control-label"
+    b.wrapper :grid_wrapper, tag: "div", class: "col-sm-9" do |ba|
+      ba.use :input, class: "form-check-input", error_class: "is-invalid", valid_class: ""
+      ba.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+      ba.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
+    end
+  end
+
+  # horizontal file input
+  config.wrappers :horizontal_file, tag: "div", class: "form-group row", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
+    b.optional :minlength
+    b.optional :readonly
+    b.use :label, class: "col-sm-3 form-control-label"
+    b.wrapper :grid_wrapper, tag: "div", class: "col-sm-9" do |ba|
+      ba.use :input, error_class: "is-invalid", valid_class: ""
+      ba.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+      ba.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
+    end
+  end
+
+  # horizontal multi select
+  config.wrappers :horizontal_multi_select, tag: "div", class: "form-group row", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :label, class: "col-sm-3 control-label"
+    b.wrapper :grid_wrapper, tag: "div", class: "col-sm-9" do |ba|
+      ba.wrapper tag: "div", class: "d-flex flex-row justify-content-between align-items-center" do |bb|
+        bb.use :input, class: "form-control mx-1", error_class: "is-invalid", valid_class: ""
+      end
+      ba.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+      ba.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
+    end
+  end
+
+  # horizontal range input
+  config.wrappers :horizontal_range, tag: "div", class: "form-group row", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :readonly
+    b.optional :step
+    b.use :label, class: "col-sm-3 form-control-label"
+    b.wrapper :grid_wrapper, tag: "div", class: "col-sm-9" do |ba|
+      ba.use :input, class: "form-control-range", error_class: "is-invalid", valid_class: ""
+      ba.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+      ba.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
+    end
+  end
+
+  # inline forms
+  #
+  # inline default_wrapper
+  config.wrappers :inline_form, tag: "span", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
     b.optional :pattern
     b.optional :min_max
     b.optional :readonly
-    b.wrapper tag: "div", class: "label-error" do |_input|
-      b.use :label
-      b.use :error, wrap_with: { tag: "span", class: "control-label" }
-    end
-    b.use :hint,  wrap_with: { tag: "p", class: "help-inline" }
-    b.use :input, class: "form-control"
+    b.use :label, class: "sr-only"
+
+    b.use :input, class: "form-control", error_class: "is-invalid", valid_class: ""
+    b.use :error, wrap_with: { tag: "div", class: "invalid-feedback" }
+    b.optional :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
   end
 
-  config.wrappers :multi_select, tag: "div", class: "form-group", error_class: "has-error" do |b|
+  # inline input for boolean
+  config.wrappers :inline_boolean, tag: "span", class: "form-check flex-wrap justify-content-start mr-sm-2", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
     b.use :html5
     b.optional :readonly
-    b.use :label, class: "control-label"
-    b.wrapper tag: "div", class: "form-inline" do |ba|
-      ba.use :error, wrap_with: { tag: "span", class: "help-block" }
-      ba.use :hint,  wrap_with: { tag: "p", class: "help-block" }
-      ba.use :input, class: "form-control"
+    b.use :input, class: "form-check-input", error_class: "is-invalid", valid_class: ""
+    b.use :label, class: "form-check-label"
+    b.use :error, wrap_with: { tag: "div", class: "invalid-feedback" }
+    b.optional :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
+  end
+
+  # bootstrap custom forms
+  #
+  # custom input for boolean
+  config.wrappers :custom_boolean, tag: "fieldset", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
+    b.use :html5
+    b.optional :readonly
+    b.wrapper :form_check_wrapper, tag: "div", class: "custom-control custom-checkbox" do |bb|
+      bb.use :input, class: "custom-control-input", error_class: "is-invalid", valid_class: ""
+      bb.use :label, class: "custom-control-label"
+      bb.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback" }
+      bb.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
     end
   end
-  # Wrappers for forms and inputs using the Bootstrap toolkit.
-  # Check the Bootstrap docs (http://getbootstrap.com)
-  # to learn about the different styles for forms and inputs,
-  # buttons and other elements.
+
+  config.wrappers :custom_boolean_switch, tag: "fieldset", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
+    b.use :html5
+    b.optional :readonly
+    b.wrapper :form_check_wrapper, tag: "div", class: "custom-control custom-checkbox-switch" do |bb|
+      bb.use :input, class: "custom-control-input", error_class: "is-invalid", valid_class: ""
+      bb.use :label, class: "custom-control-label"
+      bb.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback" }
+      bb.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
+    end
+  end
+
+  # custom input for radio buttons and check boxes
+  config.wrappers :custom_collection, item_wrapper_class: "custom-control", tag: "fieldset", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
+    b.use :html5
+    b.optional :readonly
+    b.wrapper :legend_tag, tag: "legend", class: "col-form-label pt-0" do |ba|
+      ba.use :label_text
+    end
+    b.use :input, class: "custom-control-input", error_class: "is-invalid", valid_class: ""
+    b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
+  end
+
+  # custom input for inline radio buttons and check boxes
+  config.wrappers :custom_collection_inline, item_wrapper_class: "custom-control custom-control-inline", tag: "fieldset", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
+    b.use :html5
+    b.optional :readonly
+    b.wrapper :legend_tag, tag: "legend", class: "col-form-label pt-0" do |ba|
+      ba.use :label_text
+    end
+    b.use :input, class: "custom-control-input", error_class: "is-invalid", valid_class: ""
+    b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
+  end
+
+  # custom file input
+  config.wrappers :custom_file, tag: "div", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
+    b.optional :readonly
+    b.use :label, class: "form-control-label"
+    b.wrapper :custom_file_wrapper, tag: "div", class: "custom-file" do |ba|
+      ba.use :input, class: "custom-file-input", error_class: "is-invalid", valid_class: ""
+      ba.use :label, class: "custom-file-label"
+      ba.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback" }
+    end
+    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
+  end
+
+  # custom multi select
+  config.wrappers :custom_multi_select, tag: "div", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :label, class: "form-control-label"
+    b.wrapper tag: "div", class: "d-flex flex-row justify-content-between align-items-center" do |ba|
+      ba.use :input, class: "custom-select mx-1", error_class: "is-invalid", valid_class: ""
+    end
+    b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
+  end
+
+  # custom range input
+  config.wrappers :custom_range, tag: "div", class: "form-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :readonly
+    b.optional :step
+    b.use :label, class: "form-control-label"
+    b.use :input, class: "custom-range", error_class: "is-invalid", valid_class: ""
+    b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback d-block" }
+    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
+  end
+
+  # Input Group - custom component
+  # see example app and config at https://github.com/rafaelfranca/simple_form-bootstrap
+  # config.wrappers :input_group, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  #   b.use :html5
+  #   b.use :placeholder
+  #   b.optional :maxlength
+  #   b.optional :minlength
+  #   b.optional :pattern
+  #   b.optional :min_max
+  #   b.optional :readonly
+  #   b.use :label, class: 'form-control-label'
+  #   b.wrapper :input_group_tag, tag: 'div', class: 'input-group' do |ba|
+  #     ba.optional :prepend
+  #     ba.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: ''
+  #     ba.optional :append
+  #   end
+  #   b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+  #   b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  # end
+
+  # Floating Labels form
+  #
+  # floating labels default_wrapper
+  config.wrappers :floating_labels_form, tag: "div", class: "form-label-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
+    b.optional :pattern
+    b.optional :min_max
+    b.optional :readonly
+    b.use :input, class: "form-control", error_class: "is-invalid", valid_class: ""
+    b.use :label, class: "form-control-label"
+    b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback" }
+    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
+  end
+
+  # custom multi select
+  config.wrappers :floating_labels_select, tag: "div", class: "form-label-group", error_class: "form-group-invalid", valid_class: "form-group-valid" do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :input, class: "custom-select custom-select-lg", error_class: "is-invalid", valid_class: ""
+    b.use :label, class: "form-control-label"
+    b.use :full_error, wrap_with: { tag: "div", class: "invalid-feedback" }
+    b.use :hint, wrap_with: { tag: "small", class: "form-text text-muted" }
+  end
+
+  # The default wrapper to be used by the FormBuilder.
   config.default_wrapper = :vertical_form
+
+  # Custom wrappers for input types. This should be a hash containing an input
+  # type as key and the wrapper that will be used for all inputs with specified type.
   config.wrapper_mappings = {
-    check_boxes: :vertical_radio_and_checkboxes,
-    radio_buttons: :vertical_radio_and_checkboxes,
-    file: :vertical_file_input,
     boolean: :vertical_boolean,
-    datetime: :multi_select,
-    date: :multi_select,
-    time: :multi_select
+    check_boxes: :vertical_collection,
+    date: :vertical_multi_select,
+    datetime: :vertical_multi_select,
+    file: :vertical_file,
+    radio_buttons: :vertical_collection,
+    range: :vertical_range,
+    time: :vertical_multi_select
   }
+
+  # enable custom form wrappers
+  # config.wrapper_mappings = {
+  #   boolean:       :custom_boolean,
+  #   check_boxes:   :custom_collection,
+  #   date:          :custom_multi_select,
+  #   datetime:      :custom_multi_select,
+  #   file:          :custom_file,
+  #   radio_buttons: :custom_collection,
+  #   range:         :custom_range,
+  #   time:          :custom_multi_select
+  # }
 end

--- a/spec/controllers/scanned_resources_controller_spec.rb
+++ b/spec/controllers/scanned_resources_controller_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe ScannedResourcesController, type: :controller do
         expect(assigns(:change_set)).to be_a RecordingChangeSet
         expect(response.body).to have_field "Source Metadata ID"
         expect(response.body).to have_field "Title"
-        expect(response.body).to have_selector "p.help-block", text: "Required if Source Metadata ID is blank"
+        expect(response.body).to have_text "Required if Source Metadata ID is blank"
       end
     end
 

--- a/spec/features/ephemera_box_spec.rb
+++ b/spec/features/ephemera_box_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "Ephemera Boxes" do
 
     scenario "users see validation errors" do
       visit polymorphic_path [:edit, ephemera_box]
-      expect(page.find(:css, ".has-error")).to have_content "has an invalid checkdigit"
+      expect(page).to have_content "has an invalid checkdigit"
     end
   end
 


### PR DESCRIPTION
This removes the is-valid classes because it was making select boxes
green on a new form.

Closes #5189
Closes #5184
Closes #5179