### PR TITLE
Fix bulk ingest preserve file names check box.

### DIFF
--- a/app/views/bulk_ingest/show.html.erb
+++ b/app/views/bulk_ingest/show.html.erb
@@ -1,7 +1,7 @@
 <h2>Bulk Ingest <%= @resource_class.human_readable_type.pluralize %></h2>
 
 <div class="col-md-12">
-  <%= form_tag polymorphic_path([main_app, :bulk_ingest]), class: "bulk-ingest-form", id: "browse-everything-form" do |f| %>
+  <%= form_tag polymorphic_path([main_app, :bulk_ingest], resource_type: params[:resource_type].to_s), class: "bulk-ingest-form", id: "browse-everything-form" do |f| %>
     <div class="row">
       <div role="main" class="col-xs-12 col-sm-8">
         <div id="metadata" class="form-panel-content">
@@ -23,7 +23,7 @@
               </div>
               <div class="form-group">
                 <div class="form-check">
-                  <%= check_box_tag 'preserve_file_names', class: "form-check-input" %>
+                  <%= check_box_tag 'preserve_file_names', "1", false, class: "form-check-input" %>
                   <label class="form-check-label" for="preserve_file_names">
                     Preserve File Names (prevents naming files 1/2/3 etc)
                   </label>

--- a/spec/views/bulk_ingest/show.html.erb_spec.rb
+++ b/spec/views/bulk_ingest/show.html.erb_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "bulk_ingest/show.html.erb" do
+  it "renders a check box to preserve file names" do
+    assign :resource_class, ScannedResource
+    assign :visibility, []
+    assign :states, []
+    assign :collections, []
+    render
+
+    expect(rendered).to have_selector "input[type='checkbox'][name='preserve_file_names'][value='1']"
+  end
+end


### PR DESCRIPTION
This got broken when we moved the form around - the second argument isn't HTML options, it's the value of the check box when checked.

Closes #5757