### PR TITLE
Make shapefile reprojection more fault tolerant

### DIFF
--- a/app/derivative_services/geo_derivatives/processors/ogr.rb
+++ b/app/derivative_services/geo_derivatives/processors/ogr.rb
@@ -11,8 +11,9 @@ module GeoDerivatives
         # #param options [Hash] creation options
         # @param out_path [String] processor output file path
         def self.reproject(in_path, out_path, options)
-          execute "env SHAPE_ENCODING= ogr2ogr -q -nln #{options[:id]} -f 'ESRI Shapefile'"\
-                    " -t_srs #{options[:output_srid]} -preserve_fid '#{out_path}' '#{in_path}'"
+          execute "env OGR_ENABLE_PARTIAL_REPROJECTION=YES env SHAPE_ENCODING= ogr2ogr -q "\
+                  "-nln #{options[:id]} -f 'ESRI Shapefile' -t_srs #{options[:output_srid]} "\
+                  "-preserve_fid '#{out_path}' '#{in_path}'"
         end
       end
     end


### PR DESCRIPTION
When regenerating derivates for vector resources, we came across several errors in the gdal/ogr reprojection step.

```
Unable to execute command "env SHAPE_ENCODING= ogr2ogr -q -nln p-69ae9063-fa7f-45bf-8fe2-269b2b6c36b1 -f 'ESRI Shapefile' -t_srs EPSG:4326 -preserve_fid '/tmp/sufia20230929-7277-znakjp_1695996295528' '/tmp/sufia20230929-7277-znakjp_out'". 
Exit code: pid 26089 exit 1 Error message: ERROR 1: Failed to reproject feature 8979 (geometry probably out of source or destination SRS).
ERROR 1: Terminating translation prematurely after failed translation of layer world_mines (use -skipfailures to skip errors)
```

```
Unable to execute command "env SHAPE_ENCODING= ogr2ogr -q -nln p-c3497631-f7dc-4ada-89e3-c13886beac64 -f 'ESRI Shapefile' -t_srs EPSG:4326 -preserve_fid '/tmp/sufia20230929-4163-t17ubm_1695995459867' '/tmp/sufia20230929-4163-t17ubm_out'". 
Exit code: pid 13527 exit 1 Error message: ERROR 1: Full reprojection failed, but partial is possible if you define OGR_ENABLE_PARTIAL_REPROJECTION configuration option to TRUE ERROR 1: Failed to reproject feature 2 (geometry probably out of source or destination SRS). 
ERROR 1: Terminating translation prematurely after failed translation of layer Cuba_2012_census_social_municipality (use -skipfailures to skip errors)
```

This PR the sets OGR_ENABLE_PARTIAL_REPROJECTION to YES to make the process more fault tolerant.