### PR TITLE
Add optimistic lock token checking to PreserveResourceJob

### DIFF
--- a/app/change_set_persisters/change_set_persister/preserve_resource.rb
+++ b/app/change_set_persisters/change_set_persister/preserve_resource.rb
@@ -3,7 +3,7 @@
 class ChangeSetPersister
   class PreserveResource
     attr_reader :change_set_persister, :change_set, :post_save_resource
-    delegate :metadata_adapter, to: :change_set_persister
+    delegate :metadata_adapter, :query_service, to: :change_set_persister
 
     def initialize(change_set_persister:, change_set:, post_save_resource: nil)
       @change_set = change_set
@@ -12,16 +12,28 @@ class ChangeSetPersister
     end
 
     def run
-      cs = change_set.class.new(post_save_resource)
+      # Reload the resource because some after_save change_set persisters, like
+      # AppendToParent, update the resource which changes the lock token value.
+      cs = change_set.class.new(reload(post_save_resource))
       return unless cs.try(:preserve?)
+
+      lock_tokens = cs[Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK] || []
+      lock_tokens = lock_tokens.map(&:serialize)
+
       # It's important that we inline this for parents, to ensure that a race
       # condition doesn't happen which makes it so that two jobs get queued up
       # that each call PreserveChildrenJob, resulting in multiple file uploads
       if cs.try(:member_ids).present?
-        PreserveResourceJob.perform_now(id: cs.id.to_s)
+        PreserveResourceJob.perform_now(id: cs.id.to_s, lock_tokens: lock_tokens)
       else
-        PreserveResourceJob.perform_later(id: cs.id.to_s)
+        PreserveResourceJob.perform_later(id: cs.id.to_s, lock_tokens: lock_tokens)
       end
+    end
+
+    def reload(resource)
+      query_service.find_by(id: resource.id)
+    rescue Valkyrie::Persistence::ObjectNotFoundError
+      resource
     end
   end
 end

--- a/app/change_sets/change_set.rb
+++ b/app/change_sets/change_set.rb
@@ -92,6 +92,12 @@ class ChangeSet < Valkyrie::ChangeSet
   # around with the change_set in ChangeSetPersister instead, at some point.
   property :created_file_sets, virtual: true, multiple: true, required: false, default: []
 
+  # Add optimistic lock token property
+  property :optimistic_lock_token,
+           multiple: true,
+           required: true,
+           type: Valkyrie::Types::Set.of(Valkyrie::Types::OptimisticLockToken)
+
   def initialize(*args)
     super.tap do
       fix_multivalued_keys

--- a/app/change_sets/event_change_set.rb
+++ b/app/change_sets/event_change_set.rb
@@ -6,6 +6,10 @@ class EventChangeSet < ChangeSet
   property :child_property, multiple: false
   property :child_id, multiple: false, type: Valkyrie::Types::ID
   property :message, multiple: false, required: true
+  property :optimistic_lock_token,
+            multiple: true,
+            required: true,
+            type: Valkyrie::Types::Set.of(Valkyrie::Types::OptimisticLockToken)
 
   def preserve?
     false

--- a/app/change_sets/file_set_change_set.rb
+++ b/app/change_sets/file_set_change_set.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 class FileSetChangeSet < ChangeSet
   self.fields = [:title]
-  property :optimistic_lock_token,
-           multiple: true,
-           required: true,
-           type: Valkyrie::Types::Set.of(Valkyrie::Types::OptimisticLockToken)
   property :files, virtual: true, multiple: true, required: false
   property :viewing_hint, multiple: false, required: false
   property :hocr_content, multiple: false, required: false

--- a/app/change_sets/tombstone_change_set.rb
+++ b/app/change_sets/tombstone_change_set.rb
@@ -6,6 +6,10 @@ class TombstoneChangeSet < ChangeSet
   property :file_set_original_filename
   property :preservation_object
   property :parent_id
