### PR TITLE
Actively preserve un-preserved children.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,6 +101,7 @@ group :development do
   gem "foreman"
   gem "listen"
   gem "ruby-prof"
+  gem "solargraph"
   gem "spring"
   gem "web-console"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,10 +195,12 @@ GEM
       aws-sigv4 (~> 1.4)
     aws-sigv4 (1.5.1)
       aws-eventstream (~> 1, >= 1.0.2)
+    backport (1.2.0)
     bagit (0.4.4)
       docopt (~> 0.5.0)
       validatable (~> 1.6)
     bcrypt (3.1.18)
+    benchmark (0.2.0)
     benchmark-ips (2.10.0)
     bindex (0.8.1)
     bixby (3.0.2)
@@ -360,6 +362,7 @@ GEM
       dry-inflector (~> 1.0, < 2)
       dry-logic (>= 1.4, < 2)
       zeitwerk (~> 2.6)
+    e2mmap (0.1.0)
     ebnf (2.3.1)
       amazing_print (~> 1.4)
       htmlentities (~> 4.3)
@@ -515,6 +518,7 @@ GEM
       faraday (>= 0.9)
       json
     iso-639 (0.3.5)
+    jaro_winkler (1.5.4)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -554,6 +558,10 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
+    kramdown (2.4.0)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     launchy (2.5.0)
       addressable (~> 2.7)
     lcsort (0.9.1)
@@ -744,6 +752,8 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     retriable (3.1.2)
+    reverse_markdown (2.1.1)
+      nokogiri
     rexml (3.2.5)
     riiif (2.4.0)
       deprecation (>= 1.0.0)
@@ -866,6 +876,21 @@ GEM
     simpleidn (0.2.1)
       unf (~> 0.1.4)
     slop (4.9.2)
+    solargraph (0.48.0)
+      backport (~> 1.2)
+      benchmark
+      bundler (>= 1.17.2)
+      diff-lcs (~> 1.4)
+      e2mmap
+      jaro_winkler (~> 1.5)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.1)
+      parser (~> 3.0)
+      reverse_markdown (>= 1.0.5, < 3)
+      rubocop (>= 0.52)
+      thor (~> 1.0)
+      tilt (~> 2.0)
+      yard (~> 0.9, >= 0.9.24)
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
@@ -952,6 +977,7 @@ GEM
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
+    webrick (1.7.0)
     websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
@@ -960,6 +986,8 @@ GEM
       chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yard (0.9.28)
+      webrick (~> 1.7.0)
     zeitwerk (2.6.6)
 
 PLATFORMS
@@ -1069,6 +1097,7 @@ DEPENDENCIES
   sidekiq-pro!
   simple_form
   simplecov
+  solargraph
   spring
   sprockets
   sqlite3

--- a/app/jobs/preserve_children_job.rb
+++ b/app/jobs/preserve_children_job.rb
@@ -3,10 +3,14 @@ class PreserveChildrenJob < ApplicationJob
   delegate :metadata_adapter, to: :change_set_persister
   delegate :query_service, to: :metadata_adapter
 
-  def perform(id:)
+  def perform(id:, unpreserved_only: true)
     resource = query_service.find_by(id: id)
-    unpreserved_ids = query_service.custom_queries.find_never_preserved_child_ids(resource: resource)
-    unpreserved_ids.each do |member_id|
+    ids = if unpreserved_only
+            query_service.custom_queries.find_never_preserved_child_ids(resource: resource)
+          else
+            resource.member_ids || []
+          end
+    ids.each do |member_id|
       member = query_service.find_by(id: member_id)
       lock_tokens = member[Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK] || []
       lock_tokens = lock_tokens.map(&:serialize)

--- a/app/jobs/preserve_children_job.rb
+++ b/app/jobs/preserve_children_job.rb
@@ -5,7 +5,8 @@ class PreserveChildrenJob < ApplicationJob
 
   def perform(id:)
     resource = query_service.find_by(id: id)
-    (resource.try(:member_ids) || []).each do |member_id|
+    unpreserved_ids = query_service.custom_queries.find_never_preserved_child_ids(resource: resource)
+    unpreserved_ids.each do |member_id|
       member = query_service.find_by(id: member_id)
       lock_tokens = member[Valkyrie::Persistence::Attributes::OPTIMISTIC_LOCK] || []
       lock_tokens = lock_tokens.map(&:serialize)

--- a/app/queries/find_never_preserved_child_ids.rb
+++ b/app/queries/find_never_preserved_child_ids.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+class FindNeverPreservedChildIds
+  def self.queries
+    [:find_never_preserved_child_ids]
+  end
+
+  attr_reader :query_service
+  delegate :orm_class, to: :resource_factory
+  delegate :adapter, to: :query_service
+  delegate :connection, to: :adapter
+  delegate :resource_factory, to: :query_service
+  def initialize(query_service:)
+    @query_service = query_service
+  end
+
+  def find_never_preserved_child_ids(resource:)
+    # Get IDs of resources that have preservation objects.
+    file_set_ids = adapter.connection[preservation_object_query, id: resource.id.to_s].to_a.map { |x| x[:file_set_id] }
+    # Subtract those from member_ids
+    resource.member_ids.select do |member_id|
+      !file_set_ids.include?(member_id)
+    end
+  end
+
+  def preservation_object_query
+    <<-SQL
+      SELECT b.member->>'id' AS file_set_id FROM orm_resources a,
+      jsonb_array_elements(a.metadata->'member_ids') AS b(member)
+      JOIN orm_resources preservation_object ON b.member->'id' = preservation_object.metadata->'preserved_object_id'->0->'id' WHERE a.id = :id AND preservation_object.internal_resource = 'PreservationObject'
+    SQL
+  end
+end

