### PR TITLE
Allow auditor to not check metadata checksums.

### DIFF
--- a/app/services/preserver/preservation_checker.rb
+++ b/app/services/preserver/preservation_checker.rb
@@ -3,13 +3,13 @@ class Preserver
   # Encapsulate logic for converting a binary node to a preservation node.
   class PreservationChecker
     # @return [Array<Metadata | Binary>]
-    def self.for(resource:, preservation_object:)
-      binaries_for(resource: resource, preservation_object: preservation_object) + metadata_for(resource: resource, preservation_object: preservation_object)
+    def self.for(resource:, preservation_object:, skip_metadata_checksum: false)
+      binaries_for(resource: resource, preservation_object: preservation_object) + metadata_for(resource: resource, preservation_object: preservation_object, skip_checksum: skip_metadata_checksum)
     end
 
-    def self.metadata_for(resource:, preservation_object:)
+    def self.metadata_for(resource:, preservation_object:, skip_checksum: false)
       [
-        Metadata.new(resource: resource, preservation_object: preservation_object)
+        Metadata.new(resource: resource, preservation_object: preservation_object, skip_checksum: skip_checksum)
       ]
     end
 
@@ -18,10 +18,11 @@ class Preserver
     end
 
     class Metadata
-      attr_reader :resource, :preservation_object
-      def initialize(resource:, preservation_object:)
+      attr_reader :resource, :preservation_object, :skip_checksum
+      def initialize(resource:, preservation_object:, skip_checksum:)
         @resource = resource
         @preservation_object = preservation_object
+        @skip_checksum = skip_checksum
       end
 
       def preservation_file_exists?
@@ -35,6 +36,7 @@ class Preserver
       end
 
       def preserved_file_checksums_match?
+        return true if skip_checksum
         compact_local_md5 == preservation_file.io.file.data[:file].md5
       end
 

--- a/lib/tasks/preservation.rake
+++ b/lib/tasks/preservation.rake
@@ -5,7 +5,7 @@ namespace :figgy do
   namespace :preservation do
     desc "Reports the number of unpreserved models."
     task count_unpreserved: :environment do
-      auditor = PreservationStatusReporter.new
+      auditor = PreservationStatusReporter.new(skip_metadata_checksum: true)
       auditor.load_state!(state_directory: Rails.root.join("tmp", "rake_preservation_audit"))
       failed_count = auditor.cloud_audit_failures.to_a.size
       puts "Number of Resources Needing Re-Preserved: #{failed_count}"

--- a/spec/services/preservation_status_reporter_spec.rb
+++ b/spec/services/preservation_status_reporter_spec.rb
@@ -72,6 +72,16 @@ RSpec.describe PreservationStatusReporter do
       expect(reporter.progress_bar.progress).to eq 13
     end
 
+    it "can skip checking for bad metadata checksums if requested" do
+      stub_ezid
+      # - a scannedresource with a metadata node that has the wrong checksum
+      create_resource_bad_metadata_checksum
+
+      reporter = described_class.new(suppress_progress: true, skip_metadata_checksum: true)
+      # Ensure count of resources it's auditing
+      expect(reporter.cloud_audit_failures.to_a.length).to eq 0
+    end
+
     it "can start at a given timestamp and only reprocess those" do
       stub_ezid
       no_preserving_resource = nil


### PR DESCRIPTION
Until we resolve #5978 this lets us get started with finding resources that have either never been preserved or have broken binaries.