### PR TITLE
Use new PreservationFile use value

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,9 @@ jobs:
     steps:
       - browser-tools/install-chrome
       - browser-tools/install-chromedriver
+      - run:
+          name: remove errant LICENSE file
+          command: rm LICENSE.chromedriver
       - checkout
       - node/install:
           install-yarn: true

--- a/app/characterization_services/imagemagick_characterization_service.rb
+++ b/app/characterization_services/imagemagick_characterization_service.rb
@@ -68,7 +68,7 @@ class ImagemagickCharacterizationService
     @file_object ||= Valkyrie::StorageAdapter.find_by(id: primary_file.file_identifiers[0])
   end
 
-  # Retrieve the master file from the FileSet
+  # Retrieve the primary file from the FileSet
   # @return [FileMetadata]
   def primary_file
     @file_set.primary_file

--- a/app/characterization_services/mediainfo_characterization_service.rb
+++ b/app/characterization_services/mediainfo_characterization_service.rb
@@ -11,7 +11,7 @@ class MediainfoCharacterizationService
   attr_reader :file_set, :persister
 
   # Constructor
-  # @param file_set [FileSet] FileSet in which the master binary file is stored
+  # @param file_set [FileSet] FileSet in which the primary binary file is stored
   # @param persister [ChangeSetPersister] ChangeSet persister for the FileSet and parent resource
   def initialize(file_set:, persister:)
     @file_set = file_set
@@ -165,7 +165,7 @@ class MediainfoCharacterizationService
       @file_object ||= Valkyrie::StorageAdapter.find_by(id: preservation_file.file_identifiers[0])
     end
 
-    # Retrieves the master binary file in this FileSet
+    # Retrieves the primary binary file in this FileSet
     # @return [FileNode]
     def preservation_file
       if parent.try(:image_resource?)

--- a/app/derivative_services/audio_derivative_service.rb
+++ b/app/derivative_services/audio_derivative_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # Generates MP3s from uploaded WAV files.
 # @note This will not generate files for any Resource that stores its primary
-# file as a PreservationMaster instead of an original file.
+# file as a PreservationFile instead of an original file.
 class AudioDerivativeService
   class Factory
     attr_reader :change_set_persister
@@ -28,7 +28,7 @@ class AudioDerivativeService
     @resource ||= query_service.find_by(id: id)
   end
 
-  # Only ever checks primary_file, if this were to check preservation_master
+  # Only ever checks primary_file, if this were to check preservation_file
   # it would override derivatives for MediaResources. Take care!
   def target_file
     resource.original_file || resource.intermediate_files.first

--- a/app/derivative_services/pdf_derivative_service.rb
+++ b/app/derivative_services/pdf_derivative_service.rb
@@ -133,7 +133,7 @@ class PDFDerivativeService
     pdf_file_metadata = resource.file_metadata.select { |f| f.use == [Valkyrie::Vocab::PCDMUse.OriginalFile] }.find(&:pdf?)
     return unless pdf_file_metadata
 
-    pdf_file_metadata.use = [Valkyrie::Vocab::PCDMUse.PreservationMasterFile]
+    pdf_file_metadata.use = [Valkyrie::Vocab::PCDMUse.PreservationFile]
     resource.file_metadata = resource.file_metadata.select { |x| x.id != pdf_file_metadata.id } + [pdf_file_metadata]
     persister.save(resource: resource)
   end

--- a/app/models/ingestable_audio_file.rb
+++ b/app/models/ingestable_audio_file.rb
@@ -13,7 +13,7 @@ class IngestableAudioFile
   end
 
   def mime_type
-    if master? || intermediate?
+    if preservation_file? || intermediate?
       "audio/x-wav"
     else
       "audio/mpeg"
@@ -22,8 +22,8 @@ class IngestableAudioFile
   alias content_type mime_type
 
   def use
-    if master?
-      Valkyrie::Vocab::PCDMUse.PreservationMasterFile
+    if preservation_file?
+      Valkyrie::Vocab::PCDMUse.PreservationFile
     elsif intermediate?
       Valkyrie::Vocab::PCDMUse.IntermediateFile
     elsif access?
@@ -31,7 +31,7 @@ class IngestableAudioFile
     end
   end
 
-  def master?
+  def preservation_file?
     path.to_s.end_with?("_pm.wav")
   end
 

