### PR TITLE
Allow access to member_ids for resources in GraphQL.

### DIFF
--- a/app/graphql/types/resource.rb
+++ b/app/graphql/types/resource.rb
@@ -25,6 +25,7 @@ module Types::Resource
   field :ocr_content, [String], null: true
   field :embed, Types::EmbedType, null: true
   field :notice, Types::NoticeType, null: true
+  field :member_ids, [String], null: true
 
   definition_methods do
     def resolve_type(object, _context)

--- a/spec/graphql/figgy_schema_spec.rb
+++ b/spec/graphql/figgy_schema_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe FiggySchema do
 
   describe "resource query" do
     # provide a query string for `result`
-    let(:resource) { FactoryBot.create_for_repository(:scanned_resource, viewing_hint: "individuals", notice_type: "senior_thesis") }
+    let(:resource) { FactoryBot.create_for_repository(:scanned_resource, viewing_hint: "individuals", notice_type: "senior_thesis", member_ids: [member.id]) }
+    let(:member) { FactoryBot.create_for_repository(:file_set) }
     let(:id) { resource.id }
     let(:query_string) { %|{ resource(id: "#{id}") { viewingHint } }| }
 
@@ -28,6 +29,13 @@ RSpec.describe FiggySchema do
       it "returns a viewing hint" do
         # calling `result` executes the query
         expect(result["data"]["resource"]["viewingHint"]).to eq("individuals")
+      end
+    end
+
+    context "when requesting member_ids" do
+      let(:query_string) { %|{ resource(id: "#{id}") { memberIds } }| }
+      it "returns it" do
+        expect(result["data"]["resource"]["memberIds"]).to eq([member.id.to_s])
       end
     end
 

--- a/spec/graphql/types/resource_spec.rb
+++ b/spec/graphql/types/resource_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Types::Resource do
     it { is_expected.to have_field(:orangelightId).of_type(String) }
     it { is_expected.to have_field(:sourceMetadataIdentifier) }
     it { is_expected.to have_field(:thumbnail).of_type("Thumbnail") }
+    it { is_expected.to have_field(:member_ids) }
   end
   describe ".resolve_type" do
     it "returns a ScannedResourceType for a ScannedResource" do


### PR DESCRIPTION
This is much faster than getting members and then their ID.

Work in support of https://github.com/pulibrary/orangelight/pull/3527