### PR TITLE
Use FlatGeobuf as intermediate format for generating pmtiles

### DIFF
--- a/app/derivative_services/geo_derivatives/processors/ogr.rb
+++ b/app/derivative_services/geo_derivatives/processors/ogr.rb
@@ -23,8 +23,8 @@ module GeoDerivatives
         # @param out_path [String] processor output file path
         def self.cloud_reproject(in_path, out_path, options)
           execute "env OGR_ENABLE_PARTIAL_REPROJECTION=YES env ogr2ogr -q "\
-                  "-nln #{options[:id]} -f GeoJSON -t_srs EPSG:4326 "\
-                  "-preserve_fid '#{out_path}' '#{in_path}'"
+                  "-nln #{options[:id]} -f FlatGeobuf -t_srs EPSG:4326 "\
+                  "-preserve_fid '#{out_path}.fgb' '#{in_path}'"
         end
       end
     end

--- a/app/derivative_services/geo_derivatives/processors/tippecanoe.rb
+++ b/app/derivative_services/geo_derivatives/processors/tippecanoe.rb
@@ -11,7 +11,7 @@ module GeoDerivatives
         # @param out_path [String] processor output file path
         def self.generate_pmtiles(in_path, out_path, _options)
           execute "tippecanoe --maximum-tile-features=10000 --no-tile-size-limit " \
-            "-zg --coalesce-densest-as-needed --extend-zooms-if-still-dropping -o #{out_path} #{in_path}"
+            "-zg --coalesce-densest-as-needed --extend-zooms-if-still-dropping -o #{out_path} #{in_path}.fgb"
         end
       end
     end


### PR DESCRIPTION
Using GeoJSON as an intermediate format was causing issues with UTF8 characters. Flatgeobuff is a recommended format for use with Tippecanoe. 