### PR TITLE
Check self for cloud/local fixity tests

### DIFF
--- a/app/queries/deep_cloud_fixity_count.rb
+++ b/app/queries/deep_cloud_fixity_count.rb
@@ -41,7 +41,6 @@ class DeepCloudFixityCount
           from deep_members member
           JOIN orm_resources po ON member.id = (po.metadata->'preserved_object_id'->0->>'id')::UUID
           JOIN orm_resources event ON po.id = (event.metadata->'resource_id'->0->>'id')::UUID
-          WHERE member.internal_resource = 'FileSet'
           AND po.internal_resource = 'PreservationObject'
           AND event.internal_resource = 'Event'
           AND event.metadata @> :event_metadata

--- a/app/queries/deep_cloud_fixity_count.rb
+++ b/app/queries/deep_cloud_fixity_count.rb
@@ -31,6 +31,8 @@ class DeepCloudFixityCount
           JOIN orm_resources member ON (b.member->>'id')::UUID = member.id
           WHERE a.id = :id
           UNION
+          select * from orm_resources WHERE id = :id
+          UNION
           SELECT mem.*
           FROM deep_members f,
           jsonb_array_elements(f.metadata->'member_ids') AS g(member)

--- a/app/queries/deep_local_fixity_count.rb
+++ b/app/queries/deep_local_fixity_count.rb
@@ -32,6 +32,8 @@ class DeepLocalFixityCount
           JOIN orm_resources member ON (b.member->>'id')::UUID = member.id
           WHERE a.id = :id
           UNION
+          select * from orm_resources WHERE id = :id
+          UNION
           SELECT mem.*
           FROM deep_members f,
           jsonb_array_elements(f.metadata->'member_ids') AS g(member)

--- a/app/values/health_report/cloud_fixity_check.rb
+++ b/app/values/health_report/cloud_fixity_check.rb
@@ -16,27 +16,14 @@ class HealthReport::CloudFixityCheck
 
   def status
     @status ||=
-      if fixity_map[0]&.positive?
+      if wayfinder.deep_failed_cloud_fixity_count.positive?
         :needs_attention
-      elsif fixity_map[2]&.positive?
+      elsif wayfinder.deep_repairing_cloud_fixity_count.positive?
         :repairing
-      elsif fixity_map[nil]&.positive?
+      elsif unknown_count.positive?
         :in_progress
       else
         :healthy
-      end
-  end
-
-  def fixity_map
-    return {} unless resource.decorate.respond_to?(:file_sets)
-    @cloud_fixity_map ||=
-      begin
-        m = {}
-        m[0] = wayfinder.deep_failed_cloud_fixity_count if wayfinder.deep_failed_cloud_fixity_count.positive?
-        m[1] = wayfinder.deep_succeeded_cloud_fixity_count if wayfinder.deep_succeeded_cloud_fixity_count.positive?
-        m[2] = wayfinder.deep_repairing_cloud_fixity_count if wayfinder.deep_repairing_cloud_fixity_count.positive?
-        m[nil] = unknown_count if unknown_count.positive?
-        m
       end
   end
 

--- a/app/values/health_report/cloud_fixity_check.rb
+++ b/app/values/health_report/cloud_fixity_check.rb
@@ -28,7 +28,11 @@ class HealthReport::CloudFixityCheck
   end
 
   def summary
-    I18n.t("health_status.cloud_fixity_check.summary.#{status}")
+    if resource.respond_to?(:member_ids)
+      I18n.t("health_status.cloud_fixity_check.summary.#{status}")
+    else
+      I18n.t("health_status.cloud_fixity_check.summary.self.#{status}")
+    end
   end
 
   def type

--- a/app/values/health_report/local_fixity_check.rb
+++ b/app/values/health_report/local_fixity_check.rb
@@ -20,31 +20,23 @@ class HealthReport::LocalFixityCheck
 
   def status
     @status ||=
-      if fixity_map[0]&.positive?
+      if wayfinder.deep_failed_local_fixity_count.positive?
         :needs_attention
-      elsif fixity_map[2]&.positive?
+      elsif wayfinder.deep_repairing_local_fixity_count.positive?
         :repairing