--- a/app/nested_resources/file_metadata.rb
+++ b/app/nested_resources/file_metadata.rb
@@ -67,7 +67,8 @@ class FileMetadata < Valkyrie::Resource
   end
 
   def preservation_file?
-    use.include?(Valkyrie::Vocab::PCDMUse.PreservationMasterFile)
+    use.include?(Valkyrie::Vocab::PCDMUse.PreservationFile) ||
+      use.include?(Valkyrie::Vocab::PCDMUse.PreservationMasterFile)
   end
 
   def preserved_metadata?

--- a/app/views/catalog/_members_file_set.html.erb
+++ b/app/views/catalog/_members_file_set.html.erb
@@ -40,7 +40,7 @@
   <% end %>
   <% resource.preservation_files.each do |file| %>
     <tr>
-      <td><span class="badge badge-info">Preservation Master</span>&nbsp;<%= file.label.first %></td>
+      <td><span class="badge badge-info">Preservation File</span>&nbsp;<%= file.label.first %></td>
       <%= render partial: 'file_detail', locals: { file: file } %>
     </tr>
   <% end %>

--- a/spec/change_set_persisters/change_set_persister_spec.rb
+++ b/spec/change_set_persisters/change_set_persister_spec.rb
@@ -395,7 +395,7 @@ RSpec.describe ChangeSetPersister do
         change_set = change_set_class.new(resource, characterize: true)
         change_set.files = [file]
 
-        attributes = { id: SecureRandom.uuid, use: [Valkyrie::Vocab::PCDMUse.OriginalFile, Valkyrie::Vocab::PCDMUse.PreservationMasterFile] }
+        attributes = { id: SecureRandom.uuid, use: [Valkyrie::Vocab::PCDMUse.OriginalFile, Valkyrie::Vocab::PCDMUse.PreservationFile] }
         file_metadata_node = FileMetadata.for(file: file).new(attributes)
         allow(FileMetadata).to receive(:for).and_return(file_metadata_node)
 

--- a/spec/characterization_services/mediainfo_characterization_service_spec.rb
+++ b/spec/characterization_services/mediainfo_characterization_service_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe MediainfoCharacterizationService do
   let(:query_service) { adapter.query_service }
   let(:change_set_persister) { ChangeSetPersister.new(metadata_adapter: adapter, storage_adapter: storage_adapter) }
   let(:resource) do
-    attributes = { id: SecureRandom.uuid, use: [Valkyrie::Vocab::PCDMUse.OriginalFile, Valkyrie::Vocab::PCDMUse.PreservationMasterFile] }
+    attributes = { id: SecureRandom.uuid, use: [Valkyrie::Vocab::PCDMUse.OriginalFile, Valkyrie::Vocab::PCDMUse.PreservationFile] }
     file_metadata_node = FileMetadata.for(file: file).new(attributes)
     allow(FileMetadata).to receive(:for).and_return(file_metadata_node)
 

--- a/spec/characterization_services/null_characterization_service_spec.rb
+++ b/spec/characterization_services/null_characterization_service_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe NullCharacterizationService do
         resource = FactoryBot.create_for_repository(:scanned_resource, files: [pdf_file])
         file_set = resource.decorate.members.first
         pdf_file_metadata = file_set.file_metadata.first
-        pdf_file_metadata.use = [Valkyrie::Vocab::PCDMUse.PreservationMasterFile]
+        pdf_file_metadata.use = [Valkyrie::Vocab::PCDMUse.PreservationFile]
         file_set.file_metadata = [pdf_file_metadata]
         file_set = adapter.persister.save(resource: file_set)
 

--- a/spec/controllers/scanned_maps_controller_spec.rb
+++ b/spec/controllers/scanned_maps_controller_spec.rb
@@ -327,7 +327,7 @@ RSpec.describe ScannedMapsController, type: :controller do
   end
 
   # Tests functionality defined in `app/controllers/concerns/geo_resource_controller.rb`
-  #   Acts as a 'master spec' in this regard
+  #   Acts as a global spec in this regard
   describe "PUT /concern/scanned_maps/:id/extract_metadata/:file_set_id" do
     with_queue_adapter :inline
     let(:user) { FactoryBot.create(:admin) }

