### PR TITLE
improve mosaics

### DIFF
--- a/app/change_set_persisters/change_set_persister/generate_mosaic.rb
+++ b/app/change_set_persisters/change_set_persister/generate_mosaic.rb
@@ -19,7 +19,7 @@ class ChangeSetPersister
 
       def published?(change_set)
         published_states = change_set.resource.decorate.workflow_class.ark_mint_states
-        change_set.changed?(:state) && published_states.include?(change_set.state.to_s)
+        published_states.include?(change_set.state.to_s)
       end
 
       def mosaic?(resource)

--- a/app/change_set_persisters/change_set_persister/generate_mosaic.rb
+++ b/app/change_set_persisters/change_set_persister/generate_mosaic.rb
@@ -11,7 +11,8 @@ class ChangeSetPersister
     def run
       return unless mosaic?(post_save_resource)
       return unless published?(change_set)
-      MosaicJob.perform_later(post_save_resource.id.to_s)
+      fingerprint = query_service.custom_queries.mosaic_fingerprint_for(id: post_save_resource.id)
+      MosaicJob.perform_later(resource_id: post_save_resource.id.to_s, fingerprint: fingerprint)
       change_set
     end
 
@@ -33,6 +34,10 @@ class ChangeSetPersister
         else
           false
         end
+      end
+
+      def query_service
+        change_set_persister.query_service
       end
   end
 end

--- a/app/controllers/tile_metadata_controller.rb
+++ b/app/controllers/tile_metadata_controller.rb
@@ -33,13 +33,13 @@ class TileMetadataController < ApplicationController
 
     def cached_mosaic_path
       # Cache expires after 10 minutes. Race condition TTL set to 60 seconds - if
-      # the fingerprinted mosaic is not found in S3, then it is generated on the
+      # the  mosaic is not found in S3, then it is generated on the
       # fly which can take some time. This multiple calls to the endpoint from
       # generating the document at the same time.
       Rails.cache.fetch("mosaic-manifest-#{params[:id]}", expires_in: 600, race_condition_ttl: 60) do
         resource = find_resource(params[:id])
         return nil unless resource.is_a?(RasterResource) || resource.is_a?(ScannedMap)
-        TileMetadataService.new(resource: resource).path
+        Valkyrie::Storage::Disk::BucketedStorage.new(base_path: base_path).generate(resource: resource, original_filename: "mosaic.json", file: nil).to_s
       end
     end
 

--- a/app/controllers/tile_metadata_controller.rb
+++ b/app/controllers/tile_metadata_controller.rb
@@ -39,7 +39,7 @@ class TileMetadataController < ApplicationController
       Rails.cache.fetch("mosaic-manifest-#{params[:id]}", expires_in: 600, race_condition_ttl: 60) do
         resource = find_resource(params[:id])
         return nil unless resource.is_a?(RasterResource) || resource.is_a?(ScannedMap)
-        Valkyrie::Storage::Disk::BucketedStorage.new(base_path: base_path).generate(resource: resource, original_filename: "mosaic.json", file: nil).to_s
+        TileMetadataService.new(resource: resource).path
       end
     end
 

--- a/app/derivative_services/raster_resource_derivative_service.rb
+++ b/app/derivative_services/raster_resource_derivative_service.rb
@@ -188,7 +188,8 @@ class RasterResourceDerivativeService
     def generate_mosaic
       ancestor_resource = find_ancestor(resource)
       return unless ancestor_resource.is_a?(RasterResource) || ancestor_resource.is_a?(ScannedMap)
-      MosaicJob.perform_later(ancestor_resource.id.to_s)
+      fingerprint = query_service.custom_queries.mosaic_fingerprint_for(id: ancestor_resource.id)
+      MosaicJob.perform_later(resource_id: ancestor_resource.id.to_s, fingerprint: fingerprint)
     end
 
     # Recursively find a resource's base ancestor

--- a/app/derivative_services/raster_resource_derivative_service.rb
+++ b/app/derivative_services/raster_resource_derivative_service.rb
@@ -185,6 +185,9 @@ class RasterResourceDerivativeService
       end
     end
 
+    # The mosaic needs to be regenerated if any part of a MapSet's hierarchy changes, so
+    # for any map resource look up in its hierarchy for the root node and regenerate the Mosaic
+    # if it should have one.
     def generate_mosaic
       ancestor_resource = find_ancestor(resource)
       return unless ancestor_resource.is_a?(RasterResource) || ancestor_resource.is_a?(ScannedMap)

--- a/app/derivative_services/raster_resource_derivative_service.rb
+++ b/app/derivative_services/raster_resource_derivative_service.rb
@@ -188,7 +188,6 @@ class RasterResourceDerivativeService
     def generate_mosaic
       ancestor_resource = find_ancestor(resource)
       return unless ancestor_resource.is_a?(RasterResource) || ancestor_resource.is_a?(ScannedMap)
-      return unless ancestor_resource.decorate.public_readable_state?
       MosaicJob.perform_later(ancestor_resource.id.to_s)
     end
 

--- a/app/derivative_services/raster_resource_derivative_service.rb
+++ b/app/derivative_services/raster_resource_derivative_service.rb
@@ -193,7 +193,7 @@ class RasterResourceDerivativeService
     end
 
     # Recursively find a resource's base ancestor
-    # E.g. Find the MapSet in this chain: FileSet -> RasterResource -> ScannedMap -> ScannedMap*
+    # E.g. Finds the MapSet in this chain: FileSet -> RasterResource -> ScannedMap -> ScannedMap*
     def find_ancestor(resource)
       parent = resource.decorate.parents&.first
       if parent