+  property :optimistic_lock_token,
+            multiple: true,
+            required: true,
+            type: Valkyrie::Types::Set.of(Valkyrie::Types::OptimisticLockToken)
 
   def preserve?
     false

--- a/app/indexers/parent_issue_indexer.rb
+++ b/app/indexers/parent_issue_indexer.rb
@@ -19,8 +19,8 @@ class ParentIssueIndexer
 
   def parent_keys_suppress
     [:id, :internal_resource, :created_at, :updated_at, :new_record, :read_groups, :read_users, :edit_users,
-     :edit_groups, :member_ids, :member_of_collection_ids, :state, :thumbnail_id, :visibility, :workflow_note,
-     :pending_uploads, :start_canvas, :viewing_direction, :viewing_hint]
+     :edit_groups, :member_ids, :member_of_collection_ids, :optimistic_lock_token, :state, :thumbnail_id,
+     :visibility, :workflow_note, :pending_uploads, :start_canvas, :viewing_direction, :viewing_hint]
   end
 
   def parents

--- a/app/jobs/preserve_resource_job.rb
+++ b/app/jobs/preserve_resource_job.rb
@@ -14,7 +14,27 @@ class PreserveResourceJob < ApplicationJob
     Rails.logger.info "Object not found: #{id}"
   end
 
-  def change_set_persister
-    ChangeSetPersister.default
-  end
+  private
+
+    def change_set_persister
+      ChangeSetPersister.default
+    end
+
+    # If a resource has optimistic locking enabled, check if the lock tokens
+    # passsed in as a Job parameter match the lock tokens on the resource.
+    def token_valid?(resource:, lock_tokens:)
+      if lock_tokens.present? && resource.optimistic_locking_enabled?
+        resource_lock_tokens = resource[Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK]
+        return false if resource_lock_tokens != deserialize_tokens(lock_tokens)
+      end
+
+      true
+    end
+
+    # Deserialize lock tokens into OptimisticLockToken objects
+    def deserialize_tokens(lock_tokens)
+      lock_tokens.map do |lock_token|
+        Valkyrie::Persistence::OptimisticLockToken.deserialize(lock_token)
+      end
+    end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,6 +2,8 @@
 # Models events which modify resources
 
 class Event < Valkyrie::Resource
+  enable_optimistic_locking
+
   attribute :type, Valkyrie::Types::String
   attribute :status, Valkyrie::Types::String
 

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 class FileSet < Resource
-  enable_optimistic_locking
   include Valkyrie::Resource::AccessControls
   attribute :title, Valkyrie::Types::Set
   attribute :file_metadata, Valkyrie::Types::Set.of(FileMetadata.optional)

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 class Resource < Valkyrie::Resource
+  enable_optimistic_locking
   def self.human_readable_type
     @human_readable_type ||=
       begin

--- a/app/models/tombstone.rb
+++ b/app/models/tombstone.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Tombstone < Valkyrie::Resource
+  enable_optimistic_locking
   attribute :file_set_id, Valkyrie::Types::ID
   attribute :file_set_title
   attribute :file_set_original_filename

--- a/app/utils/data_seeder.rb
+++ b/app/utils/data_seeder.rb
@@ -188,7 +188,8 @@ class DataSeeder
   private
 
     def add_child_resource(child:, parent_id:)
-      change_set = ChangeSet.for(child)
+      reloaded_child = query_service.find_by(id: child.id)
+      change_set = ChangeSet.for(reloaded_child)
       change_set.append_id = parent_id
       change_set_persister.save(change_set: change_set)
     end
@@ -243,13 +244,15 @@ class DataSeeder
 
     def add_file(resource:, file: nil)
       ingestable_file = file || IngestableFile.new(file_path: Rails.root.join("spec", "fixtures", "files", "example.tif"), mime_type: "image/tiff", original_filename: "example.tif")
-      change_set = ChangeSet.for(resource)
+      reloaded_resource = query_service.find_by(id: resource.id)
+      change_set = ChangeSet.for(reloaded_resource)
       change_set.files = [ingestable_file]
       change_set_persister.save(change_set: change_set)
     end
 
     def add_member(parent:, member:)
