### PR TITLE
Attach caption HLS manifest to primary manifest. 

### DIFF
--- a/app/nested_resources/file_metadata.rb
+++ b/app/nested_resources/file_metadata.rb
@@ -28,6 +28,9 @@ class FileMetadata < Valkyrie::Resource
   # PDF Metadata
   attribute :page_count, Valkyrie::Types::Integer
 
+  # Caption Metadata
+  attribute :caption_language, Valkyrie::Types::String.default("eng")
+
   # preservation attributes
   # ID of the object this node is a preservation copy of. A PreservationObject's
   # binary_node (which is a FileMetadata object) uses this value to point to a

--- a/app/nested_resources/file_metadata.rb
+++ b/app/nested_resources/file_metadata.rb
@@ -29,7 +29,7 @@ class FileMetadata < Valkyrie::Resource
   attribute :page_count, Valkyrie::Types::Integer
 
   # Caption Metadata
-  attribute :caption_language, Valkyrie::Types::String.default("eng")
+  attribute :caption_language, Valkyrie::Types::String.optional
 
   # preservation attributes
   # ID of the object this node is a preservation copy of. A PreservationObject's

--- a/app/values/hls_manifest.rb
+++ b/app/values/hls_manifest.rb
@@ -7,12 +7,17 @@ class HlsManifest
   # returns the manifest referenced by file_metadata, mutated if needed.
   # @return [#to_s] Object whose #to_s method returns an HLS Manifest.
   def self.for(file_set:, file_metadata:, as: nil, auth_token: nil)
-    return unless file_metadata.hls_manifest? || file_metadata.caption?
-    return new(file_set: file_set, file_metadata: file_metadata, auth_token: auth_token) unless as == "stream"
-    if file_metadata.hls_manifest?
+    # Captions need a manifest to point to the VTT
+    return Caption.new(file_set: file_set, file_metadata: file_metadata, auth_token: auth_token) if file_metadata.caption?
+    return unless file_metadata.hls_manifest?
+    # IIIF Manifests link to a "primary" HLS manifest, which contains links to the caption
+    # manifest and the video manifest. Build it dynamically because it's easier.
+    if as == "stream"
       Primary.new(file_set: file_set, file_metadata: file_metadata, auth_token: auth_token)
     else
-      Caption.new(file_set: file_set, file_metadata: file_metadata, auth_token: auth_token)
+      # If not asked for the primary manifest, just render the video HLS manifest
+      # ffmpeg created (with auth_tokens if appropriate)
+      new(file_set: file_set, file_metadata: file_metadata, auth_token: auth_token) unless as == "stream"
     end
   end
 

--- a/app/values/hls_manifest.rb
+++ b/app/values/hls_manifest.rb
@@ -7,11 +7,12 @@ class HlsManifest
   # returns the manifest referenced by file_metadata, mutated if needed.
   # @return [#to_s] Object whose #to_s method returns an HLS Manifest.
   def self.for(file_set:, file_metadata:, as: nil, auth_token: nil)
-    return unless file_metadata.hls_manifest?
-    if as == "stream"
+    return unless file_metadata.hls_manifest? || file_metadata.caption?
+    return new(file_set: file_set, file_metadata: file_metadata, auth_token: auth_token) unless as == "stream"
+    if file_metadata.hls_manifest?
       Primary.new(file_set: file_set, file_metadata: file_metadata, auth_token: auth_token)
     else
-      new(file_set: file_set, file_metadata: file_metadata, auth_token: auth_token)
+      Caption.new(file_set: file_set, file_metadata: file_metadata, auth_token: auth_token)
     end
   end
 

--- a/app/values/hls_manifest.rb
+++ b/app/values/hls_manifest.rb
@@ -17,7 +17,7 @@ class HlsManifest
     else
       # If not asked for the primary manifest, just render the video HLS manifest
       # ffmpeg created (with auth_tokens if appropriate)
-      new(file_set: file_set, file_metadata: file_metadata, auth_token: auth_token) unless as == "stream"
+      new(file_set: file_set, file_metadata: file_metadata, auth_token: auth_token)
     end
   end
 