--- a/app/jobs/mosaic_job.rb
+++ b/app/jobs/mosaic_job.rb
@@ -12,7 +12,7 @@ class MosaicJob < ApplicationJob
     @fingerprint = fingerprint
     return unless valid_fingerprint?
     raise JobRunning if currently_running?
-    TileMetadataService.new(resource: resource, generate: true).path
+    path = TileMetadataService.new(resource: resource, generate: true).path
     # TODO: Trigger job/process to invalidate cache
   end
 

--- a/app/jobs/mosaic_job.rb
+++ b/app/jobs/mosaic_job.rb
@@ -7,6 +7,8 @@ class MosaicJob < ApplicationJob
   delegate :query_service, to: :metadata_adapter
 
   attr_reader :resource_id
+  # TODO: Pass in current thumbprint and check against current.
+  # Cancel job if they don't match.
   def perform(resource_id)
     @resource_id = resource_id
     raise JobRunning if currently_running?

--- a/app/jobs/mosaic_job.rb
+++ b/app/jobs/mosaic_job.rb
@@ -4,12 +4,25 @@ class MosaicJob < ApplicationJob
   queue_as :low
   delegate :query_service, to: :metadata_adapter
 
+  attr_reader :resource_id
   def perform(resource_id)
-    resource = query_service.find_by(id: Valkyrie::ID.new(resource_id))
+    @resource_id = resource_id
+    return if currently_enqueued?
     TileMetadataService.new(resource: resource).path
   end
 
   private
+
+    def currently_enqueued?
+      queue = Sidekiq::Queue.new("low")
+      job = queue.find { |j| j.item.dig("args", 0, "job_class") == "MosaicJob" && j.item.dig("args", 0, "arguments", 0) == resource_id }
+      return true if job
+      false
+    end
+
+    def resource
+      query_service.find_by(id: Valkyrie::ID.new(resource_id))
+    end
 
     def metadata_adapter
       Valkyrie::MetadataAdapter.find(:indexing_persister)

--- a/app/jobs/mosaic_job.rb
+++ b/app/jobs/mosaic_job.rb
@@ -12,9 +12,7 @@ class MosaicJob < ApplicationJob
     @fingerprint = fingerprint
     return unless valid_fingerprint?
     raise JobRunning if currently_running?
-    path = TileMetadataService.new(resource: resource, generate: true).path
-    path
-    # TODO: Trigger job/process to invalidate cache
+    TileMetadataService.new(resource: resource, generate: true).path
   end
 
   private

--- a/app/jobs/mosaic_job.rb
+++ b/app/jobs/mosaic_job.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 class MosaicJob < ApplicationJob
   discard_on TileMetadataService::Error
-  queue_as :low
+  queue_as :serial
   delegate :query_service, to: :metadata_adapter
 
   attr_reader :resource_id
   def perform(resource_id)
     @resource_id = resource_id
     return if currently_enqueued?
-    TileMetadataService.new(resource: resource).path
+    TileMetadataService.new(resource: resource, generate: true).path
   end
 
   private
 
     def currently_enqueued?
-      queue = Sidekiq::Queue.new("low")
+      queue = Sidekiq::Queue.new("serial")
       job = queue.find { |j| j.item.dig("args", 0, "job_class") == "MosaicJob" && j.item.dig("args", 0, "arguments", 0) == resource_id }
       return true if job
       false

--- a/app/jobs/mosaic_job.rb
+++ b/app/jobs/mosaic_job.rb
@@ -13,6 +13,7 @@ class MosaicJob < ApplicationJob
     return unless valid_fingerprint?
     raise JobRunning if currently_running?
     path = TileMetadataService.new(resource: resource, generate: true).path
+    path
     # TODO: Trigger job/process to invalidate cache
   end
 

--- a/app/jobs/mosaic_job.rb
+++ b/app/jobs/mosaic_job.rb
@@ -17,11 +17,17 @@ class MosaicJob < ApplicationJob
 
   private
 
+    # Compare the mosaic fingerprint passed in when the job was created with the
+    # current fingerprint. If they don't match, this implies that the mosiac
+    # structure was changed and the job should exit without generating a mosaic
+    # document. Another mosaic job on the queue will have the current fingerprint value.
     def valid_fingerprint?
       current_fingerprint = query_service.custom_queries.mosaic_fingerprint_for(id: resource.id)
       current_fingerprint == fingerprint
     end
 
+    # Only one MosaicJob per resource should run at a time. This is to prevent conditions
+    # where mosaic jobs finish out of order and produce an incorrect mosaic json document.
     def currently_running?
       workers = Sidekiq::Workers.new
       _, _, work = workers.find { |_, _, work| work.dig("payload", "args", 0, "job_class") == "MosaicJob" && work.dig("payload", "args", 0, "arguments", 0, "resource_id") == resource.id }

--- a/app/services/tile_metadata_service.rb
+++ b/app/services/tile_metadata_service.rb
@@ -11,7 +11,7 @@ class TileMetadataService
     @generate = generate
   end
 
-  def path
+  def full_path
     raise Error if raster_file_sets.empty?
     if mosaic?
       # Path to mosaic.json file
@@ -20,6 +20,10 @@ class TileMetadataService
       # Path to cloud raster file
       raster_paths.first
     end
+  end
+
+  def path
+    full_path.gsub(base_path, "")
   end
 
   def mosaic?

--- a/app/services/tile_metadata_service.rb
+++ b/app/services/tile_metadata_service.rb
@@ -4,10 +4,11 @@
 # It calls out to the MosaicGenerator as needed.
 class TileMetadataService
   class Error < StandardError; end
-  attr_reader :resource
+  attr_reader :resource, :generate
   # @param resource [RasterResource, ScannedMap]
-  def initialize(resource:)
+  def initialize(resource:, generate: false)
     @resource = resource.decorate
+    @generate = generate
   end
 
   def path
