### PR TITLE
Consistency in NotFoundErrors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -57,7 +57,7 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  rescue_from Valkyrie::Persistence::ObjectNotFoundError, with: :resource_not_found
+  rescue_from Valkyrie::Persistence::ObjectNotFoundError, Blacklight::Exceptions::RecordNotFound, with: :resource_not_found
   def resource_not_found(_exception)
     respond_to do |format|
       format.json { head :not_found }

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -108,7 +108,7 @@ class ResourcesController < ApplicationController
   rescue Valkyrie::Persistence::ObjectNotFoundError => not_found_error
     after_update_error not_found_error
   rescue Valkyrie::Persistence::StaleObjectError
-    flash[:alert] = "Sorry, another user or process updated this resource simultaneously.  Please resubmit your changes."
+    flash[:alert] = "Sorry, another user or process updated this resource simultaneously. Please resubmit your changes."
     after_update_failure
   end
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -662,6 +662,7 @@ RSpec.describe CatalogController do
         expect(response).to be_successful
       end
     end
+
     context "when rendered for an admin" do
       before do
         sign_in FactoryBot.create(:admin)
@@ -802,6 +803,7 @@ RSpec.describe CatalogController do
         expect(response.body).to have_link playlist.title.first, href: "/catalog/#{playlist.id}"
       end
     end
+
     context "when rendered for a user" do
       render_views
       it "doesn't render the workflow panel" do
@@ -810,6 +812,12 @@ RSpec.describe CatalogController do
         get :show, params: { id: resource.id.to_s }
 
         expect(response.body).not_to have_content "Review and Approval"
+      end
+    end
+
+    context "when Blacklight does not find the id" do
+      it "redirects" do
+        expect { get :show, params: { id: "notarealid" } }.not_to raise_error
       end
     end
   end

--- a/spec/controllers/scanned_resources_controller_spec.rb
+++ b/spec/controllers/scanned_resources_controller_spec.rb
@@ -288,7 +288,7 @@ RSpec.describe ScannedResourcesController, type: :controller do
           patch :update, params: { id: resource.id.to_s, scanned_resource: { title: ["Two"] } }
 
           expect(response).to render_template "base/edit"
-          expect(flash[:alert]).to eq "Sorry, another user or process updated this resource simultaneously.  Please resubmit your changes."
+          expect(flash[:alert]).to eq "Sorry, another user or process updated this resource simultaneously. Please resubmit your changes."
         end
       end
     end


### PR DESCRIPTION
Treat Blacklight::Exceptions::NotFoundError the same as
Valkyrie::Persistence::ObjectNotFoundError

closes #5442

I'm not really sure about this. The other option would be to accept the current behavior and ignore the error in honeybadger. The error does show up like a regular 404 to the browser. Which is a default rails page :(