### PR TITLE
Refactor reports controller to use new CSVReport class

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -43,8 +43,9 @@ class ReportsController < ApplicationController
     respond_to do |format|
       format.html
       format.csv do
-        send_data hashes_to_csv(["id", "component_id", "ark", "url"], @resources.map { |r| resource_hash(r) }),
-                  filename: "pulfa-ark-report-#{params[:since_date]}-to-#{Time.zone.today}.csv"
+        hashes = @resources.map { |r| resource_hash(r) }
+        csv_report = CSVReport.new(hashes, fields: ["id", "component_id", "ark", "url"])
+        send_data csv_report.hashes_to_csv, filename: "pulfa-ark-report-#{params[:since_date]}-to-#{Time.zone.today}.csv"
       end
     end
   end
@@ -58,15 +59,6 @@ class ReportsController < ApplicationController
         ark: resource.identifier&.first,
         url: helpers.manifest_url(resource)
       }
-    end
-
-    def hashes_to_csv(fields, resources)
-      CSV.generate(headers: true) do |csv|
-        csv << fields
-        resources.each do |h|
-          csv << fields.map { |field| h[field.to_sym] }
-        end
-      end
     end
 
     def find_identifiers_to_reconcile

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -16,8 +16,8 @@ class ReportsController < ApplicationController
     respond_to do |format|
       format.html
       format.csv do
-        send_data to_csv(@resources, fields: fields.index_by(&:to_sym)),
-                  filename: "#{@ephemera_project.title.parameterize}-data-#{Time.zone.today}.csv"
+        csv_report = CSVReport.new(@resources, fields: fields.index_by(&:to_sym))
+        send_data csv_report.to_csv, filename: "#{@ephemera_project.title.parameterize}-data-#{Time.zone.today}.csv"
       end
     end
   end
@@ -28,8 +28,8 @@ class ReportsController < ApplicationController
     respond_to do |format|
       format.html
       format.csv do
-        send_data to_csv(@resources, fields: { source_metadata_identifier: "bibid", identifier: "ark", title: "title" }),
-                  filename: "identifiers-to-reconcile-#{Time.zone.today}.csv"
+        csv_report = CSVReport.new(@resources, fields: { source_metadata_identifier: "bibid", identifier: "ark", title: "title" })
+        send_data csv_report.to_csv, filename: "identifiers-to-reconcile-#{Time.zone.today}.csv"
       end
     end
   end
@@ -73,20 +73,6 @@ class ReportsController < ApplicationController
       @identifiers_to_reconcile ||= query_service.custom_queries.find_identifiers_to_reconcile.select do |r|
         PulMetadataServices::Client.catalog?(r.source_metadata_identifier.first)
       end
-    end
-
-    def to_csv(records, fields:)
-      CSV.generate(headers: true) do |csv|
-        csv << fields.map { |_k, v| v }
-        records.each do |record|
-          csv << fields.map { |k, _v| values_or_labels(record, k) }
-        end
-      end
-    end
-
-    def values_or_labels(record, field)
-      val = record.send(field)
-      Array.wrap(val).map { |v| v.respond_to?(:label) ? v.label : v }.join(";")
     end
 
     def find_resource(id)

--- a/app/values/csv_report.rb
+++ b/app/values/csv_report.rb
@@ -32,6 +32,20 @@ class CSVReport
     fields.map(&:to_s).map(&:humanize)
   end
 
+  def to_csv
+    CSV.generate(headers: true) do |csv|
+      csv << fields.map { |_k, v| v }
+      resources.each do |record|
+        csv << fields.map { |k, _v| values_or_labels(record, k) }
+      end
+    end
+  end
+
+  def values_or_labels(record, field)
+    val = record.send(field)
+    Array.wrap(val).map { |v| v.respond_to?(:label) ? v.label : v }.join(";")
+  end
+
   class Row
     attr_reader :resource, :fields
     def initialize(resource, fields: [])

--- a/app/values/csv_report.rb
+++ b/app/values/csv_report.rb
@@ -41,11 +41,6 @@ class CSVReport
     end
   end
 
-  def values_or_labels(record, field)
-    val = record.send(field)
-    Array.wrap(val).map { |v| v.respond_to?(:label) ? v.label : v }.join(";")
-  end
-
   class Row
     attr_reader :resource, :fields
     def initialize(resource, fields: [])
@@ -88,4 +83,11 @@ class CSVReport
       Array.wrap(resource.try(:imported_metadata))[0] || ImportedMetadata.new
     end
   end
+
+  private
+
+    def values_or_labels(record, field)
+      val = record.send(field)
+      Array.wrap(val).map { |v| v.respond_to?(:label) ? v.label : v }.join(";")
+    end
 end

--- a/app/values/csv_report.rb
+++ b/app/values/csv_report.rb
@@ -41,6 +41,15 @@ class CSVReport
     end
   end
 
+  def hashes_to_csv
+    CSV.generate(headers: true) do |csv|
+      csv << fields
+      resources.each do |h|
+        csv << fields.map { |field| h[field.to_sym] }
+      end
+    end
+  end
+
   class Row
     attr_reader :resource, :fields
     def initialize(resource, fields: [])


### PR DESCRIPTION
Closes #5687 

Moved the `to_csv` and `hashes_to_csv` methods from the ReportsController to the CSVReport class (the CSVReport class didn't previously have a method that returns a CSV string directly), in order to put code converting objects to CSVs in the same place. The ReportsController now makes calls to the CSVReport class.