### PR TITLE
Remove references to Cantaloupe

### DIFF
--- a/architecture-decisions/0007-pyramidal-tiffs.md
+++ b/architecture-decisions/0007-pyramidal-tiffs.md
@@ -1,6 +1,7 @@
 # 7. Pyramidal Tiffs & AWS Serverless Delivery
 
 Date: 2020-03-27
+Updated: 2022-10-31
 
 ## Status
 
@@ -31,8 +32,6 @@ request) will use to respond to IIIF image server requests, using Northwestern's
    Image API requests using those pyramidal tiffs.
 3. Configure an Amazon CloudFront cache in front of the lambda to automatically 
    cache tiles and info.jsons for one year.
-4. Continue to simultaneously generate JP2s for Cantaloupe, in case we find we
-   want to revert to our previous strategy.
 
 ## Consequences
 

--- a/config/config.yml
+++ b/config/config.yml
@@ -24,7 +24,6 @@ defaults: &defaults
   geo_derivative_path: <%= Rails.root.join("tmp", "geo_derivatives") %>
   stream_derivatives_path: <%= Rails.root.join("tmp", "stream_derivatives") %>
   repository_path: <%= Rails.root.join("tmp", "files") %>
-  cantaloupe_url: <%= ENV.fetch('CANTALOUPE_URL', 'http://localhost:8182/iiif/2/') %>
   pyramidal_url: <%= ENV.fetch('PYRAMIDAL_URL', 'http://localhost:8182/iiif/2/') %>
   bag_path: <%= Rails.root.join("tmp", "bags") %>
   pudl_root: <%= Rails.root.join("tmp", "pudl_root") %>
@@ -257,7 +256,6 @@ test:
   pudl_root: <%= Rails.root.join("spec", "fixtures", "test_pudl_root") %>
   disk_preservation_path: <%= Rails.root.join("tmp", "cloud_backup_test#{ENV["TEST_ENV_NUMBER"]}") %>
   test_cloud_geo_derivative_path: <%= Rails.root.join("tmp", "cloud_geo_derivatives#{ENV["TEST_ENV_NUMBER"]}") %>
-  cantaloupe_url: 'http://localhost:8182/iiif/2/'
   pyramidal_url: 'http://localhost:8182/pyramidals/iiif/2/'
   events:
     log_file: '/dev/null'

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -432,7 +432,7 @@ RSpec.describe ManifestBuilder do
     end
 
     context "when in staging" do
-      it "generates pyramidal cantaloupe links" do
+      it "generates pyramidal links" do
         allow(Rails.env).to receive(:development?).and_return(false)
         allow(Rails.env).to receive(:test?).and_return(false)
 

--- a/spec/services/manifest_builder_v3_spec.rb
+++ b/spec/services/manifest_builder_v3_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe ManifestBuilderV3 do
 
   context "when in staging" do
     let(:resource) { FactoryBot.create_for_repository(:scanned_map, files: [file]) }
-    it "generates pyramidal cantaloupe links" do
+    it "generates pyramidal links" do
       allow(Rails.env).to receive(:development?).and_return(false)
       allow(Rails.env).to receive(:test?).and_return(false)
 


### PR DESCRIPTION
Works towards #4837

(Not done yet, need to remove references in princeton_ansible as well)