### PR TITLE
Fix ocr upload_file test

### DIFF
--- a/spec/characterization_services/geo_characterization_service_spec.rb
+++ b/spec/characterization_services/geo_characterization_service_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe GeoCharacterizationService do
   context "when a file set contains a preservation file and an intermediate file" do
     let(:tika_output) { tika_shapefile_output }
     it "characterizes both files" do
-      preservation = fixture_file_upload("files/vector/shapefile.zip", "application/zip", Valkyrie::Vocab::PCDMUse.PreservationFile)
+      preservation = fixture_file_with_use("files/vector/shapefile.zip", "application/zip", Valkyrie::Vocab::PCDMUse.PreservationFile)
       resource = FactoryBot.create_for_repository(:vector_resource, files: [preservation])
       file_set = query_service.find_members(resource: resource).first
       IngestIntermediateFileJob.perform_now(file_path: Rails.root.join("spec", "fixtures", "files", "vector", "shapefile.zip"), file_set_id: file_set.id)

--- a/spec/characterization_services/imagemagick_characterization_service_spec.rb
+++ b/spec/characterization_services/imagemagick_characterization_service_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe ImagemagickCharacterizationService do
 
   context "when a file set contains a preservation file and an intermediate file" do
     it "characterizes both files" do
-      preservation = fixture_file_upload("files/example.tif", "image/tiff", Valkyrie::Vocab::PCDMUse.PreservationFile)
+      preservation = fixture_file_with_use("files/example.tif", "image/tiff", Valkyrie::Vocab::PCDMUse.PreservationFile)
       resource = FactoryBot.create_for_repository(:scanned_resource, files: [preservation])
       file_set = query_service.find_members(resource: resource).first
       IngestIntermediateFileJob.perform_now(file_path: Rails.root.join("spec", "fixtures", "files", "example.tif"), file_set_id: file_set.id)

--- a/spec/characterization_services/mediainfo_characterization_service_spec.rb
+++ b/spec/characterization_services/mediainfo_characterization_service_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe MediainfoCharacterizationService do
 
     context "when a file set contains a preservation audio file and an intermediate audio file" do
       it "characterizes both files" do
-        preservation = fixture_file_upload("files/audio_file.wav", "audio/x-wav", Valkyrie::Vocab::PCDMUse.PreservationFile)
+        preservation = fixture_file_with_use("files/audio_file.wav", "audio/x-wav", Valkyrie::Vocab::PCDMUse.PreservationFile)
         recording = FactoryBot.create_for_repository(:recording, files: [preservation])
         file_set = query_service.find_members(resource: recording).first
         IngestIntermediateFileJob.perform_now(file_path: Rails.root.join("spec", "fixtures", "files", "audio_file.wav"), file_set_id: file_set.id)

--- a/spec/characterization_services/pdf_characterization_service_spec.rb
+++ b/spec/characterization_services/pdf_characterization_service_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe PDFCharacterizationService do
 
   context "when a file set contains a preservation file and an intermediate file" do
     it "characterizes both files" do
-      preservation = fixture_file_upload("files/sample.pdf", "application/pdf", Valkyrie::Vocab::PCDMUse.PreservationFile)
+      preservation = fixture_file_with_use("files/sample.pdf", "application/pdf", Valkyrie::Vocab::PCDMUse.PreservationFile)
       resource = FactoryBot.create_for_repository(:scanned_resource, files: [preservation])
       file_set = query_service.find_members(resource: resource).first
       IngestIntermediateFileJob.perform_now(file_path: Rails.root.join("spec", "fixtures", "files", "sample.pdf"), file_set_id: file_set.id)

--- a/spec/characterization_services/tika_file_characterization_service_spec.rb
+++ b/spec/characterization_services/tika_file_characterization_service_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe TikaFileCharacterizationService do
   context "when a file set contains a preservation file and an intermediate file" do
     let(:tika_output) { tika_shapefile_output }
     it "characterizes both files" do
-      preservation = fixture_file_upload("files/vector/shapefile.zip", "application/zip", Valkyrie::Vocab::PCDMUse.PreservationFile)
+      preservation = fixture_file_with_use("files/vector/shapefile.zip", "application/zip", Valkyrie::Vocab::PCDMUse.PreservationFile)
       resource = FactoryBot.create_for_repository(:simple_resource, files: [preservation])
       file_set = query_service.find_members(resource: resource).first
       IngestIntermediateFileJob.perform_now(file_path: Rails.root.join("spec", "fixtures", "files", "vector", "shapefile.zip"), file_set_id: file_set.id)

--- a/spec/controllers/deletion_markers_controller_spec.rb
+++ b/spec/controllers/deletion_markers_controller_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "rails_helper"
-include FixtureFileUpload
 
 RSpec.describe DeletionMarkersController, type: :controller do
   let(:user) { FactoryBot.create(:admin) }

--- a/spec/controllers/ephemera_boxes_controller_spec.rb
+++ b/spec/controllers/ephemera_boxes_controller_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "rails_helper"
-include FixtureFileUpload
 
 RSpec.describe EphemeraBoxesController, type: :controller do
   let(:user) { nil }

--- a/spec/controllers/ephemera_fields_controller_spec.rb
+++ b/spec/controllers/ephemera_fields_controller_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "rails_helper"
-include FixtureFileUpload
 
 RSpec.describe EphemeraFieldsController, type: :controller do
   let(:user) { nil }