@@ -30,7 +31,10 @@ class TileMetadataService
 
   def mosaic_path
     # build default mosaic file
-    raise Error unless MosaicGenerator.new(output_path: tmp_file.path, raster_paths: raster_paths).run
+    if @generate
+      raise Error unless MosaicGenerator.new(output_path: tmp_file.path, raster_paths: raster_paths).run
+    end
+
     build_node(default_filename)
     Valkyrie::Storage::Disk::BucketedStorage.new(base_path: base_path).generate(resource: resource, original_filename: default_filename, file: nil).to_s
   end

--- a/app/values/tile_path.rb
+++ b/app/values/tile_path.rb
@@ -8,13 +8,7 @@ class TilePath
 
   def tilejson
     return unless valid?
-    # Our tile service doesn't know how to resolve IDs for development, so just
-    # put the direct URL to S3 here.
-    if Rails.env.development?
-      "#{tileserver}/#{endpoint}/tilejson.json?url=#{TileMetadataService.new(resource: resource).path}"
-    else
-      "#{tileserver}/#{id}/#{endpoint}/tilejson.json"
-    end
+    "#{tileserver}/#{id}/#{endpoint}/tilejson.json"
   end
 
   def wmts
@@ -70,11 +64,5 @@ class TilePath
 
     def raster_file_sets
       @raster_file_sets ||= query_service.custom_queries.mosaic_file_sets_for(id: resource.id)
-    end
-
-    def raster_paths
-      raster_file_sets.map do |fs|
-        fs.file_metadata.map(&:cloud_uri)
-      end.flatten.compact
     end
 end

--- a/app/values/tile_path.rb
+++ b/app/values/tile_path.rb
@@ -13,18 +13,18 @@ class TilePath
     if Rails.env.development?
       "#{tileserver}/#{endpoint}/tilejson.json?url=#{TileMetadataService.new(resource: resource).path}"
     else
-      "#{tileserver}/#{endpoint}/tilejson.json?id=#{id}"
+      "#{tileserver}/#{id}/#{endpoint}/tilejson.json"
     end
   end
 
   def wmts
     return unless valid?
-    "#{tileserver}/#{endpoint}/WMTSCapabilities.xml?id=#{id}"
+    "#{tileserver}/#{id}/#{endpoint}/WMTSCapabilities.xml"
   end
 
   def xyz
     return unless valid?
-    "#{tileserver}/#{endpoint}/tiles/WebMercatorQuad/{z}/{x}/{y}@1x.png?id=#{id}"
+    "#{tileserver}/#{id}/#{endpoint}/tiles/WebMercatorQuad/{z}/{x}/{y}@1x.png"
   end
 
   private
@@ -38,7 +38,13 @@ class TilePath
     end
 
     def id
