### PR TITLE
Revert UV manager refactor

### DIFF
--- a/app/graphql/types/resource.rb
+++ b/app/graphql/types/resource.rb
@@ -103,9 +103,7 @@ module Types::Resource
     nil
   end
 
-  def embed
-    Embed.for(resource: object, ability: ability).to_graphql
-  end
+  def embed; end
 
   def query_service
     Valkyrie::MetadataAdapter.find(:indexing_persister).query_service

--- a/app/graphql/types/scanned_resource_type.rb
+++ b/app/graphql/types/scanned_resource_type.rb
@@ -26,4 +26,8 @@ class Types::ScannedResourceType < Types::BaseObject
   def source_metadata_identifier
     Array.wrap(object.source_metadata_identifier).first
   end
+
+  def embed
+    Embed.for(resource: object, ability: ability).to_graphql
+  end
 end

--- a/app/javascript/test/viewer/uv_manager.spec.js
+++ b/app/javascript/test/viewer/uv_manager.spec.js
@@ -70,7 +70,6 @@ describe('UVManager', () => {
       } else { return null }
     })
 
-    // This makes it so global.UV.URLDataProvider.get returns our mock data
     const provider = jest.fn().mockImplementation(() => {
       return { get: getResult }
     })
@@ -80,7 +79,6 @@ describe('UVManager', () => {
     jest.spyOn(window.location, 'assign').mockImplementation(() => true)
   }
 
-  let figgy_id = "12345"
   function stubQuery(embedHash) {
     global.fetch = jest.fn(() =>
       Promise.resolve({
@@ -88,11 +86,12 @@ describe('UVManager', () => {
         json: () => Promise.resolve(
           {
             "data": {
-              "resource":
+              "resourcesByFiggyIds": [
                 {
-                  "id": figgy_id,
+                  "id": component_id,
                   "embed": embedHash
                 }
+              ]
             }
           }
         )
@@ -118,9 +117,23 @@ describe('UVManager', () => {
       expect(LeafletViewer).not.toHaveBeenCalled()
     })
 
+    it('redirects to viewer auth if the manifest 401s', async () => {
+      document.body.innerHTML = initialHTML
+      mockJquery()
+      mockManifests(401)
+      mockUvProvider()
+
+      // Initialize
+      const uvManager = new UVManager()
+      await uvManager.initialize()
+      expect(window.location.assign).toHaveBeenCalledWith('/viewer/12345/auth')
+      expect(LeafletViewer).not.toHaveBeenCalled()
+    })
+
     it('falls back to a default viewer URI if not using a figgy manifest', async () => {
       document.body.innerHTML = initialHTML
       mockJquery()
+      mockManifests(401)
       mockUvProvider(true)
 
       // Initialize

--- a/app/javascript/test/viewer/uv_manager.spec.js
+++ b/app/javascript/test/viewer/uv_manager.spec.js
@@ -91,9 +91,7 @@ describe('UVManager', () => {
               "resource":
                 {
                   "id": figgy_id,
-                  "__typename": "ScannedResource",
-                  "embed": embedHash,
-                  "label": "Test"
+                  "embed": embedHash
                 }
             }
           }

--- a/app/javascript/test/viewer/uv_manager.spec.js
+++ b/app/javascript/test/viewer/uv_manager.spec.js
@@ -81,7 +81,7 @@ describe('UVManager', () => {
   }
 
   let figgy_id = "12345"
-  function stubQuery(embedHash, label='Test', type='ScannedResource') {
+  function stubQuery(embedHash) {
     global.fetch = jest.fn(() =>
       Promise.resolve({
         status: 200,
@@ -91,9 +91,9 @@ describe('UVManager', () => {
               "resource":
                 {
                   "id": figgy_id,
-                  "__typename": type,
+                  "__typename": "ScannedResource",
                   "embed": embedHash,
-                  "label": label
+                  "label": "Test"
                 }
             }
           }
@@ -103,25 +103,6 @@ describe('UVManager', () => {
   }
 
   describe('initialize', () => {
-    it('loads a viewer and title for a playlist', async () => {
-      document.body.innerHTML = initialHTML
-      mockJquery()
-      mockUvProvider()
-      stubQuery({
-        "type": "html",
-        "content": "<iframe src='https://figgy.princeton.edu/viewer#?manifest=https://figgy.princeton.edu/concern/scanned_resources/78e15d09-3a79-4057-b358-4fde3d884bbb/manifest'></iframe>",
-        "status": "authorized"
-      },
-        "Test Playlist",
-        "Playlist"
-      )
-
-      // Initialize
-      const uvManager = new UVManager()
-      await uvManager.initialize()
-      expect(document.getElementById('title').innerHTML).toBe('Test Playlist')
-    })
-
     it('redirects to viewer auth if graph says unauthenticated', async () => {
       document.body.innerHTML = initialHTML
       mockJquery()

--- a/app/javascript/test/viewer/uv_manager.spec.js
+++ b/app/javascript/test/viewer/uv_manager.spec.js
@@ -102,10 +102,6 @@ describe('UVManager', () => {
     )
   }
 
-  beforeEach(() => {
-    jest.clearAllMocks()
-  })
-
   describe('initialize', () => {
     it('loads a viewer and title for a playlist', async () => {
       document.body.innerHTML = initialHTML

--- a/app/javascript/viewer/uv_manager.js
+++ b/app/javascript/viewer/uv_manager.js
@@ -60,10 +60,13 @@ export default class UVManager {
       .then((response) => response.data.resource)
   }
 
-  // Adds a tabbed viewer for Leaflet to show rasters, especially for mosaics.
   buildLeafletViewer () {
     this.leafletViewer = new LeafletViewer(this.figgyId, this.tabManager)
     return this.leafletViewer.loadLeaflet()
+  }
+
+  checkManifest () {
+    return $.ajax(this.manifest, { type: 'HEAD' })
   }
 
   createUV (data, status, graphql_data) {
@@ -143,6 +146,15 @@ export default class UVManager {
       setTimeout(function () {
         this.waitForElementToDisplay(selector, time, callback)
       }.bind(this), time)
+    }
+  }
+
+  requestAuth (data, status) {
+    // needs authorizaton
+    if (data.status === 401) {
+      if (this.manifest.includes(window.location.host)) {
+        window.location.assign('/viewer/' + this.figgyId + '/auth')
+      }
     }
   }
 

--- a/app/javascript/viewer/uv_manager.js
+++ b/app/javascript/viewer/uv_manager.js
@@ -18,18 +18,6 @@ export default class UVManager {
   }
 
   async loadUV () {
-    if this.isFiggyManifest() {
-      const result = await this.checkFiggyStatus()
-      if
-        .then(this.createUV.bind(this))
-        // If creating the UV fails, don't build leaflet.
-        .then(() => { return this.buildLeafletViewer() })
-        .catch(this.requestAuth.bind(this))
-        .promise()
-    } else {
-      return this.createUV()
-    }
-
     return this.checkManifest()
       .then(this.createUV.bind(this))
       // If creating the UV fails, don't build leaflet.
@@ -37,33 +25,6 @@ export default class UVManager {
       .catch(this.requestAuth.bind(this))
       .promise()
   }
-
-    async checkFiggy() {
-      var url = "https://figgy.princeton.edu/graphql";
-      var data = JSON.stringify({ query:`{
-        resourcesByFiggyIds(id: "` + this.figgyId + `"){
-          id,
-          embed {
-            type,
-            content,
-            status
-          }
-        }
-       }`
-      })
-      return fetch(url,
-        {
-          method: "POST",
-          credentials: 'include',
-          body: data,
-          headers: {
-            'Content-Type': 'application/json',
-          }
-        }
-      )
-        .then((response) => response.json())
-        .then((response) => response.data.resourcesByFiggyIds[0])
-    },
 
   buildLeafletViewer () {
     this.leafletViewer = new LeafletViewer(this.figgyId, this.tabManager)
@@ -153,7 +114,6 @@ export default class UVManager {
   }
 
   requestAuth (data, status) {
-    // needs authorizaton
     if (data.status === 401) {
       if (this.manifest.includes(window.location.host)) {
         window.location.assign('/viewer/' + this.figgyId + '/auth')

--- a/app/javascript/viewer/uv_manager.js
+++ b/app/javascript/viewer/uv_manager.js
@@ -68,6 +68,8 @@ export default class UVManager {
 
   createUV (data, status, graphql_data) {
     this.tabManager.onTabSelect(() => setTimeout(() => this.resize(), 100))
+    // TODO: There's no link headers to get a hold of anymore, we'll have to update
+    // title from GraphQL instead.
     this.processTitle(graphql_data)
     this.uvElement.show()
     this.uv = createUV('#uv', {

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,7 @@ module Figgy
   class Application < Rails::Application
     config.load_defaults "6.0"
     config.action_controller.forgery_protection_origin_check = false
+    config.action_dispatch.cookies_same_site_protection = :none
     config.assets.quiet = true
     config.generators do |generate|
       generate.helper false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 Rails.application.configure do
-  config.action_dispatch.cookies_same_site_protection = :none
   config.cache_classes = true
   config.eager_load = true
   config.consider_all_requests_local       = false

--- a/spec/features/scanned_resource_spec.rb
+++ b/spec/features/scanned_resource_spec.rb
@@ -26,15 +26,4 @@ RSpec.feature "Scanned Resource" do
     expect(page).to have_content "Embargo Date"
     expect(page).to have_content "Senior Thesis"
   end
-
-  scenario "show page has a viewer", js: true do
-    file = fixture_file_upload("files/example.tif", "image/tiff")
-    resource = FactoryBot.create_for_repository(:scanned_resource, files: [file])
-
-    visit solr_document_path(id: resource.id)
-
-    within_frame(find(".uv-container > iframe")) do
-      expect(page).to have_selector(".uv.en-gb")
-    end
-  end
 end


### PR DESCRIPTION
Reverts #5471 and #5472 due to #5474

- Revert "todo is done"
- Revert "Remove unneeded code, add comment to leaflet viewer."
- Revert "Clear all mocks before each test."
- Revert "Add js unit test for playlist title"
- Revert "Add a viewer integration test"
- Revert "Use processTitle for playlists."
- Revert "Update GraphQL to use the resource query."
- Revert "WIP refactor UV manager javascript"
