### PR TITLE
Restore assumption that a cloud preservation is a successful fixity check

### DIFF
--- a/app/queries/find_deep_preservation_object_count.rb
+++ b/app/queries/find_deep_preservation_object_count.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+class FindDeepPreservationObjectCount
+  def self.queries
+    [:find_deep_preservation_object_count]
+  end
+
+  attr_reader :query_service
+  delegate :resource_factory, to: :query_service
+  def initialize(query_service:)
+    @query_service = query_service
+  end
+
+  def find_deep_preservation_object_count(resource:)
+    query_service.connection[relationship_query, id: resource.id.to_s].first[:count]
+  end
+
+  def relationship_query
+    <<-SQL
+        WITH RECURSIVE deep_members AS (
+          select member.*
+          FROM orm_resources a,
+          jsonb_array_elements(a.metadata->'member_ids') AS b(member)
+          JOIN orm_resources member ON (b.member->>'id')::UUID = member.id
+          WHERE a.id = :id
+          UNION
+          SELECT mem.*
+          FROM deep_members f,
+          jsonb_array_elements(f.metadata->'member_ids') AS g(member)
+          JOIN orm_resources mem ON (g.member->>'id')::UUID = mem.id
+          WHERE f.metadata @> '{"member_ids": [{}]}'
+        ), deep_preservation_objects AS (
+          select member.id AS file_set_id, po.*
+          from deep_members member
+          JOIN orm_resources po ON member.id = (po.metadata->'preserved_object_id'->0->>'id')::UUID
+          WHERE member.internal_resource = 'FileSet'
+          AND po.internal_resource = 'PreservationObject'
+        )
+        select COUNT(DISTINCT file_set_id) AS count FROM deep_preservation_objects
+    SQL
+  end
+end

--- a/app/wayfinders/base_wayfinder.rb
+++ b/app/wayfinders/base_wayfinder.rb
@@ -136,11 +136,14 @@ class BaseWayfinder
     )
   end
 
+  # This method encodes the assumption that the existence of a preservation
+  # object, with no other events, represents a success
+  # This is because google checks fixity when a resource is preserved
   def deep_succeeded_cloud_fixity_count
-    @deep_succeeded_cloud_fixity_count ||= query_service.custom_queries.deep_cloud_fixity_count(
-      resource: resource,
-      status: Event::SUCCESS
-    )
+    @deep_succeeded_cloud_fixity_count ||=
+      query_service.custom_queries.find_deep_preservation_object_count(resource: resource) -
+      deep_repairing_cloud_fixity_count -
+      deep_failed_cloud_fixity_count
   end
 
   def deep_repairing_cloud_fixity_count

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -419,6 +419,7 @@ Rails.application.config.to_prepare do
     CountAllOfModel,
     DeepLocalFixityCount,
     FindDeepChildrenWithProperty,
+    FindDeepPreservationObjectCount,
     FindIdsWithPropertyNotEmpty,
     DeepCloudFixityCount,
     PagedAllQuery,


### PR DESCRIPTION
And prevent regression by adding a test
closes #5864
