### PR TITLE
Add Complete When Processed to Bulk Ingest

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,6 +46,7 @@ Metrics/BlockLength:
     - '**/*.rake'
     - 'app/controllers/catalog_controller.rb'
     - 'app/models/book_workflow.rb'
+    - 'app/models/geo_workflow.rb'
     - 'config/environments/**/*'
     - 'spec/**/*'
     - 'config/initializers/*'

--- a/app/controllers/bulk_ingest_controller.rb
+++ b/app/controllers/bulk_ingest_controller.rb
@@ -122,8 +122,10 @@ class BulkIngestController < ApplicationController
       params[:resource_type].classify
     end
 
+    # All valid workflow states except complete - prefer
+    # complete_when_processed.
     def workflow_states
-      workflow_class.aasm.states.map { |s| s.name.to_s }
+      workflow_class.aasm.states.map { |s| s.name.to_s } - ["complete"]
     end
 
     def workflow_class

--- a/app/models/book_workflow.rb
+++ b/app/models/book_workflow.rb
@@ -9,6 +9,7 @@ class BookWorkflow < BaseWorkflow
     state :pending, initial: true
     state :metadata_review
     state :final_review
+    state :complete_when_processed
     state :complete
     state :takedown
     state :flagged

--- a/app/models/book_workflow.rb
+++ b/app/models/book_workflow.rb
@@ -25,6 +25,7 @@ class BookWorkflow < BaseWorkflow
       transitions from: :final_review, to: :complete
       transitions from: :pending, to: :complete
       transitions from: :metadata_review, to: :complete
+      transitions from: :complete_when_processed, to: :complete
     end
 
     # takedown/restore workflow

--- a/app/models/draft_complete_workflow.rb
+++ b/app/models/draft_complete_workflow.rb
@@ -6,6 +6,7 @@
 class DraftCompleteWorkflow < BaseWorkflow
   aasm do
     state :draft, initial: true
+    state :complete_when_processed
     state :complete
 
     # ingest workflow

--- a/app/models/draft_complete_workflow.rb
+++ b/app/models/draft_complete_workflow.rb
@@ -12,6 +12,7 @@ class DraftCompleteWorkflow < BaseWorkflow
     # ingest workflow
     event :make_complete do
       transitions from: :draft, to: :complete
+      transitions from: :complete_when_processed, to: :complete
     end
     event :make_draft do
       transitions from: :complete, to: :draft

--- a/app/models/geo_workflow.rb
+++ b/app/models/geo_workflow.rb
@@ -4,6 +4,7 @@ class GeoWorkflow < BaseWorkflow
   aasm do
     state :pending, initial: true
     state :final_review
+    state :complete_when_processed
     state :complete
     state :takedown
     state :flagged
@@ -15,6 +16,7 @@ class GeoWorkflow < BaseWorkflow
     event :make_complete do
       transitions from: :pending, to: :complete
       transitions from: :final_review, to: :complete
+      transitions from: :complete_when_processed, to: :complete
     end
 
     # takedown/restore workflow

--- a/app/services/auto_completer.rb
+++ b/app/services/auto_completer.rb
@@ -16,6 +16,7 @@ class AutoCompleter
   end
 
   def run
+    Rails.logger.info("Performing auto-completion of complete_when_processed resources")
     eligible_resources.each do |resource|
       change_set = ChangeSet.for(resource)
       change_set.validate(state: "complete")
@@ -23,6 +24,7 @@ class AutoCompleter
     rescue StandardError
       Honeybadger.notify "Exception occurred trying to auto-complete resource #{resource.id}"
     end
+    Rails.logger.info("Performed auto-completion of complete_when_processed resources")
   end
 
   private

