### PR TITLE
Repairing metadata should requeue a fixity check.

### DIFF
--- a/app/services/repair_cloud_fixity.rb
+++ b/app/services/repair_cloud_fixity.rb
@@ -46,6 +46,7 @@ class RepairCloudFixity
 
     def repair_metadata
       Preserver.for(change_set: ChangeSet.for(resource), change_set_persister: ChangeSetPersister.default).preserve!
+      CloudFixity::FixityRequestor.queue_resource_check!(id: resource.id.to_s)
     end
 
     def create_failed_cloud_fixity_event

--- a/spec/services/repair_cloud_fixity_spec.rb
+++ b/spec/services/repair_cloud_fixity_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe RepairCloudFixity do
       described_class.run(event: failed_event)
       expect(Preserver).not_to have_received(:for).with(force_preservation: true, change_set: anything, change_set_persister: anything)
       expect(preserver_double).to have_received(:preserve!)
+      expect(CloudFixity::FixityRequestor).to have_received(:queue_resource_check!).with(id: resource.id.to_s)
     end
   end
 


### PR DESCRIPTION
Refs #6010