### PR TITLE
Delegate IO methods to an opened file instance in IngestableFile

### DIFF
--- a/app/models/ingestable_file.rb
+++ b/app/models/ingestable_file.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 class IngestableFile < Valkyrie::Resource
+  delegate_missing_to :opened_file
   attribute :file_path, Valkyrie::Types::String
   attribute :mime_type, Valkyrie::Types::String
   attribute :original_filename, Valkyrie::Types::String
@@ -33,6 +34,13 @@ class IngestableFile < Valkyrie::Resource
   end
 
   private
+
+    def opened_file
+      @opened_file ||=
+        begin
+          File.open(path)
+        end
+    end
 
     def copied_file_name
       return @copied_file_name if @copied_file_name

--- a/spec/models/ingestable_file_spec.rb
+++ b/spec/models/ingestable_file_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe IngestableFile do
+  it "delegates IO methods to a file" do
+    file = described_class.new(file_path: Rails.root.join("spec", "fixtures", "files", "example.tif"))
+
+    expect(file).to respond_to(:read)
+  end
+end


### PR DESCRIPTION
This conforms to the expected interface for `Valkyrie::StorageAdapter#upload`, and
fixes an issue with uploading to AWS for vector resources.

Closes #5377
