### PR TITLE
Cache eligible CDL item IDs for 5 minutes.

### DIFF
--- a/app/services/cdl/eligible_item_service.rb
+++ b/app/services/cdl/eligible_item_service.rb
@@ -4,13 +4,15 @@ module CDL
   class EligibleItemService
     class << self
       def item_ids(source_metadata_identifier:)
-        return [] unless RemoteRecord.catalog?(source_metadata_identifier)
-        item_ids = get_item_ids(source_metadata_identifier: source_metadata_identifier)
-        # If no matches, try the alma ID version.
-        if item_ids.empty?
-          get_item_ids(source_metadata_identifier: "99#{source_metadata_identifier}3506421")
-        else
-          item_ids
+        Rails.cache.fetch("cdl_item_ids_#{source_metadata_identifier}", expires_in: 5.minutes) do
+          return [] unless RemoteRecord.catalog?(source_metadata_identifier)
+          item_ids = get_item_ids(source_metadata_identifier: source_metadata_identifier)
+          # If no matches, try the alma ID version.
+          if item_ids.empty?
+            get_item_ids(source_metadata_identifier: "99#{source_metadata_identifier}3506421")
+          else
+            item_ids
+          end
         end
       end
 

--- a/spec/services/cdl/eligible_item_service_spec.rb
+++ b/spec/services/cdl/eligible_item_service_spec.rb
@@ -98,6 +98,14 @@ RSpec.describe CDL::EligibleItemService do
       it "returns the item pid" do
         expect(described_class.item_ids(source_metadata_identifier: bib_id)).to eq ["23202918780006421"]
       end
+
+      it "caches the response for 5 minutes" do
+        allow(Rails.cache).to receive(:fetch).and_call_original
+
+        expect(described_class.item_ids(source_metadata_identifier: bib_id)).to be_present
+
+        expect(Rails.cache).to have_received(:fetch).with("cdl_item_ids_#{bib_id}", expires_in: 5.minutes)
+      end
     end
 
     context "a non-alma ID has no items, but an alma one does" do


### PR DESCRIPTION
This should speed up lookups for back-to-back CDL status in the catalog, but still be able to respond to taking CDL items off.

Work towards #6061