### PR TITLE
Preserve Recordings only when complete

### DIFF
--- a/app/change_sets/recording_change_set.rb
+++ b/app/change_sets/recording_change_set.rb
@@ -50,6 +50,6 @@ class RecordingChangeSet < ChangeSet
   end
 
   def preserve?
-    persisted?
+    persisted? && state == "complete"
   end
 end

--- a/spec/change_sets/recording_change_set_spec.rb
+++ b/spec/change_sets/recording_change_set_spec.rb
@@ -120,6 +120,12 @@ RSpec.describe RecordingChangeSet do
     context "when persisted" do
       let(:form_resource) { FactoryBot.create_for_repository(:complete_recording) }
 
+      context "and incomplete" do
+        let(:form_resource) { FactoryBot.create_for_repository(:draft_recording) }
+        it "is not preserved" do
+          expect(change_set.preserve?).to be false
+        end
+      end
       it "is preserved" do
         expect(change_set.preserve?).to be true
       end


### PR DESCRIPTION
Closes #5787 

The ticket also calls for EphemeraFolders/EphemeraBoxes to only record when complete, but a couple things make me think we should leave it as is:

For EphemeraBox, there's a note that Boxes only have metadata so we may as well always preserve. That seems reasonable to me, and a decision we made in 2019: https://github.com/pulibrary/figgy/commit/b7ce523fcd259908b01cf5a8b6008ea64e246e86#diff-538bcb5518f90600d4fab5442eea649edbb2d6482067af948ec55c5c6abba714R49-R52

For EphemeraFolders, Draft is a "Public Readable State" because metadata is published the moment it's created. I think if we're displaying it to users we should preserve it.