-      member_change_set = ChangeSet.for(member)
+      reloaded_member = query_service.find_by(id: member.id)
+      member_change_set = ChangeSet.for(reloaded_member)
       member_change_set.append_id = parent.id
       change_set_persister.save(change_set: member_change_set)
       logger.info "Added #{member.class} #{member.id} to #{parent.class} #{parent.title || parent.box_number}"

--- a/spec/adapters/indexing_adapter_spec.rb
+++ b/spec/adapters/indexing_adapter_spec.rb
@@ -59,12 +59,14 @@ RSpec.describe IndexingAdapter do
 
   it "doesn't index certain models" do
     resource = FactoryBot.create_for_repository(:event)
+    reloaded_resource = query_service.find_by(id: resource.id)
     allow(adapter.index_adapter.persister).to receive(:save_all)
     allow(adapter.index_adapter.persister).to receive(:save)
     persister.buffer_into_index do |buffered_adapter|
-      buffered_adapter.persister.save(resource: resource)
+      buffered_adapter.persister.save(resource: reloaded_resource)
     end
-    persister.save(resource: resource)
+    reloaded_resource = query_service.find_by(id: resource.id)
+    persister.save(resource: reloaded_resource)
 
     expect(adapter.index_adapter.persister).not_to have_received(:save_all)
     expect(adapter.index_adapter.persister).not_to have_received(:save)

--- a/spec/change_set_persisters/change_set_persister/apply_remote_metadata_spec.rb
+++ b/spec/change_set_persisters/change_set_persister/apply_remote_metadata_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 RSpec.describe ChangeSetPersister::ApplyRemoteMetadata do
   let(:change_set_persister) { ChangeSetPersister.default }
   let(:change_set_class) { ScannedResourceChangeSet }
+  let(:query_service) { ChangeSetPersister.default.query_service }
   let(:blade) { "123456" }
   before do
     stub_ezid(shoulder: "99999/fk4", blade: blade)
@@ -105,7 +106,8 @@ RSpec.describe ChangeSetPersister::ApplyRemoteMetadata do
       stub_catalog(bib_id: "123456")
       resource = FactoryBot.create_for_repository(:scanned_resource, source_metadata_identifier: "123456", import_metadata: true)
       expect(resource.title.first.to_s).to eq "Earth rites : fertility rites in pre-industrial Britain / Janet and Colin Bord."
-      change_set = ChangeSet.for(resource)
+      reloaded = query_service.find_by(id: resource.id)
+      change_set = ChangeSet.for(reloaded)
       change_set.validate(source_metadata_identifier: "", title: "Test")
       output = change_set_persister.save(change_set: change_set)
 

--- a/spec/change_set_persisters/change_set_persister_spec.rb
+++ b/spec/change_set_persisters/change_set_persister_spec.rb
@@ -1374,7 +1374,8 @@ RSpec.describe ChangeSetPersister do
         resource = FactoryBot.create_for_repository(:complete_scanned_resource, files: [file])
         file_set = Wayfinder.for(resource).members.first
         file_set.read_groups = []
-        resource = change_set_persister.metadata_adapter.persister.save(resource: resource)
+        reloaded_resource = query_service.find_by(id: resource.id)
+        resource = change_set_persister.metadata_adapter.persister.save(resource: reloaded_resource)
         change_set_persister.metadata_adapter.persister.save(resource: file_set)
         change_set = ChangeSet.for(resource)
 
@@ -1388,7 +1389,8 @@ RSpec.describe ChangeSetPersister do
       it "saves to a backup location" do
         file = fixture_file_upload("files/example.tif", "image/tiff")
         resource = FactoryBot.create_for_repository(:pending_scanned_resource, files: [file])
-        change_set = ChangeSet.for(resource)
+        reloaded_resource = query_service.find_by(id: resource.id)
+        change_set = ChangeSet.for(reloaded_resource)
         change_set.validate(state: "complete")
 
         output = change_set_persister.save(change_set: change_set)