--- a/app/services/auto_completer.rb
+++ b/app/services/auto_completer.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+# Finds resources which are marked to be completed when processed, makes sure
+# they have files, and makes sure those files are processed, then completes them
+# if so.
+class AutoCompleter
+  def self.run
+    ChangeSetPersister.default.buffer_into_index do |buffered_change_set_persister|
+      new(change_set_persister: buffered_change_set_persister).run
+    end
+  end
+
+  attr_reader :change_set_persister
+  delegate :query_service, to: :change_set_persister
+  def initialize(change_set_persister:)
+    @change_set_persister = change_set_persister
+  end
+
+  def run
+    eligible_resources.each do |resource|
+      change_set = ChangeSet.for(resource)
+      change_set.validate(state: "complete")
+      change_set_persister.save(change_set: change_set) if change_set.valid?
+    rescue StandardError
+      Honeybadger.notify "Exception occurred trying to auto-complete resource #{resource.id}"
+    end
+  end
+
+  private
+
+    # Only complete resources which have complete_when_processed, have members,
+    # and those members are processed.
+    def eligible_resources
+      resources_with_members.select do |resource|
+        query_service.custom_queries.find_deep_children_with_property(
+          resource: resource,
+          model: "FileSet",
+          property: :processing_status,
+          value: "in process",
+          count: true
+        ).zero?
+      end
+    end
+
+    def resources_with_members
+      complete_when_processed_resources.select do |resource|
+        !resource.member_ids.empty?
+      end
+    end
+
+    def complete_when_processed_resources
+      query_service.custom_queries.find_by_property(property: :state, value: "complete_when_processed", lazy: true)
+    end
+end

