### PR TITLE
Enable Preserver::Importer to set correct PCDM use on recovered files

### DIFF
--- a/app/services/preserver/importer.rb
+++ b/app/services/preserver/importer.rb
@@ -11,23 +11,16 @@ class Preserver
     # @param resource [PreservationObject]
     def self.from_preservation_object(resource:, change_set_persister:, storage_adapter: nil)
       file_metadata = resource.metadata_node
-      metadata_file_identifier = if file_metadata.nil?
-                                   nil
-                                 else
-                                   file_metadata.file_identifiers.first
-                                 end
-      binary_nodes = resource.binary_nodes
-      binary_file_identifiers = binary_nodes.map(&:file_identifiers)
-      binary_file_identifiers.flatten!
-
+      metadata_file_identifier = file_metadata&.file_identifiers&.first
+      binary_file_identifiers = resource.binary_nodes.map(&:file_identifiers).flatten
       resource_storage_adapter = storage_adapter || default_storage_adapter
-      instance = new(
+
+      new(
         metadata_file_identifier: metadata_file_identifier,
         binary_file_identifiers: binary_file_identifiers,
         change_set_persister: change_set_persister,
         storage_adapter: resource_storage_adapter
-      )
-      instance.import!
+      ).import!
     end
 
     def initialize(metadata_file_identifier:, binary_file_identifiers:, change_set_persister:, storage_adapter: nil)
@@ -38,73 +31,42 @@ class Preserver
     end
 
     def import!
-      fs = build_file_set
-      fs_change_set = ChangeSet.for(fs)
-
       files = import_binary_nodes(binary_file_identifiers)
-      fs_change_set.validate(files: files)
+      fs_change_set = ChangeSet.for(file_set)
 
-      persisted = nil
+      # Delete historic metadata because we are about to add new ones for the restored file(s)
+      fs_change_set.validate(files: files, file_metadata: [])
+
+      imported = nil
       change_set_persister.buffer_into_index do |buffered_change_set_persister|
-        persisted = buffered_change_set_persister.save(change_set: fs_change_set, external_resource: true)
+        imported = buffered_change_set_persister.save(change_set: fs_change_set, external_resource: true)
       end
-      persisted
+
+      imported
     end
 
     private
 
-      def resource_class
-        FileSet
+      def file_set
+        @file_set ||= begin
+                        Valkyrie.config.metadata_adapter.resource_factory.to_resource(object: resource_object)
+                      rescue Valkyrie::StorageAdapter::FileNotFound
+                        FileSet.new
+                      end
       end
 
-      def build_id(json)
-        Valkyrie::ID.new(json["id"])
-      end
-
-      def build_optimistic_lock_token(json)
-        return unless json.key?("adapter_id")
-
-        adapter_id = build_id(json["adapter_id"])
-        token = json["token"]
-
-        Valkyrie::Persistence::OptimisticLockToken.new(
-          adapter_id: adapter_id,
-          token: token
-        )
-      end
-
-      def build_file_set
-        return resource_class.new if metadata_file_identifier.nil?
+      def resource_object
+        metadata_file_contents = storage_adapter.find_by(id: metadata_file_identifier).read
         metadata_json = JSON.parse(metadata_file_contents)
-        # Delete historic metadata because we are about to add new ones for the
-        # restored file(s)
-        metadata_json.delete("file_metadata")
-        resource_object = { metadata: metadata_json }
-        file_set = Valkyrie.config.metadata_adapter.resource_factory.to_resource(object: resource_object)
-        optimistic_lock_token = metadata_json["optimistic_lock_token"].map do |lock_json|
-          build_optimistic_lock_token(lock_json)
-        end
-        file_set.optimistic_lock_token = optimistic_lock_token
-        file_set
-      rescue Valkyrie::StorageAdapter::FileNotFound => not_found_error
-        Rails.logger.error("#{metadata_file_identifier} could not be retrieved: #{not_found_error.message}")
-        resource_class.new
+        # Set the lock version so the Valkyrie ORM Converter can generate a lock token
+        lock_version = metadata_json.dig("optimistic_lock_token", 0, "token")
+
+        { metadata: metadata_json, lock_version: lock_version }
       end
 
-      def metadata_file_contents
-        @metadata_file_contents ||= begin
-          file = storage_adapter.find_by(id: metadata_file_identifier)
-          file.read
-        end
-      end
-
-      def use_from_metadata(file_identifier)
-        metadata_json = JSON.parse(metadata_file_contents)
-        fs = Valkyrie.config.metadata_adapter.resource_factory.to_resource(object: { metadata: metadata_json })
-        file_metadata = fs.file_metadata.find { |fm| file_identifier.id.include? fm.id.id }
-        file_metadata.use
-      rescue Valkyrie::StorageAdapter::FileNotFound
-        Valkyrie::Vocab::PCDMUse.OriginalFile
+      def import_binary_nodes(file_identifiers)
+        files = file_identifiers.map { |file_id| import_binary_node(file_id) }
+        files.compact
       end
 
       def import_binary_node(file_identifier)
@@ -120,9 +82,14 @@ class Preserver
         nil
       end
 
-      def import_binary_nodes(file_identifiers)
-        files = file_identifiers.map { |file_id| import_binary_node(file_id) }
-        files.compact
+      # Get file PCDM use value from imported file metadata
+      def use_from_metadata(file_identifier)
+        file_metadata = file_set.file_metadata.find { |fm| file_identifier.id.include? fm.id.id }
+        if file_metadata
+          file_metadata.use
+        else
+          Valkyrie::Vocab::PCDMUse.OriginalFile
+        end
       end
 
       def default_storage_adapter

--- a/spec/services/preserver/importer_spec.rb
+++ b/spec/services/preserver/importer_spec.rb
@@ -16,6 +16,7 @@ describe Preserver::Importer do
   end
   let(:persisted_file_set) do
     file_set.read_groups = []
+    file_set.primary_file.use = [Valkyrie::Vocab::PCDMUse.IntermediateFile]
     change_set_persister.metadata_adapter.persister.save(resource: file_set)
   end
   let(:preservation_object) do
@@ -61,6 +62,7 @@ describe Preserver::Importer do
       )
 
       expect(imported).to be_a FileSet
+      expect(imported.primary_file.use).to eq [Valkyrie::Vocab::PCDMUse.IntermediateFile]
       expect(imported.optimistic_lock_token).not_to be_empty
       expect(imported.optimistic_lock_token.first).to be_a Valkyrie::Persistence::OptimisticLockToken
       imported_file_metadata = imported.file_metadata
@@ -128,6 +130,7 @@ describe Preserver::Importer do
         expect(imported.optimistic_lock_token.first).to be_a Valkyrie::Persistence::OptimisticLockToken
         imported_file_metadata = imported.file_metadata
         expect(imported_file_metadata).not_to be_empty
+        expect(imported.primary_file.use).to eq [Valkyrie::Vocab::PCDMUse.OriginalFile]
         expect(imported.title).to be_empty
       end
     end


### PR DESCRIPTION
- Enable Preserver::Importer to set correct PCDM use on recovered files
- Refactor Preserver::Importer

Closes #5546 