### PR TITLE
Remove rights-statement class from all over the place

### DIFF
--- a/app/views/bulk_edit/resources_edit.html.erb
+++ b/app/views/bulk_edit/resources_edit.html.erb
@@ -42,7 +42,7 @@
           <%= select_tag :visibility,
               options_from_collection_for_select(ControlledVocabulary.for(:visibility).all, "value", "label"),
               include_blank: "[Do not update]",
-              input_html: { class: 'form-control rights-statement' },
+              input_html: { class: 'form-control' },
               required: false %>
         </div>
         <div class="row">

--- a/app/views/records/edit_fields/_downloadable.html.erb
+++ b/app/views/records/edit_fields/_downloadable.html.erb
@@ -6,5 +6,5 @@
               value_method: :value,
               hint: "Set which users can download this resource",
               include_blank: false,
-              input_html: { class: 'form-control rights-statement' },
+              input_html: { class: 'form-control' },
               required: f.object.required?(key) %>

--- a/app/views/records/edit_fields/_field_name.html.erb
+++ b/app/views/records/edit_fields/_field_name.html.erb
@@ -4,5 +4,5 @@
               collection: ControlledVocabulary.for(:ephemera_field).all,
               label_method: :label,
               value_method: :value,
-              input_html: { class: 'form-control rights-statement', data: { notable: ControlledVocabulary.for(:ephemera_field).all.select(&:notable?).map(&:value) }},
+              input_html: { class: 'form-control', data: { notable: ControlledVocabulary.for(:ephemera_field).all.select(&:notable?).map(&:value) }},
               required: f.object.required?(key) %>

--- a/app/views/records/edit_fields/_holding_location.html.erb
+++ b/app/views/records/edit_fields/_holding_location.html.erb
@@ -3,5 +3,5 @@
               collection: ControlledVocabulary.for(key).all.sort_by(&:label),
               label_method: :label,
               value_method: :value,
-              input_html: { class: 'form-control rights-statement' },
+              input_html: { class: 'form-control' },
               required: f.object.required?(key) %>

--- a/app/views/records/edit_fields/_notice_type.html.erb
+++ b/app/views/records/edit_fields/_notice_type.html.erb
@@ -4,5 +4,5 @@
               label_method: :label,
               value_method: :value,
               include_blank: true,
-              input_html: { class: 'form-control rights-statement' },
+              input_html: { class: 'form-control' },
               required: f.object.required?(key) %>

--- a/app/views/records/edit_fields/_ocr_language.html.erb
+++ b/app/views/records/edit_fields/_ocr_language.html.erb
@@ -5,5 +5,5 @@
               value_method: :value,
               hint: "Set this field to trigger OCR generation",
               include_blank: true,
-              input_html: { class: 'form-control rights-statement' },
+              input_html: { class: 'form-control' },
               required: f.object.required?(key) %>

--- a/app/views/records/edit_fields/_pdf_type.html.erb
+++ b/app/views/records/edit_fields/_pdf_type.html.erb
@@ -4,5 +4,5 @@
               label_method: :label,
               value_method: :value,
               include_blank: false,
-              input_html: { class: 'form-control rights-statement' },
+              input_html: { class: 'form-control' },
               required: f.object.required?(key) %>

--- a/app/views/records/edit_fields/_preservation_policy.html.erb
+++ b/app/views/records/edit_fields/_preservation_policy.html.erb
@@ -4,5 +4,5 @@
               label_method: :label,
               value_method: :value,
               include_blank: true,
-              input_html: { class: 'form-control rights-statement' },
+              input_html: { class: 'form-control' },
               required: f.object.required?(key) %>

--- a/app/views/records/edit_fields/_service_targets.html.erb
+++ b/app/views/records/edit_fields/_service_targets.html.erb
@@ -1,6 +1,6 @@
   <%= f.input key,
               as: :select,
               collection: ["tiles"],
-              input_html: { class: 'form-control rights-statement' },
+              input_html: { class: 'form-control' },
               include_blank: true,
               required: f.object.required?(key) %>


### PR DESCRIPTION
Note to reviewer: We didn't see this class used anywhere else, and it was interfering with our local javascript. Is there somewhere we should check that we may have overlooked? A double-check would be appreciated.

It's used in the javascript that activates the rights statement note,
but it was present in a bunch of fields on the edit form. No evidence of
further use in other javascript or in styling. We also checked upstream.

fixes #5188