### PR TITLE
Removes the double injection of Datadog trace ID in Figgy logs.

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 require_relative "application"
+Datadog.configuration.tracing.log_injection = false
 Rails.application.initialize!


### PR DESCRIPTION
See
https://github.com/DataDog/dd-trace-rb/issues/2012#issuecomment-1196877495