### PR TITLE
Disable queueing for cloud fixity checks.

### DIFF
--- a/app/services/cloud_fixity.rb
+++ b/app/services/cloud_fixity.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+# :nocov:
 module CloudFixity
   require "google/cloud/pubsub"
   class Worker
@@ -103,3 +104,4 @@ module CloudFixity
     end
   end
 end
+# :nocov:

--- a/app/services/cloud_fixity.rb
+++ b/app/services/cloud_fixity.rb
@@ -75,12 +75,12 @@ module CloudFixity
     end
 
     def self.queue_resources(resources, publisher)
-      resources.each do |resource|
-        publish_file_metadata(resource, resource.metadata_node, publisher, :metadata_node) if resource.metadata_node.present?
-        resource.binary_nodes.each do |binary_node|
-          publish_file_metadata(resource, binary_node, publisher, :binary_nodes)
-        end
-      end
+      # resources.each do |resource|
+      #   publish_file_metadata(resource, resource.metadata_node, publisher, :metadata_node) if resource.metadata_node.present?
+      #   resource.binary_nodes.each do |binary_node|
+      #     publish_file_metadata(resource, binary_node, publisher, :binary_nodes)
+      #   end
+      # end
     end
 
     def self.publish_file_metadata(resource, file_metadata, publisher, child_property)

--- a/spec/services/cloud_fixity_spec.rb
+++ b/spec/services/cloud_fixity_spec.rb
@@ -78,6 +78,8 @@ RSpec.describe CloudFixity do
 
   describe ".queue_daily_check!" do
     it "queues a random per-day subset given an annual percent to check" do
+      # @see https://github.com/pulibrary/figgy/issues/6067
+      skip "feature disabled while we finalize preservation"
       id = SecureRandom.uuid
       id2 = SecureRandom.uuid
       resources = Array.new(10) do |_n|
@@ -121,6 +123,8 @@ RSpec.describe CloudFixity do
 
   describe ".queue_resource_check!" do
     it "queues a single resource to check" do
+      # @see https://github.com/pulibrary/figgy/issues/6067
+      skip "feature disabled while we finalize preservation"
       id = SecureRandom.uuid
       id2 = SecureRandom.uuid
       resource = FactoryBot.create_for_repository(:scanned_resource)


### PR DESCRIPTION
For some reason something's sending hundreds of thousands of these. It's too many, and too expensive, and a Repair's being sent for every one which is even more expensive. So turning this off for now while we investigate.

This is deployed to production.