### PR TITLE
Refactor preservation audit over full repository vs list of ids

### DIFF
--- a/app/services/preservation_status_reporter.rb
+++ b/app/services/preservation_status_reporter.rb
@@ -123,6 +123,8 @@ class PreservationStatusReporter
       FileUtils.mkdir_p(@io_directory)
       if recheck_ids
         @found_resource_path = io_directory.join(RECHECK_OUTPUT_FILE)
+        # rotate previous output
+        FileUtils.mv(@found_resource_path, @found_resource_path.to_s.split(".").first.concat("#{DateTime.now}.txt")) if File.exist?(@found_resource_path)
       else
         @timestamp_file_path = io_directory.join("since.txt")
         @since = @timestamp_file_path.read if @timestamp_file_path.exist?

--- a/app/services/preservation_status_reporter.rb
+++ b/app/services/preservation_status_reporter.rb
@@ -122,6 +122,7 @@ class PreservationStatusReporter
       @io_directory = Pathname.new(io_directory)
       FileUtils.mkdir_p(@io_directory)
       if recheck_ids
+        ids_from_csv # cache these before rotating the file
         @found_resource_path = io_directory.join(RECHECK_OUTPUT_FILE)
         rotate_file(@found_resource_path)
       else
@@ -154,7 +155,12 @@ class PreservationStatusReporter
     end
 
     def ids_from_csv
-      @ids_from_csv ||= CSV.read(io_directory.join(FULL_AUDIT_OUTPUT_FILE)).flatten
+      @ids_from_csv ||=
+        if File.exist?(io_directory.join(RECHECK_OUTPUT_FILE))
+          CSV.read(io_directory.join(RECHECK_OUTPUT_FILE)).flatten
+        else
+          CSV.read(io_directory.join(FULL_AUDIT_OUTPUT_FILE)).flatten
+        end
     end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/services/preservation_status_reporter.rb
+++ b/app/services/preservation_status_reporter.rb
@@ -11,6 +11,9 @@ require "ruby-progressbar/outputs/null"
 
 # rubocop:disable Metrics/ClassLength
 class PreservationStatusReporter
+  FULL_AUDIT_OUTPUT_FILE = "bad_resources.txt"
+  RECHECK_OUTPUT_FILE = "bad_resources_recheck.txt"
+
   # Check all resources with resumable state
   def self.run_full_audit(io_directory:)
     new(io_directory: io_directory).cloud_audit_failures
@@ -70,14 +73,6 @@ class PreservationStatusReporter
     @progress_bar ||= ProgressBar.create format: "%a %e %P% Querying: %c from %C", output: progress_output, total: audited_resource_count
   end
 
-  def full_audit_output_file
-    "bad_resources.txt"
-  end
-
-  def recheck_output_file
-    "bad_resources_recheck.txt"
-  end
-
   private
 
     # Preservation object doesn't exist, is missing a metadata or binary node, or the checksums don't match.
@@ -127,11 +122,11 @@ class PreservationStatusReporter
       @io_directory = Pathname.new(io_directory)
       FileUtils.mkdir_p(@io_directory)
       if recheck_ids
-        @found_resource_path = io_directory.join(recheck_output_file)
+        @found_resource_path = io_directory.join(RECHECK_OUTPUT_FILE)
       else
         @timestamp_file_path = io_directory.join("since.txt")
         @since = @timestamp_file_path.read if @timestamp_file_path.exist?
-        @found_resource_path = io_directory.join(full_audit_output_file)
+        @found_resource_path = io_directory.join(FULL_AUDIT_OUTPUT_FILE)
         @found_resources = Set.new(@found_resource_path.read.split.map { |x| Valkyrie::ID.new(x) }) if @found_resource_path.exist?
       end
     end
@@ -145,7 +140,7 @@ class PreservationStatusReporter
     end
 
     def ids_from_csv
