### PR TITLE
Update spec to check for content before path.

### DIFF
--- a/spec/features/bulk_edit_spec.rb
+++ b/spec/features/bulk_edit_spec.rb
@@ -113,8 +113,8 @@ RSpec.feature "Bulk edit", js: true do
       accept_alert do
         click_button("Apply Edits")
       end
-      expect(current_path).to eq root_path
       expect(page).to have_content "1 resources were queued for bulk update."
+      expect(current_path).to eq root_path
       updated = adapter.query_service.find_by(id: member_scanned_resource.id)
       expect(updated.state).to eq ["complete"]
       expect(updated.member_of_collection_ids).to eq [collection.id]


### PR DESCRIPTION
The path check doesn't wait, so sometimes the tests would fail on a timing issue.

Closes #5571