### PR TITLE
Use catalog path for redirect after failing to delete collection

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -46,7 +46,7 @@ class CollectionsController < ResourcesController
     # deleted collections.
     if Wayfinder.for(@change_set.resource).members_count.positive?
       flash[:alert] = "Unable to delete a collection with members. Please transfer membership to another collection before deleting this collection."
-      redirect_to collection_path(@change_set.resource)
+      redirect_to solr_document_path(@change_set.resource.id.to_s)
     else
       yield
     end

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CollectionsController, type: :controller do
         collection = query_service.find_by(id: collection.id)
         expect(collection).to be_present
         expect(flash["alert"]).to eq "Unable to delete a collection with members. Please transfer membership to another collection before deleting this collection."
-        expect(response).to redirect_to "/collections/#{collection.id}"
+        expect(response).to redirect_to "/catalog/#{collection.id}"
       end
       it "can delete an empty collection" do
         collection = FactoryBot.create_for_repository(:collection)


### PR DESCRIPTION
Turns out we were just sending it to a bad path.

Closes #5797