### PR TITLE
Fix bulk edit for vector and raster resources

### DIFF
--- a/app/controllers/bulk_edit_controller.rb
+++ b/app/controllers/bulk_edit_controller.rb
@@ -43,7 +43,7 @@ class BulkEditController < ApplicationController
     end
 
     def load_removable_collections
-      @removable_collections = @collections.reject { |c| c.title == edit_params["f"]["member_of_collection_titles_ssim"][0] }
+      @removable_collections = @collections.reject { |c| c.title == edit_params["f"].fetch(:member_of_collection_titles_ssim, [])[0] }
     end
 
     # Prepare / execute the search and process into id arrays

--- a/spec/controllers/bulk_edit_controller_spec.rb
+++ b/spec/controllers/bulk_edit_controller_spec.rb
@@ -33,6 +33,17 @@ RSpec.describe BulkEditController, type: :controller do
         expect(response).to redirect_to("/users/auth/cas")
       end
     end
+    context "when bulk editing vector resources and not faceting on collection" do
+      let(:resource1) { FactoryBot.create_for_repository(:vector_resource, title: "Resource 1 - Significant") }
+      let(:resource2) { FactoryBot.create_for_repository(:vector_resource, title: "Resource 2 - Significant") }
+      let(:params) { { f: { state_ssim: state }, q: "significant" } }
+
+      it "renders the selected " do
+        get :resources_edit, params: params
+        expect(response.body).to have_content("Bulk edit 2 resources")
+        expect(response.body).to have_field("mark_complete")
+      end
+    end
   end
 
   describe "POST /bulk_edit" do


### PR DESCRIPTION
Allows Vector and Raster resources to be bulk edited. Because these resource types are not in Collections, the `load_removable_collections` method needs to be more tolerant of queries without a member_of_collection param.

Closes #5890 