### PR TITLE
Make order manager handle resources w/ deleted members.

### DIFF
--- a/app/graphql/mutations/update_resource.rb
+++ b/app/graphql/mutations/update_resource.rb
@@ -50,6 +50,7 @@ class Mutations::UpdateResource < Mutations::BaseMutation
   def valid_member_ids?(change_set, attributes)
     return true if attributes[:member_ids].blank?
     change_set_ids = change_set.resource.member_ids.map(&:to_s)
+    # change_set_ids = 
     member_ids = attributes[:member_ids].map(&:to_s)
     return true if change_set_ids.sort == member_ids.sort
     change_set.errors.add(:member_ids, "can only be used to re-order.")

--- a/app/graphql/mutations/update_resource.rb
+++ b/app/graphql/mutations/update_resource.rb
@@ -49,8 +49,7 @@ class Mutations::UpdateResource < Mutations::BaseMutation
 
   def valid_member_ids?(change_set, attributes)
     return true if attributes[:member_ids].blank?
-    change_set_ids = change_set.resource.member_ids.map(&:to_s)
-    # change_set_ids = 
+    change_set_ids = query_service.custom_queries.find_persisted_member_ids(resource: change_set.resource)
     member_ids = attributes[:member_ids].map(&:to_s)
     return true if change_set_ids.sort == member_ids.sort
     change_set.errors.add(:member_ids, "can only be used to re-order.")

--- a/app/queries/find_persisted_member_ids.rb
+++ b/app/queries/find_persisted_member_ids.rb
@@ -1,0 +1,18 @@
+class FindPersistedMemberIds
+  def self.queries
+    [:find_member_ids]
+  end
+
+  attr_reader :query_service
+  delegate :orm_class, to: :resource_factory
+  delegate :resource_factory, to: :query_service
+  def initialize(query_service:)
+    @query_service = query_service
+  end
+
+  # Return all member ids as a result of joind query.
+  # This is useful when member_ids contains ids of deleted resources.
+  def find_persisted_member_ids(resource:)
+
+  end
+end

--- a/app/queries/find_persisted_member_ids.rb
+++ b/app/queries/find_persisted_member_ids.rb
@@ -1,11 +1,11 @@
+# frozen_string_literal: true
 class FindPersistedMemberIds
   def self.queries
-    [:find_member_ids]
+    [:find_persisted_member_ids]
   end
 
   attr_reader :query_service
-  delegate :orm_class, to: :resource_factory
-  delegate :resource_factory, to: :query_service
+  delegate :connection, to: :query_service
   def initialize(query_service:)
     @query_service = query_service
   end
@@ -13,6 +13,17 @@ class FindPersistedMemberIds
   # Return all member ids as a result of joind query.
   # This is useful when member_ids contains ids of deleted resources.
   def find_persisted_member_ids(resource:)
+    connection[find_persisted_member_ids_query, resource.id.to_s].map do |member|
+      member[:id]
+    end
+  end
 
+  def find_persisted_member_ids_query
+    <<-SQL
+          SELECT member.id FROM orm_resources a,
+          jsonb_array_elements(a.metadata->'member_ids') WITH ORDINALITY AS b(member, member_pos)
+          JOIN orm_resources member ON (b.member->>'id')::UUID = member.id WHERE a.id = ?
+          ORDER BY b.member_pos
+    SQL
   end
 end

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -419,7 +419,8 @@ Rails.application.config.to_prepare do
     LatestMemberTimestamp,
     FindBySourceMetadataIdentifier,
     MosaicFingerprintQuery,
-    MosaicFileSetQuery
+    MosaicFileSetQuery,
+    FindPersistedMemberIds
   ].each do |query_handler|
     Valkyrie.config.metadata_adapter.query_service.custom_queries.register_query_handler(query_handler)
   end

--- a/spec/graphql/mutations/update_resource_spec.rb
+++ b/spec/graphql/mutations/update_resource_spec.rb
@@ -83,6 +83,20 @@ RSpec.describe Mutations::UpdateResource do
         expect(output[:errors]).to be_nil
         expect(output[:resource].member_ids).to eq [member2.id, member1.id]
       end
+
+      context "when there is a non-existant member id in the resource" do
+        it "does not error" do
+          member1 = FactoryBot.create_for_repository(:file_set)
+          member2 = FactoryBot.create_for_repository(:file_set)
+          id = Valkyrie::ID.new(SecureRandom.uuid)
+          resource = FactoryBot.create_for_repository(:scanned_resource, member_ids: [member1.id, member2.id, id])
+          mutation = create_mutation
+
+          output = mutation.resolve(id: resource.id, member_ids: [member2.id.to_s, member1.id.to_s])
+          expect(output[:errors]).to be_nil
+          expect(output[:resource].member_ids).to eq [member2.id, member1.id]
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Closes https://github.com/pulibrary/figgy/issues/5363

Things we did:

1. We wrote a test to make sure a non-existent member ID in a resource
   doesn't cause an error in graphql.
2. We wrote a query that prevents that from happening by using the same
   kind of join query the order manager uses, which will not return deleted
   member_ids.
3. We used that query instead of using #member_ids on the resource.

Co-authored-by: Shaun Ellis <shaun@sdellis.com>
Co-authored-by: Eliot Jordan <eliot.jordan@gmail.com>