### PR TITLE
Run yarn install on production workers

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -82,7 +82,7 @@ before "deploy:assets:precompile", "deploy:whenever"
 namespace :deploy do
   desc "Run rake yarn install"
   task :yarn_install do
-    on roles(:web) do
+    on roles(:web, :worker) do
       within release_path do
         execute("cd #{release_path} && yarn install")
       end


### PR DESCRIPTION
Closes #5284 

Mapnik is needed by workers and is installed via yarn/npm.