### PR TITLE
Display PreservationObject creation date as the cloud fixity date if file has no events

### DIFF
--- a/app/decorators/file_set_decorator.rb
+++ b/app/decorators/file_set_decorator.rb
@@ -39,7 +39,12 @@ class FileSetDecorator < Valkyrie::ResourceDecorator
   delegate :downloadable?, to: :parent
 
   def cloud_fixity_success_of(file_id)
-    cloud_fixity_events_for(file_id).find(&:current?)&.status
+    events = cloud_fixity_events_for(file_id)
+    if events.present?
+      events.find(&:current?)&.status
+    elsif preservation_object_for(file_id)
+      Event::SUCCESS
+    end
   end
 
   def cloud_fixity_last_success_date_of(file_id)

--- a/app/decorators/file_set_decorator.rb
+++ b/app/decorators/file_set_decorator.rb
@@ -45,10 +45,10 @@ class FileSetDecorator < Valkyrie::ResourceDecorator
   def cloud_fixity_last_success_date_of(file_id)
     events = cloud_fixity_events_for(file_id)
     if events.present?
-      events.select(&:successful?).map(&:created_at).max || "n/a"
+      format_date(events.select(&:successful?).map(&:created_at).max)
     else
       preservation_object = preservation_object_for(file_id)
-      preservation_object&.created_at || "n/a"
+      format_date(preservation_object&.created_at)
     end
   end
 
@@ -69,7 +69,15 @@ class FileSetDecorator < Valkyrie::ResourceDecorator
       property: :metadata,
       value: { status: Event::SUCCESS, resource_id: id, child_id: file_id }
     ).map(&:created_at).max
-    event_date || "n/a"
+    format_date(event_date)
+  end
+
+  def format_date(date)
+    if date
+      date.strftime("%b %d, %Y @ %I:%M %P")
+    else
+      "n/a"
+    end
   end
 
   def custom_queries

--- a/spec/decorators/file_set_decorator_spec.rb
+++ b/spec/decorators/file_set_decorator_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe FileSetDecorator do
     context "when there is a preservation object and no events for a file" do
       let(:cloud_good_event) {}
       it "returns success" do
-        expect(decorator.cloud_fixity_success_of(good_file.id)).to eq nil
+        expect(decorator.cloud_fixity_success_of(good_file.id)).to eq("SUCCESS")
         expect(decorator.cloud_fixity_last_success_date_of(good_file.id)).to include("Sep 25, 2023")
       end
     end

--- a/spec/decorators/file_set_decorator_spec.rb
+++ b/spec/decorators/file_set_decorator_spec.rb
@@ -49,13 +49,13 @@ RSpec.describe FileSetDecorator do
   end
 
   describe "fixity" do
-    let(:created_at) { "2023-09-26T17:33:35.013Z" }
+    let(:created_at) { "2023-09-25T17:33:35.013Z" }
     let(:good_file) { FileMetadata.new(label: "good.jp2", id: SecureRandom.uuid, use: Valkyrie::Vocab::PCDMUse.PreservationFile) }
     let(:bad_file) { FileMetadata.new(label: "bad.tif", id: SecureRandom.uuid, use: Valkyrie::Vocab::PCDMUse.IntermediateFile) }
     let(:derivative_file) { FileMetadata.new(label: "derivative.tif", id: SecureRandom.uuid, use: Valkyrie::Vocab::PCDMUse.ServiceFile) }
     let(:good_file_pres) { FileMetadata.new(preservation_copy_of_id: good_file.id, id: SecureRandom.uuid) }
     let(:bad_file_pres) { FileMetadata.new(preservation_copy_of_id: bad_file.id, id: SecureRandom.uuid) }
-    let(:cloud_good_event) { FactoryBot.create_for_repository(:cloud_fixity_event, child_id: good_file_pres.id, status: "SUCCESS", current: true) }
+    let(:cloud_good_event) { FactoryBot.create_for_repository(:cloud_fixity_event, created_at: created_at, child_id: good_file_pres.id, status: "SUCCESS", current: true) }
     let(:cloud_bad_event) { FactoryBot.create_for_repository(:cloud_fixity_event, child_id: bad_file_pres.id, status: "FAILURE", current: true) }
     let(:pres_obj) { FactoryBot.create_for_repository(:preservation_object, created_at: created_at, preserved_object_id: file_set.id, binary_nodes: [good_file_pres, bad_file_pres]) }
     let(:file_set) { FactoryBot.create_for_repository(:file_set, file_metadata: [good_file, bad_file, derivative_file]) }
@@ -68,7 +68,7 @@ RSpec.describe FileSetDecorator do
 
     it "differentiates between the good and bad cloud files" do
       expect(decorator.cloud_fixity_success_of(good_file.id)).to eq("SUCCESS")
-      expect(decorator.cloud_fixity_last_success_date_of(good_file.id)).to eq(cloud_good_event.created_at)
+      expect(decorator.cloud_fixity_last_success_date_of(good_file.id)).to include("Sep 25, 2023")
 
       expect(decorator.cloud_fixity_success_of(bad_file.id)).to eq("FAILURE")
       expect(decorator.cloud_fixity_last_success_date_of(bad_file.id)).to eq("n/a")
