### PR TITLE
Set explicit no-data value for raster derivatives

### DIFF
--- a/app/derivative_services/geo_derivatives/processors/gdal.rb
+++ b/app/derivative_services/geo_derivatives/processors/gdal.rb
@@ -48,11 +48,11 @@ module GeoDerivatives
         def self.cloud_optimized_geotiff(in_path, out_path, _options)
           system("gdaladdo -q -r average #{in_path} 2 4 8 16 32")
           execute("gdal_translate -q -expand rgb #{in_path} #{out_path} -ot Byte -co TILED=YES "\
-                    "-co COMPRESS=LZW -co COPY_SRC_OVERVIEWS=YES")
+                    "-a_nodata 256 -co COMPRESS=LZW -co COPY_SRC_OVERVIEWS=YES")
         rescue StandardError
           # Try without expanding rgb
           execute("gdal_translate -q #{in_path} #{out_path} -ot Byte -co TILED=YES "\
-                    "-co COMPRESS=LZW -co COPY_SRC_OVERVIEWS=YES")
+                    "-a_nodata 256 -co COMPRESS=LZW -co COPY_SRC_OVERVIEWS=YES")
         end
 
         # Executes a gdal_rasterize command. Used to rasterize vector


### PR DESCRIPTION
Closes #6088

Restores transparency to clipped raster derivatives.

![Screenshot 2023-11-17 at 11 05 36 AM](https://github.com/pulibrary/figgy/assets/784196/583adfc8-7610-4f19-bde1-2cf4083ff9bb)
