### PR TITLE
Add model filter to templates wayfinder method.

### DIFF
--- a/app/wayfinders/ephemera_project_wayfinder.rb
+++ b/app/wayfinders/ephemera_project_wayfinder.rb
@@ -4,7 +4,7 @@ class EphemeraProjectWayfinder < BaseWayfinder
   relationship_by_property :ephemera_boxes, property: :member_ids, model: EphemeraBox
   relationship_by_property :ephemera_folders, property: :member_ids, model: EphemeraFolder
   relationship_by_property :ephemera_fields, property: :member_ids, model: EphemeraField
-  inverse_relationship_by_property :templates, property: :parent_id
+  inverse_relationship_by_property :templates, property: :parent_id, model: Template
 
   def ephemera_folders_count
     @ephemera_folders_count ||= query_service.custom_queries.count_members(resource: resource, model: EphemeraFolder)

--- a/spec/views/catalog/_members_ephemera_project.html.erb_spec.rb
+++ b/spec/views/catalog/_members_ephemera_project.html.erb_spec.rb
@@ -25,6 +25,20 @@ RSpec.describe "catalog/_members_ephemera_project" do
       expect(rendered).to have_selector "h2", text: "Folders"
     end
   end
+  context "when it's a project with boxes that have been deleted" do
+    it "renders the project" do
+      change_set_persister = ChangeSetPersister.default
+      child = FactoryBot.create_for_repository(:ephemera_box, state: "complete")
+      project = FactoryBot.create_for_repository(:ephemera_project, member_ids: [child.id])
+      change_set_persister.persister.save(resource: child)
+      change_set_persister.persister.save(resource: project)
+      change_set_persister.delete(change_set: ChangeSet.for(child))
+      document = SolrDocument.new(Valkyrie::MetadataAdapter.find(:index_solr).resource_factory.from_resource(resource: project))
+
+      assign :document, document
+      render
+    end
+  end
   context "when it's a project with templates" do
     let(:parent) { FactoryBot.create_for_repository(:ephemera_project) }
     let(:child) { FactoryBot.create_for_repository(:template, parent_id: parent.id) }


### PR DESCRIPTION
Both Templates and Deletion Markers use a property called parent_id as a foreign key. Templates weren't limited to Template models, so this was causing a conflict.

Closes #5772