### PR TITLE
Downgrade Google Cloud Storage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem "flutie"
 gem "font-awesome-rails"
 gem "geoserver-publish"
 gem "google-cloud-pubsub"
+# This breaks PreserveResourceJob somewhere between 1.39 and 1.44.
 gem "google-cloud-storage", "1.38.0"
 gem "graphiql-rails", "1.4.10", group: :development
 gem "graphql", "~> 1.13.19"

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem "flutie"
 gem "font-awesome-rails"
 gem "geoserver-publish"
 gem "google-cloud-pubsub"
+gem "google-cloud-storage", "1.38.0"
 gem "graphiql-rails", "1.4.10", group: :development
 gem "graphql", "~> 1.13.19"
 gem "honeybadger"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -405,8 +405,8 @@ GEM
       webrick
     google-apis-iamcredentials_v1 (0.17.0)
       google-apis-core (>= 0.11.0, < 2.a)
-    google-apis-storage_v1 (0.19.0)
-      google-apis-core (>= 0.9.0, < 2.a)
+    google-apis-storage_v1 (0.17.0)
+      google-apis-core (>= 0.7, < 2.a)
     google-cloud-core (1.6.0)
       google-cloud-env (~> 1.0)
       google-cloud-errors (~> 1.0)
@@ -422,11 +422,11 @@ GEM
       gapic-common (>= 0.17.1, < 2.a)
       google-cloud-errors (~> 1.0)
       google-iam-v1 (>= 0.4, < 2.a)
-    google-cloud-storage (1.44.0)
+    google-cloud-storage (1.38.0)
       addressable (~> 2.8)
       digest-crc (~> 0.4)
       google-apis-iamcredentials_v1 (~> 0.1)
-      google-apis-storage_v1 (~> 0.19.0)
+      google-apis-storage_v1 (~> 0.17.0)
       google-cloud-core (~> 1.6)
       googleauth (>= 0.16.2, < 2.a)
       mini_mime (~> 1.0)
@@ -1181,6 +1181,7 @@ DEPENDENCIES
   formulaic
   geoserver-publish
   google-cloud-pubsub
+  google-cloud-storage (= 1.38.0)
   graphiql-rails (= 1.4.10)
   graphql (~> 1.13.19)
   honeybadger


### PR DESCRIPTION
Closes #5746 , but we're not sure what it is about the retry logic they added in google-cloud-storage that broke this.