### PR TITLE
Remove cached_parent_id from the common schema attribute list. 

### DIFF
--- a/app/decorators/scanned_resource_decorator.rb
+++ b/app/decorators/scanned_resource_decorator.rb
@@ -17,8 +17,7 @@ class ScannedResourceDecorator < Valkyrie::ResourceDecorator
            :rights_statement,
            :actor,
            :holding_location, # suppressed in superclass, but added back in with Schema::Common
-           :downloadable,
-           :cached_parent
+           :downloadable
 
   display_in_manifest displayed_attributes, :location
   suppress_from_manifest Schema::IIIF.attributes,

--- a/app/models/schema/common.rb
+++ b/app/models/schema/common.rb
@@ -12,7 +12,6 @@ module Schema
     def self.typed_attributes
       {
         claimed_by: Valkyrie::Types::String,
-        cached_parent_id: Valkyrie::Types::ID.optional,
         embargo_date: Valkyrie::Types::String.optional
       }
     end
@@ -104,6 +103,8 @@ module Schema
       Common.typed_attributes.each do |name, type|
         attribute name, type
       end
+
+      attribute :cached_parent_id, Valkyrie::Types::ID.optional
     end
   end
 end

--- a/app/models/schema/geo.rb
+++ b/app/models/schema/geo.rb
@@ -41,6 +41,8 @@ module Schema
       Geo.typed_attributes.each do |name, type|
         attribute name, type
       end
+
+      attribute :cached_parent_id, Valkyrie::Types::ID.optional
     end
   end
 end

--- a/spec/models/linked_data/linked_imported_resource_spec.rb
+++ b/spec/models/linked_data/linked_imported_resource_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe LinkedData::LinkedImportedResource do
         :scanned_resource,
         source_metadata_identifier: source_id,
         import_metadata: true,
-        member_of_collection_ids: [collection.id]
+        member_of_collection_ids: [collection.id],
+        cached_parent_id: [Valkyrie::ID.new("")]
       )
     end
     it "returns a link to the finding aids site" do
@@ -56,6 +57,7 @@ RSpec.describe LinkedData::LinkedImportedResource do
       expect(jsonld["created_at"]).to be_nil
       expect(jsonld["updated_at"]).to be_nil
       expect(jsonld["member_of_collections"]).to be_nil
+      expect(jsonld["cached_parent_id"]).to be_nil
       collection_json = jsonld["memberOf"].find { |x| x["title"] == collection.title.first }
       expect(collection_json).to eq(
         "@id" => "http://www.example.com/catalog/#{collection.id}",


### PR DESCRIPTION
We don't want these to display, and we don't want to add an exception to
every decorator.

Closes pulibrary/dpul#1395