--- a/architecture-decisions/0010-resource-autocomplete.md
+++ b/architecture-decisions/0010-resource-autocomplete.md
@@ -1,0 +1,48 @@
+# 10. Resource Auto Completion
+
+Date: 2023-04-18
+
+## Status
+
+Accepted
+
+## Context
+
+Our users often don't have time to go back to a resource they've ingested and
+check to see if it's okay after the initial ingest, and so tend to immediately
+mark a resource complete at ingest time. Unfortunately this results in a lot of
+churn in our preservation infrastructure - every file that gets added during
+that ingest forces a re-preservation of the parent's metadata.
+
+To prevent that, and also make sure that resources are being completed that are
+useful to our patrons, we want to add a new state that will automatically mark a
+resource complete when all of its files are attached and the derivatives
+generated.
+
+This auto-completion could be handled in one of two ways - either via a cron
+job that runs on some regular interval or by utilizing [Sidekiq
+Batches](https://github.com/sidekiq/sidekiq/wiki/Batches).
+
+The cron job is not as immediate, but is easy to maintain and reason through.
+The batches allow us to track the lifecycle of the object through jobs and will
+enable early-as-possible completion, but is
+unable to handle adding files post-bulk-ingest but pre-auto-complete, would
+require us to avoid deleting jobs from Sidekiq (or the batches would never
+succeed), is harder to test, and is much harder to reason through the edge cases
+of.
+
+Further, while normally we'd have to worry about race conditions in the cron
+job, all of our resources have optimistic locking enabled - if two crons run into
+one another, one will win appropriately and the second will error. We can then
+send those errors to Honeybadger to track any problems with the auto completer.
+
+## Decision
+
+We will use a cron job that will automatically complete all resources that are
+`complete_when_processed`, have members, and all of its file sets are processed.
+
+## Consequences
+
+* We'll be unable to tell from the UI when a resource will never possibly
+    complete because we won't be tracking the actual jobs involved. We may have
+    to add some other kind of job tracking in the future.

--- a/architecture-decisions/0010-resource-autocomplete.md
+++ b/architecture-decisions/0010-resource-autocomplete.md
@@ -23,17 +23,17 @@ This auto-completion could be handled in one of two ways - either via a cron
 job that runs on some regular interval or by utilizing [Sidekiq
 Batches](https://github.com/sidekiq/sidekiq/wiki/Batches).
 
-The cron job is not as immediate, but is easy to maintain and reason through.
-The batches allow us to track the lifecycle of the object through jobs and will
-enable early-as-possible completion, but is
+The cron job would not be as immediate, but would be easy to maintain and reason through.
+The batches would allow us to track the lifecycle of the object through jobs and would
+enable early-as-possible completion, but would be
 unable to handle adding files post-bulk-ingest but pre-auto-complete, would
 require us to avoid deleting jobs from Sidekiq (or the batches would never
-succeed), is harder to test, and is much harder to reason through the edge cases
+succeed), would be harder to test, and would be much harder to reason through the edge cases
 of.
 
 Further, while normally we'd have to worry about race conditions in the cron
 job, all of our resources have optimistic locking enabled - if two crons run into
-one another, one will win appropriately and the second will error. We can then
+one another, one would win appropriately and the second would error. We could then
 send those errors to Honeybadger to track any problems with the auto completer.
 
 ## Decision

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -132,6 +132,9 @@ en:
     final_review:
       label: 'Final Review'
       desc:  'Awaiting final approval before being published'
+    complete_when_processed:
+      label: 'Complete (When Processed)'
+      desc: 'Awaiting processing, will automatically progress to Complete when done.'
     complete:
       label: 'Complete'
       desc:  'Published and accessible according to access control rules'

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -36,6 +36,10 @@ every :hour, roles: [:db] do
   rake "figgy:cdl:automatic_completion"
 end
 
+every 30.minutes, roles: [:db] do
+  rake "figgy:auto_complete:run"
+end
+
 # Example:
 #
 # set :output, "/path/to/my/cron_log.log"

--- a/lib/tasks/auto_complete.rake
+++ b/lib/tasks/auto_complete.rake
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+namespace :figgy do
+  namespace :auto_complete do
+    desc "Complete all processed complete_when_processed resources."
+    task run: :environment do
+      AutoCompleter.run
+    end
+  end
+end

--- a/spec/controllers/bulk_ingest_controller_spec.rb
+++ b/spec/controllers/bulk_ingest_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe BulkIngestController do
     context "when logged in" do
       it "assigns workflow states based on the resource type" do
         get :show, params: { resource_type: "scanned_maps" }
-        expect(assigns(:states)).to eq ["pending", "final_review", "complete", "takedown", "flagged"]
+        expect(assigns(:states)).to eq ["pending", "final_review", "complete_when_processed", "takedown", "flagged"]
       end
 
       it "assigns collections" do

--- a/spec/models/book_workflow_spec.rb
+++ b/spec/models/book_workflow_spec.rb
@@ -81,7 +81,7 @@ describe BookWorkflow do
 
   describe "valid_states" do
     it "returns all the appropriate states" do
-      expect(workflow.valid_states).to eq [:pending, :metadata_review, :final_review, :complete, :takedown, :flagged, :complete_when_processed].map(&:to_s)
+      expect(workflow.valid_states).to eq [:pending, :metadata_review, :final_review, :complete_when_processed, :complete, :takedown, :flagged].map(&:to_s)
     end
   end
 

--- a/spec/models/book_workflow_spec.rb
+++ b/spec/models/book_workflow_spec.rb
@@ -79,6 +79,12 @@ describe BookWorkflow do
     end
   end
 
+  describe "valid_states" do
+    it "returns all the appropriate states" do
+      expect(workflow.valid_states).to eq [:pending, :metadata_review, :final_review, :complete, :takedown, :flagged, :complete_when_processed].map(&:to_s)
+    end
+  end
+
   describe "access states" do
     it "provides a list of read-accessible states" do
       expect(described_class.public_read_states).to contain_exactly "complete", "flagged"

--- a/spec/models/draft_complete_workflow_spec.rb
+++ b/spec/models/draft_complete_workflow_spec.rb
@@ -27,7 +27,7 @@ describe DraftCompleteWorkflow do
   end
 
   it "reports valid states" do
-    expect(workflow.valid_states).to eq %w[draft complete]
+    expect(workflow.valid_states).to eq %w[draft complete_when_processed complete]
   end
 
   describe "access states" do

--- a/spec/models/workflow_registry_spec.rb
+++ b/spec/models/workflow_registry_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 RSpec.describe WorkflowRegistry do
   describe ".all_states" do
     it "returns a list of all states" do
-      expect(described_class.all_states).to contain_exactly "all_in_production", "complete", "draft", "final_review",
+      expect(described_class.all_states).to contain_exactly "all_in_production", "complete", "complete_when_processed", "draft", "final_review",
                                                             "flagged", "metadata_review", "needs_qa", "new", "pending", "ready_to_ship", "received", "shipped", "takedown"
     end
   end

--- a/spec/services/auto_completer_spec.rb
+++ b/spec/services/auto_completer_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe AutoCompleter do
+  with_queue_adapter :inline
+  let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }
+  let(:file2) { fixture_file_upload("files/example.tif", "image/tiff") }
+  context "when there are complete_when_processed resources ready for completion" do
+    it "marks them complete" do
+      stub_ezid(shoulder: "99999/fk4", blade: "123456")
+      complete_resource = FactoryBot.create_for_repository(:complete_open_scanned_resource)
+      to_be_completed_resource = FactoryBot.create_for_repository(:scanned_resource, files: [file], state: "complete_when_processed")
+      no_files_resource = FactoryBot.create_for_repository(:scanned_resource, state: "complete_when_processed")
+      unprocessed_file_set = FactoryBot.create_for_repository(:file_set, processing_status: "in process")
+      unprocessed_resource = FactoryBot.create_for_repository(:scanned_resource, member_ids: [unprocessed_file_set.id], state: "complete_when_processed")
+      csp = ChangeSetPersister.default
+
+      AutoCompleter.run
+
+      # The to be completed resource is marked complete.
+      expect(csp.query_service.find_by(id: to_be_completed_resource.id).state).to eq ["complete"]
+      # The ineligible resources haven't changed.
+      expect(csp.query_service.find_by(id: complete_resource.id).updated_at).to eq complete_resource.updated_at
+      expect(csp.query_service.find_by(id: no_files_resource.id).updated_at).to eq no_files_resource.updated_at
+      expect(csp.query_service.find_by(id: unprocessed_resource.id).updated_at).to eq unprocessed_resource.updated_at
+    end
+  end
+  context "when one eligible resource ready for completion errors" do
+    it "notifies and completes the others" do
+      stub_ezid(shoulder: "99999/fk4", blade: "123456")
+      allow(Honeybadger).to receive(:notify)
+      to_be_completed_resource1 = FactoryBot.create_for_repository(:scanned_resource, files: [file], state: "complete_when_processed")
+      to_be_completed_resource2 = FactoryBot.create_for_repository(:scanned_resource, files: [file2], state: "complete_when_processed")
+      csp = ChangeSetPersister.default
+      # Stub IdentifierService to make an error happen.
+      message_calls = 0
+      allow(IdentifierService).to receive(:mint_or_update) do
+        message_calls += 1
+        raise "Broken" if message_calls == 1
+      end
+
+      AutoCompleter.run
+
+      # The resource that errored isn't changed
+      expect(csp.query_service.find_by(id: to_be_completed_resource1.id).state).to eq ["complete_when_processed"]
+      expect(Honeybadger).to have_received(:notify).exactly(1).times
+      # The valid to be completed resource is marked complete.
+      expect(csp.query_service.find_by(id: to_be_completed_resource2.id).state).to eq ["complete"]
+    end
+  end
+end

