### PR TITLE
Add migration to regenerate derivatives on filesets with too many

### DIFF
--- a/app/derivative_services/raster_resource_derivative_service.rb
+++ b/app/derivative_services/raster_resource_derivative_service.rb
@@ -179,7 +179,7 @@ class RasterResourceDerivativeService
       grandparent = parent.parents.first
       return unless grandparent.is_a? RasterResource
       return unless grandparent.decorate.public_readable_state?
-      MosaicJob.perform_later(grandparent.id)
+      MosaicJob.perform_later(grandparent.id.to_s)
     end
 
     def create_local_derivatives

--- a/app/derivative_services/raster_resource_derivative_service.rb
+++ b/app/derivative_services/raster_resource_derivative_service.rb
@@ -47,7 +47,7 @@ class RasterResourceDerivativeService
   # File membership for the parent of the Valkyrie::StorageAdapter::File is removed using #cleanup_derivative_metadata
   def cleanup_derivatives
     deleted_files = []
-    raster_derivatives = resource.file_metadata.select { |file| file.derivative? || file.thumbnail_file? }
+    raster_derivatives = resource.file_metadata.select { |file| file.derivative? || file.thumbnail_file? || file.cloud_derivative? }
     raster_derivatives.each do |file|
       storage_adapter.delete(id: file.file_identifiers.first)
       deleted_files << file.id

--- a/app/services/migrations/remove_extra_derivatives.rb
+++ b/app/services/migrations/remove_extra_derivatives.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Migrations
+  class RemoveExtraDerivatives
+    def self.call
+      new.run
+    end
+
+    def run
+      progress_bar
+      query_service.find_all_of_model(model: RasterResource).each do |resource|
+        Wayfinder.for(resource).file_sets.each do |file_set|
+          next unless extra_thumbnails?(file_set)
+
+          RegenerateDerivativesJob.perform_later(file_set.id.to_s)
+        end
+        progress_bar.progress += 1
+      end
+    end
+
+    private
+
+      def progress_bar
+        @progress_bar ||= ProgressBar.create format: "%a %e %P% Resources Processed: %c of %C", total: query_service.custom_queries.count_all_of_model(model: RasterResource)
+      end
+
+      # we only check for extra thumbnails because lots of resources might have
+      # extra derivatives (one jp2 and one tiff) from when we migrated to
+      # pyramidal tiffs, and the bug we're cleaning up from was failing after
+      # generating both the derivative and the thumbnail
+      def extra_thumbnails?(file_set)
+        file_set.file_metadata.count(&:thumbnail_file?) > 1
+      end
+
+      def query_service
+        @query_service ||= Valkyrie.config.metadata_adapter.query_service
+      end
+  end
+end

--- a/lib/tasks/migrate.rake
+++ b/lib/tasks/migrate.rake
@@ -2,6 +2,11 @@
 require "find"
 namespace :figgy do
   namespace :migrate do
+    desc "regenerate derivatives for resources with extras"
+    task remove_extra_derivatives: :environment do
+      Migrations::RemoveExtraDerivatives.call
+    end
+
     desc "Migrate users in group image_editor to group staff"
     task image_editor: :environment do
       staff = Role.where(name: "staff").first_or_create

--- a/spec/factories/file_metadata.rb
+++ b/spec/factories/file_metadata.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# You can't create these but you can build them.
+FactoryBot.define do
+  factory :file_metadata do
+    factory :image_derivative do
+      id { Valkyrie::ID.new(SecureRandom.uuid) }
+      mime_type { "image/tiff" }
+      use { Valkyrie::Vocab::PCDMUse.ServiceFile }
+    end
+
+    factory :image_thumbnail do
+      id { Valkyrie::ID.new(SecureRandom.uuid) }
+      mime_type { "image/tiff" }
+      use { Valkyrie::Vocab::PCDMUse.ThumbnailImage }
+    end
+
+    factory :image_original do
+      id { Valkyrie::ID.new(SecureRandom.uuid) }
+      mime_type { "image/tiff" }
+      use { Valkyrie::Vocab::PCDMUse.OriginalFile }
+    end
+  end
+end

--- a/spec/models/raster_resource_derivative_service_spec.rb
+++ b/spec/models/raster_resource_derivative_service_spec.rb
@@ -94,6 +94,8 @@ RSpec.describe RasterResourceDerivativeService do
       derivative_service.new(id: valid_change_set.id).cleanup_derivatives
       reloaded = query_service.find_by(id: valid_resource.id)
       expect(reloaded.file_metadata.select(&:derivative?)).to be_empty
+      expect(reloaded.file_metadata.select(&:thumbnail_file?)).to be_empty
+      expect(reloaded.file_metadata.select(&:cloud_derivative?)).to be_empty
     end
 
     it "deletes the error_message" do

--- a/spec/services/migrations/remove_extra_derivatives_spec.rb
+++ b/spec/services/migrations/remove_extra_derivatives_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Migrations::RemoveExtraDerivatives do
+  include ActiveJob::TestHelper
+  with_queue_adapter :test
+  describe ".call" do
+    it "enqueues a regenerate derivatives job for file sets with extra thumnbnails" do
+      clear_enqueued_jobs
+      file_set = FactoryBot.create_for_repository(
+        :file_set,
+        file_metadata: [FactoryBot.build(:image_thumbnail),
+                        FactoryBot.build(:image_thumbnail),
+                        FactoryBot.build(:image_original)]
+      )
+      file_set2 = FactoryBot.create_for_repository(
+        :file_set,
+        file_metadata: [FactoryBot.build(:image_thumbnail),
+                        FactoryBot.build(:image_thumbnail),
+                        FactoryBot.build(:image_original)]
+      )
+      file_set3 = FactoryBot.create_for_repository(
+        :file_set,
+        file_metadata: [FactoryBot.build(:image_derivative),
+                        FactoryBot.build(:image_thumbnail),
+                        FactoryBot.build(:image_original)]
+      )
+      FactoryBot.create_for_repository(:raster_resource, member_ids: [file_set.id, file_set2.id, file_set3.id])
+
+      described_class.call
+      expect(RegenerateDerivativesJob).to have_been_enqueued.twice
+      expect(RegenerateDerivativesJob).to have_been_enqueued.with(file_set.id.to_s)
+      expect(RegenerateDerivativesJob).to have_been_enqueued.with(file_set2.id.to_s)
+      expect(RegenerateDerivativesJob).not_to have_been_enqueued.with(file_set3.id.to_s)
+    end
+  end
+end


### PR DESCRIPTION
closes #5352
