### PR TITLE
Refactor UV Manager to use GraphQL instead of Manifest HTTP Codes

### DIFF
--- a/app/graphql/types/resource.rb
+++ b/app/graphql/types/resource.rb
@@ -103,7 +103,9 @@ module Types::Resource
     nil
   end
 
-  def embed; end
+  def embed
+    Embed.for(resource: object, ability: ability).to_graphql
+  end
 
   def query_service
     Valkyrie::MetadataAdapter.find(:indexing_persister).query_service

--- a/app/graphql/types/scanned_resource_type.rb
+++ b/app/graphql/types/scanned_resource_type.rb
@@ -26,8 +26,4 @@ class Types::ScannedResourceType < Types::BaseObject
   def source_metadata_identifier
     Array.wrap(object.source_metadata_identifier).first
   end
-
-  def embed
-    Embed.for(resource: object, ability: ability).to_graphql
-  end
 end

--- a/app/javascript/test/viewer/uv_manager.spec.js
+++ b/app/javascript/test/viewer/uv_manager.spec.js
@@ -81,7 +81,7 @@ describe('UVManager', () => {
   }
 
   let figgy_id = "12345"
-  function stubQuery(embedHash) {
+  function stubQuery(embedHash, label='Test', type='ScannedResource') {
     global.fetch = jest.fn(() =>
       Promise.resolve({
         status: 200,
@@ -91,9 +91,9 @@ describe('UVManager', () => {
               "resource":
                 {
                   "id": figgy_id,
-                  "__typename": "ScannedResource",
+                  "__typename": type,
                   "embed": embedHash,
-                  "label": "Test"
+                  "label": label
                 }
             }
           }
@@ -103,6 +103,25 @@ describe('UVManager', () => {
   }
 
   describe('initialize', () => {
+    it('loads a viewer and title for a playlist', async () => {
+      document.body.innerHTML = initialHTML
+      mockJquery()
+      mockUvProvider()
+      stubQuery({
+        "type": "html",
+        "content": "<iframe src='https://figgy.princeton.edu/viewer#?manifest=https://figgy.princeton.edu/concern/scanned_resources/78e15d09-3a79-4057-b358-4fde3d884bbb/manifest'></iframe>",
+        "status": "authorized"
+      },
+        "Test Playlist",
+        "Playlist"
+      )
+
+      // Initialize
+      const uvManager = new UVManager()
+      await uvManager.initialize()
+      expect(document.getElementById('title').innerHTML).toBe('Test Playlist')
+    })
+
     it('redirects to viewer auth if graph says unauthenticated', async () => {
       document.body.innerHTML = initialHTML
       mockJquery()

--- a/app/javascript/test/viewer/uv_manager.spec.js
+++ b/app/javascript/test/viewer/uv_manager.spec.js
@@ -91,7 +91,9 @@ describe('UVManager', () => {
               "resource":
                 {
                   "id": figgy_id,
-                  "embed": embedHash
+                  "__typename": "ScannedResource",
+                  "embed": embedHash,
+                  "label": "Test"
                 }
             }
           }

--- a/app/javascript/test/viewer/uv_manager.spec.js
+++ b/app/javascript/test/viewer/uv_manager.spec.js
@@ -70,6 +70,7 @@ describe('UVManager', () => {
       } else { return null }
     })
 
+    // This makes it so global.UV.URLDataProvider.get returns our mock data
     const provider = jest.fn().mockImplementation(() => {
       return { get: getResult }
     })
@@ -79,6 +80,7 @@ describe('UVManager', () => {
     jest.spyOn(window.location, 'assign').mockImplementation(() => true)
   }
 
+  let figgy_id = "12345"
   function stubQuery(embedHash) {
     global.fetch = jest.fn(() =>
       Promise.resolve({
@@ -86,12 +88,11 @@ describe('UVManager', () => {
         json: () => Promise.resolve(
           {
             "data": {
-              "resourcesByFiggyIds": [
+              "resource":
                 {
-                  "id": component_id,
+                  "id": figgy_id,
                   "embed": embedHash
                 }
-              ]
             }
           }
         )
@@ -117,23 +118,9 @@ describe('UVManager', () => {
       expect(LeafletViewer).not.toHaveBeenCalled()
     })
 
-    it('redirects to viewer auth if the manifest 401s', async () => {
-      document.body.innerHTML = initialHTML
-      mockJquery()
-      mockManifests(401)
-      mockUvProvider()
-
-      // Initialize
-      const uvManager = new UVManager()
-      await uvManager.initialize()
-      expect(window.location.assign).toHaveBeenCalledWith('/viewer/12345/auth')
-      expect(LeafletViewer).not.toHaveBeenCalled()
-    })
-
     it('falls back to a default viewer URI if not using a figgy manifest', async () => {
       document.body.innerHTML = initialHTML
       mockJquery()
-      mockManifests(401)
       mockUvProvider(true)
 
       // Initialize

--- a/app/javascript/test/viewer/uv_manager.spec.js
+++ b/app/javascript/test/viewer/uv_manager.spec.js
@@ -102,6 +102,10 @@ describe('UVManager', () => {
     )
   }
 
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   describe('initialize', () => {
     it('loads a viewer and title for a playlist', async () => {
       document.body.innerHTML = initialHTML

--- a/app/javascript/test/viewer/uv_manager.spec.js
+++ b/app/javascript/test/viewer/uv_manager.spec.js
@@ -42,17 +42,22 @@ describe('UVManager', () => {
       delete global.createUV
     }
   })
-  function buildMocks (status, externalManifest = false) {
+  function mockJquery () {
     // Mock jQuery
     const clickable = { click: () => clickable, on: () => clickable, is: () => clickable, outerHeight: () => clickable, width: () => clickable, height: () => clickable, hide: () => clickable, show: () => clickable, children: () => clickable }
     global.$ = jest.fn().mockImplementation(() => clickable)
+  }
 
+  function mockManifests (status) {
     // Mock $.ajax
     const data = { status: status }
     const jqxhr = { getResponseHeader: () => null }
     global.$.ajax = jest.fn().mockImplementation(() => {
       if (status !== 200) { return jQ.Deferred().reject(data, status, jqxhr) } else { return jQ.Deferred().resolve(data, status, jqxhr) }
     })
+  }
+
+  function mockUvProvider (externalManifest = false) {
     const getResult = jest.fn().mockImplementation(function (k) {
       if (k === 'manifest') {
         if (externalManifest === true) {
@@ -64,7 +69,7 @@ describe('UVManager', () => {
         return 'https://figgy.princeton.edu/uv/uv_config.json'
       } else { return null }
     })
-    // Mock UV Provider
+
     const provider = jest.fn().mockImplementation(() => {
       return { get: getResult }
     })
@@ -74,10 +79,36 @@ describe('UVManager', () => {
     jest.spyOn(window.location, 'assign').mockImplementation(() => true)
   }
 
+  function stubQuery(embedHash) {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        status: 200,
+        json: () => Promise.resolve(
+          {
+            "data": {
+              "resourcesByFiggyIds": [
+                {
+                  "id": component_id,
+                  "embed": embedHash
+                }
+              ]
+            }
+          }
+        )
+      })
+    )
+  }
+
   describe('initialize', () => {
-    it('redirects to viewer auth if the manifest 401s', async () => {
+    it('redirects to viewer auth if graph says unauthenticated', async () => {
       document.body.innerHTML = initialHTML
-      buildMocks(401)
+      mockJquery()
+      mockUvProvider()
+      stubQuery({
+        "type": null,
+        "content": null,
+        "status": "unauthenticated"
+      })
 
       // Initialize
       const uvManager = new UVManager()
@@ -85,9 +116,25 @@ describe('UVManager', () => {
       expect(window.location.assign).toHaveBeenCalledWith('/viewer/12345/auth')
       expect(LeafletViewer).not.toHaveBeenCalled()
     })
+
+    it('redirects to viewer auth if the manifest 401s', async () => {
+      document.body.innerHTML = initialHTML
+      mockJquery()
+      mockManifests(401)
+      mockUvProvider()
+
+      // Initialize
+      const uvManager = new UVManager()
+      await uvManager.initialize()
+      expect(window.location.assign).toHaveBeenCalledWith('/viewer/12345/auth')
+      expect(LeafletViewer).not.toHaveBeenCalled()
+    })
+
     it('falls back to a default viewer URI if not using a figgy manifest', async () => {
       document.body.innerHTML = initialHTML
-      buildMocks(401, true)
+      mockJquery()
+      mockManifests(401)
+      mockUvProvider(true)
 
       // Initialize
       const uvManager = new UVManager()

--- a/app/javascript/viewer/uv_manager.js
+++ b/app/javascript/viewer/uv_manager.js
@@ -23,7 +23,7 @@ export default class UVManager {
       if (result.embed.status === 'unauthenticated') {
         return window.location.assign('/viewer/' + this.figgyId + '/auth')
       } else if (result.embed.status === 'authorized') {
-        this.createUV()
+        this.createUV(null, null, result)
         this.buildLeafletViewer()
       }
     } else {
@@ -36,6 +36,8 @@ export default class UVManager {
     var data = JSON.stringify({ query:`{
         resource(id: "` + this.figgyId + `"){
           id,
+          __typename,
+          label,
           embed {
             type,
             content,
@@ -67,11 +69,11 @@ export default class UVManager {
     return $.ajax(this.manifest, { type: 'HEAD' })
   }
 
-  createUV (data, status, jqXHR) {
+  createUV (data, status, graphql_data) {
     this.tabManager.onTabSelect(() => setTimeout(() => this.resize(), 100))
     // TODO: There's no link headers to get a hold of anymore, we'll have to update
     // title from GraphQL instead.
-    // this.processTitle(jqXHR)
+    this.processTitle(graphql_data)
     this.uvElement.show()
     this.uv = createUV('#uv', {
       root: 'uv',
@@ -172,18 +174,15 @@ export default class UVManager {
     }
   }
 
-  processTitle (jqXHR) {
-    var linkHeader = jqXHR.getResponseHeader('Link')
-    if (linkHeader) {
-      var titleMatch = /title="(.+?)"/.exec(linkHeader)
-      if (titleMatch[1]) {
-        var title = titleMatch[1]
-        var titleElement = document.getElementById('title')
-        titleElement.textContent = title
-        titleElement.style.display = 'block'
-        this.resize()
-      }
+  processTitle (graphql_data) {
+    if (graphql_data === undefined || graphql_data.__typename !== 'Playlist') {
+      return
     }
+    var title = graphql_data.label
+    var titleElement = document.getElementById('title')
+    titleElement.textContent = title
+    titleElement.style.display = 'block'
+    this.resize()
   }
 
   resize () {

--- a/app/javascript/viewer/uv_manager.js
+++ b/app/javascript/viewer/uv_manager.js
@@ -60,13 +60,10 @@ export default class UVManager {
       .then((response) => response.data.resource)
   }
 
+  // Adds a tabbed viewer for Leaflet to show rasters, especially for mosaics.
   buildLeafletViewer () {
     this.leafletViewer = new LeafletViewer(this.figgyId, this.tabManager)
     return this.leafletViewer.loadLeaflet()
-  }
-
-  checkManifest () {
-    return $.ajax(this.manifest, { type: 'HEAD' })
   }
 
   createUV (data, status, graphql_data) {
@@ -146,15 +143,6 @@ export default class UVManager {
       setTimeout(function () {
         this.waitForElementToDisplay(selector, time, callback)
       }.bind(this), time)
-    }
-  }
-
-  requestAuth (data, status) {
-    // needs authorizaton
-    if (data.status === 401) {
-      if (this.manifest.includes(window.location.host)) {
-        window.location.assign('/viewer/' + this.figgyId + '/auth')
-      }
     }
   }
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,6 @@ module Figgy
   class Application < Rails::Application
     config.load_defaults "6.0"
     config.action_controller.forgery_protection_origin_check = false
-    config.action_dispatch.cookies_same_site_protection = :none
     config.assets.quiet = true
     config.generators do |generate|
       generate.helper false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 Rails.application.configure do
+  config.action_dispatch.cookies_same_site_protection = :none
   config.cache_classes = true
   config.eager_load = true
   config.consider_all_requests_local       = false

--- a/spec/features/scanned_resource_spec.rb
+++ b/spec/features/scanned_resource_spec.rb
@@ -26,4 +26,15 @@ RSpec.feature "Scanned Resource" do
     expect(page).to have_content "Embargo Date"
     expect(page).to have_content "Senior Thesis"
   end
+
+  scenario "show page has a viewer", js: true do
+    file = fixture_file_upload("files/example.tif", "image/tiff")
+    resource = FactoryBot.create_for_repository(:scanned_resource, files: [file])
+
+    visit solr_document_path(id: resource.id)
+
+    within_frame(find(".uv-container > iframe")) do
+      expect(page).to have_selector(".uv.en-gb")
+    end
+  end
 end


### PR DESCRIPTION
This refactor will make it easier to create a click through populated from the graphql response.

Also it's less weird, and more consistent with the strategy we put in place for Pulfalight.