--- a/spec/controllers/ephemera_folders_controller_spec.rb
+++ b/spec/controllers/ephemera_folders_controller_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "rails_helper"
-include FixtureFileUpload
 
 RSpec.describe EphemeraFoldersController, type: :controller do
   let(:user) { nil }

--- a/spec/controllers/ephemera_projects_controller_spec.rb
+++ b/spec/controllers/ephemera_projects_controller_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "rails_helper"
-include FixtureFileUpload
 
 RSpec.describe EphemeraProjectsController, type: :controller do
   let(:user) { nil }

--- a/spec/controllers/ephemera_terms_controller_spec.rb
+++ b/spec/controllers/ephemera_terms_controller_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "rails_helper"
-include FixtureFileUpload
 
 RSpec.describe EphemeraTermsController, type: :controller do
   let(:user) { nil }

--- a/spec/controllers/ephemera_vocabularies_controller_spec.rb
+++ b/spec/controllers/ephemera_vocabularies_controller_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "rails_helper"
-include FixtureFileUpload
 
 RSpec.describe EphemeraVocabulariesController, type: :controller do
   let(:user) { nil }

--- a/spec/controllers/file_sets_controller_spec.rb
+++ b/spec/controllers/file_sets_controller_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "rails_helper"
-include FixtureFileUpload
 
 RSpec.describe FileSetsController, type: :controller do
   let(:persister) { Valkyrie.config.metadata_adapter.persister }

--- a/spec/controllers/playlists_controller_spec.rb
+++ b/spec/controllers/playlists_controller_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "rails_helper"
-include FixtureFileUpload
 
 RSpec.describe PlaylistsController, type: :controller do
   with_queue_adapter :inline

--- a/spec/controllers/raster_resources_controller_spec.rb
+++ b/spec/controllers/raster_resources_controller_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "rails_helper"
-include FixtureFileUpload
 
 RSpec.describe RasterResourcesController, type: :controller do
   let(:user) { nil }

--- a/spec/controllers/scanned_maps_controller_spec.rb
+++ b/spec/controllers/scanned_maps_controller_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "rails_helper"
-include FixtureFileUpload
 
 RSpec.describe ScannedMapsController, type: :controller do
   include Rails.application.routes.url_helpers

--- a/spec/controllers/scanned_resources_controller_spec.rb
+++ b/spec/controllers/scanned_resources_controller_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "rails_helper"
-include FixtureFileUpload
 
 RSpec.describe ScannedResourcesController, type: :controller do
   with_queue_adapter :inline

--- a/spec/controllers/vector_resources_controller_spec.rb
+++ b/spec/controllers/vector_resources_controller_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "rails_helper"
-include FixtureFileUpload
 
 RSpec.describe VectorResourcesController, type: :controller do
   let(:user) { nil }

--- a/spec/jobs/local_fixity_job_spec.rb
+++ b/spec/jobs/local_fixity_job_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe LocalFixityJob do
     end
 
     context "with a preservation file and an intermediate file" do
-      let(:file) { fixture_file_upload("files/example.tif", "image/tiff", Valkyrie::Vocab::PCDMUse.PreservationFile) }
+      let(:file) { fixture_file_with_use("files/example.tif", "image/tiff", Valkyrie::Vocab::PCDMUse.PreservationFile) }
 
       it "creates a local_fixity Event for both files" do
         IngestIntermediateFileJob.perform_now(file_path: Rails.root.join("spec", "fixtures", "files", "example.tif"), file_set_id: file_set.id)
@@ -80,7 +80,7 @@ RSpec.describe LocalFixityJob do
     end
 
     context "with a preservation file and an intermediate file and the checksum doesn't match" do
-      let(:file) { fixture_file_upload("files/example.tif", "image/tiff", Valkyrie::Vocab::PCDMUse.PreservationFile) }
+      let(:file) { fixture_file_with_use("files/example.tif", "image/tiff", Valkyrie::Vocab::PCDMUse.PreservationFile) }
 
       it "creates a local_fixity Event for both files" do
         allow(Honeybadger).to receive(:notify)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,8 +20,8 @@ end
 
 RSpec.configure do |config|
   config.include Features, type: :feature
-  # Use local fixture_file_upload method
-  config.include FixtureFileUpload
+  # Use local fixture_file_with_use method
+  config.include FixtureFileWithUse
   config.infer_base_class_for_anonymous_controllers = false
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = false

--- a/spec/support/fixture_file_with_use.rb
+++ b/spec/support/fixture_file_with_use.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-module FixtureFileUpload
-  def fixture_file_upload(file, mime_type = nil, use = Valkyrie::Vocab::PCDMUse.OriginalFile)
+module FixtureFileWithUse
+  def fixture_file_with_use(file, mime_type = nil, use = Valkyrie::Vocab::PCDMUse.OriginalFile)
     file_path = Rails.root.join("spec", "fixtures", file)
     file = Rack::Test::UploadedFile.new(file_path, mime_type)
     original_filename = File.basename(file_path)


### PR DESCRIPTION
~~Controller tests don't like decorated `Rack::Test::UploadedFile` objects.~~

Updated to rename the spec support method causing the exception so we're not overriding.