@@ -1414,7 +1416,8 @@ RSpec.describe ChangeSetPersister do
       it "preserves it inline" do
         file = fixture_file_upload("files/example.tif", "image/tiff")
         resource = FactoryBot.create_for_repository(:pending_scanned_resource, files: [file])
-        change_set = ChangeSet.for(resource)
+        reloaded_resource = query_service.find_by(id: resource.id)
+        change_set = ChangeSet.for(reloaded_resource)
         change_set.validate(state: "complete")
 
         output = change_set_persister.save(change_set: change_set)
@@ -1429,7 +1432,8 @@ RSpec.describe ChangeSetPersister do
       it "refreshes the preserved metadata" do
         file = fixture_file_upload("files/example.tif", "image/tiff")
         resource = FactoryBot.create_for_repository(:complete_scanned_resource, files: [file])
-        change_set_persister.save(change_set: ChangeSet.for(resource))
+        reloaded_resource = query_service.find_by(id: resource.id)
+        change_set_persister.save(change_set: ChangeSet.for(reloaded_resource))
         file_set = Wayfinder.for(resource).members.first
 
         modified = File.mtime(disk_preservation_path.join(resource.id.to_s, "#{resource.id}.json"))
@@ -1468,7 +1472,8 @@ RSpec.describe ChangeSetPersister do
       it "Deletes FileSet PreservationObjects, moves file set PreservationObjects into tombstones" do
         file = fixture_file_upload("files/example.tif", "image/tiff")
         resource = FactoryBot.create_for_repository(:pending_scanned_resource, files: [file])
-        change_set = ChangeSet.for(resource)
+        reloaded_resource = query_service.find_by(id: resource.id)
+        change_set = ChangeSet.for(reloaded_resource)
         change_set.validate(state: "complete")
 
         output = change_set_persister.save(change_set: change_set)
@@ -1495,7 +1500,8 @@ RSpec.describe ChangeSetPersister do
       it "deletes all previously created FileSet tombstones for that parent, related PreservationObjects, and cleans up the Preservation file store" do
         file = fixture_file_upload("files/example.tif", "image/tiff")
         resource = FactoryBot.create_for_repository(:pending_scanned_resource, files: [file])
-        change_set = ChangeSet.for(resource)
+        reloaded_resource = query_service.find_by(id: resource.id)
+        change_set = ChangeSet.for(reloaded_resource)
         change_set.validate(state: "complete")
 
         output = change_set_persister.save(change_set: change_set)
@@ -1529,7 +1535,8 @@ RSpec.describe ChangeSetPersister do
       it "re-adds the FileSet" do
         file = fixture_file_upload("files/example.tif", "image/tiff")
         resource = FactoryBot.create_for_repository(:pending_scanned_resource, files: [file])
-        change_set = ChangeSet.for(resource)
+        reloaded_resource = query_service.find_by(id: resource.id)
+        change_set = ChangeSet.for(reloaded_resource)
         change_set.validate(state: "complete")
 
         output = change_set_persister.save(change_set: change_set)
@@ -1564,8 +1571,9 @@ RSpec.describe ChangeSetPersister do
         file = fixture_file_upload("files/vector/shapefile.zip", "application/zip")
         xml = fixture_file_upload("files/geo_metadata/fgdc.xml", "application/xml; schema=fgdc")
         vector_resource = FactoryBot.create_for_repository(:complete_vector_resource, files: [file, xml])
+        reloaded_resource = query_service.find_by(id: vector_resource.id)
 
-        output = change_set_persister.save(change_set: ChangeSet.for(vector_resource))
+        output = change_set_persister.save(change_set: ChangeSet.for(reloaded_resource))
         preservation_object = Wayfinder.for(output).preservation_objects.first
         expect(preservation_object).not_to eq nil
 