--- a/spec/services/auto_completer_spec.rb
+++ b/spec/services/auto_completer_spec.rb
@@ -42,10 +42,9 @@ RSpec.describe AutoCompleter do
       AutoCompleter.run
 
       # The resource that errored isn't changed
-      expect(csp.query_service.find_by(id: to_be_completed_resource1.id).state).to eq ["complete_when_processed"]
+      expect([csp.query_service.find_by(id: to_be_completed_resource1.id).state,
+              csp.query_service.find_by(id: to_be_completed_resource2.id).state].flatten).to contain_exactly "complete", "complete_when_processed"
       expect(Honeybadger).to have_received(:notify).exactly(1).times
-      # The valid to be completed resource is marked complete.
-      expect(csp.query_service.find_by(id: to_be_completed_resource2.id).state).to eq ["complete"]
     end
   end
 end


### PR DESCRIPTION
This adds the "complete_when_processed" state which can't be advanced to, but can be selected in bulk ingest.

It also adds an auto-completer - every 30 minutes every resource which is marked `complete_when_processed` will be marked complete if it has members and all of its members, deep, are processed.

One downside of the auto-completer is that for bulk-ingested MVWs it marks all the volumes as "complete_when_processed", but when the MVW is marked complete it marks it for the children - so we get stale object errors for the volumes: https://app.honeybadger.io/projects/53391/faults/95377090. Maybe that's okay? Maybe we want to ignore stale object error exceptions and not notify?



Closes #5579, closes #5566

<img width="1194" alt="Screen Shot 2023-04-18 at 3 32 43 PM" src="https://user-images.githubusercontent.com/2806645/232919810-758865da-df83-46e7-bdf0-ab77be0af769.png">

<img width="1211" alt="Screen Shot 2023-04-18 at 3 36 01 PM" src="https://user-images.githubusercontent.com/2806645/232919946-73f0ffdf-aa07-45bf-b704-118035fc05e1.png">
