### PR TITLE
Correctly index RasterResources with ScannedMap parents

### DIFF
--- a/app/indexers/member_of_indexer.rb
+++ b/app/indexers/member_of_indexer.rb
@@ -29,6 +29,7 @@ class MemberOfIndexer
   end
 
   def raster_set_member
-    resource.is_a?(RasterResource) && parents.first.is_a?(RasterResource)
+    return false unless resource.is_a?(RasterResource)
+    parents.first.is_a?(RasterResource) || parents.first.is_a?(ScannedMap)
   end
 end

--- a/app/services/geo_discovery/document_builder/relationship_builder.rb
+++ b/app/services/geo_discovery/document_builder/relationship_builder.rb
@@ -29,10 +29,15 @@ module GeoDiscovery
           resource_decorator.model.is_a?(ScannedMap)
         end
 
+        def raster?
+          resource_decorator.model.is_a?(RasterResource)
+        end
+
         # Returns an array of parent document ids (slugs).
         # @return [Array] parent document slugs.
         def source
-          return unless scanned_map? && parent?
+          return unless scanned_map? || raster?
+          return unless parent?
           parents
         end
 
@@ -40,7 +45,8 @@ module GeoDiscovery
         # @return [Boolean] should document be supressed?
         def suppressed
           return false if resource_decorator.model.gbl_suppressed_override == "1"
-          return false unless scanned_map? && parent?
+          return false unless scanned_map? || raster?
+          return false unless parent?
           true
         end
     end

--- a/spec/indexers/member_of_indexer_spec.rb
+++ b/spec/indexers/member_of_indexer_spec.rb
@@ -14,12 +14,24 @@ RSpec.describe MemberOfIndexer do
     end
 
     context "for raster resources" do
-      it "indexes parent resource ids" do
-        child = FactoryBot.create_for_repository(:raster_resource)
-        parent = FactoryBot.create_for_repository(:raster_resource, member_ids: child.id)
-        output = described_class.new(resource: child).to_solr
+      context "when the parent is a RasterResource" do
+        it "indexes parent resource ids" do
+          child = FactoryBot.create_for_repository(:raster_resource)
+          parent = FactoryBot.create_for_repository(:raster_resource, member_ids: child.id)
+          output = described_class.new(resource: child).to_solr
 
-        expect(output["member_of_ssim"]).to eq ["id-#{parent.id}"]
+          expect(output["member_of_ssim"]).to eq ["id-#{parent.id}"]
+        end
+      end
+
+      context "when the parent is a ScannedMap" do
+        it "indexes parent resource ids" do
+          child = FactoryBot.create_for_repository(:raster_resource)
+          parent = FactoryBot.create_for_repository(:scanned_map, member_ids: child.id)
+          output = described_class.new(resource: child).to_solr
+
+          expect(output["member_of_ssim"]).to eq ["id-#{parent.id}"]
+        end
       end
     end
   end

--- a/spec/services/geo_discovery/document_builder_spec.rb
+++ b/spec/services/geo_discovery/document_builder_spec.rb
@@ -462,6 +462,25 @@ describe GeoDiscovery::DocumentBuilder, skip_fixity: true do
         expect(refs["http://www.opengis.net/def/serviceType/ogc/wmts"]).to eq "https://map-tiles-test.example.com/mosaicjson/WMTSCapabilities.xml?id=#{id}"
         expect(refs["https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames"]).to eq "https://map-tiles-test.example.com/mosaicjson/tiles/WebMercatorQuad/{z}/{x}/{y}@1x.png?id=#{id}"
       end
+
+      context "with a child resource" do
+        let(:parent_work) do
+          FactoryBot.create_for_repository(
+            :raster_set_with_files,
+            coverage: coverage.to_s
+          )
+        end
+
+        let(:geo_work) do
+          query_service.find_by(id: parent_work.member_ids.first)
+        end
+
+        it "returns a suppressed document with a source field" do
+          geo_work
+          expect(document["suppressed_b"]).to eq true
+          expect(document["dc_source_sm"]).to eq ["princeton-#{parent_work.id}"]
+        end
+      end
     end
 
     context "with an authenticated raster set" do


### PR DESCRIPTION
Work towards #5858.

Fixes display and indexing issues in both Figgy and Pulmap. RasterResources will need to be re-indexed in both systems.
- Index RasterResources as member if parent is ScannedMap
- Generate correct geoblacklight documents for rasters with scanned map parents