-      @ids_from_csv ||= CSV.read(io_directory.join(full_audit_output_file)).flatten
+      @ids_from_csv ||= CSV.read(io_directory.join(FULL_AUDIT_OUTPUT_FILE)).flatten
     end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/services/preservation_status_reporter.rb
+++ b/app/services/preservation_status_reporter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Checks every resource in the database. If it should be preserved, then checks
+# Checks resource preservation status. If it should be preserved, then checks
 # that all its files and its metadata are preserved and have the correct
 # MD5 checksums.
 # Future use case: We'll get this to where it returns nothing. If down the road
@@ -8,31 +8,36 @@
 # failing.
 require "ruby-progressbar"
 require "ruby-progressbar/outputs/null"
+
+# rubocop:disable Metrics/ClassLength
 class PreservationStatusReporter
-  attr_reader :since, :suppress_progress, :records_per_group, :parallel_threads, :skip_metadata_checksum, :csv_path
+  # Check all resources with resumable state
+  def self.run_full_audit(io_directory:)
+    new(io_directory: io_directory).cloud_audit_failures
+  end
+
+  # Check resources by id, using the list output in the full audit
+  def self.run_recheck(io_directory:)
+    new(io_directory: io_directory, recheck_ids: true).cloud_audit_failures
+  end
+
+  attr_reader :since, :suppress_progress, :records_per_group, :parallel_threads, :skip_metadata_checksum, :io_directory, :recheck_ids
+
   # rubocop:disable Metrics/ParameterLists
-  def initialize(since: nil, suppress_progress: false, records_per_group: 100, parallel_threads: 10, skip_metadata_checksum: false, csv_path: nil)
-    @since = since
+  def initialize(suppress_progress: false, records_per_group: 100, parallel_threads: 10, skip_metadata_checksum: false, io_directory:, recheck_ids: false)
     @suppress_progress = suppress_progress
     @records_per_group = records_per_group
     @parallel_threads = parallel_threads
     @found_resources = Set.new
     @skip_metadata_checksum = skip_metadata_checksum
-    @csv_path = csv_path
+    @recheck_ids = recheck_ids
+    initialize_io_directory(io_directory)
   end
   # rubocop:enable Metrics/ParameterLists
 
   # @return [Array<Valkyrie::ID>]
   def cloud_audit_failures
     @cloud_audit_failures ||= Lazily.concat(@found_resources, run_cloud_audit).uniq
-  end
-
-  def audited_resource_count
-    if csv_path
-      ids_from_csv.count
-    else
-      query_service.custom_queries.count_all_except_models(except_models: unpreserved_models, since: since)
-    end
   end
 
   # @return [Array<Valkyrie::ID>] a lazy enumerator
@@ -52,30 +57,12 @@ class PreservationStatusReporter
     end.flatten
   end
 
-  # Preservation object doesn't exist, is missing a metadata or binary node, or the checksums don't match.
-  def incorrectly_preserved?(resource)
-    preservation_object = Wayfinder.for(resource).preservation_object
-    checkers = Preserver::PreservationChecker.for(resource: resource, preservation_object: preservation_object, skip_metadata_checksum: skip_metadata_checksum)
-    if preservation_object&.metadata_node.nil?
-      true
-    elsif checkers.any? { |x| !x.preserved? || !x.preservation_file_exists? || !x.preserved_file_checksums_match? }
-      true
+  def audited_resource_count
+    if recheck_ids
+      ids_from_csv.count
     else
-      false
+      query_service.custom_queries.count_all_except_models(except_models: unpreserved_models, since: since)
     end
-  end
-
-  def unpreserved_models
-    [
-      DeletionMarker,
-      Event,
-      PreservationObject,
-      CDL::ResourceChargeList
-    ]
-  end
-
-  def query_service
-    Valkyrie.config.metadata_adapter.query_service
   end
 
   # Progress bar stuff
@@ -83,36 +70,74 @@ class PreservationStatusReporter
     @progress_bar ||= ProgressBar.create format: "%a %e %P% Querying: %c from %C", output: progress_output, total: audited_resource_count
   end
 
