### PR TITLE
Restore GeoServer raster publishing

### DIFF
--- a/app/services/geoserver_publish_service.rb
+++ b/app/services/geoserver_publish_service.rb
@@ -95,6 +95,7 @@ class GeoserverPublishService
     # Provide the type of geospatial layer type
     # @return [String]
     def layer_type
+      return "geotiff" if parent.model.is_a?(RasterResource)
       "shapefile"
     end
 


### PR DESCRIPTION
Fixes issue with publishing a raster derivative to GeoServer.

Closes #5416 