### PR TITLE
Add and use default values in stub_ezid

### DIFF
--- a/spec/change_set_persisters/change_set_persister/apply_remote_metadata_spec.rb
+++ b/spec/change_set_persisters/change_set_persister/apply_remote_metadata_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ChangeSetPersister::ApplyRemoteMetadata do
   let(:query_service) { ChangeSetPersister.default.query_service }
   let(:blade) { "123456" }
   before do
-    stub_ezid(shoulder: "99999/fk4", blade: blade)
+    stub_ezid
     stub_catalog(bib_id: "991234563506421")
   end
   context "when a bibid source_metadata_identifier is set for the first time on a scanned resource" do

--- a/spec/change_set_persisters/change_set_persister/generate_mosaic_spec.rb
+++ b/spec/change_set_persisters/change_set_persister/generate_mosaic_spec.rb
@@ -5,11 +5,9 @@ RSpec.describe ChangeSetPersister::GenerateMosaic do
   let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
   let(:storage_adapter) { Valkyrie::StorageAdapter.find(:disk_via_copy) }
   let(:change_set_persister) { ChangeSetPersister.new(metadata_adapter: adapter, storage_adapter: storage_adapter) }
-  let(:shoulder) { "99999/fk4" }
-  let(:blade) { "123456" }
 
   before do
-    stub_ezid(shoulder: shoulder, blade: blade)
+    stub_ezid
     allow(MosaicJob).to receive(:perform_later)
   end
 

--- a/spec/change_set_persisters/change_set_persister/mint_identifier_spec.rb
+++ b/spec/change_set_persisters/change_set_persister/mint_identifier_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ChangeSetPersister::MintIdentifier do
   describe "#run" do
     let(:identifier_service) { class_double(IdentifierService).as_stubbed_const transfer_nested_constants: true }
     let(:shoulder) { "99999/fk4" }
-    let(:blade) { "123456" }
+    let(:blade) { "newark" }
     let(:new_ark) { "ark:/#{shoulder}#{blade}" }
 
     before do

--- a/spec/change_set_persisters/change_set_persister/update_aspace_dao_spec.rb
+++ b/spec/change_set_persisters/change_set_persister/update_aspace_dao_spec.rb
@@ -3,14 +3,12 @@
 require "rails_helper"
 
 RSpec.describe ChangeSetPersister::UpdateAspaceDao do
-  let(:shoulder) { "99999/fk4" }
-  let(:blade) { "123456" }
   with_queue_adapter :inline
   it "updates ASpace with a new DAO when an item is marked complete" do
     stub_aspace_login
     stub_find_archival_object(component_id: "MC001.01_c000001")
     stub_findingaid(pulfa_id: "MC001.01_c000001")
-    stub_ezid(shoulder: shoulder, blade: blade)
+    stub_ezid
     mocked_digital_object_create = stub_create_digital_object
     mocked_archival_object_update = stub_archival_object_update(archival_object_id: "260330")
     change_set_persister = ChangeSetPersister.default
@@ -34,7 +32,7 @@ RSpec.describe ChangeSetPersister::UpdateAspaceDao do
     stub_aspace_login
     stub_find_archival_object(component_id: "MC001.01_c000001")
     stub_findingaid(pulfa_id: "MC001.01_c000001")
-    stub_ezid(shoulder: shoulder, blade: blade)
+    stub_ezid
     stub_find_digital_object_by_figgy_id(already_exists: true)
     mocked_digital_object_update = stub_digital_object_update
     mocked_archival_object_update = stub_archival_object_update(archival_object_id: "260330")
@@ -56,7 +54,7 @@ RSpec.describe ChangeSetPersister::UpdateAspaceDao do
     stub_aspace_login
     stub_find_archival_object(component_id: "MC001.01_c000001")
     stub_findingaid(pulfa_id: "MC001.01_c000001")
-    stub_ezid(shoulder: shoulder, blade: blade)
+    stub_ezid
     mocked_digital_object_create = stub_create_digital_object
     mocked_archival_object_update = stub_archival_object_update(archival_object_id: "260330")
     # Stub preservation since we have a stubbed FileSet with no real content to
@@ -85,7 +83,7 @@ RSpec.describe ChangeSetPersister::UpdateAspaceDao do
     stub_find_archival_object(component_id: "MC230_c117")
     stub_find_digital_object(ref: "/repositories/3/digital_objects/12331")
     stub_findingaid(pulfa_id: "MC230_c117")
-    stub_ezid(shoulder: shoulder, blade: blade)
+    stub_ezid
     mocked_digital_object_create = stub_create_digital_object
     mocked_archival_object_update = stub_archival_object_update(archival_object_id: "298998")
     change_set_persister = ChangeSetPersister.default

--- a/spec/controllers/bulk_edit_controller_spec.rb
+++ b/spec/controllers/bulk_edit_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe BulkEditController, type: :controller do
   describe "POST /bulk_edit" do
     let(:params) { { mark_complete: "1", search_params: { f: { member_of_collection_titles_ssim: collection_title, state_ssim: state }, q: "significant" } } }
     before do
-      stub_ezid(shoulder: "99999/fk4", blade: "123456")
+      stub_ezid
     end
     context "when not logged in" do
       let(:user) { nil }

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe CatalogController, type: :controller do
     context "with metadata imported from voyager" do
       it "can search by imported local identifiers" do
         stub_catalog(bib_id: "9985434293506421")
-        stub_ezid(shoulder: "99999/fk4", blade: "8543429")
+        stub_ezid
         resource = FactoryBot.create_for_repository(:complete_scanned_resource, source_metadata_identifier: "9985434293506421", import_metadata: true)
         reloaded_resource = query_service.find_by(id: resource.id)
         persister.save(resource: reloaded_resource)