@@ -86,16 +86,16 @@ RSpec.describe FileSetDecorator do
       let(:cloud_good_event) {}
       it "returns success" do
         expect(decorator.cloud_fixity_success_of(good_file.id)).to eq nil
-        expect(decorator.cloud_fixity_last_success_date_of(good_file.id)).to eq(created_at)
+        expect(decorator.cloud_fixity_last_success_date_of(good_file.id)).to include("Sep 25, 2023")
       end
     end
 
     context "when local fixity is sucessful" do
       it "reports success for the primary file, and nothing for other files" do
-        local_event = FactoryBot.create_for_repository(:local_fixity_success, resource_id: file_set.id, child_id: good_file.id, current: true)
+        FactoryBot.create_for_repository(:local_fixity_success, created_at: created_at, resource_id: file_set.id, child_id: good_file.id, current: true)
         FactoryBot.create_for_repository(:local_fixity_failure, resource_id: file_set.id, child_id: bad_file.id, current: true)
         expect(decorator.local_fixity_success_of(good_file.id)).to eq("SUCCESS")
-        expect(decorator.local_fixity_last_success_date_of(good_file.id)).to eq(local_event.created_at)
+        expect(decorator.local_fixity_last_success_date_of(good_file.id)).to include("Sep 25, 2023")
         expect(decorator.local_fixity_success_of(bad_file.id)).to eq("FAILURE")
         expect(decorator.local_fixity_last_success_date_of(bad_file.id)).to eq("n/a")
         expect(decorator.local_fixity_success_of(derivative_file.id)).to eq("n/a")

--- a/spec/decorators/file_set_decorator_spec.rb
+++ b/spec/decorators/file_set_decorator_spec.rb
@@ -49,6 +49,7 @@ RSpec.describe FileSetDecorator do
   end
 
   describe "fixity" do
+    let(:created_at) { "2023-09-26T17:33:35.013Z" }
     let(:good_file) { FileMetadata.new(label: "good.jp2", id: SecureRandom.uuid, use: Valkyrie::Vocab::PCDMUse.PreservationFile) }
     let(:bad_file) { FileMetadata.new(label: "bad.tif", id: SecureRandom.uuid, use: Valkyrie::Vocab::PCDMUse.IntermediateFile) }
     let(:derivative_file) { FileMetadata.new(label: "derivative.tif", id: SecureRandom.uuid, use: Valkyrie::Vocab::PCDMUse.ServiceFile) }
@@ -56,7 +57,7 @@ RSpec.describe FileSetDecorator do
     let(:bad_file_pres) { FileMetadata.new(preservation_copy_of_id: bad_file.id, id: SecureRandom.uuid) }
     let(:cloud_good_event) { FactoryBot.create_for_repository(:cloud_fixity_event, child_id: good_file_pres.id, status: "SUCCESS", current: true) }
     let(:cloud_bad_event) { FactoryBot.create_for_repository(:cloud_fixity_event, child_id: bad_file_pres.id, status: "FAILURE", current: true) }
-    let(:pres_obj) { FactoryBot.create_for_repository(:preservation_object, preserved_object_id: file_set.id, binary_nodes: [good_file_pres, bad_file_pres]) }
+    let(:pres_obj) { FactoryBot.create_for_repository(:preservation_object, created_at: created_at, preserved_object_id: file_set.id, binary_nodes: [good_file_pres, bad_file_pres]) }
     let(:file_set) { FactoryBot.create_for_repository(:file_set, file_metadata: [good_file, bad_file, derivative_file]) }
 
     before do
@@ -73,7 +74,7 @@ RSpec.describe FileSetDecorator do
       expect(decorator.cloud_fixity_last_success_date_of(bad_file.id)).to eq("n/a")
     end
 
-    context "when there's no preservation for a file" do
+    context "when there's no preservation object for a file" do
       let(:good_file_pres) { FileMetadata.new(preservation_copy_of_id: SecureRandom.uuid, id: SecureRandom.uuid) }
       it "returns in progress" do
         expect(decorator.cloud_fixity_success_of(good_file.id)).to eq nil
@@ -81,7 +82,15 @@ RSpec.describe FileSetDecorator do
       end
     end
 
-    context "when local fixtiy is sucessful" do
+    context "when there is a preservation object and no events for a file" do
+      let(:cloud_good_event) {}
+      it "returns success" do
+        expect(decorator.cloud_fixity_success_of(good_file.id)).to eq nil
+        expect(decorator.cloud_fixity_last_success_date_of(good_file.id)).to eq(created_at)
+      end
+    end
+
+    context "when local fixity is sucessful" do
       it "reports success for the primary file, and nothing for other files" do
         local_event = FactoryBot.create_for_repository(:local_fixity_success, resource_id: file_set.id, child_id: good_file.id, current: true)
         FactoryBot.create_for_repository(:local_fixity_failure, resource_id: file_set.id, child_id: bad_file.id, current: true)


### PR DESCRIPTION
Closes #5979 

- Display PreservationObject creation date as the cloud fixity date if file has no events
- Improve cloud and local fixity date formatting

![Screenshot 2023-09-26 at 1 59 06 PM](https://github.com/pulibrary/figgy/assets/784196/1dfc1554-01c2-4373-9506-d9b95bb96d22)