-      resource.id.to_s.delete("-")
+      if mosaic?
+        resource.id.to_s.delete("-")
+      else
+        fs = query_service.custom_queries.mosaic_file_sets_for(id: resource.id).first
+        fm = fs.file_metadata.find { |m| m.cloud_uri.present? }
+        fm.cloud_uri.gsub(/^.*\/\//, "").split("/")[-2].delete("-")
+      end
     end
 
     def tileserver
@@ -54,7 +60,7 @@ class TilePath
     def mosaic?
       # A mosaic is single service comprised of multiple raster datasets.
       # This tests if there are multiple child raster FileSets.
-      return true if raster_file_sets.count > 1
+      return true if raster_file_sets && raster_file_sets.count > 1
       false
     end
 
@@ -64,5 +70,11 @@ class TilePath
 
     def raster_file_sets
       @raster_file_sets ||= query_service.custom_queries.mosaic_file_sets_for(id: resource.id)
+    end
+
+    def raster_paths
+      raster_file_sets.map do |fs|
+        fs.file_metadata.map(&:cloud_uri)
+      end.flatten.compact
     end
 end

--- a/config/initializers/honeybadger.rb
+++ b/config/initializers/honeybadger.rb
@@ -3,6 +3,7 @@
 # Errors for honeybadger to ignore.
 # https://docs.honeybadger.io/ruby/getting-started/ignoring-errors.html#ignore-programmatically
 Honeybadger.configure do |config|
+  config.exceptions.ignore += ["MosaicJob::JobRunning"]
   config.before_notify do |notice|
     # Ignore Shapefile encoding errors.
     if /ogr2ogr -q -nln/.match?(notice.error_message)

--- a/spec/change_set_persisters/change_set_persister_spec.rb
+++ b/spec/change_set_persisters/change_set_persister_spec.rb
@@ -1868,6 +1868,7 @@ RSpec.describe ChangeSetPersister do
   context "when deleting a raster geo FileSet", run_real_characterization: true, run_real_derivatives: true do
     before do
       allow(GeoserverPublishJob).to receive(:perform_now)
+      allow(MosaicJob).to receive(:perform_later)
     end
 
     it "does not trigger a geoserver publish job" do

--- a/spec/controllers/tile_metadata_controller_spec.rb
+++ b/spec/controllers/tile_metadata_controller_spec.rb
@@ -12,8 +12,6 @@ RSpec.describe TileMetadataController, type: :controller do
     FileUtils.rm_rf(Figgy.config["test_cloud_geo_derivative_path"])
   end
 
-  let(:cloud_path) { Pathname.new(Figgy.config["test_cloud_geo_derivative_path"]) }
-
   describe "#tilejson" do
     with_queue_adapter :inline
     it "redirects to the tilejson URL" do
@@ -38,37 +36,14 @@ RSpec.describe TileMetadataController, type: :controller do
     context "with a RasterSet" do
       with_queue_adapter :inline
 
-      it "returns json with the fingerprinted mosaic uri" do
+      it "returns json with the mosaic uri" do
         mosaic_generator = instance_double(MosaicGenerator)
         allow(mosaic_generator).to receive(:run).and_return(true)
         allow(MosaicGenerator).to receive(:new).and_return(mosaic_generator)
         raster_set = FactoryBot.create_for_repository(:raster_set_with_files, id: "331d70a5-4bd9-4a65-80e4-763c8f6b34fd")
-        fingerprint = query_service.custom_queries.mosaic_fingerprint_for(id: raster_set.id)
         get :metadata, params: { id: raster_set.id, format: :json }
 
-        expect(JSON.parse(response.body)["uri"]).to end_with("tmp/cloud_geo_derivatives#{ENV['TEST_ENV_NUMBER']}/33/1d/70/331d70a54bd94a6580e4763c8f6b34fd/mosaic-#{fingerprint}.json")
-      end
-    end
-
-    context "when a RasterSet is updated" do
-      with_queue_adapter :inline
-
-      it "returns json with a different mosaic uri" do
-        mosaic_generator = instance_double(MosaicGenerator)
-        allow(mosaic_generator).to receive(:run).and_return(true)
-        allow(MosaicGenerator).to receive(:new).and_return(mosaic_generator)
-        raster_set = FactoryBot.create_for_repository(:raster_set_with_three_files, id: "331d70a5-4bd9-4a65-80e4-763c8f6b34fd")
-        first_fingerprint = query_service.custom_queries.mosaic_fingerprint_for(id: raster_set.id)
-
-        # Delete file from of raster_set member
-        child = Wayfinder.for(raster_set).members.first
-        grandchild = Wayfinder.for(child).members.first
-        persister.delete(resource: grandchild)
-        second_fingerprint = query_service.custom_queries.mosaic_fingerprint_for(id: raster_set.id)
-
-        get :metadata, params: { id: raster_set.id, format: :json }
-        expect(JSON.parse(response.body)["uri"]).not_to end_with("tmp/cloud_geo_derivatives#{ENV['TEST_ENV_NUMBER']}/33/1d/70/331d70a54bd94a6580e4763c8f6b34fd/mosaic-#{first_fingerprint}.json")
-        expect(JSON.parse(response.body)["uri"]).to end_with("tmp/cloud_geo_derivatives#{ENV['TEST_ENV_NUMBER']}/33/1d/70/331d70a54bd94a6580e4763c8f6b34fd/mosaic-#{second_fingerprint}.json")
+        expect(JSON.parse(response.body)["uri"]).to end_with("tmp/cloud_geo_derivatives#{ENV['TEST_ENV_NUMBER']}/33/1d/70/331d70a54bd94a6580e4763c8f6b34fd/mosaic.json")
       end
     end
 
@@ -90,16 +65,15 @@ RSpec.describe TileMetadataController, type: :controller do
     end
 
     context "with a MapSet that has Raster grandchildren" do
-      it "returns json with the fingerprinted mosaic uri" do
+      it "returns json with the mosaic uri" do
         scanned_map = FactoryBot.create_for_repository(:scanned_map_with_multiple_clipped_raster_children)
         map_set = FactoryBot.create_for_repository(:scanned_map, member_ids: [scanned_map.id], id: "331d70a5-4bd9-4a65-80e4-763c8f6b34fd")
         mosaic_generator = instance_double(MosaicGenerator)
         allow(mosaic_generator).to receive(:run).and_return(true)
         allow(MosaicGenerator).to receive(:new).and_return(mosaic_generator)
-        fingerprint = query_service.custom_queries.mosaic_fingerprint_for(id: map_set.id)
         get :metadata, params: { id: map_set.id, format: :json }
 
-        expect(JSON.parse(response.body)["uri"]).to end_with("tmp/cloud_geo_derivatives#{ENV['TEST_ENV_NUMBER']}/33/1d/70/331d70a54bd94a6580e4763c8f6b34fd/mosaic-#{fingerprint}.json")
+        expect(JSON.parse(response.body)["uri"]).to end_with("tmp/cloud_geo_derivatives#{ENV['TEST_ENV_NUMBER']}/33/1d/70/331d70a54bd94a6580e4763c8f6b34fd/mosaic.json")
       end
     end
 

--- a/spec/controllers/tile_metadata_controller_spec.rb
+++ b/spec/controllers/tile_metadata_controller_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe TileMetadataController, type: :controller do
   let(:persister) { adapter.persister }
   let(:query_service) { adapter.query_service }
 
+  before do
+    allow(MosaicJob).to receive(:perform_later)
+  end
+
   after(:all) do
     # Clean up mosaic.json documents and cloud rasters after test suite
     FileUtils.rm_rf(Figgy.config["test_cloud_geo_derivative_path"])
@@ -19,7 +23,7 @@ RSpec.describe TileMetadataController, type: :controller do
 
       get :tilejson, params: { id: raster_set.id, format: :json }
 
-      expect(response).to redirect_to "https://map-tiles-test.example.com/mosaicjson/tilejson.json?id=#{raster_set.id.to_s.tr('-', '')}"
+      expect(response).to redirect_to "https://map-tiles-test.example.com/#{raster_set.id.to_s.tr('-', '')}/mosaicjson/tilejson.json"
     end
     it "returns not_found if not given a mosaic" do
       scanned_resource = FactoryBot.create_for_repository(:scanned_resource)
@@ -43,7 +47,7 @@ RSpec.describe TileMetadataController, type: :controller do
         raster_set = FactoryBot.create_for_repository(:raster_set_with_files, id: "331d70a5-4bd9-4a65-80e4-763c8f6b34fd")
         get :metadata, params: { id: raster_set.id, format: :json }
 
-        expect(JSON.parse(response.body)["uri"]).to end_with("tmp/cloud_geo_derivatives#{ENV['TEST_ENV_NUMBER']}/33/1d/70/331d70a54bd94a6580e4763c8f6b34fd/mosaic.json")
+        expect(JSON.parse(response.body)["uri"]).to end_with("/33/1d/70/331d70a54bd94a6580e4763c8f6b34fd/mosaic.json")
       end
     end
 
@@ -73,7 +77,7 @@ RSpec.describe TileMetadataController, type: :controller do
         allow(MosaicGenerator).to receive(:new).and_return(mosaic_generator)
         get :metadata, params: { id: map_set.id, format: :json }
 
-        expect(JSON.parse(response.body)["uri"]).to end_with("tmp/cloud_geo_derivatives#{ENV['TEST_ENV_NUMBER']}/33/1d/70/331d70a54bd94a6580e4763c8f6b34fd/mosaic.json")
+        expect(JSON.parse(response.body)["uri"]).to end_with("/33/1d/70/331d70a54bd94a6580e4763c8f6b34fd/mosaic.json")
       end
     end
 

--- a/spec/decorators/raster_resource_decorator_spec.rb
+++ b/spec/decorators/raster_resource_decorator_spec.rb
@@ -20,6 +20,11 @@ RSpec.describe RasterResourceDecorator do
                        coverage: imported_coverage
                      }])
   end