-  def progress_output
-    ProgressBar::Outputs::Null if suppress_progress
+  def full_audit_output_file
+    "bad_resources.txt"
   end
 
-  # State Management
-  def load_state!(state_directory:)
-    state_directory = Pathname.new(state_directory)
-    FileUtils.mkdir_p(state_directory)
-    @state_file_path = state_directory.join("since.txt")
-    @since = @state_file_path.read if @state_file_path.exist?
-    @found_resource_path = state_directory.join("bad_resources.txt")
-    @found_resources = Set.new(@found_resource_path.read.split.map { |x| Valkyrie::ID.new(x) }) if @found_resource_path.exist?
-  end
-
-  def processed(last_checked:, bad_resource_ids:)
-    return unless @state_file_path
-    File.open(@state_file_path, "w") do |f|
-      f.write(last_checked.created_at.to_s)
-    end
-    File.open(@found_resource_path, "a") do |f|
-      bad_resource_ids.each do |resource_id|
-        f.puts resource_id
-      end
-    end
+  def recheck_output_file
+    "bad_resources_recheck.txt"
   end
 
   private
 
+    # Preservation object doesn't exist, is missing a metadata or binary node, or the checksums don't match.
+    def incorrectly_preserved?(resource)
+      preservation_object = Wayfinder.for(resource).preservation_object
+      checkers = Preserver::PreservationChecker.for(resource: resource, preservation_object: preservation_object, skip_metadata_checksum: skip_metadata_checksum)
+      if preservation_object&.metadata_node.nil?
+        true
+      elsif checkers.any? { |x| !x.preserved? || !x.preservation_file_exists? || !x.preserved_file_checksums_match? }
+        true
+      else
+        false
+      end
+    end
+
+    def unpreserved_models
+      [
+        DeletionMarker,
+        Event,
+        PreservationObject,
+        CDL::ResourceChargeList
+      ]
+    end
+
+    def query_service
+      Valkyrie.config.metadata_adapter.query_service
+    end
+
+    def progress_output
+      ProgressBar::Outputs::Null if suppress_progress
+    end
+
+    def processed(last_checked:, bad_resource_ids:)
+      unless recheck_ids
+        File.open(@timestamp_file_path, "w") do |f|
+          f.write(last_checked.created_at.to_s)
+        end
+      end
+      File.open(@found_resource_path, "a") do |f|
+        bad_resource_ids.each do |resource_id|
+          f.puts resource_id
+        end
+      end
+    end
+
+    def initialize_io_directory(io_directory)
+      @io_directory = Pathname.new(io_directory)
+      FileUtils.mkdir_p(@io_directory)
+      if recheck_ids
+        @found_resource_path = io_directory.join(recheck_output_file)
+      else
+        @timestamp_file_path = io_directory.join("since.txt")
+        @since = @timestamp_file_path.read if @timestamp_file_path.exist?
+        @found_resource_path = io_directory.join(full_audit_output_file)
+        @found_resources = Set.new(@found_resource_path.read.split.map { |x| Valkyrie::ID.new(x) }) if @found_resource_path.exist?
+      end
+    end
+
     def resource_query
-      if csv_path
+      if recheck_ids
         query_service.custom_queries.memory_efficient_find_many_by_ids(ids: ids_from_csv)
       else
         query_service.custom_queries.memory_efficient_all(except_models: unpreserved_models, order: true, since: since)
@@ -120,6 +145,7 @@ class PreservationStatusReporter
     end
 
     def ids_from_csv
-      @ids_from_csv ||= CSV.read(csv_path).flatten
+      @ids_from_csv ||= CSV.read(io_directory.join(full_audit_output_file)).flatten
     end
 end
+# rubocop:enable Metrics/ClassLength

