### PR TITLE
Add optimistic lock token checking to PreserveResourceJob

### DIFF
--- a/app/change_set_persisters/change_set_persister/preserve_resource.rb
+++ b/app/change_set_persisters/change_set_persister/preserve_resource.rb
@@ -3,7 +3,7 @@
 class ChangeSetPersister
   class PreserveResource
     attr_reader :change_set_persister, :change_set, :post_save_resource
-    delegate :metadata_adapter, to: :change_set_persister
+    delegate :metadata_adapter, :query_service, to: :change_set_persister
 
     def initialize(change_set_persister:, change_set:, post_save_resource: nil)
       @change_set = change_set
@@ -12,16 +12,28 @@ class ChangeSetPersister
     end
 
     def run
-      cs = change_set.class.new(post_save_resource)
+      # Reload the resource because some after_save change_set persisters, like
+      # AppendToParent, update the resource which changes the lock token value.
+      cs = change_set.class.new(reload(post_save_resource))
       return unless cs.try(:preserve?)
+
+      lock_tokens = cs[Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK] || []
+      lock_tokens = lock_tokens.map(&:serialize)
+
       # It's important that we inline this for parents, to ensure that a race
       # condition doesn't happen which makes it so that two jobs get queued up
       # that each call PreserveChildrenJob, resulting in multiple file uploads
       if cs.try(:member_ids).present?
-        PreserveResourceJob.perform_now(id: cs.id.to_s)
+        PreserveResourceJob.perform_now(id: cs.id.to_s, lock_tokens: lock_tokens)
       else
-        PreserveResourceJob.perform_later(id: cs.id.to_s)
+        PreserveResourceJob.perform_later(id: cs.id.to_s, lock_tokens: lock_tokens)
       end
+    end
+
+    def reload(resource)
+      query_service.find_by(id: resource.id)
+    rescue Valkyrie::Persistence::ObjectNotFoundError
+      resource
     end
   end
 end

--- a/app/jobs/preserve_resource_job.rb
+++ b/app/jobs/preserve_resource_job.rb
@@ -4,8 +4,12 @@ class PreserveResourceJob < ApplicationJob
   delegate :metadata_adapter, to: :change_set_persister
   delegate :query_service, to: :metadata_adapter
 
-  def perform(id:)
+  # @param id [String] resource id
+  # @param lock_tokens [Array<String>] serialized lock tokens
+  def perform(id:, lock_tokens: nil)
     resource = query_service.find_by(id: id)
+    return unless token_valid?(resource: resource, lock_tokens: lock_tokens)
+
     change_set_persister.buffer_into_index do |buffered_change_set_persister|
       change_set = ChangeSet.for(resource)
       Preserver.for(change_set: change_set, change_set_persister: buffered_change_set_persister).preserve!
@@ -14,7 +18,27 @@ class PreserveResourceJob < ApplicationJob
     Rails.logger.info "Object not found: #{id}"
   end
 
-  def change_set_persister
-    ChangeSetPersister.default
-  end
+  private
+
+    def change_set_persister
+      ChangeSetPersister.default
+    end
+
+    # If a resource has optimistic locking enabled, check if the lock tokens
+    # passsed in as a Job parameter match the lock tokens on the resource.
+    def token_valid?(resource:, lock_tokens:)
+      if lock_tokens.present? && resource.optimistic_locking_enabled?
+        resource_lock_tokens = resource[Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK]
+        return false if resource_lock_tokens != deserialize_tokens(lock_tokens)
+      end
+
+      true
+    end
+
+    # Deserialize lock tokens into OptimisticLockToken objects
+    def deserialize_tokens(lock_tokens)
+      lock_tokens.map do |lock_token|
+        Valkyrie::Persistence::OptimisticLockToken.deserialize(lock_token)
+      end
+    end
 end

--- a/spec/jobs/preserve_resource_job_spec.rb
+++ b/spec/jobs/preserve_resource_job_spec.rb
@@ -6,4 +6,31 @@ RSpec.describe PreserveResourceJob do
   it "does not error when given a non-existent ID" do
     expect { described_class.perform_now(id: "none") }.not_to raise_error
   end
+
+  context "when passing in serialized lock tokens" do
+    before do
+      allow(Preserver).to receive(:for).and_return(Preserver::NullPreserver)
+    end
+
+    context "with a FileSet and the tokens are valid" do
+      it "preserves the resource" do
+        fs = FactoryBot.create_for_repository(:file_set)
+        valid_tokens = fs[Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK]
+        valid_tokens.map!(&:serialize)
+
+        described_class.perform_now(id: fs.id, lock_tokens: valid_tokens)
+        expect(Preserver).to have_received(:for)
+      end
+    end
+
+    context "with a FileSet and the tokens are invalid" do
+      it "exits early" do
+        fs = FactoryBot.create_for_repository(:file_set)
+        invalid_tokens = ["lock_token:token:99"]
+
+        described_class.perform_now(id: fs.id, lock_tokens: invalid_tokens)
+        expect(Preserver).not_to have_received(:for)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Refs #3592 

- In PreserverResourceJob, adds logic to compare lock tokens passed as a param with current lock token values and exit early if they don't match.
- Works for FileSets and ResourceChangeLists. Will be enabled for all resources when this PR is merged: https://github.com/pulibrary/figgy/pull/5585