### PR TITLE
Fix PDF file handle overload

### DIFF
--- a/app/derivative_services/pdf_derivative_service.rb
+++ b/app/derivative_services/pdf_derivative_service.rb
@@ -37,7 +37,7 @@ class PDFDerivativeService
   def add_file_sets(files)
     resource = parent
     change_set_persister.buffer_into_index do |buffered_change_set_persister|
-      files.each_slice(200) do |file_slice|
+      files.each_slice(page_slice) do |file_slice|
         change_set = ChangeSet.for(resource)
         change_set.validate(files: file_slice)
         resource = buffered_change_set_persister.save(change_set: change_set)
@@ -77,19 +77,18 @@ class PDFDerivativeService
     @resource ||= query_service.find_by(id: id)
   end
 
+  def page_slice
+    50
+  end
+
   def convert_pages
     image = Vips::Image.pdfload(filename, access: :sequential, memory: true)
     pages = image.get_value("pdf-n_pages")
     files = Array.new(pages).lazy.each_with_index.map do |_, page|
-      # Ruby's set to mark and sweep for GC, and we can't explicitly close VIPS
-      # references. The file handles aren't freed up until the garbage collector
-      # runs, but it's 4 handles per VIPS access. So force a GC to keep the
-      # handles low.
-      # See https://github.com/libvips/ruby-vips/issues/67
-      GC.start
-      page_image = Vips::Image.new_from_file(filename, access: :sequential, memory: true, page: page, dpi: 300)
+      # Extract the slice of images to disk if we're on an index where it's
+      # necessary.
       location = temporary_output(page).to_s
-      page_image.tiffsave(location)
+      `vips pdfload #{filename} #{location} --page #{page} --n 1 --dpi 300 --access sequential`
       build_file(page + 1, location)
     end
     files

--- a/app/derivative_services/pdf_derivative_service.rb
+++ b/app/derivative_services/pdf_derivative_service.rb
@@ -85,8 +85,6 @@ class PDFDerivativeService
     image = Vips::Image.pdfload(filename, access: :sequential, memory: true)
     pages = image.get_value("pdf-n_pages")
     files = Array.new(pages).lazy.each_with_index.map do |_, page|
-      # Extract the slice of images to disk if we're on an index where it's
-      # necessary.
       location = temporary_output(page).to_s
       `vips pdfload #{filename} #{location} --page #{page} --n 1 --dpi 300 --access sequential`
       build_file(page + 1, location)

--- a/app/models/ingestable_file.rb
+++ b/app/models/ingestable_file.rb
@@ -24,8 +24,6 @@ class IngestableFile < Valkyrie::Resource
   #   various bulk ingest jobs.
   attribute :copy_before_ingest, Valkyrie::Types::Bool
 
-  delegate :close, to: :file
-
   def content_type
     mime_type
   end
@@ -37,8 +35,9 @@ class IngestableFile < Valkyrie::Resource
 
   def close
     # Clean up all the file handles.
-    opened_file.try(:close) if File.exist?(path)
-    file.try(:close) if File.exist?(file_path)
+    opened_file.try(:close) if @opened_file
+    file.try(:close) if @file
+    copied_temp_file.try(:close) if @copied_temp_file
   end
 
   private


### PR DESCRIPTION
This PR does a few things:

* Use the VIPS command line over the ruby interface for PDFs to avoid memory and file handle management issues of PDFs - spawning the process only long enough for it to die lets it clean up after itself.
* Close file handles for FileAppender on `#close` even if the file isn't there, but not if the instance variable hasn't been initialized - we were getting errors before without the file existence check, but it turns out that's because if the file's not there it can't instantiate, it's not that it can't close a file handle to a deleted file, and if we don't close the handle the system holds onto it.
* Remove all the GC management stuff from the PDF derivative service - by shelling out and managing file handles we don't need it.
* Reduce the number of pages it extracts at a time to 50 - this should cut down the amount of disk space needed per PDF derivative by a factor of 4.

Before this PR while processing a derivative if I ran `sudo lsof | grep pdf | wc -l ` the opened file handle count would start in the thousands and get increasingly larger until the background job broke. With these changes it's always 20-30.

Further, it allowed https://figgy-staging.princeton.edu/catalog/8588b15a-8029-46a0-979c-d68f4f5f1735 to create derivatives (it extracted the pages in about 17 minutes for 1000 pages.)

Closes #5937