### PR TITLE
Use a primary HLS manifest

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -12,8 +12,7 @@ class DownloadsController < ApplicationController
   end
 
   def send_content
-    # Only append auth tokens to HLS if necessary, otherwise let normal behavior
-    # take care of sending it.
+    # HLS manifests are created dynamically, don't send the file directly.
     return send_hls if params[:as] == "stream" || file_desc.mime_type.first.to_s == "application/x-mpegURL"
     # Necessary until a Rack version is released which allows for multiple
     # HTTP_X_ACCEL_MAPPING. When this commit is in a released version:

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -30,8 +30,7 @@ class DownloadsController < ApplicationController
   end
 
   def send_hls
-    return send_primary_hls_manifest if params[:as] == "stream"
-    manifest = HlsManifest.for(file_set: resource, file_metadata: file_desc, auth_token: params[:auth_token])
+    manifest = HlsManifest.for(file_set: resource, file_metadata: file_desc, as: params[:as], auth_token: params[:auth_token])
     render plain: manifest.to_s
   end
 

--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -14,7 +14,7 @@ class DownloadsController < ApplicationController
   def send_content
     # Only append auth tokens to HLS if necessary, otherwise let normal behavior
     # take care of sending it.
-    return send_hls if file_desc.mime_type.first.to_s == "application/x-mpegURL" && params[:auth_token].present?
+    return send_hls if params[:as] == "stream" || file_desc.mime_type.first.to_s == "application/x-mpegURL"
     # Necessary until a Rack version is released which allows for multiple
     # HTTP_X_ACCEL_MAPPING. When this commit is in a released version:
     # https://github.com/rack/rack/commit/f2361997623e5141e6baa907d79f1212b36fbb8b
@@ -30,11 +30,9 @@ class DownloadsController < ApplicationController
   end
 
   def send_hls
-    playlist = M3u8::Playlist.read(File.open(binary_file.disk_path))
-    playlist.items.each do |item|
-      item.segment = "#{item.segment}?auth_token=#{params[:auth_token]}"
-    end
-    render plain: playlist.to_s
+    return send_primary_hls_manifest if params[:as] == "stream"
+    manifest = HlsManifest.for(file_set: resource, file_metadata: file_desc, auth_token: params[:auth_token])
+    render plain: manifest.to_s
   end
 
   def send_fgdc

--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -621,9 +621,9 @@ class ManifestBuilder
     def download_url
       return if derivative.nil?
       if helper.token_authorizable?(parent_node.resource)
-        helper.download_url(resource.try(:proxied_object_id) || resource.id, derivative.id, auth_token: parent_node.resource.auth_token)
+        helper.download_url(resource.try(:proxied_object_id) || resource.id, derivative.id, auth_token: parent_node.resource.auth_token, as: "stream", format: "m3u8")
       else
-        helper.download_url(resource.try(:proxied_object_id) || resource.id, derivative.id)
+        helper.download_url(resource.try(:proxied_object_id) || resource.id, derivative.id, as: "stream", format: "m3u8")
       end
     end
 

--- a/app/values/hls_manifest.rb
+++ b/app/values/hls_manifest.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
+# Class responsible for converting an HLS manifest (.m3u8) file from ffmpeg to
+# include an auth token in its file references, if appropriate.
 class HlsManifest
+  # Factory method for returning the different kinds of manifests. If asked for
+  # a "stream" then it generates a manifest dynamically, otherwise it simply
+  # returns the manifest referenced by file_metadata, mutated if needed.
+  # @return [#to_s] Object whose #to_s method returns an HLS Manifest.
   def self.for(file_set:, file_metadata:, as: nil, auth_token: nil)
-    return unless file_metadata.mime_type.first.to_s == "application/x-mpegURL"
+    return unless file_metadata.hls_manifest?
     if as == "stream"
       Primary.new(file_set: file_set, file_metadata: file_metadata, auth_token: auth_token)
     else

--- a/app/values/hls_manifest.rb
+++ b/app/values/hls_manifest.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+class HlsManifest
+  def self.for(file_set:, file_metadata:, auth_token: nil)
+    if file_metadata.mime_type.first.to_s == "application/x-mpegURL"
+      new(file_set: file_set, file_metadata: file_metadata, auth_token: auth_token)
+    end
+  end
+
+  attr_reader :file_set, :file_metadata, :auth_token
+  delegate :to_s, to: :playlist
+
+  def initialize(file_set:, file_metadata:, auth_token:)
+    @file_set = file_set
+    @file_metadata = file_metadata
+    @auth_token = auth_token
+    apply_auth_token if auth_token.present?
+  end
+
+  def apply_auth_token
+    playlist.items.each do |item|
+      item.segment = "#{item.segment}?auth_token=#{auth_token}"
+    end
+  end
+
+  def playlist
+    @playlist ||= M3u8::Playlist.read(binary_file.io)
+  end
+
+  def binary_file
+    @binary_file ||= Valkyrie::StorageAdapter.find_by(id: file_metadata.file_identifiers.first)
+  end
+end

--- a/app/values/hls_manifest.rb
+++ b/app/values/hls_manifest.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 class HlsManifest
-  def self.for(file_set:, file_metadata:, auth_token: nil)
-    if file_metadata.mime_type.first.to_s == "application/x-mpegURL"
+  def self.for(file_set:, file_metadata:, as: nil, auth_token: nil)
+    return unless file_metadata.mime_type.first.to_s == "application/x-mpegURL"
+    if as == "stream"
+      Primary.new(file_set: file_set, file_metadata: file_metadata, auth_token: auth_token)
+    else
       new(file_set: file_set, file_metadata: file_metadata, auth_token: auth_token)
     end
   end
