### PR TITLE
Use custom base docker image

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,0 +1,15 @@
+FROM cimg/ruby:2.7.5-browsers
+
+RUN git clone https://github.com/pulibrary/figgy.git \
+  && cd figgy \
+  && sudo apt update -y \
+  && sudo sh ./bin/ci_mediainfo_install.sh \
+  && sudo apt-get install gdal-bin libgdal-dev tesseract-ocr tesseract-ocr-ita tesseract-ocr-eng mediainfo ffmpeg postgresql-client ocrmypdf lsof python3-pip python-is-python3 imagemagick build-essential pkg-config glib2.0-dev libexpat1-dev \
+  && sudo sh ./bin/ci_free_tds_install.sh \
+  && sudo sh ./bin/ci_openjpeg_install.sh \
+  && sudo sh ./bin/ci_vips_install.sh \
+  && sudo pip3 install pip -U \
+  && sudo pip3 install setuptools -U \
+  && sudo pip3 install cogeo-mosaic \
+  && cd .. \
+  && sudo rm -rf figgy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     working_directory: ~/figgy
     docker:
-      - image: cimg/ruby:2.7.5-browsers
+      - image: pulibrary/ci-figgy:1.2
         environment:
           RAILS_ENV: test
           FIGGY_DB_HOST: localhost
@@ -23,12 +23,6 @@ jobs:
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
       - checkout
-      - run: sudo apt update -y
-      - run: sudo sh bin/ci_mediainfo_install.sh
-      - run: sudo apt-get install gdal-bin libgdal-dev mediainfo lsof python3-pip python-is-python3 imagemagick build-essential pkg-config glib2.0-dev libexpat1-dev
-      - run: sudo sh bin/ci_free_tds_install.sh
-      - run: sudo sh bin/ci_openjpeg_install.sh
-      - run: sudo sh bin/ci_vips_install.sh
       - node/install:
           install-yarn: true
           node-version: '12.16.1'
@@ -62,7 +56,7 @@ jobs:
   test:
     working_directory: ~/figgy
     docker:
-      - image: cimg/ruby:2.7.5-browsers
+      - image: pulibrary/ci-figgy:1.2
         environment:
           RAILS_ENV: test
           FIGGY_DB_HOST: localhost
@@ -86,15 +80,6 @@ jobs:
       - browser-tools/install-chromedriver
       - attach_workspace:
           at: '~/figgy'
-      - run: sudo apt update -y
-      - run: sudo sh bin/ci_mediainfo_install.sh
-      - run: sudo apt-get install gdal-bin libgdal-dev tesseract-ocr tesseract-ocr-ita tesseract-ocr-eng mediainfo ffmpeg postgresql-client ocrmypdf lsof python3-pip python-is-python3 imagemagick build-essential pkg-config glib2.0-dev libexpat1-dev
-      - run: sudo sh bin/ci_free_tds_install.sh
-      - run: sudo sh bin/ci_openjpeg_install.sh
-      - run: sudo sh bin/ci_vips_install.sh
-      - run: sudo pip3 install pip -U
-      - run: sudo pip3 install setuptools -U
-      - run: sudo pip3 install cogeo-mosaic
       - node/install:
           install-yarn: true
           node-version: '12.16.1'
@@ -139,7 +124,7 @@ jobs:
   coverage_report:
     working_directory: ~/figgy
     docker:
-      - image: circleci/ruby:2.7.5-node-browsers
+      - image: pulibrary/ci-figgy:1.2
     steps:
       - attach_workspace:
           at: '~/figgy'
@@ -155,7 +140,7 @@ jobs:
   rubocop:
     working_directory: ~/figgy
     docker:
-      - image: cimg/ruby:2.7.5-browsers
+      - image: pulibrary/ci-figgy:1.2
         environment:
           RAILS_ENV: test
           FIGGY_DB_HOST: localhost
@@ -167,12 +152,6 @@ jobs:
       - browser-tools/install-chromedriver
       - attach_workspace:
           at: '~/figgy'
-      - run: sudo apt update -y
-      - run: sudo sh bin/ci_mediainfo_install.sh
-      - run: sudo apt-get install gdal-bin libgdal-dev mediainfo lsof python-is-python3 imagemagick build-essential pkg-config glib2.0-dev libexpat1-dev
-      - run: sudo sh bin/ci_free_tds_install.sh
-      - run: sudo sh bin/ci_openjpeg_install.sh
-      - run: sudo sh bin/ci_vips_install.sh
       - node/install:
           install-yarn: true
           node-version: '12.16.1'

--- a/README.md
+++ b/README.md
@@ -193,6 +193,21 @@ To enable:
    production or staging and deploy the branch.
 1. Deploy `main` again when reindexing is complete.
 
+## Maintaining CircleCI base image
+
+We maintain a Figgy Docker image for use in CircleCI. The Dockerfile is
+located in the `.circleci` directory. To update a package, dependency, or ruby
+version, make edits to the Dockerfile. Then build and push the image to Docker Hub using
+the following steps (be sure to increment the version):
+
+```
+cd .circleci/
+docker login # login to docker hub
+docker build -t pulibrary/ci-figgy:{version} .
+docker push pulibrary/ci-figgy:{version}
+```
+
+
 ## More
 Valkyrie Documentation:
 - For links to helpful valkyrie documentation and troubleshooting tips, visit the [Valkyrie wiki](https://github.com/samvera-labs/valkyrie/wiki).


### PR DESCRIPTION
Speed up CI build and run times by using custom Figgy docker image.