### PR TITLE
Don't use buffered persister in CharacterizationJob so error messages are saved

### DIFF
--- a/app/jobs/characterization_job.rb
+++ b/app/jobs/characterization_job.rb
@@ -5,9 +5,8 @@ class CharacterizationJob < ApplicationJob
   # @param file_set_id [string] stringified Valkyrie id
   def perform(file_set_id)
     file_set = query_service.find_by(id: Valkyrie::ID.new(file_set_id))
-    metadata_adapter.persister.buffer_into_index do |buffered_adapter|
-      Valkyrie::Derivatives::FileCharacterizationService.for(file_set: file_set, persister: buffered_adapter.persister).characterize
-    end
+    Valkyrie::Derivatives::FileCharacterizationService.for(file_set: file_set, persister: metadata_adapter.persister).characterize
+
     CreateDerivativesJob.set(queue: queue_name).perform_later(file_set_id)
   rescue Valkyrie::Persistence::ObjectNotFoundError => error
     Valkyrie.logger.warn "#{self.class}: #{error}: Failed to find the resource #{file_set_id}"

--- a/app/jobs/recharacterize_job.rb
+++ b/app/jobs/recharacterize_job.rb
@@ -20,9 +20,7 @@ class RecharacterizeJob < ApplicationJob
 
   def recharacterize(file_sets)
     file_sets.each do |file_set|
-      @metadata_adapter.persister.buffer_into_index do |buffered_adapter|
-        Valkyrie::Derivatives::FileCharacterizationService.for(file_set: file_set, persister: buffered_adapter.persister).characterize
-      end
+      Valkyrie::Derivatives::FileCharacterizationService.for(file_set: file_set, persister: @metadata_adapter.persister).characterize
     end
   end
 end

--- a/spec/derivative_services/external_metadata_derivative_service_spec.rb
+++ b/spec/derivative_services/external_metadata_derivative_service_spec.rb
@@ -46,16 +46,9 @@ RSpec.describe ExternalMetadataDerivativeService do
     end
   end
 
-  before do
-    allow(EventGenerator::GeoblacklightEventGenerator).to receive(:new).and_return(event_generator)
-    allow(event_generator).to receive(:record_updated)
-  end
-
-  it "extracts metadata from the file into the parent resource and triggers an update event", rabbit_stubbed: true do
+  it "extracts metadata from the file into the parent resource" do
     parent = query_service.find_by(id: parent_resource.id)
     expect(parent.title).to eq ["China census data by county, 2000-2010"]
     expect(parent.visibility).to eq ["open"]
-    # Twice for VectorResource
-    expect(event_generator).to have_received(:record_updated).exactly(2).times
   end
 end

--- a/spec/jobs/characterization_job_spec.rb
+++ b/spec/jobs/characterization_job_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe CharacterizationJob do
+  describe ".perform" do
+    let(:change_set_persister) { ChangeSetPersister.default }
+    let(:query_service) { change_set_persister.query_service }
+
+    context "when provided with a file which is not a valid image file" do
+      it "adds an error message to the file set" do
+        file = fixture_file_upload("files/invalid.tif", "image/tiff")
+        book = change_set_persister.save(change_set: ScannedResourceChangeSet.new(ScannedResource.new, files: [file]))
+        book_members = query_service.find_members(resource: book)
+        invalid_file_set = book_members.first
+
+        expect { described_class.perform_now(invalid_file_set.id) }.to raise_error(MiniMagick::Invalid)
+        file_set = query_service.find_by(id: invalid_file_set.id)
+        expect(file_set.file_metadata[0].error_message.first).to start_with "Error during characterization:"
+      end
+    end
+  end
+end

--- a/spec/jobs/recharacterize_job_spec.rb
+++ b/spec/jobs/recharacterize_job_spec.rb
@@ -3,21 +3,34 @@ require "rails_helper"
 
 RSpec.describe RecharacterizeJob do
   describe ".perform" do
-    let(:char) { instance_double("Valkyrie::Derivatives::FileCharacterizationService") }
-    let(:child_file_set) { FactoryBot.create_for_repository(:file_set) }
-    let(:parent_file_set) { FactoryBot.create_for_repository(:file_set) }
-    let(:parent) { FactoryBot.create_for_repository(:scanned_resource, member_ids: [parent_file_set.id, child.id]) }
-    let(:child) { FactoryBot.create_for_repository(:scanned_resource, member_ids: [child_file_set.id]) }
+    let(:change_set_persister) { ChangeSetPersister.default }
+    let(:query_service) { change_set_persister.query_service }
 
-    before do
-      allow(Valkyrie::Derivatives::FileCharacterizationService).to receive(:for).and_return(char)
-      allow(char).to receive(:characterize)
-      parent
+    context "when passing a non-FileSet parent id" do
+      it "invokes Valkyrie::Derivatives::FileCharacterizationService" do
+        char = instance_double("Valkyrie::Derivatives::FileCharacterizationService")
+        child_file_set = FactoryBot.create_for_repository(:file_set)
+        parent_file_set = FactoryBot.create_for_repository(:file_set)
+        child = FactoryBot.create_for_repository(:scanned_resource, member_ids: [child_file_set.id])
+        parent = FactoryBot.create_for_repository(:scanned_resource, member_ids: [parent_file_set.id, child.id])
+        allow(Valkyrie::Derivatives::FileCharacterizationService).to receive(:for).and_return(char)
+        allow(char).to receive(:characterize)
+        described_class.perform_now(parent.id)
+        expect(char).to have_received(:characterize).twice
+      end
     end
 
-    it "invokes Valkyrie::Derivatives::FileCharacterizationService" do
-      described_class.perform_now(parent.id)
-      expect(char).to have_received(:characterize).twice
+    context "when provided with a file which is not a valid image file" do
+      it "adds an error message to the file set" do
+        file = fixture_file_upload("files/invalid.tif", "image/tiff")
+        book = change_set_persister.save(change_set: ScannedResourceChangeSet.new(ScannedResource.new, files: [file]))
+        book_members = query_service.find_members(resource: book)
+        invalid_file_set = book_members.first
+
+        expect { described_class.perform_now(invalid_file_set.id) }.to raise_error(MiniMagick::Invalid)
+        file_set = query_service.find_by(id: invalid_file_set.id)
+        expect(file_set.file_metadata[0].error_message.first).to start_with "Error during characterization:"
+      end
     end
   end
 end


### PR DESCRIPTION
- Characterization failure messages were not being saved on the FileSet when run in production. The issue was the buffered persister which rolled back once the job errored.

- Also removes troublesome and unnecessary ExternalMetadataService test. 

Closes #6059 

Working in staging:
![Screenshot 2024-01-18 at 1 38 21 PM](https://github.com/pulibrary/figgy/assets/784196/cb490ded-99dd-4173-a7a8-b9e8290ce179)




