### PR TITLE
Prevent infinite repair loop when FileSet is not preserved.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,6 +41,7 @@ Metrics/AbcSize:
     - 'app/jobs/browse_everything_ingest_job.rb'
     - 'app/services/file_appender.rb'
     - 'app/services/cdl/charge_manager.rb'
+    - 'app/jobs/cloud_fixity_job.rb'
 Metrics/BlockLength:
   Exclude:
     - '**/*.rake'

--- a/app/jobs/cloud_fixity_job.rb
+++ b/app/jobs/cloud_fixity_job.rb
@@ -15,6 +15,8 @@ class CloudFixityJob < ApplicationJob
     # Do not create an event and honeybadger notification if the preservation
     # object or the preseved resource no longer exist. This happens on occasion.
     return unless resources_exist?
+    # Don't try to fix something that won't preserve when we ask it to.
+    return unless ChangeSet.for(preserved_resource).preserve?
     event_change_set = EventChangeSet.new(Event.new)
     event_change_set.validate(type: :cloud_fixity, status: updated_status, resource_id: preservation_object_id, child_property: child_property.to_sym, child_id: child_id, current: true)
     raise "Unable to update fixity. Invalid event: #{event_change_set.errors.full_messages.to_sentence}" unless event_change_set.valid?


### PR DESCRIPTION
Work towards #6067 

I'm not totally sold on this - I might work on adding some way to ensure that repairing doesn't happen multiple times? I'm not sure how though. Maybe store a count somewhere?