### PR TITLE
Render V3 seeAlso property in av manifests

### DIFF
--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -803,7 +803,7 @@ class ManifestBuilder
     # Instantiate the Manifest
     # @return [IIIFManifest]
     def manifest
-      @manifest ||= if av_collection? || recording?
+      @manifest ||= if av_collection? || av?
                       IIIFManifest::V3::ManifestFactory.new(@resource, manifest_service_locator: ManifestServiceLocatorV3).to_h
                     # If not multi-part and a collection, it's not a MVW
                     elsif @resource.viewing_hint.blank? && @resource.collection?
@@ -814,7 +814,7 @@ class ManifestBuilder
                     end
     end
 
-    def recording?
+    def av?
       # Skip check if it's a Collection node, for performance.
       return false if resource.collection?
       av_presenters = resource.work_presenters.select(&:av_manifest?)

--- a/app/services/manifest_builder/manifest_service_locator_v3.rb
+++ b/app/services/manifest_builder/manifest_service_locator_v3.rb
@@ -31,7 +31,7 @@ class ManifestBuilder
       # Class accessor for the "see also" builder
       # @return [Class]
       def see_also_builder
-        ManifestBuilder::SeeAlsoBuilder
+        ManifestBuilderV3::SeeAlsoBuilder
       end
 
       ##

--- a/spec/services/manifest_builder_spec.rb
+++ b/spec/services/manifest_builder_spec.rb
@@ -728,6 +728,7 @@ RSpec.describe ManifestBuilder do
     it "builds a manifest for playing video back", run_real_characterization: true, run_real_derivatives: true do
       output = manifest_builder.build
       expect(output).to include "items"
+      expect(output["seeAlso"]).to be_a Array
       canvases = output["items"]
       expect(canvases.length).to eq 1
       expect(canvases.first["items"][0]["items"][0]["body"]["duration"]).to eq 5.312


### PR DESCRIPTION
Closes #6245 

- Render V3 seeAlso property in av manifests
- Change method name to reflect both audio and video
