### PR TITLE
Update webpacker config to resolve chunk error

### DIFF
--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -2,4 +2,8 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'development'
 
 const environment = require('./environment')
 
-module.exports = environment.toWebpackConfig()
+const config = environment.toWebpackConfig()
+
+config.output.filename = 'js/[name]-[hash].js'
+
+module.exports = config


### PR DESCRIPTION
When running `bundle exec foreman start` for development, the following error appeared:
```
16:06:28 frontend.1 | ERROR in chunk application [entry]                                                                                                                                              
16:06:28 frontend.1 | js/[name]-[contenthash].js                                                                                                                                                      
16:06:28 frontend.1 | Cannot use [chunkhash] or [contenthash] for chunk in 'js/[name]-[contenthash].js' (use [hash] instead)  
```
The solution was to set the filename of `config.output` in `config/webpack/development.js`. Although we will be moving away from webpacker completely, the purpose of this PR is to document the issue in case it comes up before the transition.