@@ -122,7 +122,7 @@ RSpec.describe CatalogController, type: :controller do
       end
       it "can search by call number" do
         stub_catalog(bib_id: "99100017893506421")
-        stub_ezid(shoulder: "99999/fk4", blade: "8543429")
+        stub_ezid
 
         resource = FactoryBot.create_for_repository(:scanned_map, state: "complete", title: [], source_metadata_identifier: "99100017893506421", import_metadata: true)
         reloaded_resource = query_service.find_by(id: resource.id)
@@ -132,7 +132,7 @@ RSpec.describe CatalogController, type: :controller do
       end
       it "can search by various imported fields" do
         stub_catalog(bib_id: "99100017893506421")
-        stub_ezid(shoulder: "99999/fk4", blade: "8543429")
+        stub_ezid
         resource = FactoryBot.create_for_repository(:scanned_map, state: "complete", title: [], source_metadata_identifier: "99100017893506421", import_metadata: true)
         reloaded_resource = query_service.find_by(id: resource.id)
         persister.save(resource: reloaded_resource)
@@ -146,7 +146,7 @@ RSpec.describe CatalogController, type: :controller do
     context "with metadata imported from pulfa" do
       it "can search by box and folder numbers" do
         stub_findingaid(pulfa_id: "AC044_c0003")
-        stub_ezid(shoulder: "99999/fk4", blade: "8543429")
+        stub_ezid
 
         resource = FactoryBot.create_for_repository(:complete_scanned_resource, title: [], source_metadata_identifier: "AC044_c0003", import_metadata: true)
         reloaded_resource = query_service.find_by(id: resource.id)
@@ -163,7 +163,7 @@ RSpec.describe CatalogController, type: :controller do
       let(:track) { FactoryBot.create_for_repository(:file_set, title: "Title not in imported metadata") }
       before do
         stub_catalog(bib_id: "9935150723506421")
-        stub_ezid(shoulder: "99999/fk4", blade: "1234567")
+        stub_ezid
         recording
       end
 
@@ -565,7 +565,7 @@ RSpec.describe CatalogController, type: :controller do
       let(:resource) { FactoryBot.create_for_repository(:pending_scanned_map, title: "title") }
 
       before do
-        stub_ezid(shoulder: "99999/fk4", blade: "")
+        stub_ezid
         reloaded_resource = query_service.find_by(id: resource.id)
         change_set = ChangeSet.for(reloaded_resource)
         change_set.validate(state: "complete")

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe CatalogController, type: :controller do
       render_views
       it "can search by imported metadata title" do
         stub_catalog(bib_id: "991234563506421")
-        stub_ezid(shoulder: "99999/fk4", blade: "123456")
+        stub_ezid
         resource = FactoryBot.create_for_repository(:complete_scanned_resource, source_metadata_identifier: "991234563506421", import_metadata: true)
         reloaded_resource = query_service.find_by(id: resource.id)
         output = persister.save(resource: reloaded_resource)
@@ -179,7 +179,7 @@ RSpec.describe CatalogController, type: :controller do
     end
     it "can search by ARK" do
       stub_catalog(bib_id: "991234563506421")
-      stub_ezid(shoulder: "99999/fk4", blade: "123456")
+      stub_ezid
       resource = FactoryBot.create_for_repository(:complete_scanned_resource, source_metadata_identifier: "991234563506421", import_metadata: true)
       reloaded_resource = query_service.find_by(id: resource.id)
       persister.save(resource: reloaded_resource)
@@ -759,7 +759,7 @@ RSpec.describe CatalogController, type: :controller do
       it "renders RDF views" do
         stub_catalog(bib_id: "991234563506421")
         stub_catalog_context
-        stub_ezid(shoulder: "99999/fk4", blade: "123456")
+        stub_ezid
         collection = FactoryBot.create_for_repository(:collection)
         resource = FactoryBot.create_for_repository(
           :complete_scanned_resource,

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe DownloadsController do
       let(:resource) { FactoryBot.create_for_repository(:complete_scanned_resource, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, files: [sample_file]) }
 
       before do
-        stub_ezid(shoulder: "99999/fk4", blade: "123456")
+        stub_ezid
       end
 
       it "redirects to login" do
@@ -88,7 +88,7 @@ RSpec.describe DownloadsController do
       let(:resource) { FactoryBot.create_for_repository(:complete_scanned_resource, visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, files: [sample_file]) }
 
       before do
-        stub_ezid(shoulder: "99999/fk4", blade: "123456")
+        stub_ezid
       end
 
       it "allows downloading the file" do
@@ -153,7 +153,7 @@ RSpec.describe DownloadsController do
       it "allows download", run_real_derivatives: true, run_real_characterization: true do
         sign_in user
         file = fixture_file_upload("files/audio_file.wav", "audio/x-wav")
-        stub_ezid(shoulder: "99999/fk4", blade: "123456")
+        stub_ezid
         parent = FactoryBot.create_for_repository(:complete_recording, files: [file], visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED)
         file_set = Wayfinder.for(parent).members.first
         partial = file_set.derivative_partial_files.first
@@ -165,7 +165,7 @@ RSpec.describe DownloadsController do
       it "disallows download of the original file", run_real_derivatives: true, run_real_characterization: true do
         sign_in user
         file = fixture_file_upload("files/audio_file.wav", "audio/x-wav")
-        stub_ezid(shoulder: "99999/fk4", blade: "123456")
+        stub_ezid
         parent = FactoryBot.create_for_repository(:complete_recording, files: [file], visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED)
         file_set = Wayfinder.for(parent).members.first
         wav_file = file_set.original_files.first

--- a/spec/controllers/numismatics/coins_controller_spec.rb
+++ b/spec/controllers/numismatics/coins_controller_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Numismatics::CoinsController, type: :controller do
   describe "GET /concern/coins/:id/manifest" do
     let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }
     before do
