### PR TITLE
Allow search results for child records with parameter

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -156,6 +156,11 @@ class CatalogController < ApplicationController
       assumed_boundaries: [1100, Time.current.year + 1],
       segments: true
     }
+    config.add_facet_field "membership_facet", label: "Membership", query: {
+      no_parent: { label: "No Parent", fq: "!member_of_ssim:['' TO *]" },
+      has_parent: { label: "Has Parent", fq: "member_of_ssim:['' TO *]" }
+    }
+
     config.add_facet_fields_to_solr_request!
 
     config.add_results_collection_tool(:sort_widget)

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -6,19 +6,13 @@ class SearchBuilder < Blacklight::SearchBuilder
   # Add a filter query to restrict the search to documents the current user has access to
   include Hydra::AccessControlsEnforcement
   delegate :unreadable_states, to: :current_ability
-  self.default_processor_chain += [:filter_models, :filter_parented, :hide_incomplete, :hide_suppressed]
+  self.default_processor_chain += [:filter_models, :hide_incomplete, :hide_suppressed]
 
   # Add queries that excludes everything except for works and collections
   def filter_models(solr_parameters)
     return if blacklight_params[:all_models] == "true"
     solr_parameters[:fq] ||= []
     solr_parameters[:fq] << "!{!terms f=internal_resource_ssim}#{models_to_solr_clause}"
-  end
-
-  # Keeps child resources of multi-volume works (MVWs) from appearing in results
-  def filter_parented(solr_params)
-    solr_params[:fq] ||= []
-    solr_params[:fq] << "!member_of_ssim:['' TO *]"
   end
 
   def hide_incomplete(solr_params)

--- a/app/views/shared/_site_search.html.erb
+++ b/app/views/shared/_site_search.html.erb
@@ -2,7 +2,7 @@
   <div class="input-group" id="search-input">
     <legend class="accessible-hidden">Search <%=t('product_name')%></legend>
     <%= label_tag :catalog_search, t('search.form.q.label'), :class => "accessible-hidden" %>
-    <%= render Blacklight::HiddenSearchStateComponent.new(params: (search_state.params_for_search().except(:q, :search_field, :qt, :page, :utf8))) %>
+    <%= render Blacklight::HiddenSearchStateComponent.new(params: (search_state.params_for_search("f"=>{"membership_facet"=>["no_parent"]}).except(:q, :search_field, :qt, :page, :utf8))) %>
     <%= text_field_tag(:q, params[:q], :class => "q search-query form-control", :id => "catalog_search", :placeholder => t('search.form.q.placeholder'), :size => "30", :tabindex => "1", :type => "search") %>
     <div class="input-group-append">
       <button type="submit" class="search-submit btn btn-primary" id="keyword-search-submit" tabindex="2">

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -530,7 +530,7 @@ RSpec.describe CatalogController, type: :controller do
       sign_in FactoryBot.create(:admin)
     end
 
-    context "with a scanned resource" do
+    context "with a scanned resource and the default membership facet value" do
       it "doesn't display children of parented resources" do
         child = persister.save(resource: FactoryBot.build(:complete_scanned_resource))
         parent = persister.save(resource: FactoryBot.build(:complete_scanned_resource, member_ids: child.id))
@@ -538,10 +538,26 @@ RSpec.describe CatalogController, type: :controller do
         #   ChangeSetPersister.
         persister.save(resource: child)
 
-        get :index, params: { q: "" }
+        get :index, params: { q: "", f: { "membership_facet" => "no_parent" } }
 
         expect(assigns(:response).documents.length).to eq 1
         expect(assigns(:response).documents.first.resource.id).to eq parent.id
+      end
+    end
+
+    context "with a scanned resource and the has_parent membership facet value" do
+      it "displays children of parented resources" do
+        child = persister.save(resource: FactoryBot.build(:complete_scanned_resource))
+        persister.save(resource: FactoryBot.build(:complete_scanned_resource, member_ids: child.id))
+
+        # Re-save to get member_of to index, not necessary if going through
+        #   ChangeSetPersister.
+        persister.save(resource: child)
+
+        get :index, params: { q: "", f: { "membership_facet" => "has_parent" } }
+
+        expect(assigns(:response).documents.length).to eq 1
+        expect(assigns(:response).documents.first.resource.id).to eq child.id
       end
     end
 


### PR DESCRIPTION
Closes #6001

- Adds membership facet with two values: "no parent" and "has parent"
- Sets the default facet to "no parent" to replicate the current default search filter
- Removes the filter_parented search filter
- Allows for searching child resources

![Screenshot 2023-10-03 at 12 13 55 PM](https://github.com/pulibrary/figgy/assets/784196/370eb940-1f72-44bb-978b-a8c04ab8e9c7)

![Screenshot 2023-10-03 at 12 14 08 PM](https://github.com/pulibrary/figgy/assets/784196/78b1a83d-8705-4104-b3dc-7cdc2d345573)

