### PR TITLE
Add specific content warnings when they're available.

### DIFF
--- a/app/graphql/types/resource.rb
+++ b/app/graphql/types/resource.rb
@@ -109,10 +109,7 @@ module Types::Resource
   end
 
   def notice
-    return if object.try(:notice_type).blank?
-    ControlledVocabulary.for(:notice_type).find(object.notice_type.first).to_graphql.tap do |notice_graphql|
-      notice_graphql[:text_html] = notice_graphql[:definition]
-    end
+    ControlledVocabulary.for(:notice_type).for(object)&.to_graphql
   end
 
   def query_service

--- a/app/models/controlled_vocabulary.rb
+++ b/app/models/controlled_vocabulary.rb
@@ -346,7 +346,7 @@ class ControlledVocabulary
         super.tap do |notice_graphql|
           notice_graphql[:heading] = I18n.t("notices.#{value}.heading")
           notice_graphql[:accept_label] = I18n.t("notices.#{value}.accept_label")
-          notice_graphql[:text_html] = I18n.t("notices.#{value}.definition", message: message)
+          notice_graphql[:text_html] = I18n.t("notices.#{value}.message", message: message)
         end
       end
 

--- a/app/models/controlled_vocabulary.rb
+++ b/app/models/controlled_vocabulary.rb
@@ -350,6 +350,9 @@ class ControlledVocabulary
         end
       end
 
+      # For specific content warnings the definition field is used to store the
+      # content warning from the imported metadata. This will be blank for all
+      # of the boilerplate warnings.
       def message
         Array.wrap(definition).join(" ")
       end

--- a/config/authorities/notices.yml
+++ b/config/authorities/notices.yml
@@ -1,20 +1,9 @@
+# You can find the UI elements for these in config/locales/en.yml under the
+# notices key.
 :terms:
   - :value: "harmful_content"
     :label: "Harmful Content"
-    :heading: "Content Warning"
-    :accept_label: "View Content"
-    :definition: >-
-      <p>This collection includes materials and images that are harmful (in that they are racist, transphobic, or otherwise demeaning). For more information on harmful content please see the PUL statement on Harmful Content: <a href="https://library.princeton.edu/statement-harmful-content">https://library.princeton.edu/statement-harmful-content</a></p>
   - :value: "explicit_content"
     :label: "Explicit Content"
-    :heading: "Content Warning"
-    :accept_label: "View Content"
-    :definition: >-
-      <p>This collection includes materials and images that are explicit (in that they contain nudity and graphic content).</p>
   - :value: "senior_thesis"
     :label: "Senior Thesis"
-    :heading: "Terms and Conditions for Using Princeton University Senior Theses"
-    :accept_label: "Accept"
-    :definition: >-
-      <p>The Princeton University Senior Theses DataSpace community is a catalog of theses written by seniors at Princeton University from 1926 to the present. Senior theses submitted from 2014 forward contain a full-text PDF that is accessible only on the Princeton University network. Theses written prior to 2014 are available by visiting the Princeton University Archives at the Mudd Manuscript Library. Email <a href="mailto:mudd@princeton.edu">mudd@princeton.edu</a> with any questions.</p>
-      <p>Most theses are protected by copyright. The copyright law of the United States governs the making of photocopies or other reproductions of material under copyright. Under certain conditions specified in the law, libraries and archives are authorized to furnish a photocopy or other reproduction. These reproductions of copyrighted material must be for educational and/or research purposes consistent with “fair use” as defined by 17 U.S.C. 107. A photocopy or other reproduction provided by a library is not to be “used for any purpose other than private study, scholarship or research.” If a user makes a request for, or later uses, a photocopy or other reproduction for purposes in excess of “fair use,” that individual may be liable for copyright infringement.</p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -166,23 +166,23 @@ en:
     harmful_content:
       heading: "Content Warning"
       accept_label: "View Content"
-      definition: >-
+      message: >-
         <p>This collection includes materials and images that are harmful (in that they are racist, transphobic, or otherwise demeaning). For more information on harmful content please see the PUL statement on Harmful Content: <a href="https://library.princeton.edu/statement-harmful-content">https://library.princeton.edu/statement-harmful-content</a></p>
     explicit_content:
       heading: "Content Warning"
       accept_label: "View Content"
-      definition: >-
+      message: >-
         <p>This collection includes materials and images that are explicit (in that they contain nudity and graphic content).</p>
     senior_thesis:
-      :heading: "Terms and Conditions for Using Princeton University Senior Theses"
-      :accept_label: "Accept"
-      :definition: >-
+      heading: "Terms and Conditions for Using Princeton University Senior Theses"
+      accept_label: "Accept"
+      message: >-
         <p>The Princeton University Senior Theses DataSpace community is a catalog of theses written by seniors at Princeton University from 1926 to the present. Senior theses submitted from 2014 forward contain a full-text PDF that is accessible only on the Princeton University network. Theses written prior to 2014 are available by visiting the Princeton University Archives at the Mudd Manuscript Library. Email <a href="mailto:mudd@princeton.edu">mudd@princeton.edu</a> with any questions.</p>
         <p>Most theses are protected by copyright. The copyright law of the United States governs the making of photocopies or other reproductions of material under copyright. Under certain conditions specified in the law, libraries and archives are authorized to furnish a photocopy or other reproduction. These reproductions of copyrighted material must be for educational and/or research purposes consistent with “fair use” as defined by 17 U.S.C. 107. A photocopy or other reproduction provided by a library is not to be “used for any purpose other than private study, scholarship or research.” If a user makes a request for, or later uses, a photocopy or other reproduction for purposes in excess of “fair use,” that individual may be liable for copyright infringement.</p>
     specific_harmful_content:
       heading: "Content Warning"
       accept_label: "View Content"
