### PR TITLE
Stop using temp files for PDF Derivatives

### DIFF
--- a/app/derivative_services/pdf_derivative_service.rb
+++ b/app/derivative_services/pdf_derivative_service.rb
@@ -103,7 +103,7 @@ class PDFDerivativeService
       container_attributes: {
         title: pad_with_zeroes(page)
       },
-      copy_before_ingest: true
+      copy_before_ingest: false
     )
   end
 
@@ -112,7 +112,7 @@ class PDFDerivativeService
   end
 
   def tmpdir
-    @tmpdir ||= Pathname.new(Dir.mktmpdir("pdf_derivatives"))
+    @tmpdir ||= Pathname.new(FileUtils.mkdir_p("#{Dir.tmpdir}/derivative_generation/pdf-#{SecureRandom.uuid}").first)
   end
 
   def temporary_output(page)

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -28,6 +28,10 @@ every :day, at: "11:00 PM", roles: [:db] do
   rake "figgy:clean:expired_local_files"
 end
 
+every :day, at: "12:00 PM", roles: [:db] do
+  rake "figgy:clean:derivative_artifacts"
+end
+
 every 10.minutes, roles: [:db] do
   rake "figgy:cdl:bulk_hold_process"
 end

--- a/lib/tasks/clean.rake
+++ b/lib/tasks/clean.rake
@@ -26,5 +26,17 @@ namespace :figgy do
 
       tus_storage.expire_files(expiration_date)
     end
+
+    desc "Clean old derivative processing files"
+    task derivative_artifacts: :environment do
+      all_files = Dir.glob("#{Dir.tmpdir}/derivative_generation")
+      expiration_date = 1.day.ago
+      all_files.each do |file|
+        if File.mtime(file) <= expiration_date
+          FileUtils.rm_rf(file)
+          puts "Cleaned #{file}"
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
They're randomly disappearing, likely because of garbage collection. A cleanup process we run daily can instead make sure that abandoned files are deleted.

Work towards #5964