@@ -13,6 +16,7 @@ class HlsManifest
     @file_set = file_set
     @file_metadata = file_metadata
     @auth_token = auth_token
+    playlist.target = file_set.primary_file.duration.first.to_i + 1
     apply_auth_token if auth_token.present?
   end
 

--- a/app/values/hls_manifest/primary.rb
+++ b/app/values/hls_manifest/primary.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+class HlsManifest::Primary
+  # Primary HLS manifests include the video HLS manifest as well as any caption
+  # manifests. In the future it would also allow us to attach streams at
+  # different qualities, or multiple kinds of captions/subtitles.
+  attr_reader :file_set, :file_metadata, :auth_token
+  delegate :to_s, to: :playlist
+
+  def initialize(file_set:, file_metadata:, auth_token:)
+    @file_set = file_set
+    @file_metadata = file_metadata
+    @auth_token = auth_token
+    attach_av_track
+  end
+
+  def playlist
+    @playlist ||= M3u8::Playlist.new
+  end
+
+  def attach_av_track
+    playlist.items << M3u8::PlaylistItem.new(
+      profile: "high",
+      subtitles: "subs",
+      bandwidth: 540,
+      uri: helper.download_path(file_set.id, file_metadata.id, auth_token: auth_token)
+    )
+  end
+
+  def helper
+    @helper ||= ManifestBuilder::ManifestHelper.new
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,7 +56,7 @@ Rails.application.routes.draw do
     concerns :iiif_search
   end
 
-  get "/downloads/:resource_id/file/:id", to: "downloads#show", as: :download
+  get "/downloads/:resource_id/file/:id(/:as)", to: "downloads#show", as: :download
   get "/manifests/:id/v3", to: "manifests#v3", as: :manifest_v3, defaults: { format: :json }
   get "/tilemetadata/:id", to: "tile_metadata#metadata", as: :tile_metadata, defaults: { format: :json }
   get "/tilemetadata/:id/tilejson", to: "tile_metadata#tilejson", as: :tile_metadata_tilejson, defaults: { format: :json }

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -2,6 +2,7 @@
 require "rails_helper"
 
 RSpec.describe DownloadsController do
+  include ActiveJob::TestHelper
   let(:meta) { Valkyrie.config.metadata_adapter }
   let(:disk) { Valkyrie.config.storage_adapter }
   let(:change_set_persister) { ChangeSetPersister.new(metadata_adapter: meta, storage_adapter: disk) }
@@ -131,7 +132,23 @@ RSpec.describe DownloadsController do
     end
 
     context "with an HLS playlist FileSet and ?as=stream" do
-      xit "creates a primary playlist with the auth token" do
+      it "doesn't append an auth token if not given", run_real_derivatives: true, run_real_characterization: true do
+        stub_ezid
+        output = nil
+        perform_enqueued_jobs do
+          output = FactoryBot.create_for_repository(:scanned_resource_with_video_and_captions, state: "complete")
+        end
+        file_set = Wayfinder.for(output).file_sets.first
+        file_metadata = file_set.file_metadata.find(&:hls_manifest?)
+
+        get :show, params: { resource_id: file_set.id.to_s, id: file_metadata.id.to_s, as: "stream", format: "m3u8" }
+
+        expect(response).to be_successful
+        playlist = M3u8::Playlist.read(response.body)
+        expect(playlist.items.length).to eq 1
+        expect(playlist.items[0].uri).to eq "/downloads/#{file_set.id}/file/#{file_metadata.id}"
+      end
+      it "creates a primary playlist with the auth token" do
         token = AuthToken.create!(group: ["admin"], label: "admin_token")
         change_set_persister = ChangeSetPersister.default
         file_set = FactoryBot.create_for_repository(:file_set)

--- a/spec/controllers/playlists_controller_spec.rb
+++ b/spec/controllers/playlists_controller_spec.rb
@@ -315,7 +315,7 @@ RSpec.describe PlaylistsController, type: :controller do
           first_annotation_page = first_canvas["items"].first
           first_annotation = first_annotation_page["items"].first
           file_node1 = file_set1.file_metadata.find(&:derivative?)
-          expect(first_annotation["body"]).to include("id" => "http://www.example.com/downloads/#{file_set1.id}/file/#{file_node1.id}?auth_token=#{persisted.auth_token}")
+          expect(first_annotation["body"]).to include("id" => "http://www.example.com/downloads/#{file_set1.id}/file/#{file_node1.id}/stream.m3u8?auth_token=#{persisted.auth_token}")
         end
       end
     end

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -321,7 +321,7 @@ RSpec.describe ManifestBuilder do
             first_annotation_page = first_canvas["items"].first
             first_annotation = first_annotation_page["items"].first
             file_node1 = file_set1.file_metadata.find(&:derivative?)
-            expect(first_annotation["body"]).to include("id" => "http://www.example.com/downloads/#{file_set1.id}/file/#{file_node1.id}?auth_token=#{persisted.auth_token}")
+            expect(first_annotation["body"]).to include("id" => "http://www.example.com/downloads/#{file_set1.id}/file/#{file_node1.id}/stream.m3u8?auth_token=#{persisted.auth_token}")
           end
         end
 


### PR DESCRIPTION
This adds a primary manifest in front of the AV manifests, as a place we
can put transcripts.

This also refactors where generating HLS manifests happens, so we can
add to that logic without changing DownloadsController all the time.

Work towards https://github.com/pulibrary/figgy/issues/6181