### PR TITLE
Serve generated PDF even if it couldn't save

### DIFF
--- a/app/services/pdf_service.rb
+++ b/app/services/pdf_service.rb
@@ -18,7 +18,13 @@ class PDFService
       change_set_persister.buffer_into_index do |buffered_changeset_persister|
         change_set.validate(file_metadata: [pdf_file])
         buffered_changeset_persister.save(change_set: change_set)
+      # rubocop:disable Lint/SuppressedException
+      rescue Valkyrie::Persistence::StaleObjectError
+        # If a user initiatves PDF generation, waits, then gives up and tries again,
+        # the second one may fail because the first one successfully generated the PDF
+        # and then saved before the second one did. Just serve the generated PDF.
       end
+      # rubocop:enable Lint/SuppressedException
     end
 
     pdf_file

--- a/spec/requests/scanned_resource_spec.rb
+++ b/spec/requests/scanned_resource_spec.rb
@@ -43,6 +43,19 @@ RSpec.describe "ScannedResource requests", type: :request do
     end
   end
 
+  context "when the PDF is generated but an optimistic lock prevents save" do
+    it "serves the generated PDF anyway" do
+      buffered_csp_mock = instance_double(ChangeSetPersister::Basic)
+      allow(buffered_csp_mock).to receive(:save).and_raise(Valkyrie::Persistence::StaleObjectError)
+      csp_mock = instance_double(ChangeSetPersister::Basic)
+      allow(csp_mock).to receive(:buffer_into_index).and_yield(buffered_csp_mock)
+      pdf_service = PDFService.new(csp_mock)
+      allow(PDFService).to receive(:new).and_return(pdf_service)
+      expect { get "/concern/scanned_resources/#{scanned_resource.id}/pdf" }.not_to raise_error("Valkyrie::Persistence::StaleObjectError")
+      expect(response.status).to eq 302
+    end
+  end
+
   context "when the file metadata for the PDF exists but the file binary cannot be retrieved" do
     before do
       allow(Valkyrie.logger).to receive(:error)


### PR DESCRIPTION
due to an optimistic lock error
closes #5680