--- a/app/queries/find_never_preserved_child_ids.rb
+++ b/app/queries/find_never_preserved_child_ids.rb
@@ -17,8 +17,8 @@ class FindNeverPreservedChildIds
     # Get IDs of resources that have preservation objects.
     file_set_ids = adapter.connection[preservation_object_query, id: resource.id.to_s].to_a.map { |x| x[:file_set_id] }
     # Subtract those from member_ids
-    resource.member_ids.select do |member_id|
-      !file_set_ids.include?(member_id)
+    resource.member_ids.reject do |member_id|
+      file_set_ids.include?(member_id)
     end
   end
 

--- a/app/services/preserver.rb
+++ b/app/services/preserver.rb
@@ -25,11 +25,7 @@ class Preserver
   # to preserve themselves, because their parent is set up to be.
   def preserve!
     preserve_binary_content(force: force_preservation)
-    if preserve_children?
-      preserve_metadata && preserve_children
-    else
-      preserve_metadata
-    end
+    preserve_metadata && preserve_children
   end
 
   private
@@ -99,6 +95,7 @@ class Preserver
 
     def preserve_children
       return unless resource.try(:member_ids).present? && change_set.try(:preserve_children?)
+      return if change_set_persister.query_service.custom_queries.find_never_preserved_child_ids(resource: resource).blank?
       PreserveChildrenJob.perform_later(id: resource.id.to_s)
     end
 

--- a/app/services/preserver.rb
+++ b/app/services/preserver.rb
@@ -25,14 +25,11 @@ class Preserver
   # to preserve themselves, because their parent is set up to be.
   def preserve!
     preserve_binary_content(force: force_preservation)
-    preserve_metadata && preserve_children
+    preserve_metadata
+    preserve_children
   end
 
   private
-
-    def preserve_children?
-      @created_preservation_object == true
-    end
 
     def preserve_binary_content(force: false)
       # Initialize so it saves early - if two Preservers are running at the
@@ -93,10 +90,16 @@ class Preserver
       change_set_persister.persister.save(resource: PreservationObject.new(preserved_object_id: resource.id))
     end
 
+    # Always check for unpreserved members, but preserve all members if the
+    # parent structure has changed or the parent's newly preserved.
+    def only_preserve_unpreserved_members?
+      @membership_changed != true && @created_preservation_object != true
+    end
+
     def preserve_children
       return unless resource.try(:member_ids).present? && change_set.try(:preserve_children?)
-      return if change_set_persister.query_service.custom_queries.find_never_preserved_child_ids(resource: resource).blank?
-      PreserveChildrenJob.perform_later(id: resource.id.to_s)
+      return if change_set_persister.query_service.custom_queries.find_never_preserved_child_ids(resource: resource).blank? && only_preserve_unpreserved_members?
+      PreserveChildrenJob.perform_later(id: resource.id.to_s, unpreserved_only: only_preserve_unpreserved_members?)
     end
 
     def preserve_metadata
@@ -124,7 +127,7 @@ class Preserver
       # e.g. I moved /1/a/metadata.json to /2/a/metadata.json
       if preservation_object.metadata_node&.file_identifiers.present? && preservation_object.metadata_node.file_identifiers[0] != uploaded_file.id
         # Parent structure has changed, re-preserve children.
-        preserve_children
+        @membership_changed = true
         preserve_binary_content(force: true)
         # clean up the old files, e.g. /1/a/metadata.json from example above
         CleanupFilesJob.perform_later(file_identifiers: preservation_object.metadata_node.file_identifiers.map(&:to_s))

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -421,7 +421,8 @@ Rails.application.config.to_prepare do
     FindBySourceMetadataIdentifier,
     MosaicFingerprintQuery,
     MosaicFileSetQuery,
-    FindPersistedMemberIds
+    FindPersistedMemberIds,
+    FindNeverPreservedChildIds
   ].each do |query_handler|
     Valkyrie.config.metadata_adapter.query_service.custom_queries.register_query_handler(query_handler)
   end

--- a/spec/queries/find_never_preserved_child_ids_spec.rb
+++ b/spec/queries/find_never_preserved_child_ids_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe FindNeverPreservedChildIds do
+  context "when there is a resource with a PreservationObject, and some children with and some children without PreservationObjects" do
+    it "returns the child IDs that don't have PreservationObjects", db_cleaner_deletion: true do
+      file1 = FactoryBot.create_for_repository(:file_set)
+      FactoryBot.create_for_repository(:preservation_object, preserved_object_id: file1.id)
+      file2 = FactoryBot.create_for_repository(:file_set)
+      resource = FactoryBot.create_for_repository(:scanned_resource, member_ids: [file1.id, file2.id])
+      FactoryBot.create_for_repository(:preservation_object, preserved_object_id: resource.id)
+
+      output = ChangeSetPersister.default.query_service.custom_queries.find_never_preserved_child_ids(resource: resource)
+
+      expect(output).to eq [file2.id]
+    end
+  end
+end


### PR DESCRIPTION
When preserving this now checks for children which don't have PreservationObjects and queues them up, rather than relying on it being the first time the parent was preserved.

This should fix any race conditions where that first attempt is missed, and will allow resources to preserve children on subsequent saves.

Closes #3463 