### PR TITLE
Send params to GeoServer::Publish as keywords

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -390,8 +390,8 @@ GEM
       googleapis-common-protos-types (>= 1.3.1, < 2.a)
       googleauth (~> 1.0)
       grpc (~> 1.36)
-    geoserver-publish (0.5.0)
-      faraday
+    geoserver-publish (0.6.0)
+      faraday (~> 2.2)
     globalid (1.1.0)
       activesupport (>= 5.0)
     google-apis-core (0.11.0)

--- a/app/services/geoserver_publish_service.rb
+++ b/app/services/geoserver_publish_service.rb
@@ -9,7 +9,7 @@ class GeoserverPublishService
   end
 
   def create
-    Geoserver::Publish.send(create_method, create_params)
+    Geoserver::Publish.send(create_method, **create_params)
   end
 
   def delete
@@ -50,7 +50,7 @@ class GeoserverPublishService
     def delete_layer(workspace = nil)
       updated_params = delete_params
       updated_params[:workspace_name] = workspace if workspace
-      Geoserver::Publish.send(delete_method, updated_params)
+      Geoserver::Publish.send(delete_method, **updated_params)
     rescue StandardError => e
       logger.info(e.message)
     end

--- a/spec/services/geoserver_publish_service_spec.rb
+++ b/spec/services/geoserver_publish_service_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe GeoserverPublishService do
       }
       service.create
 
-      expect(Geoserver::Publish).to have_received(:shapefile).with(hash_including(params))
+      expect(Geoserver::Publish).to have_received(:shapefile).with(id: params[:id], workspace_name: params[:workspace_name], title: params[:title], file_path: anything)
     end
   end
 
@@ -87,8 +87,8 @@ RSpec.describe GeoserverPublishService do
     it "calls delete on both public and authenticated workspaces and creates new layer" do
       service.update
 
-      expect(Geoserver::Publish).to have_received(:delete_shapefile).with(hash_including(workspace_name: Figgy.config["geoserver"]["authenticated"]["workspace"]))
-      expect(Geoserver::Publish).to have_received(:delete_shapefile).with(hash_including(workspace_name: Figgy.config["geoserver"]["open"]["workspace"]))
+      expect(Geoserver::Publish).to have_received(:delete_shapefile).with(workspace_name: Figgy.config["geoserver"]["authenticated"]["workspace"], id: anything)
+      expect(Geoserver::Publish).to have_received(:delete_shapefile).with(workspace_name: Figgy.config["geoserver"]["open"]["workspace"], id: anything)
       expect(Geoserver::Publish).to have_received(:shapefile)
     end
 


### PR DESCRIPTION
Closes #5808 

- Send keyword params as required in Ruby 3.
- Update geoserver-pusblish gem to fix issue with newer version of Faraday.