### PR TITLE
Force select2-dropdown opacity to be 1.

### DIFF
--- a/app/assets/stylesheets/components/form.scss
+++ b/app/assets/stylesheets/components/form.scss
@@ -21,8 +21,7 @@
       height: 100%;
       padding: 5px;
     }
-  }
-}
+  } }
 
 #metadata {
   .nested-fields {
@@ -373,6 +372,9 @@ form.button-to {
 }
 
 .select2-container {
+  .select2-dropdown {
+    opacity: 1 !important;
+  }
   .select2-search__field {
     height: 36px;
   }


### PR DESCRIPTION
There was a bug where the opacity would get set to 0 sometimes for some reason, making the options hidden.

Closes #6047