-      elsif fixity_map[nil]&.positive?
+      elsif unknown_count.positive?
         :in_progress
       else
         :healthy
       end
   end
 
-  def fixity_map
-    @local_fixity_map ||=
-      begin
-        m = {}
-        m[0] = wayfinder.deep_failed_local_fixity_count if wayfinder.deep_failed_local_fixity_count.positive?
-        m[1] = wayfinder.deep_succeeded_local_fixity_count if wayfinder.deep_succeeded_local_fixity_count.positive?
-        m[2] = wayfinder.deep_repairing_local_fixity_count if wayfinder.deep_repairing_local_fixity_count.positive?
-        m[nil] = unknown_count if unknown_count.positive?
-        m
-      end
-  end
-
   def summary
-    I18n.t("health_status.local_fixity_check.summary.#{status}")
+    if resource.respond_to?(:member_ids)
+      I18n.t("health_status.local_fixity_check.summary.#{status}")
+    else
+      I18n.t("health_status.local_fixity_check.summary.self.#{status}")
+    end
   end
 
   private

--- a/app/views/catalog/_health_status.html.erb
+++ b/app/views/catalog/_health_status.html.erb
@@ -1,25 +1,23 @@
-<% unless resource.is_a? FileSet %>
-  <div id="health-status">
-    <a href="#" data-toggle="modal" data-target="#healthModal">
-      <lux-icon-base icon-color="<%= t("health_status.status.#{health_report.status}.icon_color") %>">
-        <lux-icon-<%= t("health_status.status.#{health_report.status}.icon") %>></lux-icon-<%= t("health_status.status.#{health_report.status}.icon") %>>
-      </lux-icon-base>
-      Preservation Status: <%= t("health_status.status.#{health_report.status}.label") %>
-    </a>
-    <div class="modal" tabindex="-1" role="dialog" id="healthModal">
-      <div class="modal-dialog" role="document">
-        <div class="modal-content">
-          <div class="modal-header">
-            <h5 class="modal-title"><%= image_tag "health-report-graphic.svg" %> Resource Health Report</h5>
-            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-              <span aria-hidden="true">&times;</span>
-            </button>
-          </div>
-          <div class="modal-body">
-            <%= render partial: "health_status_check", collection: health_report.checks, as: :check %>
-          </div>
+<div id="health-status">
+  <a href="#" data-toggle="modal" data-target="#healthModal">
+    <lux-icon-base icon-color="<%= t("health_status.status.#{health_report.status}.icon_color") %>">
+      <lux-icon-<%= t("health_status.status.#{health_report.status}.icon") %>></lux-icon-<%= t("health_status.status.#{health_report.status}.icon") %>>
+    </lux-icon-base>
+    Preservation Status: <%= t("health_status.status.#{health_report.status}.label") %>
+  </a>
+  <div class="modal" tabindex="-1" role="dialog" id="healthModal">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title"><%= image_tag "health-report-graphic.svg" %> Resource Health Report</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          <%= render partial: "health_status_check", collection: health_report.checks, as: :check %>
         </div>
       </div>
     </div>
   </div>
-<% end %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -182,6 +182,11 @@ en:
     local_fixity_check:
       type: 'Local Fixity'
       summary:
+        self:
+          in_progress: "Local fixity check is in progress this resource. If this doesn't resolve itself then contact DLS with a link to this resource via #digital-library."
+          healthy: 'All local file checksums are verified.'
+          needs_attention: 'This resource failed Local Fixity Checks. Contact DLS with a link to this resource via #digital-library.'
+          repairing: "This resource is in the process of being repaired. If this doesn't resolve itself then contact DLS with a link to this resource via #digital-library."
         in_progress: "Local fixity check is in progress for one or more files. If this doesn't resolve itself then contact DLS with a link to this resource via #digital-library."
         healthy: 'All local file checksums are verified.'
         needs_attention: 'One or more files failed Local Fixity Checks. Contact DLS with a link to this resource via #digital-library.'
@@ -189,6 +194,11 @@ en:
     cloud_fixity_check:
       type: 'Cloud Fixity'
       summary:
