### PR TITLE
Use temp file to pass raster paths to cogeo-mosaic

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 ruby 2.7.5
 nodejs 16.15.0
-java zulu-8.56.0.23
+java zulu-8.58.0.13
 python 3.9.1
 yarn 1.22.10

--- a/app/services/tile_metadata_service.rb
+++ b/app/services/tile_metadata_service.rb
@@ -31,7 +31,7 @@ class TileMetadataService
     document_path = Valkyrie::Storage::Disk::BucketedStorage.new(base_path: base_path).generate(resource: resource, original_filename: fingerprinted_filename, file: nil).to_s
     return document_path if storage_adapter.find_by(id: mosaic_file_id)
   rescue Valkyrie::StorageAdapter::FileNotFound
-    raise Error unless MosaicGenerator.new(output_path: tmp_file.path, raster_paths: raster_paths.join("\n")).run
+    raise Error unless MosaicGenerator.new(output_path: tmp_file.path, raster_paths: raster_paths).run
 
     # build default mosaic file
     build_node(default_filename)

--- a/spec/services/tile_metadata_service_spec.rb
+++ b/spec/services/tile_metadata_service_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe TileMetadataService do
         generator = described_class.new(resource: map_set)
 
         generator.path
-        expect(MosaicGenerator).to have_received(:new).with(output_path: anything, raster_paths: file_set.file_metadata.first.cloud_uri)
+        expect(MosaicGenerator).to have_received(:new).with(output_path: anything, raster_paths: [file_set.file_metadata.first.cloud_uri])
       end
     end
 


### PR DESCRIPTION
- Use temp file to pass raster paths to cogeo-mosaic
- Bump asdf java version up a minor version to allow M1 and non-M1 machines

Closes #5079 