### PR TITLE
Notify with the event id when it has no resource_id

### DIFF
--- a/app/views/fixity_dashboard/_fixity_table.html.erb
+++ b/app/views/fixity_dashboard/_fixity_table.html.erb
@@ -10,12 +10,16 @@
   <tbody>
     <% resources.each do |event| %>
       <% resource = event.affected_resource %>
-      <tr>
-        <td><%= link_to resource.title.first, ContextualPath.new(child: resource, parent_id: resource.parent&.id).show %></td>
-        <td><%= link_to(resource.parent.title.first, ContextualPath.new(child: resource.parent).show) if resource.parent %></td>
-        <td><%= event.status %></td>
-        <td><%= event.updated_at %></td>
-      </tr>
+      <% if resource %>
+        <tr>
+          <td><%= link_to resource.title.first, ContextualPath.new(child: resource, parent_id: resource.parent&.id).show %></td>
+          <td><%= link_to(resource.parent.title.first, ContextualPath.new(child: resource.parent).show) if resource.parent %></td>
+          <td><%= event.status %></td>
+          <td><%= event.updated_at %></td>
+        </tr>
+      <% else %>
+        <% Honeybadger.notify("Event #{event.id} has no resource_id") %>
+      <% end %>
     <% end %>
   </tbody>
 </table>

--- a/spec/views/fixity_dashboard/_fixity_table.html.erb_spec.rb
+++ b/spec/views/fixity_dashboard/_fixity_table.html.erb_spec.rb
@@ -9,12 +9,18 @@ RSpec.describe "fixity_dashboard/_fixity_table" do
     end
     let(:original_file) { instance_double FileMetadata }
 
-    before do
+    it "links to file set without parent" do
       render partial: "fixity_table", locals: { resources: [local_fixity_event.decorate] }
+      expect(rendered).to have_link "Page 1"
     end
 
-    it "links to file set without parent" do
-      expect(rendered).to have_link "Page 1"
+    context "when an event has no resource_id" do
+      it "notifies Honeybadger and doesn't show that one" do
+        event = FactoryBot.create_for_repository(:cloud_fixity_event, current: true)
+        allow(Honeybadger).to receive(:notify)
+        expect { render partial: "fixity_table", locals: { resources: [event.decorate] } }.not_to raise_error
+        expect(Honeybadger).to have_received(:notify).with("Event #{event.id} has no resource_id")
+      end
     end
   end
 end


### PR DESCRIPTION
advances #5854