@@ -1584,6 +1592,7 @@ RSpec.describe ChangeSetPersister do
         change_set = ChangeSet.for(parent)
         change_set.validate(state: "complete")
         other_parent = FactoryBot.create_for_repository(:complete_scanned_resource)
+
         # Save in nested structure.
         change_set_persister.save(change_set: change_set)
         # Preserve `other_parent`
@@ -1725,7 +1734,8 @@ RSpec.describe ChangeSetPersister do
       it "triggers a geoserver publish job with a delete operation" do
         file = fixture_file_upload("files/vector/shapefile.zip", "application/zip")
         resource = FactoryBot.create_for_repository(:complete_open_vector_resource, files: [file])
-        vector_change_set = ChangeSet.for(resource)
+        reloaded_resource = query_service.find_by(id: resource.id)
+        vector_change_set = ChangeSet.for(reloaded_resource)
         vector_change_set.validate(state: "takedown")
         change_set_persister.save(change_set: vector_change_set)
 
@@ -1737,7 +1747,8 @@ RSpec.describe ChangeSetPersister do
       it "triggers a geoserver publish job with an update operation" do
         file = fixture_file_upload("files/vector/shapefile.zip", "application/zip")
         resource = FactoryBot.create_for_repository(:complete_open_vector_resource, title: "Vector", files: [file])
-        vector_change_set = ChangeSet.for(resource)
+        reloaded_resource = query_service.find_by(id: resource.id)
+        vector_change_set = ChangeSet.for(reloaded_resource)
         vector_change_set.validate(title: "New Vector Title")
         change_set_persister.save(change_set: vector_change_set)
 
@@ -1749,7 +1760,8 @@ RSpec.describe ChangeSetPersister do
       it "triggers a geoserver publish job with an update operation" do
         file = fixture_file_upload("files/vector/shapefile.zip", "application/zip")
         resource = FactoryBot.create_for_repository(:complete_open_vector_resource, files: [file])
-        vector_change_set = ChangeSet.for(resource)
+        reloaded_resource = query_service.find_by(id: resource.id)
+        vector_change_set = ChangeSet.for(reloaded_resource)
         vector_change_set.validate(visibility: "restricted")
         change_set_persister.save(change_set: vector_change_set)
 
@@ -1765,7 +1777,8 @@ RSpec.describe ChangeSetPersister do
       it "triggers a geoserver publish job with a delete operation" do
         file = fixture_file_upload("files/vector/shapefile.zip", "application/zip")
         resource = FactoryBot.create_for_repository(:takedown_vector_resource, files: [file])
-        vector_change_set = ChangeSet.for(resource)
+        reloaded_resource = query_service.find_by(id: resource.id)
+        vector_change_set = ChangeSet.for(reloaded_resource)
         vector_change_set.validate(state: "complete")
         change_set_persister.save(change_set: vector_change_set)
 

--- a/spec/change_set_persisters/change_set_persister_spec.rb
+++ b/spec/change_set_persisters/change_set_persister_spec.rb
@@ -1777,7 +1777,8 @@ RSpec.describe ChangeSetPersister do
       it "does not trigger a geoserver publish job" do
         file = fixture_file_upload("files/vector/shapefile.zip", "application/zip")
         resource = FactoryBot.create_for_repository(:complete_open_vector_resource, files: [file])
-        vector_change_set = ChangeSet.for(resource)
+        reloaded_resource = query_service.find_by(id: resource.id)
+        vector_change_set = ChangeSet.for(reloaded_resource)
         vector_change_set.validate(publisher: ["ESRI"])
         change_set_persister.save(change_set: vector_change_set)
 

--- a/spec/jobs/missing_thumbnail_job_spec.rb
+++ b/spec/jobs/missing_thumbnail_job_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe MissingThumbnailJob do
     let(:file) { fixture_file_upload("files/color-landscape.tif", "image/tiff") }
     let(:resource) do
       sr = FactoryBot.create_for_repository(:scanned_resource, files: [file])
