### PR TITLE
Use card instead of panel for authorized link content area

### DIFF
--- a/app/assets/stylesheets/components/show.scss
+++ b/app/assets/stylesheets/components/show.scss
@@ -38,18 +38,11 @@ ul.tabular {
     text-align: center;
       @media (min-width: $bp-small) {
         padding-top: inherit;
-	padding-bottom: inherit;
+        padding-bottom: inherit;
       }
-
-      .submit {
-        @media (min-width: $bp-medium) {
-        float: right;
-      }
-    }
   }
 
   .summary {
-    float: right;
     p {
       color: #888888;
       font-style: italic;
@@ -137,4 +130,8 @@ table.dataTable thead > tr > th {
 
 .claim-btn {
   margin-bottom: 1em;
+}
+
+h2.card-title {
+  margin-top: .75em;
 }

--- a/app/views/catalog/_auth_link_default.html.erb
+++ b/app/views/catalog/_auth_link_default.html.erb
@@ -1,9 +1,9 @@
 <% if @change_set.respond_to?(:auth_token) && @change_set.resource.decorate.public_readable_state? %>
-  <div id="auth_link" class="panel panel-default auth-link">
-    <div class="panel-heading">
-      <h2 class="panel-title">Authorized Link</h2>
+  <div id="auth_link" class="card auth-link">
+    <div class="card-header">
+      <h2 class="card-title">Authorized Link</h2>
     </div>
-    <div class="row panel-body">
+    <div class="row card-body">
       <div class="col-sm-8" id="authorized-link">
         <%= build_authorized_link %>
       </div>
@@ -21,7 +21,7 @@
       </div>
     </div>
     <% if can?(:edit, resource) %>
-      <div class="row panel-body">
+      <div class="row card-body">
         <div class="col-sm-6 summary">
           <p>Authorized links provide anonymous, public users with the ability to view playlists and play tracks.  Each link is unique, and one may generate only a single link for any given playlist.  Regeneration replaces the current link, rendering any previous links invalid.</p>
         </div>

--- a/app/views/catalog/_workflow_controls_default.html.erb
+++ b/app/views/catalog/_workflow_controls_default.html.erb
@@ -1,6 +1,10 @@
 <% if can?(:edit, resource) && @change_set.respond_to?(:workflow_class) && @change_set.respond_to?(:state) %>
   <div id="workflow_controls"class="card workflow-affix">
-    <div class="card-header">Review and Approval</div>
+    <div class="card-header">
+      <h2 class="card-title">
+        Review and Approval
+      </h2>
+    </div>
     <div id="workflow_controls_collapse" class="card-body">
       <%= simple_form_for @change_set do |f| %>
         <div class="row">


### PR DESCRIPTION
Also uses h2 for review and approval card title, improves card title
spacing
refs #5312

before:
![Screen Shot 2022-08-01 at 2 41 43 PM](https://user-images.githubusercontent.com/845363/182220898-a7d55ec9-8db5-47c7-8dff-f40126a254fc.png)

after:
![Screen Shot 2022-08-01 at 2 41 29 PM](https://user-images.githubusercontent.com/845363/182220910-41b68a53-94a6-4fdc-b2b7-47107b1b9ea1.png)

