### PR TITLE
Add a logical_order setter to scanned resource change set

### DIFF
--- a/app/change_sets/scanned_resource_change_set.rb
+++ b/app/change_sets/scanned_resource_change_set.rb
@@ -56,9 +56,7 @@ class ScannedResourceChangeSet < ChangeSet
   # filters out structure nodes that proxy deleted resources
   def logical_structure
     logical_order = (Array(fields["logical_structure"] || resource.logical_structure).first || Structure.new)
-    members = Wayfinder.for(resource).members_with_parents
-    structure_with_proxies = WithProxyForObject.new(logical_order, members)
-    logical_order.nodes = recursive_structure_node_delete(structure_with_proxies.nodes)
+    logical_order.nodes = recursive_structure_node_delete(logical_order.nodes)
     Array(logical_order)
   end
 
@@ -85,14 +83,11 @@ class ScannedResourceChangeSet < ChangeSet
 
     def recursive_structure_node_delete(nodes)
       nodes.map do |node|
-        if node.proxy.present? && node.proxy_for_object.nil?
-          nil
-        elsif node.nodes.present?
+        next if node.proxy.present? && member_ids.exclude?(node.proxy.first.id)
+        if node.nodes.present?
           node.nodes = recursive_structure_node_delete(node.nodes)
-          node
-        else
-          node
         end
+        node
       end.compact
     end
 end

--- a/spec/features/structure_manager_spec.rb
+++ b/spec/features/structure_manager_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.feature "Structure Manager" do
+  let(:user) { FactoryBot.create(:admin) }
+
+  before do
+    sign_in user
+  end
+
+  # we think there's a race condition that may prevent structure nodes from getting cleaned up
+  context "When the structure proxy was deleted and not cleaned up" do
+    scenario "users visit the structure manager interface" do
+      child1 = FactoryBot.create_for_repository(:scanned_resource, title: ["child1"])
+      structure = {
+        "label": "Top!",
+        "nodes": [
+          { "label": "Chapter 1",
+            "nodes": [
+              { "proxy": child1.id }
+            ] },
+          { "label": "Chapter 2",
+            "nodes": [
+              { "proxy": "foobar" }
+            ] }
+        ]
+      }
+      parent = FactoryBot.create_for_repository(:scanned_resource, logical_structure: [structure], member_ids: [child1.id])
+
+      visit structure_scanned_resource_path(id: parent.id)
+      expect(page).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
The new setter filters out structure nodes that try to proxy resources
that don't exist
closes #5407
