### PR TITLE
Enable ajax selct on accessions edit form

### DIFF
--- a/app/views/numismatics/accessions/_form.html.erb
+++ b/app/views/numismatics/accessions/_form.html.erb
@@ -1,0 +1,15 @@
+<h2><%= form_title(params) %></h2>
+<%= simple_form_for @change_set do |f| %>
+<div class="row lux">
+  <div class="col-xs-12 col-sm-8" role="main">
+    <div class="form-panel-content" id="metadata">
+      <%= yield "metadata_tab".to_sym if content_for? "metadata_tab".to_sym %>
+      <%= render "form_metadata", f: f %>
+    </div>
+  </div>
+
+  <div id="savewidget" class="col-xs-12 col-sm-4" role="complementary">
+    <%= render 'form_progress', f: f %>
+  </div>
+</div>
+<% end %>


### PR DESCRIPTION
Fixes AJAX select widgets on accessions edit form.

Adding `class=lux` for each div does not work - and I'm not sure why. The select widget is duplicated multiple times. The solution fI came up with for accessions is to add the `lux` class once by overriding the form partial.
