### PR TITLE
Configure same site protection to allow iFrames

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,7 @@ Bundler.require(*Rails.groups)
 module Figgy
   class Application < Rails::Application
     config.load_defaults "6.0"
+    config.action_dispatch.cookies_same_site_protection = :none
     config.assets.quiet = true
     config.generators do |generate|
       generate.helper false

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,7 @@ Bundler.require(*Rails.groups)
 module Figgy
   class Application < Rails::Application
     config.load_defaults "6.0"
+    config.action_controller.forgery_protection_origin_check = false
     config.action_dispatch.cookies_same_site_protection = :none
     config.assets.quiet = true
     config.generators do |generate|

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -21,4 +21,6 @@ Rails.application.configure do
   config.action_controller.action_on_unpermitted_parameters = false
   config.active_storage.service = :test
   config.cache_store = :null_store
+  # Mocking login only works with lax cookies.
+  config.action_dispatch.cookies_same_site_protection = :lax
 end


### PR DESCRIPTION
Fixes CDL.

I'm finding these settings that changed during the upgrade by looking at https://api.rubyonrails.org/v6.1.6.1/classes/Rails/Application/Configuration.html#method-i-load_defaults and seeing what the new `load_defaults` line did.

Closes #5336