### PR TITLE
Add a custom query to delete duplicate metadata nodes

### DIFF
--- a/app/queries/delete_duplicate_fixity_events.rb
+++ b/app/queries/delete_duplicate_fixity_events.rb
@@ -12,8 +12,9 @@ class DeleteDuplicateFixityEvents
     @query_service = query_service
   end
 
+  # @return the number of rows deleted
   def delete_duplicate_fixity_events
-    query_service.connection << delete_query
+    query_service.connection[delete_query].all.count
   end
 
   def delete_query
@@ -27,6 +28,7 @@ class DeleteDuplicateFixityEvents
       AND a.metadata @> '{"type":["cloud_fixity"],"current":[true],"child_property":["metadata_node"]}'
       AND b.metadata @> '{"type":["cloud_fixity"],"current":[true],"child_property":["metadata_node"]}'
       AND a.created_at < b.created_at
+      RETURNING a.id
     SQL
   end
 end

--- a/app/queries/delete_duplicate_fixity_events.rb
+++ b/app/queries/delete_duplicate_fixity_events.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Finds duplicate current metadata_node cloud_fixity events for the same
+# resource_id, and deletes the older one
+class DeleteDuplicateFixityEvents
+  def self.queries
+    [:delete_duplicate_fixity_events]
+  end
+
+  attr_reader :query_service
+  def initialize(query_service:)
+    @query_service = query_service
+  end
+
+  def delete_duplicate_fixity_events
+    query_service.connection << delete_query
+  end
+
+  def delete_query
+    <<-SQL
+      DELETE FROM orm_resources a
+      USING orm_resources b
+      WHERE (a.metadata->'resource_id'->0->>'id')::UUID = (b.metadata->'resource_id'->0->>'id')::UUID
+      AND a.id != b.id
+      AND a.internal_resource = 'Event'
+      AND b.internal_resource = 'Event'
+      AND a.metadata @> '{"type":["cloud_fixity"],"current":[true],"child_property":["metadata_node"]}'
+      AND b.metadata @> '{"type":["cloud_fixity"],"current":[true],"child_property":["metadata_node"]}'
+      AND a.created_at < b.created_at
+    SQL
+  end
+end

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -398,6 +398,7 @@ Rails.application.config.to_prepare do
   # Register custom queries for the default Valkyrie metadata adapter
   # (see Valkyrie::Persistence::CustomQueryContainer)
   [
+    DeleteDuplicateFixityEvents,
     FindByLocalIdentifier,
     FindByProperty,
     FindManyByProperty,

--- a/spec/queries/delete_duplicate_fixity_events_spec.rb
+++ b/spec/queries/delete_duplicate_fixity_events_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe DeleteDuplicateFixityEvents do
+  with_queue_adapter :inline
+  subject(:query) { described_class.new(query_service: query_service) }
+
+  let(:metadata_adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
+  let(:query_service) { metadata_adapter.query_service }
+
+  describe "#delete_duplicate_fixity_events" do
+    context "when there are multiple current metadata_node events" do
+      it "deletes the earliest-created duplicate" do
+        # create some duplicates
+        ids = Array.new(2) { Valkyrie::ID.new(SecureRandom.uuid) }
+        events_to_create = ids.map do |id|
+          Array.new(2) do
+            FactoryBot.create_for_repository(:cloud_fixity_event, child_property: "metadata_node", resource_id: id, current: true)
+          end
+        end
+        # create a non-current event
+        FactoryBot.create_for_repository(:cloud_fixity_event, child_property: "metadata_node", resource_id: ids.first, current: false)
+        # create a local fixity event
+        FactoryBot.create_for_repository(:local_fixity_success, child_property: "binary_node", resource_id: ids.first, child_id: Valkyrie::ID.new(SecureRandom.uuid), current: true)
+        # create a binary node event
+        FactoryBot.create_for_repository(:cloud_fixity_event, child_property: "binary_node", resource_id: ids.first, child_id: Valkyrie::ID.new(SecureRandom.uuid), current: true)
+
+        expect(query_service.find_all_of_model(model: Event).count).to eq 7
+        query.delete_duplicate_fixity_events
+        events = query_service.find_all_of_model(model: Event)
+        expect(events.count).to eq 5
+        events_to_create.each do |tuple|
+          expect { query_service.find_by(id: tuple.first.id) }.to raise_error(Valkyrie::Persistence::ObjectNotFoundError)
+          expect { query_service.find_by(id: tuple.last.id) }.not_to raise_error # (Valkyrie::Persistence::ObjectNotFoundError)
+        end
+      end
+    end
+  end
+end

--- a/spec/queries/delete_duplicate_fixity_events_spec.rb
+++ b/spec/queries/delete_duplicate_fixity_events_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe DeleteDuplicateFixityEvents do
         FactoryBot.create_for_repository(:cloud_fixity_event, child_property: "binary_node", resource_id: ids.first, child_id: Valkyrie::ID.new(SecureRandom.uuid), current: true)
 
         expect(query_service.find_all_of_model(model: Event).count).to eq 7
-        query.delete_duplicate_fixity_events
+        deletion_count = query.delete_duplicate_fixity_events
+        expect(deletion_count).to eq 2
         events = query_service.find_all_of_model(model: Event)
         expect(events.count).to eq 5
         events_to_create.each do |tuple|


### PR DESCRIPTION
This will allow us to put in place the unique constraint in #5930

I think we'll need to rebase that PR on this one, and delete this query (more importantly its test, which will start to fail once that database migration exists).

refs #5938