-      stub_ezid(shoulder: "99999/fk4", blade: "123456")
+      stub_ezid
     end
     it "returns a IIIF manifest for a resource with a file" do
       coin = FactoryBot.create_for_repository(:complete_open_coin, files: [file])

--- a/spec/controllers/numismatics/issues_controller_spec.rb
+++ b/spec/controllers/numismatics/issues_controller_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe Numismatics::IssuesController, type: :controller do
   describe "GET /concern/numismatic_issues/:id/manifest" do
     let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }
     before do
-      stub_ezid(shoulder: "99999/fk4", blade: "123456")
+      stub_ezid
     end
     it "returns a IIIF manifest for a resource with a file" do
       coin = FactoryBot.create_for_repository(:complete_open_coin, files: [file])

--- a/spec/controllers/oai_controller_spec.rb
+++ b/spec/controllers/oai_controller_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe OaiController do
     context "when requesting a Louis-Alexandre Berthier set" do
       it "returns all the resources in oai_dc" do
         collection = FactoryBot.create_for_repository(:collection, slug: "C0022")
-        stub_ezid(shoulder: "99999/fk4", blade: "123456")
+        stub_ezid
         stub_findingaid(pulfa_id: "C0022_c0145")
         FactoryBot.create_for_repository(:complete_scanned_resource, member_of_collection_ids: collection.id, source_metadata_identifier: "C0022_c0145", import_metadata: true)
 
@@ -99,7 +99,7 @@ RSpec.describe OaiController do
           collection = FactoryBot.create_for_repository(:collection, slug: "C0022")
           file1 = fixture_file_upload("files/abstract.tiff", "image/tiff")
           file2 = fixture_file_upload("files/abstract.tiff", "image/tiff")
-          stub_ezid(shoulder: "99999/fk4", blade: "123456")
+          stub_ezid
           stub_catalog(bib_id: bib_id)
           child1 = FactoryBot.create_for_repository(:complete_scanned_resource, files: [file1])
           child2 = FactoryBot.create_for_repository(:complete_scanned_resource, files: [file2])
@@ -129,7 +129,7 @@ RSpec.describe OaiController do
         it "returns the record with desired fields populated" do
           bib_id = "9968663863506421"
           collection = FactoryBot.create_for_repository(:collection, slug: "C0022")