--- a/spec/controllers/scanned_resources_controller_spec.rb
+++ b/spec/controllers/scanned_resources_controller_spec.rb
@@ -455,7 +455,7 @@ RSpec.describe ScannedResourcesController, type: :controller do
     let(:user) { FactoryBot.create(:admin) }
 
     # This block tests functionality defined in `app/controllers/concerns/browse_everythingable.rb`
-    #   Acts as a 'master spec' in this regard
+    #   Acts as a global spec in this regard
     describe "POST /concern/scanned_resources/:id/browse_everything_files" do
       def params_for_paths(paths, resource)
         session = BrowseEverything::Session.build(

--- a/spec/derivative_services/pdf_derivative_service_spec.rb
+++ b/spec/derivative_services/pdf_derivative_service_spec.rb
@@ -36,10 +36,10 @@ RSpec.describe PDFDerivativeService do
       end
     end
 
-    context "when given a pdf preservation master" do
+    context "when given a pdf preservation file" do
       it "is valid" do
         pdf_file_metadata = valid_resource.file_metadata.find { |f| f.use == [Valkyrie::Vocab::PCDMUse.OriginalFile] }
-        pdf_file_metadata.use = [Valkyrie::Vocab::PCDMUse.PreservationMasterFile]
+        pdf_file_metadata.use = [Valkyrie::Vocab::PCDMUse.PreservationFile]
         valid_resource.file_metadata = [pdf_file_metadata]
         adapter.persister.save(resource: valid_resource)
 
@@ -51,7 +51,7 @@ RSpec.describe PDFDerivativeService do
   describe "#create_derivatives" do
     context "when there are no errors", run_real_derivatives: true, run_real_characterization: true do
       with_queue_adapter :inline
-      it "creates an intermediate tiff for each page and marks the pdf as preservation master" do
+      it "creates an intermediate tiff for each page and marks the pdf as preservation file" do
         valid_resource
 
         reloaded_members = query_service.find_members(resource: scanned_resource)

--- a/spec/factories/file_set.rb
+++ b/spec/factories/file_set.rb
@@ -55,7 +55,7 @@ FactoryBot.define do
     factory :audio_file_set do
       file_metadata do
         [
-          FileMetadata.new(mime_type: "audio/x-wav", use: Valkyrie::Vocab::PCDMUse.PreservationMasterFile, id: "original"),
+          FileMetadata.new(mime_type: "audio/x-wav", use: Valkyrie::Vocab::PCDMUse.PreservationFile, id: "original"),
           FileMetadata.new(mime_type: "audio/mp3", use: Valkyrie::Vocab::PCDMUse.ServiceFile, id: "derivative"),
           FileMetadata.new(mime_type: "audio/x-wav", use: Valkyrie::Vocab::PCDMUse.IntermediateFile, id: "intermediate")
         ]

--- a/spec/jobs/ingest_archival_media_bag_job_spec.rb
+++ b/spec/jobs/ingest_archival_media_bag_job_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe IngestArchivalMediaBagJob do
       file_set = query_service.find_all_of_model(model: FileSet).select { |fs| fs.title.include? "32101047382401_1" }.sort_by(&:created_at).last
       expect(file_set.file_metadata.count).to eq 5
       expect(file_set.file_metadata.map { |file| file.use.first.to_s }).to contain_exactly(
-        "http://pcdm.org/use#PreservationMasterFile", # Master
+        "http://pcdm.org/use#PreservationFile", # Preservation copy
         "http://pcdm.org/use#ServiceFile", # MP3
         "http://pcdm.org/use#IntermediateFile", # Intermediate
         "http://pcdm.org/use#ServiceFile", # HLS Derivative
@@ -162,7 +162,7 @@ RSpec.describe IngestArchivalMediaBagJob do
       file_set = file_sets.select { |fs| fs.title.include? "32101047382492_1_p1" }.sort_by(&:created_at).last
       expect(file_set.file_metadata.count).to eq 5
       expect(file_set.file_metadata.map { |file| file.use.first.to_s }).to contain_exactly(
-        "http://pcdm.org/use#PreservationMasterFile", # Master
+        "http://pcdm.org/use#PreservationFile", # Preservation copy
         "http://pcdm.org/use#ServiceFile", # MP3
         "http://pcdm.org/use#IntermediateFile", # Intermediate
         "http://pcdm.org/use#ServiceFile", # HLS Derivative
@@ -172,7 +172,7 @@ RSpec.describe IngestArchivalMediaBagJob do
       file_set = file_sets.select { |fs| fs.title.include? "32101047382492_1_p2" }.sort_by(&:created_at).last
       expect(file_set.file_metadata.count).to eq 5
       expect(file_set.file_metadata.map { |file| file.use.first.to_s }).to contain_exactly(
-        "http://pcdm.org/use#PreservationMasterFile", # Master
+        "http://pcdm.org/use#PreservationFile", # Preservation copy
         "http://pcdm.org/use#ServiceFile", # MP3
         "http://pcdm.org/use#IntermediateFile", # Intermediate
         "http://pcdm.org/use#ServiceFile", # HLS Derivative

--- a/spec/jobs/ingest_intermediate_file_job_spec.rb
+++ b/spec/jobs/ingest_intermediate_file_job_spec.rb
@@ -3,9 +3,9 @@ require "rails_helper"
 
 RSpec.describe IngestIntermediateFileJob do
   describe "#perform" do
-    let(:master_file) { fixture_file_upload("files/example.tif", "image/tiff") }
+    let(:primary_file) { fixture_file_upload("files/example.tif", "image/tiff") }
     let(:file_path) { Rails.root.join("spec", "fixtures", "files", "abstract.tiff") }
-    let(:resource) { FactoryBot.create_for_repository(:scanned_resource, files: [master_file]) }
+    let(:resource) { FactoryBot.create_for_repository(:scanned_resource, files: [primary_file]) }
     let(:file_set) { resource.decorate.decorated_file_sets.first }
     let(:metadata_adapter) { Valkyrie.config.metadata_adapter }
     let(:storage_adapter) { Valkyrie::StorageAdapter.find(:disk_via_copy) }
@@ -33,7 +33,7 @@ RSpec.describe IngestIntermediateFileJob do
     context "when the existing resource has FileSets" do
       let(:second_file) { double("File") }
       let(:cleanup_files_job) { class_double("CleanupFilesJob").as_stubbed_const(transfer_nested_constants: true) }
-      let(:resource) { FactoryBot.create_for_repository(:scanned_resource, files: [master_file]) }
+      let(:resource) { FactoryBot.create_for_repository(:scanned_resource, files: [primary_file]) }
 
       before do
         allow(second_file).to receive(:original_filename).and_return("example.tif")

--- a/spec/jobs/regenerate_derivatives_job_spec.rb
+++ b/spec/jobs/regenerate_derivatives_job_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe RegenerateDerivativesJob do
       end
     end
 
-    context "with a pdf preservation master", run_real_characterization: true, run_real_derivatives: true do
+    context "with a pdf preservation file", run_real_characterization: true, run_real_derivatives: true do
       with_queue_adapter :inline
       let(:file) { fixture_file_upload("files/sample.pdf", "application/pdf") }
       let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe FileSet do
     context "when there is an original file" do
       it "returns that" do
         fm = FileMetadata.new(use: Valkyrie::Vocab::PCDMUse.OriginalFile)
-        fm2 = FileMetadata.new(use: Valkyrie::Vocab::PCDMUse.PreservationMasterFile)
+        fm2 = FileMetadata.new(use: Valkyrie::Vocab::PCDMUse.PreservationFile)
         fm3 = FileMetadata.new(use: Valkyrie::Vocab::PCDMUse.IntermediateFile)
         fs = FactoryBot.build(:file_set, file_metadata: [fm, fm2, fm3])
         expect(fs.primary_file).to eq fm
@@ -27,7 +27,7 @@ RSpec.describe FileSet do
 
     context "when there is a preservation file and no original file" do
       it "returns the preservation file" do
-        fm = FileMetadata.new(use: Valkyrie::Vocab::PCDMUse.PreservationMasterFile)
+        fm = FileMetadata.new(use: Valkyrie::Vocab::PCDMUse.PreservationFile)
         fm2 = FileMetadata.new(use: Valkyrie::Vocab::PCDMUse.IntermediateFile)
         fs = FactoryBot.build(:file_set, file_metadata: [fm, fm2])
         expect(fs.primary_file).to eq fm

--- a/spec/models/ingestable_audio_file_spec.rb
+++ b/spec/models/ingestable_audio_file_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe IngestableAudioFile do
   let(:file_path) { Rails.root.join("spec", "fixtures", "av", "la_c0652_2017_05_bag", "data", "32101047382401_1_pm.wav") }
   let(:audio_file) { described_class.new(path: file_path) }
 
-  context "with a preservation master file" do
+  context "with a preservation file" do
     let(:file_path) { Rails.root.join("spec", "fixtures", "av", "la_c0652_2017_05_bag", "data", "32101047382401_1_pm.wav") }
 
     describe "#original_filename" do
@@ -21,11 +21,11 @@ RSpec.describe IngestableAudioFile do
     end
 
     describe "#use" do
-      it { expect(audio_file.use).to eq Valkyrie::Vocab::PCDMUse.PreservationMasterFile }
+      it { expect(audio_file.use).to eq Valkyrie::Vocab::PCDMUse.PreservationFile }
     end
 
-    describe "#master?" do
-      it { expect(audio_file.master?).to eq true }
+    describe "#preservation_file?" do
+      it { expect(audio_file.preservation_file?).to eq true }
     end
 
     describe "#intermediate?" do
@@ -80,8 +80,8 @@ RSpec.describe IngestableAudioFile do
       it { expect(audio_file.use).to eq Valkyrie::Vocab::PCDMUse.IntermediateFile }
     end
 
-    describe "#master?" do
-      it { expect(audio_file.master?).to eq false }
+    describe "#preservation_file?" do
+      it { expect(audio_file.preservation_file?).to eq false }
     end
 
     describe "#intermediate?" do
@@ -115,8 +115,8 @@ RSpec.describe IngestableAudioFile do
       it { expect(audio_file.use).to eq Valkyrie::Vocab::PCDMUse.ServiceFile }
     end
 
-    describe "#master?" do
-      it { expect(audio_file.master?).to eq false }
+    describe "#preservation_file?" do
+      it { expect(audio_file.preservation_file?).to eq false }
     end
 
     describe "#intermediate?" do
@@ -132,7 +132,7 @@ RSpec.describe IngestableAudioFile do
     end
   end
 
-  context "when preservation master files have separate parts" do
+  context "when preservation files have separate parts" do
     let(:file_path) { Rails.root.join("spec", "fixtures", "av", "la_c0652_2017_05_bag4", "data", "32101047382492_1_p1_pm.wav") }
 
     describe "#barcode_with_side" do

--- a/spec/nested_resources/file_metadata_spec.rb
+++ b/spec/nested_resources/file_metadata_spec.rb
@@ -61,10 +61,26 @@ describe FileMetadata do
   end
 
   describe "preservation_file?" do
-    let(:use) { Valkyrie::Vocab::PCDMUse.PreservationMasterFile }
+    context "when it has the deprecated use value" do
+      let(:use) { Valkyrie::Vocab::PCDMUse.PreservationMasterFile }
 
-    it "determines if the FileMetadata is for a preservation (BagIt) binary file" do
-      expect(file_metadata.preservation_file?).to be true
+      it "returns true" do
+        expect(file_metadata.preservation_file?).to be true
+      end
+    end
+
+    context "when it has the new preservation use value" do
+      let(:use) { Valkyrie::Vocab::PCDMUse.PreservationFile }
+
+      it "returns true" do
+        expect(file_metadata.preservation_file?).to be true
+      end
+    end
+
+    context "when it has the original file use value" do
+      it "returns false" do
+        expect(file_metadata.preservation_file?).to be false
+      end
     end
   end
 

--- a/spec/services/bulk_ingest_intermediate_service_spec.rb
+++ b/spec/services/bulk_ingest_intermediate_service_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe BulkIngestIntermediateService do
   end
 
   context "when a resource exists" do
-    let(:master_file) { fixture_file_upload("files/example.tif", "image/tiff") }
-    let(:resource) { FactoryBot.create_for_repository(:scanned_resource, source_metadata_identifier: bib_id, files: [master_file]) }
+    let(:primary_file) { fixture_file_upload("files/example.tif", "image/tiff") }
+    let(:resource) { FactoryBot.create_for_repository(:scanned_resource, source_metadata_identifier: bib_id, files: [primary_file]) }
     let(:file_set) { resource.decorate.decorated_file_sets.first }
 
     before do


### PR DESCRIPTION
- Allow either preservation use value (until we complete a migration)
- Use new PreservationFile over deprecated term.
- Use "global" instead of "master"

advances #5542 