-      change_set = ScannedResourceChangeSet.new(sr)
+      reloaded_resource = query_service.find_by(id: sr.id)
+      change_set = ScannedResourceChangeSet.new(reloaded_resource)
       change_set.thumbnail_id = nil
       change_set_persister.save(change_set: change_set)
     end

--- a/spec/jobs/preserve_resource_job_spec.rb
+++ b/spec/jobs/preserve_resource_job_spec.rb
@@ -6,4 +6,42 @@ RSpec.describe PreserveResourceJob do
   it "does not error when given a non-existent ID" do
     expect { described_class.perform_now(id: "none") }.not_to raise_error
   end
+
+  context "when passing in serialized lock tokens" do
+    before do
+      allow(Preserver).to receive(:for).and_return(Preserver::NullPreserver)
+    end
+
+    context "with a FileSet and the tokens are valid" do
+      it "preserves the resource" do
+        fs = FactoryBot.create_for_repository(:file_set)
+        valid_tokens = fs[Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK]
+        valid_tokens.map!(&:serialize)
+
+        described_class.perform_now(id: fs.id, lock_tokens: valid_tokens)
+        expect(Preserver).to have_received(:for)
+      end
+    end
+
+    context "with a FileSet and the tokens are invalid" do
+      it "exits early" do
+        fs = FactoryBot.create_for_repository(:file_set)
+        invalid_tokens = ["lock_token:token:99"]
+
+        described_class.perform_now(id: fs.id, lock_tokens: invalid_tokens)
+        expect(Preserver).not_to have_received(:for)
+      end
+    end
+
+    context "with a ScannedResource and the tokens are valid" do
+      it "preserves the resource" do
+        sr = FactoryBot.create_for_repository(:scanned_resource)
+        valid_tokens = sr[Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK]
+        valid_tokens.map!(&:serialize)
+
+        described_class.perform_now(id: sr.id, lock_tokens: valid_tokens)
+        expect(Preserver).to have_received(:for)
+      end
+    end
+  end
 end

--- a/spec/models/numismatics/issues_feature_spec.rb
+++ b/spec/models/numismatics/issues_feature_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature "Numismatics::Issues" do
   let(:user) { FactoryBot.create(:admin) }
   let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
   let(:persister) { adapter.persister }
+  let(:query_service) { ChangeSetPersister.default.query_service }
   let(:numismatic_issue) do
     res = FactoryBot.create_for_repository(:numismatic_issue)
     persister.save(resource: res)
@@ -405,7 +406,8 @@ RSpec.feature "Numismatics::Issues" do
 
     context "when Issues have been saved" do
       let(:persisted) do
-        change_set = Numismatics::IssueChangeSet.new(numismatic_issue)
+        reloaded_resource = query_service.find_by(id: numismatic_issue.id)
+        change_set = Numismatics::IssueChangeSet.new(reloaded_resource)
         change_set_persister.save(change_set: change_set)
       end
 

--- a/spec/services/cdl/automatic_completer_spec.rb
+++ b/spec/services/cdl/automatic_completer_spec.rb
@@ -21,8 +21,10 @@ RSpec.describe CDL::AutomaticCompleter do
       with_queue_adapter :inline
       it "doesn't complete them" do
         resource = FactoryBot.create_for_repository(:draft_cdl_resource, files: [file])
+        reloaded_resource = query_service.find_by(id: resource.id)
         cs = ChangeSet.for(resource)
         cs.validate(files: [file])
+        cs.optimistic_lock_token = reloaded_resource.optimistic_lock_token
         change_set_persister.save(change_set: cs)
 
         described_class.run

--- a/spec/services/geo_discovery/document_builder_spec.rb
+++ b/spec/services/geo_discovery/document_builder_spec.rb
@@ -311,7 +311,8 @@ describe GeoDiscovery::DocumentBuilder, skip_fixity: true do
       let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }
 
       before do