--- a/lib/tasks/preservation.rake
+++ b/lib/tasks/preservation.rake
@@ -6,12 +6,19 @@ namespace :figgy do
     desc "Reports the number of unpreserved models."
     task count_unpreserved: :environment do
       state_directory = Rails.root.join("tmp", "rake_preservation_audit")
-      csv_path = ENV["CSV_PATH"]
-      auditor = PreservationStatusReporter.new(csv_path: csv_path)
-      auditor.load_state!(state_directory: state_directory)
-      failed_count = auditor.cloud_audit_failures.to_a.size
+      failures = PreservationStatusReporter.run_full_audit(io_directory: state_directory)
+      failed_count = failures.to_a.size
       puts "Number of Resources Needing Re-Preserved: #{failed_count}"
-      puts "The bad_resources.txt report and the resumption timestamp have been saved to #{state_directory}"
+      puts "The report and the resumption timestamp have been saved to #{state_directory}"
+    end
+
+    desc "Reports the number of unpreserved models."
+    task recheck_ids: :environment do
+      state_directory = Rails.root.join("tmp", "rake_preservation_audit")
+      failures = PreservationStatusReporter.run_recheck(io_directory: state_directory)
+      failed_count = failures.to_a.size
+      puts "Number of Resources Needing Re-Preserved: #{failed_count}"
+      puts "The report has been saved to #{state_directory}"
     end
   end
 end

--- a/lib/tasks/preservation.rake
+++ b/lib/tasks/preservation.rake
@@ -9,7 +9,7 @@ namespace :figgy do
       failures = PreservationStatusReporter.run_full_audit(io_directory: state_directory)
       failed_count = failures.to_a.size
       puts "Number of Resources Needing Re-Preserved: #{failed_count}"
-      puts "The report and the resumption timestamp have been saved to #{state_directory}"
+      puts "The #{PreservationStatusReporter::FULL_AUDIT_OUTPUT_FILE} report and the resumption timestamp have been saved to #{state_directory}"
     end
 
     desc "Reports the number of unpreserved models."
@@ -18,7 +18,7 @@ namespace :figgy do
       failures = PreservationStatusReporter.run_recheck(io_directory: state_directory)
       failed_count = failures.to_a.size
       puts "Number of Resources Needing Re-Preserved: #{failed_count}"
-      puts "The report has been saved to #{state_directory}"
+      puts "The #{PreservationStatusReporter::RECHECK_OUTPUT_FILE} report has been saved to #{state_directory}"
     end
   end
 end

--- a/spec/services/preservation_status_reporter_spec.rb
+++ b/spec/services/preservation_status_reporter_spec.rb
@@ -20,25 +20,21 @@ RSpec.describe PreservationStatusReporter do
     FileUtils.rm_rf(io_dir)
   end
 
-  describe ".run_full_audit" do
+  describe ".full_audit_reporter" do
     it "runs with the default params" do
       reporter = instance_double(described_class)
       allow(described_class).to receive(:new).and_return(reporter)
-      allow(reporter).to receive(:cloud_audit_failures)
-      described_class.run_full_audit(io_directory: io_dir)
+      described_class.full_audit_reporter(io_directory: io_dir)
       expect(described_class).to have_received(:new).with(io_directory: io_dir)
-      expect(reporter).to have_received(:cloud_audit_failures)
     end
   end
 
-  describe ".run_recheck" do
+  describe ".recheck_reporter" do
     it "runs with the recheck_ids flag" do
       reporter = instance_double(described_class)
       allow(described_class).to receive(:new).and_return(reporter)
-      allow(reporter).to receive(:cloud_audit_failures)
-      described_class.run_recheck(io_directory: io_dir)
+      described_class.recheck_reporter(io_directory: io_dir)
       expect(described_class).to have_received(:new).with(io_directory: io_dir, recheck_ids: true)
-      expect(reporter).to have_received(:cloud_audit_failures)
     end
   end
 


### PR DESCRIPTION
And have the id check write to a different file
closes #6108
