### PR TITLE
Use CGI.escape instead of URI.escape

### DIFF
--- a/app/decorators/ephemera_term_decorator.rb
+++ b/app/decorators/ephemera_term_decorator.rb
@@ -21,7 +21,7 @@ class EphemeraTermDecorator < Valkyrie::ResourceDecorator
   def internal_url
     return Array.wrap(model.uri).first if vocabulary.blank?
     vocabulary_uri = vocabulary.uri.to_s.end_with?("/") ? vocabulary.uri.to_s : vocabulary.uri.to_s + "/"
-    URI.join(vocabulary_uri, URI.escape(camelized_label))
+    URI.join(vocabulary_uri, CGI.escape(camelized_label))
   end
 
   def uri

--- a/spec/decorators/ephemera_term_decorator_spec.rb
+++ b/spec/decorators/ephemera_term_decorator_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe EphemeraTermDecorator do
     context "when the term contains UTF-8 characters" do
       let(:resource) { FactoryBot.create_for_repository(:ephemera_term, label: "San José, Costa Rica", member_of_vocabulary_id: vocabulary.id) }
       it "still generates a figgy uri" do
-        expect(resource.decorate.internal_url.to_s).to eq "https://figgy.princeton.edu/ns/testVocabulary/sanJos%C3%A9,CostaRica"
+        expect(resource.decorate.internal_url.to_s).to eq "https://figgy.princeton.edu/ns/testVocabulary/sanJos%C3%A9%2CCostaRica"
       end
     end
 


### PR DESCRIPTION
This is okay because we strip spaces, which CGI.escape apparently
doesn't escape to spec.

closes #5272