### PR TITLE
Set current property on local fixity events

### DIFF
--- a/spec/jobs/local_fixity_job_spec.rb
+++ b/spec/jobs/local_fixity_job_spec.rb
@@ -94,5 +94,20 @@ RSpec.describe LocalFixityJob do
         expect { query_service.find_by(id: file_set_id) }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
       end
     end
+
+    context "when an current Event already exists" do
+      it "sets that Event current property to false" do
+        described_class.perform_now(file_set_id)
+        first_event = query_service.find_all_of_model(model: Event).first
+        expect(first_event.current).to eq true
+
+        described_class.perform_now(file_set_id)
+        events = query_service.find_all_of_model(model: Event)
+        event1 = events.find { |e| e.id == first_event.id }
+        event2 = events.find { |e| e.id != first_event.id }
+        expect(event1.current).to eq false
+        expect(event2.current).to eq true
+      end
+    end
   end
 end


### PR DESCRIPTION
Update fixity job to add `current: true` to new events and set `current: false` for old events.

Closes #5686 

![Screenshot 2023-03-03 at 1 49 17 PM](https://user-images.githubusercontent.com/784196/222813723-3dd6aad2-10eb-4ca1-9bbd-dc641fb7a0e2.png)
