### PR TITLE
Fix Numismatics Forms

### DIFF
--- a/app/javascript/helpers/setup_ajax_select.js
+++ b/app/javascript/helpers/setup_ajax_select.js
@@ -34,13 +34,15 @@ function handleCocoonAfterInsert (event, elements) {
 
 // Inserts an ajax-select component before every input with a ajax_select_type
 // attribute. Example:  `<input ajax_select_type="Place"/>`
-export default function setupAjaxSelect () {
+export function setupAjaxSelect () {
   const ajaxInputs = document.querySelectorAll('input[ajax_select_type]')
   for (var i = 0; i < ajaxInputs.length; i++) {
     const ajaxInput = ajaxInputs[i]
     appendAjaxSelect(ajaxInput)
   }
+}
 
+export function setupCocoonLinks () {
   const cocoonLinks = document.querySelectorAll('.links')
   cocoonLinks.forEach(element => {
     // This needs to trigger the Vue components

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -10,7 +10,7 @@ import axios from 'axios'
 import OrderManager from '../components/OrderManager.vue'
 import setupAuthLinkClipboard from '../packs/auth_link_clipboard.js'
 import AjaxSelect from '../components/ajax-select'
-import setupAjaxSelect from '../helpers/setup_ajax_select.js'
+import { setupAjaxSelect, setupCocoonLinks } from '../helpers/setup_ajax_select.js'
 import FileUploader from '../components/file-uploader'
 import Initializer from '../figgy/figgy_boot'
 
@@ -36,8 +36,11 @@ document.addEventListener('DOMContentLoaded', () => {
       data: {
         options: []
       },
-      mounted: function () {
+      beforeCreate: function () {
         setupAjaxSelect()
+      },
+      mounted: function () {
+        setupCocoonLinks()
       }
     })
   }

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -18,7 +18,6 @@ Vue.use(system)
 
 // mount the filemanager app
 document.addEventListener('DOMContentLoaded', () => {
-  window.figgy = new Initializer()
   // Set CSRF token for axios requests.
   axios.defaults.headers.common['X-CSRF-Token'] = document.querySelector('meta[name="csrf-token"]') ? document.querySelector('meta[name="csrf-token"]').getAttribute('content') : undefined
   var elements = document.getElementsByClassName('lux')
@@ -43,4 +42,7 @@ document.addEventListener('DOMContentLoaded', () => {
     })
   }
   setupAuthLinkClipboard()
+  // It's important we initialize Figgy after mounting Vue, otherwise none of
+  // the JS will work because Vue takes it all over.
+  window.figgy = new Initializer()
 })

--- a/app/views/base/_local_upload.html.erb
+++ b/app/views/base/_local_upload.html.erb
@@ -1,3 +1,3 @@
-<div class="lux">
+<div>
   <file-uploader upload-path='<%= polymorphic_path(@change_set) %>' param-name='<%= @change_set.model_name.param_key %>[files]' patch multiple></file-uploader>
 </div>

--- a/app/views/base/order_manager.html.erb
+++ b/app/views/base/order_manager.html.erb
@@ -1,4 +1,3 @@
-<div class="lux">
 <div class="container">
   <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
@@ -11,4 +10,3 @@
   </nav>
 </div>
 <order-manager resource-id="<%= @change_set.id %>" default-thumbnail="<%= image_url('default_thumbnail.png') %>"></order-manager>
-</div>

--- a/app/views/catalog/_members_playlist.html.erb
+++ b/app/views/catalog/_members_playlist.html.erb
@@ -1,4 +1,4 @@
-<div class="lux">
+<div>
 <% if !resource.member_ids.empty? %>
   <playlist-members resource-id="<%= resource.id %>" :members="<%= proxies_with_recording_data(resource).to_json %>"></playlist-members>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:above_container) do %>
-  <div class="lux">
+  <div>
     <%= render "shared/header" %>
   </div>
   <%= render "shared/flash_message" %>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -27,6 +27,7 @@
     <%= content_for(:head) %>
   </head>
   <body class="<%= render_body_class %>">
+    <div class="lux">
     <nav id="skip-link" role="navigation" aria-label="<%= t('blacklight.skip_links.label') %>">
       <%= link_to t('blacklight.skip_links.search_field'), '#search_field', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
       <%= link_to t('blacklight.skip_links.main_content'), '#main-container', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
@@ -35,7 +36,7 @@
     <%= content_for(:above_container) %>
 
     <main>
-      <div id="main-container" class="<%= container_classes %> lux" role="main" aria-label="<%= t('blacklight.main.aria.main_container') %>">
+      <div id="main-container" class="<%= container_classes %>" role="main" aria-label="<%= t('blacklight.main.aria.main_container') %>">
         <%= content_for(:container_header) %>
 
         <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>
@@ -49,5 +50,6 @@
     <%= render partial: 'shared/footer' %>
     <%= render partial: 'shared/modal' %>
     <%= render partial: 'shared/osd_modal' %>
+    </div>
   </body>
 <% end %>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -27,7 +27,6 @@
     <%= content_for(:head) %>
   </head>
   <body class="<%= render_body_class %>">
-    <%- # Don't add a lux wrapper here - it will break non-vue javascript -%>
     <nav id="skip-link" role="navigation" aria-label="<%= t('blacklight.skip_links.label') %>">
       <%= link_to t('blacklight.skip_links.search_field'), '#search_field', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
       <%= link_to t('blacklight.skip_links.main_content'), '#main-container', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>
@@ -36,7 +35,7 @@
     <%= content_for(:above_container) %>
 
     <main>
-      <div id="main-container" class="<%= container_classes %>" role="main" aria-label="<%= t('blacklight.main.aria.main_container') %>">
+      <div id="main-container" class="<%= container_classes %> lux" role="main" aria-label="<%= t('blacklight.main.aria.main_container') %>">
         <%= content_for(:container_header) %>
 
         <%= render partial: 'shared/flash_msg', layout: 'shared/flash_messages' %>

--- a/app/views/numismatics/accessions/_form.html.erb
+++ b/app/views/numismatics/accessions/_form.html.erb
@@ -1,6 +1,6 @@
 <h2><%= form_title(params) %></h2>
 <%= simple_form_for @change_set do |f| %>
-<div class="row lux">
+<div class="row">
   <div class="col-xs-12 col-sm-8" role="main">
     <div class="form-panel-content" id="metadata">
       <%= yield "metadata_tab".to_sym if content_for? "metadata_tab".to_sym %>

--- a/app/views/numismatics/accessions/edit_fields/_firm_id.html.erb
+++ b/app/views/numismatics/accessions/edit_fields/_firm_id.html.erb
@@ -1,4 +1,4 @@
-<div class="form-group string optional lux">
+<div class="form-group string optional">
   <%= f.label :firm_id, required: f.object.required?(:firm_id) %>
   <%= link_to 'New Firm', new_numismatics_firm_path, class: 'btn btn-sm btn-primary new-link', target: '_blank'%>
   <%= f.hidden_field :firm_id, ajax_select_type: "Firm" %>

--- a/app/views/numismatics/accessions/edit_fields/_person_id.html.erb
+++ b/app/views/numismatics/accessions/edit_fields/_person_id.html.erb
@@ -1,4 +1,4 @@
-<div class="form-group string optional lux">
+<div class="form-group string optional">
   <%= f.label :person_id, required: f.object.required?(:person_id) %>
   <%= link_to 'New Person', new_numismatics_person_path, class: 'btn btn-sm btn-primary new-link', target: '_blank'%>
   <%= f.hidden_field :person_id, ajax_select_type: "Person" %>

--- a/app/views/numismatics/coins/_loan_fields.html.erb
+++ b/app/views/numismatics/coins/_loan_fields.html.erb
@@ -1,4 +1,4 @@
-<div class='nested-fields lux'>
+<div class='nested-fields'>
   <div class="row">
     <div class="col-md-6">
       <%= f.label :person_id, required: f.object.required?(:person_id) %>

--- a/app/views/numismatics/coins/_provenance_fields.html.erb
+++ b/app/views/numismatics/coins/_provenance_fields.html.erb
@@ -1,4 +1,4 @@
-<div class='nested-fields lux'>
+<div class='nested-fields'>
   <div class="row">
     <div class="col-md-6">
       <%= f.label :person_id, required: f.object.required?(:person_id) %>

--- a/app/views/numismatics/coins/edit_fields/_append_id.html.erb
+++ b/app/views/numismatics/coins/edit_fields/_append_id.html.erb
@@ -1,4 +1,4 @@
-<div class="form-group string optional lux">
+<div class="form-group string optional">
   <%= f.label :append_id, label: "Issue", required: f.object.required?(:append_id) %>
   <%= f.hidden_field :append_id, ajax_select_type: "Issue", ajax_select_initial_id: @selected_issue %>
 </div>

--- a/app/views/numismatics/coins/edit_fields/_find_place_id.html.erb
+++ b/app/views/numismatics/coins/edit_fields/_find_place_id.html.erb
@@ -1,4 +1,4 @@
-<div class="form-group string optional lux">
+<div class="form-group string optional">
   <%= f.label :find_place_id, required: f.object.required?(:find_place_id) %>
   <%= link_to 'New Place', new_numismatics_place_path, class: 'btn btn-sm btn-primary new-link', target: '_blank'%>
   <%= f.hidden_field :find_place_id, ajax_select_type: "Place" %>

--- a/app/views/numismatics/coins/edit_fields/_numismatic_citation_fields.html.erb
+++ b/app/views/numismatics/coins/edit_fields/_numismatic_citation_fields.html.erb
@@ -1,4 +1,4 @@
-<div class='nested-fields lux'>
+<div class='nested-fields'>
   <div class="row">
     <div class="col-md-6">
       <%= f.label :numismatic_reference_id, required: f.object.required?(:numismatic_reference_id) %>

--- a/app/views/numismatics/issues/_numismatic_artist_fields.html.erb
+++ b/app/views/numismatics/issues/_numismatic_artist_fields.html.erb
@@ -1,4 +1,4 @@
-<div class='nested-fields lux'>
+<div class='nested-fields'>
   <div class="row">
     <div class="col-md-6">
       <%= f.label :person_id, required: f.object.required?(:person_id) %>

--- a/app/views/numismatics/issues/edit_fields/_master_id.html.erb
+++ b/app/views/numismatics/issues/edit_fields/_master_id.html.erb
@@ -1,4 +1,4 @@
-<div class="form-group string optional lux">
+<div class="form-group string optional">
   <%= f.label :master_id, required: f.object.required?(:master_id) %>
   <%= link_to 'New Master', new_numismatics_person_path, class: 'btn btn-sm btn-primary new-link', target: '_blank'%>
   <%= f.hidden_field :master_id, ajax_select_type: "Person" %>

--- a/app/views/numismatics/issues/edit_fields/_numismatic_place_id.html.erb
+++ b/app/views/numismatics/issues/edit_fields/_numismatic_place_id.html.erb
@@ -1,4 +1,4 @@
-<div class="form-group string optional lux">
+<div class="form-group string optional">
   <%= f.label :numismatic_place_id, required: f.object.required?(:numismatic_place_id), label: "Minting Location" %>
   <%= link_to 'New Place', new_numismatics_place_path, class: 'btn btn-sm btn-primary new-link', target: '_blank'%>
   <%= f.hidden_field :numismatic_place_id, ajax_select_type: "Place" %>

--- a/app/views/numismatics/issues/edit_fields/_ruler_id.html.erb
+++ b/app/views/numismatics/issues/edit_fields/_ruler_id.html.erb
@@ -1,4 +1,4 @@
-<div class="form-group string optional lux">
+<div class="form-group string optional">
   <%= f.label :ruler_id, required: f.object.required?(:ruler_id) %>
   <%= link_to 'New Ruler', new_numismatics_person_path, class: 'btn btn-sm btn-primary new-link', target: '_blank'%>
   <%= f.hidden_field :ruler_id, ajax_select_type: "Person" %>

--- a/app/views/records/edit_fields/_numismatic_accession_id.html.erb
+++ b/app/views/records/edit_fields/_numismatic_accession_id.html.erb
@@ -1,4 +1,4 @@
-<div class="form-group string optional lux">
+<div class="form-group string optional">
   <%= f.label :numismatic_accession_id, required: f.object.required?(:numismatic_accession_id) %>
   <%= f.hidden_field :numismatic_accession_id, ajax_select_type: "Accession"  %>
 </div>

--- a/app/views/records/edit_fields/_numismatic_citation_fields.html.erb
+++ b/app/views/records/edit_fields/_numismatic_citation_fields.html.erb
@@ -1,4 +1,4 @@
-<div class='nested-fields lux'>
+<div class='nested-fields'>
   <div class="row">
     <div class="col-md-6">
       <%= f.label :numismatic_reference_id, required: f.object.required?(:numismatic_reference_id) %>

--- a/app/views/records/edit_fields/_numismatic_monogram_ids.html.erb
+++ b/app/views/records/edit_fields/_numismatic_monogram_ids.html.erb
@@ -1,4 +1,4 @@
 <label>Monogram</label>
-<span class="lux">
+<span>
   <issue-monograms :members="<%= @numismatic_monogram_attributes.to_json %>"></issue-monograms>
 </span>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,3 +1,3 @@
-<div class="lux">
+<div>
   <library-footer></library-footer>
 </div>


### PR DESCRIPTION
Removes all the lux tags, changes where we initialize the JS, and uses a single lux tag for the application.

The key here seems to be that you need to run non-vue JS -after- the vue is mounted, or it doesn't work. When I swapped everything to webpacker I made vue happen at the end on accident, which is what broke everything and necessitated controlled lux tags.

Previously we had two lux tags, one for the header and one for the body. It turned out that the numismatics code depended on that - the first lux tag would initialize vue, and add vue tags to the page in the HTML, and then the second would initialize vue and actually mount those components. To have one lux tag we have to add vue tags in beforeCreate instead so the mounting process will catch them, and then bind the cocoon helpers after mounting so the JS will work.

Closes #5276 
Closes #5273 
Closes #5274 
Closes #5277 
