### PR TITLE
Fix document_presenter deprecation

### DIFF
--- a/app/views/base/_file_manager_thumbnail.html.erb
+++ b/app/views/base/_file_manager_thumbnail.html.erb
@@ -1,3 +1,3 @@
 <%= osd_modal_for(node.resource) do %>
-  <%= presenter(node).thumbnail.thumbnail_tag({ onerror: default_icon_fallback } ) %>
+  <%= document_presenter(node).thumbnail.thumbnail_tag({ onerror: default_icon_fallback } ) %>
 <% end %>


### PR DESCRIPTION
Use #document_presenter instead of #presenter.

Closes #5249 