+
+  before do
+    allow(MosaicJob).to receive(:perform_later)
+  end
+
   it "exposes markup for rights statement" do
     expect(resource.decorate.rendered_rights_statement).not_to be_empty
     expect(resource.decorate.rendered_rights_statement.first).to match(/#{Regexp.escape(RightsStatements.no_known_copyright.to_s)}/)

--- a/spec/derivative_services/raster_resource_derivative_service_spec.rb
+++ b/spec/derivative_services/raster_resource_derivative_service_spec.rb
@@ -104,7 +104,8 @@ RSpec.describe RasterResourceDerivativeService do
       change_set = ChangeSet.for(raster)
       change_set.files = [fixture_file_upload("files/raster/geotiff.tif", "image/tif")]
       change_set_persister.save(change_set: change_set)
-      expect(MosaicJob).to have_received(:perform_later).once.with(map_set.id.to_s)
+      fingerprint = query_service.custom_queries.mosaic_fingerprint_for(id: map_set.id)
+      expect(MosaicJob).to have_received(:perform_later).once.with(resource_id: map_set.id.to_s, fingerprint: fingerprint)
     end
   end
 

--- a/spec/jobs/mosaic_job_spec.rb
+++ b/spec/jobs/mosaic_job_spec.rb
@@ -17,5 +17,38 @@ describe MosaicJob do
       described_class.perform_now(raster_set.id)
       expect(mosaic_service).to have_received(:path)
     end
+
+    context "when a MosaicJob is already enqueued" do
+      before do
+      end
+      it "does not run the TileMetadataService" do
+        raster_set = FactoryBot.create_for_repository(:raster_set_with_files)
+        job_item = {
+          "retry" => true,
+          "queue" => "low",
+          "class" => "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper",
+          "wrapped" => "MosaicJob",
+          "args" =>
+                      [{ "job_class" => "MosaicJob",
+                         "job_id" => "12cfd9ff-5555-6666-8892-f44d386967d3",
+                         "provider_job_id" => nil,
+                         "queue_name" => "low",
+                         "priority" => nil,
+                         "arguments" => [raster_set.id.to_s],
+                         "executions" => 0,
+                         "exception_executions" => {},
+                         "locale" => "en",
+                         "timezone" => "UTC",
+                         "enqueued_at" => "2023-11-03T18:26:41Z" }],
+          "jid" => "73ff1c5050ce8adba5feab66",
+          "created_at" => 1_699_036_001.1491642,
+          "enqueued_at" => 1_699_036_001.1493726
+        }
+        job_record = instance_double(Sidekiq::JobRecord, item: job_item)
+        allow(Sidekiq::Queue).to receive(:new).and_return([job_record])
+        described_class.perform_now(raster_set.id)
+        expect(mosaic_service).not_to have_received(:path)
+      end
+    end
   end
 end

--- a/spec/jobs/mosaic_job_spec.rb
+++ b/spec/jobs/mosaic_job_spec.rb
@@ -2,8 +2,6 @@
 require "rails_helper"
 
 describe MosaicJob do
-  with_queue_adapter :inline
-
   let(:mosaic_service) { instance_double(TileMetadataService) }
 
   before do
@@ -12,39 +10,45 @@ describe MosaicJob do
   end
 
   describe "#perform" do
-    it "runs the TileMetadataService" do
-      raster_set = FactoryBot.create_for_repository(:raster_set_with_files)
-      described_class.perform_now(raster_set.id)
-      expect(mosaic_service).to have_received(:path)
+    context "when a MosaicJon is not already running" do
+      with_queue_adapter :inline
+
+      it "runs the TileMetadataService" do
+        raster_set = FactoryBot.create_for_repository(:raster_set_with_files)
+        described_class.perform_now(raster_set.id)
+        expect(mosaic_service).to have_received(:path)
+      end
     end
 
-    context "when a MosaicJob is already enqueued" do
-      it "does not run the TileMetadataService" do
+    context "when a MosaicJob is already running" do
+      it "does not run the TileMetadataService and instead retries the job" do
         raster_set = FactoryBot.create_for_repository(:raster_set_with_files)
-        job_item = {
-          "retry" => true,
-          "queue" => "serial",
-          "class" => "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper",
-          "wrapped" => "MosaicJob",
-          "args" =>
-                      [{ "job_class" => "MosaicJob",
-                         "job_id" => "12cfd9ff-5555-6666-8892-f44d386967d3",
-                         "provider_job_id" => nil,
-                         "queue_name" => "serial",
-                         "priority" => nil,
-                         "arguments" => [raster_set.id.to_s],
-                         "executions" => 0,
-                         "exception_executions" => {},
-                         "locale" => "en",
-                         "timezone" => "UTC",
-                         "enqueued_at" => "2023-11-03T18:26:41Z" }],
-          "jid" => "73ff1c5050ce8adba5feab66",
-          "created_at" => 1_699_036_001.1491642,
-          "enqueued_at" => 1_699_036_001.1493726
-        }
-        job_record = instance_double(Sidekiq::JobRecord, item: job_item)
-        allow(Sidekiq::Queue).to receive(:new).and_return([job_record])
-        described_class.perform_now(raster_set.id)
+        worker_record = [nil, nil, {
+          "queue" => "low",
+          "payload" =>
+            { "retry" => true,
+              "queue" => "default",
+              "class" => "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper",
+              "wrapped" => "MosaicJob",
+              "args" =>
+              [{ "job_class" => "MosaicJob",
+                 "job_id" => "12cfd9ff-5555-6666-8892-f44d386967d3",
+                 "provider_job_id" => nil,
+                 "queue_name" => "low",
+                 "priority" => nil,
+                 "arguments" => [raster_set.id.to_s],
+                 "executions" => 0,
+                 "exception_executions" => {},
+                 "locale" => "en",
+                 "timezone" => "UTC",
+                 "enqueued_at" => "2023-11-04T03:36:39Z" }],
+              "jid" => "69bce24959abb10c538da41b",
+              "created_at" => 1_699_068_999.2283602,
+              "enqueued_at" => 1_699_068_999.2287548 },
+          "run_at" => 1_699_069_060
+        }]
+        allow(Sidekiq::Workers).to receive(:new).and_return([worker_record])
+        described_class.perform_now(raster_set.id.to_s)
         expect(mosaic_service).not_to have_received(:path)
       end
     end

--- a/spec/jobs/mosaic_job_spec.rb
+++ b/spec/jobs/mosaic_job_spec.rb
@@ -12,6 +12,12 @@ describe MosaicJob do
 
   describe "#perform" do
     context "when a MosaicJob is not currently running" do
+      let(:worker) { instance_double(Sidekiq::Workers, find: [nil, nil, nil]) }
+
+      before do
+        allow(Sidekiq::Workers).to receive(:new).and_return(worker)
+      end
+
       it "runs the TileMetadataService" do
         raster_set = FactoryBot.create_for_repository(:raster_set_with_files)
         fingerprint = query_service.custom_queries.mosaic_fingerprint_for(id: raster_set.id)

--- a/spec/jobs/mosaic_job_spec.rb
+++ b/spec/jobs/mosaic_job_spec.rb
@@ -19,20 +19,18 @@ describe MosaicJob do
     end
 
     context "when a MosaicJob is already enqueued" do
-      before do
-      end
       it "does not run the TileMetadataService" do
         raster_set = FactoryBot.create_for_repository(:raster_set_with_files)
         job_item = {
           "retry" => true,
-          "queue" => "low",
+          "queue" => "serial",
           "class" => "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper",
           "wrapped" => "MosaicJob",
           "args" =>
                       [{ "job_class" => "MosaicJob",
                          "job_id" => "12cfd9ff-5555-6666-8892-f44d386967d3",
                          "provider_job_id" => nil,
-                         "queue_name" => "low",
+                         "queue_name" => "serial",
                          "priority" => nil,
                          "arguments" => [raster_set.id.to_s],
                          "executions" => 0,

--- a/spec/jobs/mosaic_job_spec.rb
+++ b/spec/jobs/mosaic_job_spec.rb
@@ -12,8 +12,6 @@ describe MosaicJob do
 
   describe "#perform" do
     context "when a MosaicJob is not currently running" do
-      with_queue_adapter :inline
-
       it "runs the TileMetadataService" do
         raster_set = FactoryBot.create_for_repository(:raster_set_with_files)
         fingerprint = query_service.custom_queries.mosaic_fingerprint_for(id: raster_set.id)

--- a/spec/services/geo_discovery/document_builder/wxs_spec.rb
+++ b/spec/services/geo_discovery/document_builder/wxs_spec.rb
@@ -17,6 +17,7 @@ describe GeoDiscovery::DocumentBuilder::Wxs do
 
   before do
     allow(GeoserverPublishJob).to receive(:perform_later)
+    allow(MosaicJob).to receive(:perform_later)
     change_set_persister.save(change_set: change_set)
   end
 

--- a/spec/services/geo_discovery/document_builder_spec.rb
+++ b/spec/services/geo_discovery/document_builder_spec.rb
@@ -459,8 +459,8 @@ describe GeoDiscovery::DocumentBuilder, skip_fixity: true do
         geo_work
         id = geo_work.id.to_s.delete("-")
         refs = JSON.parse(document["dct_references_s"])
-        expect(refs["http://www.opengis.net/def/serviceType/ogc/wmts"]).to eq "https://map-tiles-test.example.com/mosaicjson/WMTSCapabilities.xml?id=#{id}"
-        expect(refs["https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames"]).to eq "https://map-tiles-test.example.com/mosaicjson/tiles/WebMercatorQuad/{z}/{x}/{y}@1x.png?id=#{id}"
+        expect(refs["http://www.opengis.net/def/serviceType/ogc/wmts"]).to eq "https://map-tiles-test.example.com/#{id}/mosaicjson/WMTSCapabilities.xml"
+        expect(refs["https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames"]).to eq "https://map-tiles-test.example.com/#{id}/mosaicjson/tiles/WebMercatorQuad/{z}/{x}/{y}@1x.png"
       end
 
       context "with a child resource" do

--- a/spec/services/geo_discovery/document_builder_spec.rb
+++ b/spec/services/geo_discovery/document_builder_spec.rb
@@ -29,6 +29,10 @@ describe GeoDiscovery::DocumentBuilder, skip_fixity: true do
   let(:file) { fixture_file_upload("files/vector/shapefile.zip") }
   let(:metadata_file) { fixture_file_upload("files/geo_metadata/iso.xml") }
 
+  before do
+    allow(MosaicJob).to receive(:perform_later)
+  end
+
   describe "vector resource", run_real_characterization: true do
     before do
       allow(GeoserverPublishJob).to receive(:perform_later)

--- a/spec/services/geoserver_publish_service_spec.rb
+++ b/spec/services/geoserver_publish_service_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe GeoserverPublishService do
 
   before do
     allow(GeoserverPublishJob).to receive(:perform_later)
+    allow(MosaicJob).to receive(:perform_later)
   end
 
   describe "#delete" do

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -654,6 +654,11 @@ RSpec.describe ManifestBuilder do
     let(:scanned_map) do
       FactoryBot.create_for_repository(:scanned_map, description: "Test Description", member_ids: child.id)
     end
+
+    before do
+      allow(MosaicJob).to receive(:perform_later)
+    end
+
     let(:file) { fixture_file_upload("files/raster/geotiff.tif", "image/tiff") }
     let(:child) { FactoryBot.create_for_repository(:raster_resource, files: [file]) }
     it "builds a IIIF document without the raster child" do

--- a/spec/services/manifest_builder_v3_spec.rb
+++ b/spec/services/manifest_builder_v3_spec.rb
@@ -160,6 +160,11 @@ RSpec.describe ManifestBuilderV3 do
       let(:resource) do
         FactoryBot.create_for_repository(:scanned_map, description: "Test Description", member_ids: child.id)
       end
+
+      before do
+        allow(MosaicJob).to receive(:perform_later)
+      end
+
       let(:file) { fixture_file_upload("files/raster/geotiff.tif", "image/tiff") }
       let(:child) { FactoryBot.create_for_repository(:raster_resource, files: [file]) }
       it "builds a IIIF document without the raster child" do

--- a/spec/services/tile_metadata_service_spec.rb
+++ b/spec/services/tile_metadata_service_spec.rb
@@ -3,6 +3,10 @@ require "rails_helper"
 require "shrine/storage/s3"
 
 RSpec.describe TileMetadataService do
+  before do
+    allow(MosaicJob).to receive(:perform_later)
+  end
+
   after(:all) do
     # Clean up mosaic.json documents and cloud rasters after test suite
     FileUtils.rm_rf(Figgy.config["test_cloud_geo_derivative_path"])

--- a/spec/services/tile_metadata_service_spec.rb
+++ b/spec/services/tile_metadata_service_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe TileMetadataService do
     it "generates a path to the mosaic file" do
       allow(MosaicGenerator).to receive(:new).and_call_original
       raster_set = FactoryBot.create_for_repository(:raster_set_with_files, id: "331d70a5-4bd9-4a65-80e4-763c8f6b34fd")
-      default_path = described_class.new(resource: raster_set, generate: true).path
+      default_path = described_class.new(resource: raster_set, generate: true).full_path
       expect(MosaicGenerator).to have_received(:new)
       expect(File.exist?(default_path)).to be true
     end
@@ -39,7 +39,7 @@ RSpec.describe TileMetadataService do
 
         service = described_class.new(resource: map_set, generate: true)
 
-        service.path
+        service.full_path
         expect(MosaicGenerator).to have_received(:new).with(output_path: anything, raster_paths: [file_set1.file_metadata.first.cloud_uri, file_set2.file_metadata.first.cloud_uri])
       end
     end
@@ -48,7 +48,7 @@ RSpec.describe TileMetadataService do
       it "raises TileMetadataService::Error" do
         raster_set = FactoryBot.create_for_repository(:raster_set, id: "331d70a5-4bd9-4a65-80e4-763c8f6b34fd")
         generator = described_class.new(resource: raster_set)
-        expect { generator.path }.to raise_error("TileMetadataService::Error")
+        expect { generator.full_path }.to raise_error("TileMetadataService::Error")
       end
     end
   end

--- a/spec/services/tile_metadata_service_spec.rb
+++ b/spec/services/tile_metadata_service_spec.rb
@@ -17,14 +17,11 @@ RSpec.describe TileMetadataService do
       FileUtils.rm_rf(Figgy.config["test_cloud_geo_derivative_path"])
     end
 
-    it "generates a mosaic file the mosiac path" do
+    it "generates a path to the mosaic file" do
       allow(MosaicGenerator).to receive(:new).and_call_original
       raster_set = FactoryBot.create_for_repository(:raster_set_with_files, id: "331d70a5-4bd9-4a65-80e4-763c8f6b34fd")
-      generator = described_class.new(resource: raster_set)
-      fingerprinted_path = generator.path
-      default_path = cloud_path.join("33", "1d", "70", "331d70a54bd94a6580e4763c8f6b34fd", "mosaic.json").to_s
+      default_path = described_class.new(resource: raster_set, generate: true).path
       expect(MosaicGenerator).to have_received(:new)
-      expect(File.exist?(fingerprinted_path)).to be true
       expect(File.exist?(default_path)).to be true
     end
 
@@ -40,7 +37,7 @@ RSpec.describe TileMetadataService do
         generator = instance_double(MosaicGenerator, run: "build")
         allow(MosaicGenerator).to receive(:new).and_return(generator)
 
-        service = described_class.new(resource: map_set)
+        service = described_class.new(resource: map_set, generate: true)
 
         service.path
         expect(MosaicGenerator).to have_received(:new).with(output_path: anything, raster_paths: [file_set1.file_metadata.first.cloud_uri, file_set2.file_metadata.first.cloud_uri])

--- a/spec/values/tile_path_spec.rb
+++ b/spec/values/tile_path_spec.rb
@@ -8,7 +8,8 @@ describe TilePath do
         scanned_map1 = FactoryBot.create_for_repository(:scanned_map_with_raster_children)
         scanned_map2 = FactoryBot.create_for_repository(:scanned_map_with_raster_children)
         map_set = FactoryBot.create_for_repository(:scanned_map, member_ids: [scanned_map1.id, scanned_map2.id], id: "331d70a5-4bd9-4a65-80e4-763c8f6b34fd")
-        expect(described_class.new(map_set).tilejson).to eq "https://map-tiles-test.example.com/mosaicjson/tilejson.json?id=331d70a54bd94a6580e4763c8f6b34fd"
+
+        expect(described_class.new(map_set).tilejson).to eq "https://map-tiles-test.example.com/331d70a54bd94a6580e4763c8f6b34fd/mosaicjson/tilejson.json"
       end
     end
 
@@ -19,14 +20,16 @@ describe TilePath do
         scanned_map1 = FactoryBot.create_for_repository(:scanned_map_with_raster_children)
         scanned_map2 = FactoryBot.create_for_repository(:scanned_map_with_raster_children)
         map_set = FactoryBot.create_for_repository(:scanned_map, member_ids: [scanned_map1.id, scanned_map2.id], id: "331d70a5-4bd9-4a65-80e4-763c8f6b34fd")
+
         expect(described_class.new(map_set).tilejson).to eq "https://map-tiles-test.example.com/mosaicjson/tilejson.json?url=s3://bla"
       end
     end
 
     context "with a ScannedMap that has a child RasterResource" do
       it "returns a cog tilejson path" do
-        scanned_map = FactoryBot.create_for_repository(:scanned_map_with_raster_children, id: "331d70a5-4bd9-4a65-80e4-763c8f6b34fd")
-        expect(described_class.new(scanned_map).tilejson).to eq "https://map-tiles-test.example.com/cog/tilejson.json?id=331d70a54bd94a6580e4763c8f6b34fd"
+        scanned_map = FactoryBot.create_for_repository(:scanned_map_with_raster_children)
+
+        expect(described_class.new(scanned_map).tilejson).to eq "https://map-tiles-test.example.com/testgeo/cog/tilejson.json"
       end
     end
 
@@ -34,7 +37,8 @@ describe TilePath do
       it "returns a cog tilejson path" do
         file_set = FactoryBot.create_for_repository(:geo_raster_cloud_file)
         raster = FactoryBot.create_for_repository(:raster_resource, member_ids: [file_set.id], id: "331d70a5-4bd9-4a65-80e4-763c8f6b34fd")
-        expect(described_class.new(raster).tilejson).to eq "https://map-tiles-test.example.com/cog/tilejson.json?id=331d70a54bd94a6580e4763c8f6b34fd"
+
+        expect(described_class.new(raster).tilejson).to eq "https://map-tiles-test.example.com/testgeo/cog/tilejson.json"
       end
     end
   end

--- a/spec/values/tile_path_spec.rb
+++ b/spec/values/tile_path_spec.rb
@@ -13,18 +13,6 @@ describe TilePath do
       end
     end
 
-    context "in development" do
-      it "returns the direct S3 URL, bypassing redirect logic" do
-        allow(Rails.env).to receive(:development?).and_return(true)
-        allow(TileMetadataService).to receive(:new).and_return(instance_double(TileMetadataService, path: "s3://bla"))
-        scanned_map1 = FactoryBot.create_for_repository(:scanned_map_with_raster_children)
-        scanned_map2 = FactoryBot.create_for_repository(:scanned_map_with_raster_children)
-        map_set = FactoryBot.create_for_repository(:scanned_map, member_ids: [scanned_map1.id, scanned_map2.id], id: "331d70a5-4bd9-4a65-80e4-763c8f6b34fd")
-
-        expect(described_class.new(map_set).tilejson).to eq "https://map-tiles-test.example.com/mosaicjson/tilejson.json?url=s3://bla"
-      end
-    end
-
     context "with a ScannedMap that has a child RasterResource" do
       it "returns a cog tilejson path" do
         scanned_map = FactoryBot.create_for_repository(:scanned_map_with_raster_children)


### PR DESCRIPTION
Along with https://github.com/pulibrary/geoservices-aws/pull/2, this pull request:

1. Simplifies creation mosaic json documents
2. Decouples Figgy and the TiTiler lambda service to some degree; mostly when serving tiles, which improves performance.
3. Addresses potential race conditions when generating mosaic json documents by only allowing one MosaicJob for a resource to run at a time. 
4. Makes it possible to automatically invalidate the TiTiler / CloudFront cache when the mosaic data changes. Currently, the ID for a resource which you would use to invalidate is passed to TiTiler as a query param. While it is possible to cache using query params as keys in CloudFront, it is not possible to invalidate using query params. These PRs move the id from a param to the url path. See followup issue: https://github.com/pulibrary/figgy/issues/6104
5. Sets a path for future work on restricted raster content. 

Closes #6090

- Only queue up one MosaicJob per resource at a time
- Run mosaic job on raster or scanned map ancestors
- Streamline building mosaic documents
- Simplify tile metadata controller
- Check if MosaicJob is currently running
- Allow derivatives to trigger MosaicJobs in non-complete state
- Set Honeybadger to ignore MosaicJob::JobRunning errors
- Add fingerprint check to MosaicJob
- Work on cache invalidation
- Build mosaic and cog links with id in url
- Use default tile path in development 
- Stub MosaicJob in spec