-        change_set = ScannedMapChangeSet.new(geo_work)
+        reloaded_resource = query_service.find_by(id: geo_work.id)
+        change_set = ScannedMapChangeSet.new(reloaded_resource)
         change_set.validate(thumbnail_id: child.id)
         change_set_persister.save(change_set: change_set)
       end
@@ -364,7 +365,11 @@ describe GeoDiscovery::DocumentBuilder, skip_fixity: true do
           files: [file]
         )
       end
-      let(:child_change_set) { ChangeSet.for(child) }
+      let(:child_change_set) do
+        reloaded_resource = query_service.find_by(id: child.id)
+        ChangeSet.for(reloaded_resource)
+      end
+
       let(:file) { fixture_file_upload("files/raster/geotiff.tif", "image/tiff; gdal-format=GTiff") }
 
       before do

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -560,7 +560,8 @@ RSpec.describe ManifestBuilder do
     let(:child) { FactoryBot.create_for_repository(:scanned_resource, files: [file]) }
 
     before do
-      change_set = ScannedResourceChangeSet.new(scanned_resource)
+      reloaded_resource = query_service.find_by(id: scanned_resource.id)
+      change_set = ScannedResourceChangeSet.new(reloaded_resource)
       change_set.member_ids << child.id
       change_set_persister.save(change_set: change_set)
     end

--- a/spec/services/manifest_builder_v3_spec.rb
+++ b/spec/services/manifest_builder_v3_spec.rb
@@ -187,8 +187,8 @@ RSpec.describe ManifestBuilderV3 do
     before do
       allow(Rails.env).to receive(:development?).and_return(false)
       allow(Rails.env).to receive(:test?).and_return(false)
-      # stub_catalog(bib_id: "123456")
-      change_set = ScannedMapChangeSet.new(resource, files: [file])
+      reloaded_resource = query_service.find_by(id: resource.id)
+      change_set = ScannedMapChangeSet.new(reloaded_resource, files: [file])
       output = change_set_persister.save(change_set: change_set)
       file_set_id = output.member_ids.first
       file_set = query_service.find_by(id: file_set_id)

--- a/spec/services/preserver/importer_spec.rb
+++ b/spec/services/preserver/importer_spec.rb
@@ -10,9 +10,11 @@ describe Preserver::Importer do
   let(:shoulder) { "99999/fk4" }
   let(:blade) { "123456" }
   let(:change_set_persister) { ChangeSetPersister.default }
+  let(:query_service) { change_set_persister.query_service }
   let(:storage_adapter) { Valkyrie::StorageAdapter.find(:google_cloud_storage) }
   let(:persisted_resource) do
-    change_set_persister.metadata_adapter.persister.save(resource: resource)
+    reloaded_resource = query_service.find_by(id: resource.id)
+    change_set_persister.metadata_adapter.persister.save(resource: reloaded_resource)
   end
   let(:persisted_file_set) do
     file_set.read_groups = []

--- a/spec/wayfinders/wayfinder_spec.rb
+++ b/spec/wayfinders/wayfinder_spec.rb
@@ -18,10 +18,12 @@ RSpec.describe Wayfinder do
     describe "#child_tombstones" do
       it "returns all tombstones with the given parent_id" do
         stub_ezid(shoulder: "99999/fk4", blade: "123456")
+        query_service = ChangeSetPersister.default.query_service
         file = fixture_file_upload("files/example.tif", "image/tiff")
         change_set_persister = ChangeSetPersister.default
         resource = FactoryBot.create_for_repository(:pending_scanned_resource, files: [file])
-        change_set = ChangeSet.for(resource)
+        reloaded_resource = query_service.find_by(id: resource.id)
+        change_set = ChangeSet.for(reloaded_resource)
         change_set.validate(state: "complete")
 
         output = change_set_persister.save(change_set: change_set)


### PR DESCRIPTION
- Adds optimistic lock property to (most) resources and change sets.
- Disables optimistic locking functionality by default.
- In PreserverResourceJob, adds logic to compare lock tokens passed as a param with current lock token values and exit early if they don't match.

refs #3592