-      definition: >-
+      message: >-
         <p>%{message}</p>
         <p>For more information on harmful content please see the PUL statement on Harmful Content: <a href="https://library.princeton.edu/statement-harmful-content">https://library.princeton.edu/statement-harmful-content</a></p>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -162,3 +162,27 @@ en:
     published:
       label: 'Published'
       desc: 'Published and accessible according to access control rules'
+  notices:
+    harmful_content:
+      heading: "Content Warning"
+      accept_label: "View Content"
+      definition: >-
+        <p>This collection includes materials and images that are harmful (in that they are racist, transphobic, or otherwise demeaning). For more information on harmful content please see the PUL statement on Harmful Content: <a href="https://library.princeton.edu/statement-harmful-content">https://library.princeton.edu/statement-harmful-content</a></p>
+    explicit_content:
+      heading: "Content Warning"
+      accept_label: "View Content"
+      definition: >-
+        <p>This collection includes materials and images that are explicit (in that they contain nudity and graphic content).</p>
+    senior_thesis:
+      :heading: "Terms and Conditions for Using Princeton University Senior Theses"
+      :accept_label: "Accept"
+      :definition: >-
+        <p>The Princeton University Senior Theses DataSpace community is a catalog of theses written by seniors at Princeton University from 1926 to the present. Senior theses submitted from 2014 forward contain a full-text PDF that is accessible only on the Princeton University network. Theses written prior to 2014 are available by visiting the Princeton University Archives at the Mudd Manuscript Library. Email <a href="mailto:mudd@princeton.edu">mudd@princeton.edu</a> with any questions.</p>
+        <p>Most theses are protected by copyright. The copyright law of the United States governs the making of photocopies or other reproductions of material under copyright. Under certain conditions specified in the law, libraries and archives are authorized to furnish a photocopy or other reproduction. These reproductions of copyrighted material must be for educational and/or research purposes consistent with “fair use” as defined by 17 U.S.C. 107. A photocopy or other reproduction provided by a library is not to be “used for any purpose other than private study, scholarship or research.” If a user makes a request for, or later uses, a photocopy or other reproduction for purposes in excess of “fair use,” that individual may be liable for copyright infringement.</p>
+    specific_harmful_content:
+      heading: "Content Warning"
+      accept_label: "View Content"
+      definition: >-
+        <p>%{message}</p>
+        <p>For more information on harmful content please see the PUL statement on Harmful Content: <a href="https://library.princeton.edu/statement-harmful-content">https://library.princeton.edu/statement-harmful-content</a></p>
+

--- a/spec/graphql/figgy_schema_spec.rb
+++ b/spec/graphql/figgy_schema_spec.rb
@@ -56,6 +56,21 @@ RSpec.describe FiggySchema do
         expect(notice["acceptLabel"]).to eq "Accept"
         expect(notice["textHtml"]).to start_with "<p>The Princeton University Senior Theses"
       end
+      context "for a content_warning resource" do
+        let(:resource) { FactoryBot.create_for_repository(:scanned_resource, source_metadata_identifier: "C1372_c47202-68234", import_metadata: true) }
+        it "creates a specific notice" do
+          stub_findingaid(pulfa_id: "C1372_c47202-68234")
+
+          expect(result["errors"]).to be_blank
+          notice = result["data"]["resource"]["notice"]
+
+          expect(notice["heading"]).to eq "Content Warning"
+          expect(notice["acceptLabel"]).to eq "View Content"
+          expect(notice["textHtml"]).to eq "<p>The \"Revolution in China\" album contains photographs of dead bodies.</p> " \
+            "<p>For more information on harmful content please see the PUL statement on Harmful Content: " \
+            '<a href="https://library.princeton.edu/statement-harmful-content">https://library.princeton.edu/statement-harmful-content</a></p>'
+        end
+      end
     end
 
     context "when given a file set" do

--- a/spec/models/controlled_vocabulary_spec.rb
+++ b/spec/models/controlled_vocabulary_spec.rb
@@ -22,15 +22,15 @@ RSpec.describe ControlledVocabulary do
   describe "notice_type" do
     let(:vocabulary) { described_class.for(:notice_type) }
     describe "#all" do
-      it "returns all possible notice types" do
+      it "returns all possible notice types that should be in the dropdown" do
         types = vocabulary.all
         expect(types.length).to eq 3
         expect(types[0].label).to eq "Harmful Content"
-        expect(types[0].accept_label).to eq "View Content"
+        expect(types[0].to_graphql[:accept_label]).to eq "View Content"
         expect(types[1].label).to eq "Explicit Content"
-        expect(types[1].accept_label).to eq "View Content"
+        expect(types[1].to_graphql[:accept_label]).to eq "View Content"
         expect(types[2].label).to eq "Senior Thesis"
-        expect(types[2].accept_label).to eq "Accept"
+        expect(types[2].to_graphql[:accept_label]).to eq "Accept"
       end
     end
   end


### PR DESCRIPTION
Closes #5492 

This includes a bunch of refactors @hackartisan and I had discussed before. Doing them made it easier to add a vocab that's not in ControlledVocabulary.all, but which has config for the visual display colocated with the ones which are.

There's also some refactors which utilizes polymorphism.

<img width="1165" alt="Screen Shot 2022-11-02 at 5 26 27 PM" src="https://user-images.githubusercontent.com/2806645/199626578-ddac6477-c767-4e8d-861a-8e7f405a4842.png">
