### PR TITLE
Try using seleniarm-chrome via Docker.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,6 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
     resource_class: large
     steps:
-      - browser-tools/install-chrome
       - checkout
       - node/install:
           install-yarn: true
@@ -75,13 +74,18 @@ jobs:
           POSTGRES_HOST_AUTH_METHOD: trust
       - image: solr:7.7-alpine
         command: bin/solr -cloud -noprompt -f -p 8984
+      - image: seleniarm/standalone-chromium:114.0
+        environment:
+          START_XVFB: "true"
+          SE_NODE_MAX_SESSIONS: 20
+          SE_NODE_OVERRIDE_MAX_SESSIONS: "true"
     resource_class: large
     parallelism: 4
     environment:
       SPEC_OPTS: --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
       COVERALLS_PARALLEL: true
     steps:
-      - browser-tools/install-chrome
+      # - browser-tools/install-chrome
       - attach_workspace:
           at: '~/figgy'
       - node/install:
@@ -92,6 +96,8 @@ jobs:
           command: node -v
       # Wait for DB
       - run: dockerize -wait tcp://localhost:5432 -timeout 1m
+      # Wait for chrome
+      - run: dockerize -wait tcp://localhost:4444 -timeout 1m
       # Install Bundler
       - run: gem install bundler -v '2.3.18'
       # Bundle install dependencies
@@ -162,7 +168,6 @@ jobs:
           PSQL_PAGER: ''
     resource_class: large
     steps:
-      - browser-tools/install-chrome
       - attach_workspace:
           at: '~/figgy'
       - node/install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
         command: bin/solr -cloud -noprompt -f -p 8984
       - image: seleniarm/standalone-chromium:114.0
         environment:
-          START_XVFB: "true"
+          START_XVFB: "false"
           SE_NODE_MAX_SESSIONS: 20
           SE_NODE_OVERRIDE_MAX_SESSIONS: "true"
     resource_class: large

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 ---
 version: 2.1
 orbs:
-  browser-tools: circleci/browser-tools@1.4.6
   node: circleci/node@5.0.2
 jobs:
   build:
@@ -75,17 +74,12 @@ jobs:
       - image: solr:7.7-alpine
         command: bin/solr -cloud -noprompt -f -p 8984
       - image: seleniarm/standalone-chromium:114.0
-        environment:
-          START_XVFB: "false"
-          SE_NODE_MAX_SESSIONS: 20
-          SE_NODE_OVERRIDE_MAX_SESSIONS: "true"
     resource_class: large
     parallelism: 4
     environment:
       SPEC_OPTS: --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
       COVERALLS_PARALLEL: true
     steps:
-      # - browser-tools/install-chrome
       - attach_workspace:
           at: '~/figgy'
       - node/install:

--- a/.lando.yml
+++ b/.lando.yml
@@ -31,7 +31,7 @@ services:
         driver: none
       shm_size: 2G
       ports:
-        - "4445:4444"
+        - "4444:4444"
         - "5900:5900"
         - "7900:7900"
       volumes:

--- a/spec/support/capybara_selenium.rb
+++ b/spec/support/capybara_selenium.rb
@@ -2,20 +2,12 @@
 require "capybara/rspec"
 require "selenium-webdriver"
 
-# there's a bug in capybara-screenshot that requires us to name
-#   the driver ":selenium" so we changed it from :headless_chrome"
-selenium_url = nil
-browser = :chrome
-# If we're not in CI then run Selenium from Lando. Makes it much easier to
-# upgrade versions of Chrome.
 Capybara.server_host = '0.0.0.0'
 Capybara.always_include_port = true
-browser = :remote
 if !ENV["CI"]
-  selenium_url = "http://127.0.0.1:4445/wd/hub"
   Capybara.app_host = "http://host.docker.internal:#{Capybara.server_port}"
 else
-  selenium_url = "http://127.0.0.1:4444/wd/hub"
+  # In CI all the ports from containers are on localhost.
   Capybara.app_host = "http://127.0.0.1:#{Capybara.server_port}"
 end
 
@@ -30,10 +22,10 @@ Capybara.register_driver(:selenium) do |app|
   http_client.read_timeout = 120
   http_client.open_timeout = 120
   Capybara::Selenium::Driver.new(app,
-                                 browser: browser,
+                                 browser: :remote,
                                  options: browser_options,
                                  http_client: http_client,
-                                 url: selenium_url)
+                                 url: "http://127.0.0.1:4444/wd/hub")
 end
 
 Capybara.javascript_driver = :selenium

--- a/spec/support/capybara_selenium.rb
+++ b/spec/support/capybara_selenium.rb
@@ -8,12 +8,14 @@ selenium_url = nil
 browser = :chrome
 # If we're not in CI then run Selenium from Lando. Makes it much easier to
 # upgrade versions of Chrome.
+Capybara.server_host = '0.0.0.0'
+Capybara.always_include_port = true
+Capybara.app_host = "http://host.docker.internal:#{Capybara.server_port}"
+browser = :remote
 if !ENV["CI"]
   selenium_url = "http://127.0.0.1:4445/wd/hub"
-  Capybara.server_host = '0.0.0.0'
-  Capybara.always_include_port = true
-  Capybara.app_host = "http://host.docker.internal:#{Capybara.server_port}"
-  browser = :remote
+else
+  selenium_url = "http://127.0.0.1:4444/wd/hub"
 end
 
 Capybara.register_driver(:selenium) do |app|

--- a/spec/support/capybara_selenium.rb
+++ b/spec/support/capybara_selenium.rb
@@ -10,12 +10,13 @@ browser = :chrome
 # upgrade versions of Chrome.
 Capybara.server_host = '0.0.0.0'
 Capybara.always_include_port = true
-Capybara.app_host = "http://host.docker.internal:#{Capybara.server_port}"
 browser = :remote
 if !ENV["CI"]
   selenium_url = "http://127.0.0.1:4445/wd/hub"
+  Capybara.app_host = "http://host.docker.internal:#{Capybara.server_port}"
 else
   selenium_url = "http://127.0.0.1:4444/wd/hub"
+  Capybara.app_host = "http://127.0.0.1:#{Capybara.server_port}"
 end
 
 Capybara.register_driver(:selenium) do |app|


### PR DESCRIPTION
Would get us away from having to do webdrivers and everything.

I moved the port for chrome on dev from 4445 to 4444 for consistency, so folks will probably have to `lando destroy` and `rake servers:start` after this.