### PR TITLE
Fixes hidden UV footer when tabs are present

### DIFF
--- a/app/javascript/viewer/uv_manager.js
+++ b/app/javascript/viewer/uv_manager.js
@@ -128,6 +128,7 @@ export default class UVManager {
 
     shareButton.parentNode.insertBefore(this.createIIIFDragElement(), shareButton.nextSibling)
     mobileShareButton.parentNode.insertBefore(this.createIIIFDragElement(), mobileShareButton.nextSibling)
+    this.resize()
   }
 
   createIIIFDragElement () {
@@ -207,7 +208,10 @@ export default class UVManager {
     const titleHeight = $('#title').outerHeight($('#title').is(':visible'))
     let tabHeight = 0
     if ($('#tab-container').is(':visible')) {
-      tabHeight = $('#tab-container').outerHeight(true)
+      // There is some kind of race condition that makes this way of determining tab height to fail
+      // tabHeight = $('#tab-container').outerHeight(true)
+      // hardcoding tab height as a temporary workaround
+      tabHeight = 49
     }
     this.uvElement.width(windowWidth)
     this.uvElement.height(windowHeight - titleHeight - tabHeight)

--- a/app/javascript/viewer/uv_manager.js
+++ b/app/javascript/viewer/uv_manager.js
@@ -208,16 +208,13 @@ export default class UVManager {
     const titleHeight = $('#title').outerHeight($('#title').is(':visible'))
     let tabHeight = 0
     if ($('#tab-container').is(':visible')) {
-      // There is some kind of race condition that makes this way of determining tab height to fail
-      // tabHeight = $('#tab-container').outerHeight(true)
-      // hardcoding tab height as a temporary workaround
-      tabHeight = 49
+      tabHeight = $('#tab-container').outerHeight(true)
     }
     this.uvElement.width(windowWidth)
     this.uvElement.height(windowHeight - titleHeight - tabHeight)
     this.uvElement.children('div').height(windowHeight - titleHeight - tabHeight)
     if (this.uv) { this.uv.resize() }
-    this.waitForElementToDisplay('button.share', 500, this.addViewerIcons.bind(this))
+    this.waitForElementToDisplay('button.share', 1000, this.addViewerIcons.bind(this))
   }
 
   bindResize () {


### PR DESCRIPTION
The problem was a race condition where it could not evaluate the presence of the tabs reliably before resize. This fix puts the resize at the end of the `addViewerIcons` function and extend to wait time slightly to ensure the resize accounts for the tab height. 