### PR TITLE
Add migration to fix current values migration

### DIFF
--- a/spec/services/migrations/event_current_migrator_spec.rb
+++ b/spec/services/migrations/event_current_migrator_spec.rb
@@ -16,34 +16,23 @@ RSpec.describe Migrations::EventCurrentMigrator do
       fs_pres_obj = FactoryBot.create_for_repository(:preservation_object, preserved_object_id: file_set.id, metadata_node: fs_metadata_node, binary_nodes: [fs_binary_node])
       res_pres_obj = FactoryBot.create_for_repository(:preservation_object, preserved_object_id: resource.id, metadata_node: resource_metadata_node)
 
-      fs_event1 = FactoryBot.create_for_repository(:cloud_fixity_event, resource_id: fs_pres_obj.id, child_property: "metadata_node", child_id: fs_pres_obj.metadata_node.id)
-      fs_event2 = FactoryBot.create_for_repository(:cloud_fixity_event, resource_id: fs_pres_obj.id, child_property: "metadata_node", child_id: fs_pres_obj.metadata_node.id)
+      FactoryBot.create_for_repository(:cloud_fixity_event, resource_id: fs_pres_obj.id, child_property: "metadata_node", child_id: fs_pres_obj.metadata_node.id)
+      FactoryBot.create_for_repository(:cloud_fixity_event, resource_id: fs_pres_obj.id, child_property: "metadata_node", child_id: fs_pres_obj.metadata_node.id)
 
-      resource_event1 = FactoryBot.create_for_repository(:cloud_fixity_event, resource_id: res_pres_obj.id, child_property: "metadata_node", child_id: res_pres_obj.metadata_node.id)
-      resource_event2 = FactoryBot.create_for_repository(:cloud_fixity_event, resource_id: res_pres_obj.id, child_property: "metadata_node", child_id: res_pres_obj.metadata_node.id)
+      FactoryBot.create_for_repository(:cloud_fixity_event, resource_id: res_pres_obj.id, child_property: "metadata_node", child_id: res_pres_obj.metadata_node.id)
+      FactoryBot.create_for_repository(:cloud_fixity_event, resource_id: res_pres_obj.id, child_property: "metadata_node", child_id: res_pres_obj.metadata_node.id)
 
-      file_event1 = FactoryBot.create_for_repository(:cloud_fixity_event, resource_id: fs_pres_obj.id, child_property: "binary_node", child_id: fs_pres_obj.binary_nodes.first.id)
-      file_event2 = FactoryBot.create_for_repository(:cloud_fixity_event, resource_id: fs_pres_obj.id, child_property: "binary_node", child_id: fs_pres_obj.binary_nodes.first.id)
+      FactoryBot.create_for_repository(:cloud_fixity_event, resource_id: fs_pres_obj.id, child_property: "binary_node", child_id: fs_pres_obj.binary_nodes.first.id)
+      FactoryBot.create_for_repository(:cloud_fixity_event, resource_id: fs_pres_obj.id, child_property: "binary_node", child_id: fs_pres_obj.binary_nodes.first.id, status: "FAILURE")
 
       query_service = Valkyrie.config.metadata_adapter.query_service
+      described_class.new.run_old
+
+      expect(query_service.custom_queries.find_cloud_fixity_failures).to be_empty
+
       described_class.call
 
-      fs_event2 = query_service.find_by(id: fs_event2.id)
-      expect(fs_event2.current).to eq true
-      # other fields are the same
-      expect(fs_event2.child_id).to eq fs_pres_obj.metadata_node.id
-      expect(fs_event2.resource_id).to eq fs_pres_obj.id
-      expect(fs_event2.child_property).to eq "metadata_node"
-      expect(query_service.find_by(id: file_event2.id).current).to eq true
-      expect(query_service.find_by(id: resource_event2.id).current).to eq true
-
-      expect(query_service.find_by(id: fs_event1.id).current).to be_falsey
-      # other fields are the same
-      expect(fs_event1.child_id).to eq fs_pres_obj.metadata_node.id
-      expect(fs_event1.resource_id).to eq fs_pres_obj.id
-      expect(fs_event1.child_property).to eq "metadata_node"
-      expect(query_service.find_by(id: file_event1.id).current).to be_falsey
-      expect(query_service.find_by(id: resource_event1.id).current).to be_falsey
+      expect(query_service.custom_queries.find_cloud_fixity_failures).not_to be_empty
     end
   end
 end


### PR DESCRIPTION
Fixes issue with previous migration where `current: true` should have been `current:  [true]`