+        self:
+          healthy: 'This resource is preserved and its checksums verified.'
+          needs_attention: 'This resource failed Cloud Fixity Checks. Contact DLS with a link to this resource via #digital-library.'
+          in_progress: "This resource is in the process of being preserved. If this doesn't resolve itself, edit this resource and save it again - if that still doesn't work then contact DLS with a link to this resource via #digital-library."
+          repairing: "This resource is in the process of being repaired. If this doesn't resolve itself then contact DLS with a link to this resource via #digital-library."
         healthy: 'All files are preserved and their checksums verified.'
         needs_attention: 'One or more files failed Cloud Fixity Checks. Contact DLS with a link to this resource via #digital-library.'
         in_progress: "One or more files are in the process of being preserved. If this doesn't resolve itself, edit this resource and save it again - if that still doesn't work then contact DLS with a link to this resource via #digital-library."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -183,7 +183,7 @@ en:
       type: 'Local Fixity'
       summary:
         self:
-          in_progress: "Local fixity check is in progress this resource. If this doesn't resolve itself then contact DLS with a link to this resource via #digital-library."
+          in_progress: "Local fixity check is in progress for this resource. If this doesn't resolve itself then contact DLS with a link to this resource via #digital-library."
           healthy: 'All local file checksums are verified.'
           needs_attention: 'This resource failed Local Fixity Checks. Contact DLS with a link to this resource via #digital-library.'
           repairing: "This resource is in the process of being repaired. If this doesn't resolve itself then contact DLS with a link to this resource via #digital-library."

--- a/spec/features/file_set_spec.rb
+++ b/spec/features/file_set_spec.rb
@@ -10,12 +10,12 @@ RSpec.feature "FileSet" do
     sign_in user
   end
 
-  scenario "file set show page does not have a health status" do
+  scenario "file set show page has a health status" do
     file = fixture_file_upload("files/example.tif", "image/tiff")
     resource = FactoryBot.create_for_repository(:scanned_resource, files: [file])
     file_set = Wayfinder.for(resource).file_sets.first
 
     visit solr_document_path(id: file_set.id)
-    expect(page).not_to have_selector("#health-status")
+    expect(page).to have_selector("#health-status")
   end
 end

--- a/spec/values/health_report_spec.rb
+++ b/spec/values/health_report_spec.rb
@@ -101,6 +101,20 @@ RSpec.describe HealthReport do
         expect(cloud_fixity_report.summary).to start_with "One or more files failed Cloud Fixity Checks."
       end
     end
+    context "for a FileSet with a failed cloud fixity event" do
+      it "returns :needs_attention" do
+        resource = create_file_set(cloud_fixity_status: Event::FAILURE)
+
+        report = described_class.for(resource)
+
+        expect(report.status).to eq :needs_attention
+        # Second check is cloud fixity
+        cloud_fixity_report = report.checks.second
+        expect(cloud_fixity_report.type).to eq "Cloud Fixity"
+        expect(cloud_fixity_report.status).to eq :needs_attention
+        expect(cloud_fixity_report.summary).to start_with "One or more files failed Cloud Fixity Checks."
+      end
+    end
     context "for a resource that hasn't preserved yet" do
       it "returns :in_progress" do
         fs1 = FactoryBot.create_for_repository(:file_set)

--- a/spec/values/health_report_spec.rb
+++ b/spec/values/health_report_spec.rb
@@ -103,9 +103,11 @@ RSpec.describe HealthReport do
     end
     context "for a FileSet with a failed cloud fixity event" do
       it "returns :needs_attention" do
-        resource = create_file_set(cloud_fixity_status: Event::FAILURE)
+        fs1 = create_file_set(cloud_fixity_status: Event::FAILURE)
+        resource = FactoryBot.create_for_repository(:complete_open_scanned_resource, member_ids: [fs1.id])
+        FactoryBot.create_for_repository(:preservation_object, preserved_object_id: resource.id)
 
-        report = described_class.for(resource)
+        report = described_class.for(fs1)
 
         expect(report.status).to eq :needs_attention
         # Second check is cloud fixity

--- a/spec/values/health_report_spec.rb
+++ b/spec/values/health_report_spec.rb
@@ -85,6 +85,22 @@ RSpec.describe HealthReport do
         expect(local_fixity_report.summary).to start_with "One or more files failed Local Fixity Checks."
       end
     end
