### PR TITLE
Change BulkIngestService to handle attribute params it actually receives

### DIFF
--- a/app/services/bulk_ingest_service.rb
+++ b/app/services/bulk_ingest_service.rb
@@ -108,7 +108,7 @@ class BulkIngestService
     # @param resource [Resource] the resource being used to construct child resources
     # @param file_filters [Array] the filter used for matching against the filename extension
     def attach_children(path:, resource:, file_filters: [], preserve_file_names: false, **attributes)
-      child_attributes = attributes.except(:collection)
+      child_attributes = attributes.except(:member_of_collection_ids)
       child_resources = dirs(path: path).map do |subdir_path|
         child_klass = child_klass(parent_class: resource.class, title: subdir_path.basename)
         attach_children(
@@ -135,13 +135,10 @@ class BulkIngestService
     # @param klass [Class] the class of the resource being constructed
     # @return [Resource] the newly created resource
     def new_resource(klass:, **attributes)
-      collection = attributes.delete(:collection)
-
       resource = klass.new
 
       change_set = ChangeSet.for(resource, change_set_param: change_set_param)
       return unless change_set.validate(**attributes)
-      change_set.member_of_collection_ids = [collection.id] if collection.try(:id)
 
       persisted = change_set_persister.save(change_set: change_set)
       logger.info "Created the resource #{persisted.id}"

--- a/spec/controllers/bulk_ingest_controller_spec.rb
+++ b/spec/controllers/bulk_ingest_controller_spec.rb
@@ -310,6 +310,8 @@ RSpec.describe BulkIngestController do
       expect(resource.decorate.volumes.last.file_sets.length).to eq(1)
       expect(resource.decorate.collections.first.id).to eq collection.id
       expect(resource.decorate.rights_statement.first).to eq RightsStatements.copyright_not_evaluated
+      child_resources = Wayfinder.for(resource).members
+      expect(child_resources.map(&:member_of_collection_ids)).to eq [nil, nil]
     end
   end
 end

--- a/spec/services/bulk_ingest_service_spec.rb
+++ b/spec/services/bulk_ingest_service_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe BulkIngestService do
           file_filters: [".tif"],
           source_metadata_identifier: bib,
           local_identifier: local_id,
-          collection: coll
+          member_of_collection_ids: [coll.id]
         )
 
         updated_collection = query_service.find_by(id: coll.id)
@@ -117,7 +117,7 @@ RSpec.describe BulkIngestService do
           file_filters: [".tif"],
           source_metadata_identifier: bib,
           local_identifier: local_id,
-          collection: coll,
+          member_of_collection_ids: [coll.id],
           preserve_file_names: true
         )
 
@@ -143,7 +143,7 @@ RSpec.describe BulkIngestService do
           base_directory: single_dir,
           file_filters: [".tif"],
           local_identifier: local_id,
-          collection: coll
+          member_of_collection_ids: [coll.id]
         )
 
         updated_collection = query_service.find_by(id: coll.id)
@@ -170,7 +170,7 @@ RSpec.describe BulkIngestService do
           file_filters: [".tif"],
           source_metadata_identifier: bib,
           local_identifier: local_id,
-          collection: coll
+          member_of_collection_ids: [coll.id]
         )
 
         expect(bulk_ingester).to have_received(:attach_children).with(
@@ -192,7 +192,7 @@ RSpec.describe BulkIngestService do
         stub_ezid
       end
 
-      it "ingests the resources", bulk: true do
+      it "ingests them as child resources, and does not add them to collections", bulk: true do
         coll = FactoryBot.create_for_repository(:collection)
 
         ingester.attach_dir(
@@ -200,7 +200,7 @@ RSpec.describe BulkIngestService do
           file_filters: [".tif"],
           source_metadata_identifier: bib,
           local_identifier: local_id,
-          collection: coll
+          member_of_collection_ids: [coll.id]
         )
 
         updated_collection = query_service.find_by(id: coll.id)
@@ -211,6 +211,7 @@ RSpec.describe BulkIngestService do
         expect(resource).to be_a ScannedResource
         expect(resource.source_metadata_identifier).to include(bib)
         expect(resource.local_identifier).to include(local_id)
+        expect(resource.member_of_collection_ids). to eq [coll.id]
 
         decorated_resource = resource.decorate
         expect(decorated_resource.volumes.length).to eq 2
@@ -219,6 +220,7 @@ RSpec.describe BulkIngestService do
         expect(child_resource.local_identifier).to include(local_id)
         expect(child_resource.source_metadata_identifier).to be_nil
         expect(child_resource.title).to eq ["vol1"]
+        expect(child_resource.member_of_collection_ids). to be_nil
       end
     end
 
@@ -240,7 +242,7 @@ RSpec.describe BulkIngestService do
           file_filters: [".tif"],
           source_metadata_identifier: bib,
           local_identifier: local_id,
-          collection: coll,
+          member_of_collection_ids: [coll.id],
           depositor: "tpend"
         )
 


### PR DESCRIPTION
It was handling a `collection` attribute, but it comes from the
controller as `member_of_collection_ids`

advances pulibrary/dpul#1420