--- a/app/values/hls_manifest/caption.rb
+++ b/app/values/hls_manifest/caption.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+class HlsManifest::Caption
+  # Creates an HLS manifest for the caption VTT file given in file_metadata.
+  attr_reader :file_set, :file_metadata, :auth_token
+  delegate :to_s, to: :playlist
+
+  def initialize(file_set:, file_metadata:, auth_token:)
+    @file_set = file_set
+    @file_metadata = file_metadata
+    @auth_token = auth_token
+    attach_caption
+  end
+
+  def playlist
+    @playlist ||= M3u8::Playlist.new(
+      target: duration,
+      version: 3,
+      sequence: 0
+    )
+  end
+
+  # Length of the AV track in seconds - add an extra second so it rounds up.
+  def duration
+    @duration ||= file_set.primary_file.duration.first.to_i + 1
+  end
+
+  def attach_caption
+    playlist.items << M3u8::SegmentItem.new(
+      duration: duration,
+      segment: helper.download_path(file_set.id, file_metadata.id, auth_token: auth_token)
+    )
+  end
+
+  def helper
+    @helper ||= ManifestBuilder::ManifestHelper.new
+  end
+end

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -130,6 +130,23 @@ RSpec.describe DownloadsController do
       end
     end
 
+    context "with a VTT file" do
+      with_queue_adapter :inline
+      it "can generate an HLS manifest for it", run_real_characterization: true do
+        stub_ezid
+        output = FactoryBot.create_for_repository(:scanned_resource_with_video_and_captions, state: "complete")
+        file_set = Wayfinder.for(output).file_sets.first
+        file_metadata = file_set.file_metadata.find(&:caption?)
+
+        get :show, params: { resource_id: file_set.id.to_s, id: file_metadata.id.to_s, as: "stream", format: "m3u8" }
+
+        expect(response).to be_successful
+        playlist = M3u8::Playlist.read(response.body)
+        expect(playlist.target).to eq 6
+        expect(playlist.items.length).to eq 1
+        expect(playlist.items[0].segment).to eq "/downloads/#{file_set.id}/file/#{file_metadata.id}"
+      end
+    end
     context "with an HLS playlist FileSet and ?as=stream" do
       context "with no auth token given" do
         with_queue_adapter :inline

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -155,13 +155,18 @@ RSpec.describe DownloadsController do
           output = FactoryBot.create_for_repository(:scanned_resource_with_video_and_captions, state: "complete")
           file_set = Wayfinder.for(output).file_sets.first
           file_metadata = file_set.file_metadata.find(&:hls_manifest?)
+          caption_metadata = file_set.captions.first
 
           get :show, params: { resource_id: file_set.id.to_s, id: file_metadata.id.to_s, as: "stream", format: "m3u8" }
 
           expect(response).to be_successful
           playlist = M3u8::Playlist.read(response.body)
-          expect(playlist.items.length).to eq 1
-          expect(playlist.items[0].uri).to eq "/downloads/#{file_set.id}/file/#{file_metadata.id}"
+          expect(playlist.items.length).to eq 2
+          expect(playlist.items[0].uri).to eq "/downloads/#{file_set.id}/file/#{file_metadata.id}.m3u8"
+          expect(playlist.items[0].subtitles).to eq "subs"
+          expect(playlist.items[1].uri).to eq "/downloads/#{file_set.id}/file/#{caption_metadata.id}/stream.m3u8"
+          expect(playlist.items[1].language).to eq "eng"
+          expect(playlist.items[1].characteristics).to eq "public.accessibility.describes-spoken-dialog,public.accessibility.describes-music-and-sound"
         end
       end
       it "creates a primary playlist with the auth token" do
@@ -178,7 +183,7 @@ RSpec.describe DownloadsController do
         expect(response).to be_successful
         playlist = M3u8::Playlist.read(response.body)
         expect(playlist.items.length).to eq 1
-        expect(playlist.items[0].uri).to eq "/downloads/#{output.id}/file/#{output.file_metadata.first.id}?auth_token=#{token.token}"
+        expect(playlist.items[0].uri).to eq "/downloads/#{output.id}/file/#{output.file_metadata.first.id}.m3u8?auth_token=#{token.token}"
       end
     end
 

--- a/spec/factories/scanned_resource.rb
+++ b/spec/factories/scanned_resource.rb
@@ -52,7 +52,10 @@ FactoryBot.define do
                   file_path: Rails.root.join("spec", "fixtures", "files", "caption.vtt"),
                   mime_type: "text/vtt",
                   original_filename: "caption.vtt",
-                  use: Valkyrie::Vocab::PCDMUse.Caption
+                  use: Valkyrie::Vocab::PCDMUse.Caption,
+                  node_attributes: {
+                    caption_language: "eng"
+                  }
                 )
               ]
             }


### PR DESCRIPTION
This generates an HLS manifest for caption files (VTT) and associates them with the primary manifest.

Closes https://github.com/pulibrary/figgy/issues/6181