+    context "for a FileSEt with a failed local fixity event" do
+      it "returns :needs_attention" do
+        fs1 = FactoryBot.create_for_repository(:original_file_file_set)
+        FactoryBot.create(:local_fixity_failure, resource_id: fs1.id)
+        FactoryBot.create_for_repository(:complete_open_scanned_resource, member_ids: [fs1.id])
+
+        report = described_class.for(fs1)
+
+        expect(report.status).to eq :needs_attention
+        # First check is local fixity
+        local_fixity_report = report.checks.first
+        expect(local_fixity_report.type).to eq "Local Fixity"
+        expect(local_fixity_report.status).to eq :needs_attention
+        expect(local_fixity_report.summary).to start_with "This resource failed Local Fixity Checks."
+      end
+    end
 
     context "for a resource with a failed cloud fixity event" do
       it "returns :needs_attention" do
@@ -114,7 +130,7 @@ RSpec.describe HealthReport do
         cloud_fixity_report = report.checks.second
         expect(cloud_fixity_report.type).to eq "Cloud Fixity"
         expect(cloud_fixity_report.status).to eq :needs_attention
-        expect(cloud_fixity_report.summary).to start_with "One or more files failed Cloud Fixity Checks."
+        expect(cloud_fixity_report.summary).to start_with "This resource failed Cloud Fixity Checks."
       end
     end
     context "for a resource that hasn't preserved yet" do

--- a/spec/wayfinders/wayfinder_spec.rb
+++ b/spec/wayfinders/wayfinder_spec.rb
@@ -115,6 +115,23 @@ RSpec.describe Wayfinder do
         expect(described_class.for(mvw).deep_failed_cloud_fixity_count).to eq 1
       end
 
+      it "returns 1 if there's a cloud fixity failure on itself" do
+        mvw = FactoryBot.create_for_repository(:scanned_resource)
+        metadata_node = FileMetadata.new(id: SecureRandom.uuid)
+        preservation_object = FactoryBot.create_for_repository(:preservation_object, preserved_object_id: mvw.id, metadata_node: metadata_node)
+        FactoryBot.create_for_repository(
+          :event,
+          type: :cloud_fixity,
+          status: "FAILURE",
+          resource_id: preservation_object.id,
+          child_id: metadata_node.id,
+          child_property: :metadata_node,
+          current: true
+        )
+
+        expect(described_class.for(mvw).deep_failed_cloud_fixity_count).to eq 1
+      end
+
       # rubocop:disable Metrics/MethodLength
       def create_file_set(cloud_fixity_success: true)
         file_set = FactoryBot.create_for_repository(:file_set)

--- a/spec/wayfinders/wayfinder_spec.rb
+++ b/spec/wayfinders/wayfinder_spec.rb
@@ -97,6 +97,24 @@ RSpec.describe Wayfinder do
         expect(described_class.for(mvw).deep_succeeded_cloud_fixity_count).to eq 1
       end
 
+      it "returns 1 if there's a non-FileSet with a failed fixity" do
+        volume1 = FactoryBot.create_for_repository(:scanned_resource)
+        metadata_node = FileMetadata.new(id: SecureRandom.uuid)
+        preservation_object = FactoryBot.create_for_repository(:preservation_object, preserved_object_id: volume1.id, metadata_node: metadata_node)
+        FactoryBot.create_for_repository(
+          :event,
+          type: :cloud_fixity,
+          status: "FAILURE",
+          resource_id: preservation_object.id,
+          child_id: metadata_node.id,
+          child_property: :metadata_node,
+          current: true
+        )
+        mvw = FactoryBot.create_for_repository(:scanned_resource, member_ids: [volume1.id])
+
+        expect(described_class.for(mvw).deep_failed_cloud_fixity_count).to eq 1
+      end
+
       # rubocop:disable Metrics/MethodLength
       def create_file_set(cloud_fixity_success: true)
         file_set = FactoryBot.create_for_repository(:file_set)


### PR DESCRIPTION
Closes #5807 

This adds the file set health report back and makes sure the health report checks metadata events for nested members as well as itself.