### PR TITLE
Back out requirement for specific bundler version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ gem "blacklight_range_limit"
 gem "bootsnap", require: false
 gem "bootstrap", "~> 4.0"
 gem "bootstrap_form", "~> 4.5.0"
-gem "bundler", "2.3.18"
 gem "bunny"
 gem "capistrano-passenger"
 gem "capistrano-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1176,7 +1176,6 @@ DEPENDENCIES
   bootsnap
   bootstrap (~> 4.0)
   bootstrap_form (~> 4.5.0)
-  bundler (= 2.3.18)
   bundler-audit
   bunny
   capistrano-passenger


### PR DESCRIPTION
We no longer need this since later versions of bundler first install
whatever bundler version the Gemfile.lock was generated with, then run
that to bundle. This will give us a little more flexibility on server
bundler versions.

refs pulibrary/princeton_ansible#3164