-          stub_ezid(shoulder: "99999/fk4", blade: "123456")
+          stub_ezid
           stub_catalog(bib_id: bib_id)
           resource = FactoryBot.create_for_repository(
             :complete_scanned_resource,
@@ -157,7 +157,7 @@ RSpec.describe OaiController do
         it "returns the record with desired fields populated" do
           collection = FactoryBot.create_for_repository(:collection, slug: "C0022")
           file1 = fixture_file_upload("files/abstract.tiff", "image/tiff")
-          stub_ezid(shoulder: "99999/fk4", blade: "123456")
+          stub_ezid
           stub_findingaid(pulfa_id: "C0022_c0145")
           resource = FactoryBot.create_for_repository(
             :complete_scanned_resource,
@@ -187,7 +187,7 @@ RSpec.describe OaiController do
       context "for a resource with no source metadata identifier and no file_sets" do
         it "returns the record with desired fields populated" do
           collection = FactoryBot.create_for_repository(:collection, slug: "C0022")
-          stub_ezid(shoulder: "99999/fk4", blade: "123456")
+          stub_ezid
           resource = FactoryBot.create_for_repository(:complete_scanned_resource, member_of_collection_ids: collection.id)
 
           get :index, params: { "verb" => "GetRecord", "identifier" => "oai:figgy:#{resource.id}", "metadataPrefix" => "oai_dc" }

--- a/spec/controllers/oai_controller_spec.rb
+++ b/spec/controllers/oai_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe OaiController do
     context "when requesting a Cicognara set" do
       it "returns all the Cicognara item MarcXML" do
         collection = FactoryBot.create_for_repository(:collection, slug: "cico")
-        stub_ezid(shoulder: "99999/fk4", blade: "8543429")
+        stub_ezid
         stub_catalog(bib_id: "9985434293506421")
         stub_catalog(bib_id: "9985434293506421", content_type: "application/marcxml+xml")
         FactoryBot.create_for_repository(:complete_scanned_resource, member_of_collection_ids: collection.id, source_metadata_identifier: "9985434293506421", import_metadata: true)
@@ -48,7 +48,7 @@ RSpec.describe OaiController do
     context "when there's no data" do
       it "works" do
         collection = FactoryBot.create_for_repository(:collection, slug: "cico")
-        stub_ezid(shoulder: "99999/fk4", blade: "8543429")
+        stub_ezid
         stub_catalog(bib_id: "9985434293506421")
         stub_catalog(bib_id: "9985434293506421", content_type: "application/marcxml+xml")
         FactoryBot.create_for_repository(:complete_scanned_resource, member_of_collection_ids: collection.id, source_metadata_identifier: "9985434293506421", import_metadata: true)
@@ -79,7 +79,7 @@ RSpec.describe OaiController do
 
   describe "GetRecord" do
     it "returns a specific item" do
-      stub_ezid(shoulder: "99999/fk4", blade: "8543429")
+      stub_ezid
       stub_catalog(bib_id: "9985434293506421")
       stub_catalog(bib_id: "9985434293506421", content_type: "application/marcxml+xml")
       resource = FactoryBot.create_for_repository(:complete_scanned_resource, source_metadata_identifier: "9985434293506421")
@@ -215,7 +215,7 @@ RSpec.describe OaiController do
     context "when requesting a Cicognara set" do
       it "returns all the Cicognara item MarcXML" do
         collection = FactoryBot.create_for_repository(:collection, slug: "cico")
-        stub_ezid(shoulder: "99999/fk4", blade: "8543429")
+        stub_ezid
         stub_catalog(bib_id: "9985434293506421")
         stub_catalog(bib_id: "9985434293506421", content_type: "application/marcxml+xml")
         FactoryBot.create_for_repository(:complete_scanned_resource, member_of_collection_ids: collection.id, source_metadata_identifier: "9985434293506421", import_metadata: true)
@@ -231,7 +231,7 @@ RSpec.describe OaiController do
         allow(OAI::Figgy::ValkyrieProviderModel).to receive(:limit).and_return(2)
         collection = FactoryBot.create_for_repository(:collection, slug: "cico")
         source_metadata_identifier = "9985434293506421"
-        stub_ezid(shoulder: "99999/fk4", blade: source_metadata_identifier)
+        stub_ezid
         stub_catalog(bib_id: source_metadata_identifier)
         stub_catalog(bib_id: source_metadata_identifier, content_type: "application/marcxml+xml")
         5.times do

--- a/spec/controllers/scanned_maps_controller_spec.rb
+++ b/spec/controllers/scanned_maps_controller_spec.rb
@@ -311,7 +311,7 @@ RSpec.describe ScannedMapsController, type: :controller do
   describe "GET /concern/scanned_maps/:id/manifest" do
     let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }
     before do
-      stub_ezid(shoulder: "99999/fk4", blade: "123456")
+      stub_ezid
     end
     it "returns a IIIF manifest for a resource with a file" do
       scanned_map = FactoryBot.create_for_repository(:complete_scanned_map, files: [file])

--- a/spec/controllers/scanned_resources_controller_spec.rb
+++ b/spec/controllers/scanned_resources_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ScannedResourcesController, type: :controller do
       Rails.cache.clear
     end
     it "caches a manifest between sessions" do
-      stub_ezid(shoulder: "99999/fk4", blade: "")
+      stub_ezid
       resource = FactoryBot.create_for_repository(:complete_campus_only_scanned_resource, files: [file])
 
       get :manifest, params: { id: resource.id, format: :json }
@@ -35,7 +35,7 @@ RSpec.describe ScannedResourcesController, type: :controller do
       expect(ManifestBuilder).to have_received(:new).exactly(1).times
     end
     it "caches based on a given auth token" do
-      stub_ezid(shoulder: "99999/fk4", blade: "")
+      stub_ezid
       resource = FactoryBot.create_for_repository(:complete_campus_only_scanned_resource, files: [file])
 
       get :manifest, params: { id: resource.id, format: :json }

--- a/spec/features/bulk_edit_spec.rb
+++ b/spec/features/bulk_edit_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "Bulk edit", js: true do
   end
 
   before do
-    stub_ezid(shoulder: "99999/fk4", blade: "4609321")
+    stub_ezid
 
     [collection, member_scanned_resource, nonmember_scanned_resource].each do |resource|
       change_set = ChangeSet.for(resource)

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature "Scanned Resources" do
 
     before do
       stub_catalog(bib_id: "991234563506421")
-      stub_ezid(shoulder: "99999/fk4", blade: "")
+      stub_ezid
       reloaded_resource = query_service.find_by(id: resource.id)
       change_set = ChangeSet.for(reloaded_resource)
       change_set.validate(state: "complete")

--- a/spec/features/file_set_spec.rb
+++ b/spec/features/file_set_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "FileSet" do
   let(:user) { FactoryBot.create(:admin) }
 
   before do
-    stub_ezid(shoulder: "99999/fk4", blade: "123456")
+    stub_ezid
 
     sign_in user
   end

--- a/spec/features/fixity_dashboard_spec.rb
+++ b/spec/features/fixity_dashboard_spec.rb
@@ -23,11 +23,9 @@ RSpec.feature "Fixity dashboard" do
   let(:failed_local_fixity_event) do
     FactoryBot.create_for_repository(:local_fixity_failure, resource_id: Wayfinder.for(scanned_resource).file_sets.first.id, current: true)
   end
-  let(:shoulder) { "99999/fk4" }
-  let(:blade) { "123456" }
 
   before do
-    stub_ezid(shoulder: shoulder, blade: blade)
+    stub_ezid
     sign_in user
   end
 

--- a/spec/features/scanned_resource_spec.rb
+++ b/spec/features/scanned_resource_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "Scanned Resource" do
   let(:user) { FactoryBot.create(:admin) }
 
   before do
-    stub_ezid(shoulder: "99999/fk4", blade: "123456")
+    stub_ezid
 
     sign_in user
   end

--- a/spec/features/simple_resource_spec.rb
+++ b/spec/features/simple_resource_spec.rb
@@ -17,7 +17,7 @@ RSpec.feature "SimpleChangeSets" do
   end
 
   before do
-    stub_ezid(shoulder: "99999/fk4", blade: "123456")
+    stub_ezid
 
     change_set_persister.save(change_set: change_set)
     sign_in user

--- a/spec/jobs/bulk_update_job_spec.rb
+++ b/spec/jobs/bulk_update_job_spec.rb
@@ -24,7 +24,7 @@ describe BulkUpdateJob do
     before do
       resource1
       resource2
-      stub_ezid(shoulder: "99999/fk4", blade: "123456")
+      stub_ezid
     end
 
     it "updates the resource state" do

--- a/spec/jobs/geoserver_publish_job_spec.rb
+++ b/spec/jobs/geoserver_publish_job_spec.rb
@@ -5,12 +5,10 @@ describe GeoserverPublishJob do
   with_queue_adapter :inline
 
   let(:publish_service) { instance_double(GeoserverPublishService) }
-  let(:shoulder) { "99999/fk4" }
-  let(:blade) { "123456" }
   let(:tika_output) { tika_shapefile_output }
 
   before do
-    stub_ezid(shoulder: shoulder, blade: blade)
+    stub_ezid
     allow(publish_service).to receive(:delete)
     allow(GeoserverPublishService).to receive(:new).and_return(publish_service)
   end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -13,11 +13,9 @@ describe Ability do
   let(:page_file_3) { fixture_file_upload("files/example.tif", "image/tiff") }
   let(:audio_file) { fixture_file_upload("files/audio_file.wav", "audio/x-wav") }
   let(:audio_file_2) { fixture_file_upload("files/audio_file.wav", "audio/x-wav") }
-  let(:shoulder) { "99999/fk4" }
-  let(:blade) { "123456" }
 
   before do
-    stub_ezid(shoulder: shoulder, blade: blade)
+    stub_ezid
     allow(CDL::EligibleItemService).to receive(:item_ids)
   end
 
@@ -790,10 +788,8 @@ describe Ability do
       let(:vector_resource) do
         change_set_persister.save(change_set: VectorResourceChangeSet.new(campus_only_vector_resource, files: [file]))
       end
-      let(:shoulder) { "99999/fk4" }
-      let(:blade) { "123456" }
       before do
-        stub_ezid(shoulder: shoulder, blade: blade)
+        stub_ezid
       end
 
       it {
@@ -1018,10 +1014,8 @@ describe Ability do
       let(:vector_resource) do
         change_set_persister.save(change_set: VectorResourceChangeSet.new(open_vector_resource, files: [file]))
       end
-      let(:shoulder) { "99999/fk4" }
-      let(:blade) { "123456" }
       before do
-        stub_ezid(shoulder: shoulder, blade: blade)
+        stub_ezid
       end
 
       it {
@@ -1035,10 +1029,8 @@ describe Ability do
       let(:vector_resource) do
         change_set_persister.save(change_set: VectorResourceChangeSet.new(private_vector_resource, files: [file]))
       end
-      let(:shoulder) { "99999/fk4" }
-      let(:blade) { "123456" }
       before do
-        stub_ezid(shoulder: shoulder, blade: blade)
+        stub_ezid
       end
 
       it {

--- a/spec/models/archival_media_collection_feature_spec.rb
+++ b/spec/models/archival_media_collection_feature_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Browsing archival media collections" do
   before do
     stub_findingaid(pulfa_id: "C0652")
     stub_findingaid(pulfa_id: "C0652_c0377")
-    stub_ezid(shoulder: "99999/fk4", blade: "123456")
+    stub_ezid
     member
     sign_in user
   end

--- a/spec/models/file_set_spec.rb
+++ b/spec/models/file_set_spec.rb
@@ -2,10 +2,8 @@
 require "rails_helper"
 
 RSpec.describe FileSet do
-  let(:shoulder) { "99999/fk4" }
-  let(:blade) { "123456" }
   before do
-    stub_ezid(shoulder: shoulder, blade: blade)
+    stub_ezid
   end
 
   describe "optimistic locking" do

--- a/spec/models/numismatics/coin_feature_spec.rb
+++ b/spec/models/numismatics/coin_feature_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Numismatics::Coins" do
   end
 
   before do
-    stub_ezid(shoulder: "99999/fk4", blade: "123456")
+    stub_ezid
 
     change_set_persister.save(change_set: change_set)
     sign_in user

--- a/spec/models/numismatics/issues_feature_spec.rb
+++ b/spec/models/numismatics/issues_feature_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "Numismatics::Issues" do
   end
 
   before do
-    stub_ezid(shoulder: "99999/fk4", blade: "123456")
+    stub_ezid
 
     change_set_persister.save(change_set: change_set)
     sign_in user

--- a/spec/models/oai/figgy/valkyrie_provider_model_spec.rb
+++ b/spec/models/oai/figgy/valkyrie_provider_model_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe OAI::Figgy::ValkyrieProviderModel do
   def create_scanned_resource(source_metadata_identifier:, collection_id:, member_ids: [], append_id: nil, state: "complete", visibility: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, rights_statement: RightsStatements.no_known_copyright)
     stub_catalog(bib_id: source_metadata_identifier)
     stub_catalog(bib_id: source_metadata_identifier, content_type: "application/marcxml+xml") if File.exist?(catalog_fixture_path(source_metadata_identifier, CatalogStubbing::CONTENT_TYPE_MARC_XML))
-    stub_ezid(shoulder: "99999/fk4", blade: source_metadata_identifier)
+    stub_ezid
     FactoryBot.create_for_repository(
       :complete_scanned_resource,
       member_of_collection_ids: collection_id,

--- a/spec/queries/find_identifiers_to_reconcile_spec.rb
+++ b/spec/queries/find_identifiers_to_reconcile_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe FindIdentifiersToReconcile do
 
   before do
     stub_catalog(bib_id: "991234563506421")
-    stub_ezid(shoulder: "99999/fk4", blade: "8675309")
+    stub_ezid
   end
 
   describe "#find_identifiers_to_reconcile" do

--- a/spec/queries/find_invalid_thumbnail_resources_spec.rb
+++ b/spec/queries/find_invalid_thumbnail_resources_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe FindInvalidThumbnailResources do
 
   before do
     stub_catalog(bib_id: "991234563506421")
-    stub_ezid(shoulder: "99999/fk4", blade: "8675309")
+    stub_ezid
   end
 
   describe "#find_invalid_thumbnail_resources" do

--- a/spec/queries/find_missing_thumbnail_resources_spec.rb
+++ b/spec/queries/find_missing_thumbnail_resources_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe FindMissingThumbnailResources do
 
   before do
     stub_catalog(bib_id: "991234563506421")
-    stub_ezid(shoulder: "99999/fk4", blade: "8675309")
+    stub_ezid
   end
 
   describe "#find_missing_thumbnail_resources" do

--- a/spec/requests/catalog_spec.rb
+++ b/spec/requests/catalog_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Catalog requests", type: :request do
 
       before do
         stub_catalog(bib_id: "991234563506421")
-        stub_ezid(shoulder: "99999/fk4", blade: "123456")
+        stub_ezid
       end
 
       it "downloads the original pdf" do
@@ -72,7 +72,7 @@ RSpec.describe "Catalog requests", type: :request do
 
       before do
         stub_catalog(bib_id: "991234563506421")
-        stub_ezid(shoulder: "99999/fk4", blade: "123456")
+        stub_ezid
         # used in pdf generation
         stub_request(:any, "http://www.example.com/image-service/#{scanned_resource.member_ids.first}/full/200,/0/gray.jpg")
           .to_return(body: File.open(Rails.root.join("spec", "fixtures", "files", "derivatives", "grey-pdf.jpg")), status: 200)

--- a/spec/requests/playlist_spec.rb
+++ b/spec/requests/playlist_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Playlist requests", type: :request do
   end
 
   before do
-    stub_ezid(shoulder: "99999/fk4", blade: "123456")
+    stub_ezid
     playlist
   end
 

--- a/spec/requests/scanned_map_spec.rb
+++ b/spec/requests/scanned_map_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "ScannedMap requests", type: :request do
   let(:user) { FactoryBot.create(:admin) }
 
   before do
-    stub_ezid(shoulder: "99999/fk4", blade: "123456")
+    stub_ezid
     stub_request(:any, "http://www.example.com/image-service/#{file_set.id}/full/200,/0/gray.jpg")
       .to_return(body: File.open(Rails.root.join("spec", "fixtures", "files", "derivatives", "grey-pdf.jpg")), status: 200)
   end

--- a/spec/requests/scanned_resource_spec.rb
+++ b/spec/requests/scanned_resource_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "ScannedResource requests", type: :request do
   let(:user) { FactoryBot.create(:admin) }
 
   before do
-    stub_ezid(shoulder: "99999/fk4", blade: "123456")
+    stub_ezid
     stub_request(:any, "http://www.example.com/image-service/#{file_set.id}/full/200,/0/gray.jpg")
       .to_return(body: File.open(Rails.root.join("spec", "fixtures", "files", "derivatives", "grey-pdf.jpg")), status: 200)
   end

--- a/spec/services/auto_completer_spec.rb
+++ b/spec/services/auto_completer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AutoCompleter do
   let(:file2) { fixture_file_upload("files/example.tif", "image/tiff") }
   context "when there are complete_when_processed resources ready for completion" do
     it "marks them complete" do
-      stub_ezid(shoulder: "99999/fk4", blade: "123456")
+      stub_ezid
       complete_resource = FactoryBot.create_for_repository(:complete_open_scanned_resource)
       to_be_completed_resource = FactoryBot.create_for_repository(:scanned_resource, files: [file], state: "complete_when_processed")
       no_files_resource = FactoryBot.create_for_repository(:scanned_resource, state: "complete_when_processed")
@@ -27,7 +27,7 @@ RSpec.describe AutoCompleter do
   end
   context "when a MVW is auto-completed" do
     it "doesn't error on its volume" do
-      stub_ezid(shoulder: "99999/fk4", blade: "123456")
+      stub_ezid
       allow(Honeybadger).to receive(:notify)
       parent = FactoryBot.create_for_repository(:scanned_resource, state: "complete_when_processed")
       to_be_completed_resource = FactoryBot.create_for_repository(:scanned_resource, files: [file], state: "complete_when_processed", append_id: parent.id)
@@ -46,7 +46,7 @@ RSpec.describe AutoCompleter do
   end
   context "when one eligible resource ready for completion errors" do
     it "notifies and completes the others" do
-      stub_ezid(shoulder: "99999/fk4", blade: "123456")
+      stub_ezid
       allow(Honeybadger).to receive(:notify)
       to_be_completed_resource1 = FactoryBot.create_for_repository(:scanned_resource, files: [file], state: "complete_when_processed")
       to_be_completed_resource2 = FactoryBot.create_for_repository(:scanned_resource, files: [file2], state: "complete_when_processed")

--- a/spec/services/bulk_edit_service_spec.rb
+++ b/spec/services/bulk_edit_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe BulkEditService do
   describe "#perform" do
     context "when updating state" do
       before do
-        stub_ezid(shoulder: "99999/fk4", blade: "123456")
+        stub_ezid
       end
 
       it "updates the state of the member objects and mints an ark" do
@@ -62,7 +62,7 @@ RSpec.describe BulkEditService do
 
     context "when updating multiple objects and multiple attributes" do
       before do
-        stub_ezid(shoulder: "99999/fk4", blade: "123456")
+        stub_ezid
       end
 
       it "updates them all" do

--- a/spec/services/bulk_ingest_service_spec.rb
+++ b/spec/services/bulk_ingest_service_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe BulkIngestService do
     let(:coll) { FactoryBot.create_for_repository(:collection) }
     before do
       stub_catalog(bib_id: "9946093213506421")
-      stub_ezid(shoulder: "99999/fk4", blade: "9946093213506421")
+      stub_ezid
     end
     context "with a directory of Scanned TIFFs" do
       it "ingests the resources, skipping dotfiles and ignored files" do
@@ -189,7 +189,7 @@ RSpec.describe BulkIngestService do
 
       before do
         stub_catalog(bib_id: "9946093213506421")
-        stub_ezid(shoulder: "99999/fk4", blade: "9946093213506421")
+        stub_ezid
       end
 
       it "ingests the resources", bulk: true do
@@ -231,7 +231,7 @@ RSpec.describe BulkIngestService do
       let(:coll) { FactoryBot.create_for_repository(:collection) }
       before do
         stub_catalog(bib_id: "9946093213506421")
-        stub_ezid(shoulder: "99999/fk4", blade: "9946093213506421")
+        stub_ezid
       end
 
       it "applies that metadata" do
@@ -340,7 +340,7 @@ RSpec.describe BulkIngestService do
         allow(logger).to receive(:warn)
         allow(logger).to receive(:info)
         stub_catalog(bib_id: "9946093213506421")
-        stub_ezid(shoulder: "99999/fk4", blade: "9946093213506421")
+        stub_ezid
       end
 
       it "does not ingest the resources and logs a warning" do

--- a/spec/services/cdl/automatic_completer_spec.rb
+++ b/spec/services/cdl/automatic_completer_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe CDL::AutomaticCompleter do
     context "when there's CDL items with processed files", run_real_derivatives: true, run_real_characterization: true do
       with_queue_adapter :inline
       it "completes them" do
-        stub_ezid(shoulder: "99999/fk4", blade: "")
+        stub_ezid
         stub_catalog(bib_id: "991234563506421")
         User.create!(uid: "skye", email: "skye@princeton.edu")
         User.create!(uid: "zelda", email: "zelda@princeton.edu")

--- a/spec/services/cloud_fixity_spec.rb
+++ b/spec/services/cloud_fixity_spec.rb
@@ -18,8 +18,6 @@ RSpec.describe CloudFixity do
     }.to_json
   end
   let(:subscriber) { instance_double(Google::Cloud::Pubsub::Subscriber) }
-  let(:shoulder) { "99999/fk4" }
-  let(:blade) { "123456" }
   let(:metadata_adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
   let(:query_service) { metadata_adapter.query_service }
 
@@ -28,7 +26,7 @@ RSpec.describe CloudFixity do
     described_class.instance_variable_set(:@pubsub, nil)
     described_class::FixityRequestor.instance_variable_set(:@pubsub, nil)
 
-    stub_ezid(shoulder: shoulder, blade: blade)
+    stub_ezid
     allow(Google::Cloud::Pubsub).to receive(:new).and_return(pubsub)
     allow(pubsub).to receive(:topic).and_return(topic)
     allow(topic).to receive(:subscription).and_return(subscription)

--- a/spec/services/deletion_marker_service_spec.rb
+++ b/spec/services/deletion_marker_service_spec.rb
@@ -6,8 +6,6 @@ describe DeletionMarkerService do
 
   let(:change_set_persister) { ChangeSetPersister.default }
   let(:query_service) { change_set_persister.query_service }
-  let(:shoulder) { "99999/fk4" }
-  let(:blade) { "123456" }
 
   before do
     # Make preservation deletes not actually happen to simulate a versioned
@@ -16,7 +14,7 @@ describe DeletionMarkerService do
     # This is a bug - right now all disk:// storage adapter IDs are going to
     # this adapter, no matter what, so the above never gets called.
     allow(Valkyrie::StorageAdapter.find(:disk)).to receive(:delete)
-    stub_ezid(shoulder: shoulder, blade: blade)
+    stub_ezid
   end
 
   context "when restoring a deleted resource with children" do

--- a/spec/services/migrations/accession_date_migrator_spec.rb
+++ b/spec/services/migrations/accession_date_migrator_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Migrations::AccessionDateMigrator do
 
     # context "when a map is restricted" do
     #   it "updates the rights statement to be \"in copyright\"" do
-    #     stub_ezid(shoulder: "99999/fk4", blade: "123456")
+    #     stub_ezid
     #     scanned_map = FactoryBot.create_for_repository(:complete_campus_only_scanned_map)
     #     raster_map = FactoryBot.create_for_repository(:complete_campus_only_raster_resource)
     #     vector_map = FactoryBot.create_for_repository(:complete_campus_only_vector_resource)

--- a/spec/services/migrations/map_copyright_migrator_spec.rb
+++ b/spec/services/migrations/map_copyright_migrator_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Migrations::MapCopyrightMigrator do
   describe ".call" do
     context "when a map is restricted" do
       it "updates the rights statement to be \"in copyright\"" do
-        stub_ezid(shoulder: "99999/fk4", blade: "123456")
+        stub_ezid
         scanned_map = FactoryBot.create_for_repository(:complete_campus_only_scanned_map)
         raster_map = FactoryBot.create_for_repository(:complete_campus_only_raster_resource)
         vector_map = FactoryBot.create_for_repository(:complete_campus_only_vector_resource)

--- a/spec/services/orangelight_document_spec.rb
+++ b/spec/services/orangelight_document_spec.rb
@@ -91,7 +91,7 @@ describe OrangelightDocument do
       end
 
       before do
-        stub_ezid(shoulder: "99999/fk4", blade: "123456")
+        stub_ezid
         coin
         issue
       end

--- a/spec/services/pdf_generator_spec.rb
+++ b/spec/services/pdf_generator_spec.rb
@@ -262,14 +262,12 @@ RSpec.describe PDFGenerator do
 
     context "when a resource is complete and has an ARK for identifier" do
       let(:resource) { FactoryBot.create_for_repository(:complete_open_scanned_resource, files: [file], pdf_type: ["color"], identifier: "ark:/99999/fk4") }
-      let(:shoulder) { "99999" }
-      let(:blade) { "fk4" }
       let(:ark) { instance_double(Ark) }
 
       before do
         stub_request(:any, "http://www.example.com/image-service/#{file_set.id}/full/200,/0/default.jpg")
           .to_return(body: File.open(Rails.root.join("spec", "fixtures", "files", "derivatives", "grey-pdf.jpg")), status: 200)
-        stub_ezid(shoulder: shoulder, blade: blade)
+        stub_ezid
         allow(Ark).to receive(:new).and_return(ark)
         allow(ark).to receive(:uri)
       end

--- a/spec/services/preserver/blind_importer_spec.rb
+++ b/spec/services/preserver/blind_importer_spec.rb
@@ -6,12 +6,10 @@ RSpec.describe Preserver::BlindImporter do
   let(:file2) { fixture_file_upload("files/example.tif", "image/tiff") }
   let(:query_service) { ChangeSetPersister.default.query_service }
   let(:persister) { ChangeSetPersister.default.metadata_adapter.persister }
-  let(:shoulder) { "99999/fk4" }
-  let(:blade) { "123456" }
   let(:importer) { described_class.new }
   with_queue_adapter :inline
   before do
-    stub_ezid(shoulder: shoulder, blade: blade)
+    stub_ezid
   end
   describe ".import" do
     it "can import arbitrarily deep" do

--- a/spec/services/preserver/importer_spec.rb
+++ b/spec/services/preserver/importer_spec.rb
@@ -7,8 +7,6 @@ describe Preserver::Importer do
   let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }
   let(:resource) { FactoryBot.create_for_repository(:complete_scanned_resource, files: [file]) }
   let(:file_set) { resource.decorate.file_sets.first }
-  let(:shoulder) { "99999/fk4" }
-  let(:blade) { "123456" }
   let(:change_set_persister) { ChangeSetPersister.default }
   let(:query_service) { change_set_persister.query_service }
   let(:storage_adapter) { Valkyrie::StorageAdapter.find(:google_cloud_storage) }
@@ -36,7 +34,7 @@ describe Preserver::Importer do
   end
 
   before do
-    stub_ezid(shoulder: shoulder, blade: blade)
+    stub_ezid
     persisted_file_set
     change_set = ChangeSet.for(persisted_resource)
     change_set_persister.save(change_set: change_set)

--- a/spec/services/preserver_spec.rb
+++ b/spec/services/preserver_spec.rb
@@ -16,8 +16,6 @@ describe Preserver do
   end
   let(:preservation_objects) { Wayfinder.for(resource).preservation_objects }
   let(:preservation_object) { preservation_objects.first }
-  let(:shoulder) { "99999/fk4" }
-  let(:blade) { "123456" }
   let(:change_set) { ScannedResourceChangeSet.new(unpreserved_resource) }
   let(:storage_adapter) { instance_double(Valkyrie::Storage::Disk) }
   let(:valkyrie_file) { FileMetadata.new(id: "disk://" + Rails.root.join("tmp", "cloud_backup_test", resource.id, "#{resource.id}.json").to_s) }
@@ -33,7 +31,7 @@ describe Preserver do
 
   describe "#preserve!" do
     before do
-      stub_ezid(shoulder: shoulder, blade: blade)
+      stub_ezid
       stub_catalog(bib_id: "991234563506421")
     end
 

--- a/spec/services/repair_cloud_fixity_spec.rb
+++ b/spec/services/repair_cloud_fixity_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe RepairCloudFixity do
     with_queue_adapter :inline
 
     before do
-      stub_ezid(shoulder: "99999/fk4", blade: "9946093213506421")
+      stub_ezid
     end
 
     context "when the local file matches its recorded checksum" do

--- a/spec/services/repair_local_fixity_spec.rb
+++ b/spec/services/repair_local_fixity_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe RepairLocalFixity do
 
   before do
     allow(LocalFixityJob).to receive(:perform_later)
-    stub_ezid(shoulder: "99999/fk4", blade: "123456")
+    stub_ezid
     scanned_resource
   end
 

--- a/spec/shared_specs/controllers/base_resource_controller.rb
+++ b/spec/shared_specs/controllers/base_resource_controller.rb
@@ -360,7 +360,7 @@ RSpec.shared_examples "a ResourcesController" do |*flags|
   describe "#manifest" do
     let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }
     before do
-      stub_ezid(shoulder: "99999/fk4", blade: "123456")
+      stub_ezid
     end
     it "returns a IIIF manifest for a resource with a file" do
       resource = FactoryBot.create_for_repository(manifestable_factory, files: [file])

--- a/spec/support/stub_ezid.rb
+++ b/spec/support/stub_ezid.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module EzidStubbing
-  def stub_ezid(shoulder:, blade:, location: "http://example.com")
+  def stub_ezid(shoulder: "99999/fk4", blade: "123456", location: "http://example.com")
     stub_request(:post, "https://ezid.cdlib.org/shoulder/ark:/#{shoulder}")
       .to_return(status: 200, body: "success: ark:/#{shoulder}#{blade}", headers: {})
     stub_request(:head, "http://arks.princeton.edu/ark:/#{shoulder}/#{blade}")

--- a/spec/utils/data_seeder_spec.rb
+++ b/spec/utils/data_seeder_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe DataSeeder do
   # combine tests to reduce expensive object creation
   describe "#generate_dev_data" do
     before do
-      stub_ezid(shoulder: "99999/fk4", blade: "123456")
+      stub_ezid
     end
     it "generates lots of objects" do
       n_files = mvw_volumes + # each volume member has a fileset
@@ -81,7 +81,7 @@ RSpec.describe DataSeeder do
 
   describe "#generate_collection" do
     before do
-      stub_ezid(shoulder: "99999/fk4", blade: "123456")
+      stub_ezid
     end
     it "adds a collection containing 3 scanned resources, 1 complete and 2 pending" do
       FactoryBot.create(:admin) # collection assigns an owner

--- a/spec/wayfinders/wayfinder_spec.rb
+++ b/spec/wayfinders/wayfinder_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Wayfinder do
 
     describe "#child_deletion_markers" do
       it "returns all deletion_markers with the given parent_id" do
-        stub_ezid(shoulder: "99999/fk4", blade: "123456")
+        stub_ezid
         query_service = ChangeSetPersister.default.query_service
         file = fixture_file_upload("files/example.tif", "image/tiff")
         change_set_persister = ChangeSetPersister.default


### PR DESCRIPTION
For the most part the test does not care what the shoulder and blade are. Most of the time, we just need to stub it to make webmock happy. Provide default values and use them in most specs. This will reduce confusion of what the values should be, obviating the need for documentation on the method.

Where tests were actually exercising ark behavior, I left custom values in place.

closes #5666 