### PR TITLE
Add a health check for Captions.

### DIFF
--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -121,6 +121,7 @@ class FileSet < Resource
   end
 
   # True if it's a video fileset and has no original language caption.
+  # TODO: Return true if captions aren't required, e.g. a silent film.
   def missing_captions?
     return false unless video?
     captions.select(&:original_language_caption).blank?

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -121,9 +121,9 @@ class FileSet < Resource
   end
 
   # True if it's a video fileset and has no original language caption.
-  # TODO: Return true if captions aren't required, e.g. a silent film.
   def missing_captions?
     return false unless video?
+    return false if captions_required == false
     captions.select(&:original_language_caption).blank?
   end
 

--- a/app/queries/find_uncaptioned_members.rb
+++ b/app/queries/find_uncaptioned_members.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+class FindUncaptionedMembers
+  def self.queries
+    [:find_uncaptioned_members]
+  end
+
+  attr_reader :query_service
+  delegate :resource_factory, to: :query_service
+  delegate :run_query, to: :query_service
+  def initialize(query_service:)
+    @query_service = query_service
+  end
+
+  def find_uncaptioned_members(resource:)
+    query_service.custom_queries.find_video_members(resource: resource).select(&:missing_captions?)
+  end
+end

--- a/app/queries/find_video_members.rb
+++ b/app/queries/find_video_members.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+class FindVideoMembers
+  def self.queries
+    [:find_video_members]
+  end
+
+  attr_reader :query_service
+  delegate :resource_factory, to: :query_service
+  delegate :run_query, to: :query_service
+  def initialize(query_service:)
+    @query_service = query_service
+  end
+
+  def find_video_members(resource:, count: false)
+    query_service.custom_queries.find_deep_children_with_property(resource: resource, model: FileSet, property: :file_metadata, value: [{ mime_type: ["video/mp4"] }], count: count)
+  end
+end

--- a/app/values/health_report.rb
+++ b/app/values/health_report.rb
@@ -12,7 +12,8 @@ class HealthReport
     [
       LocalFixityCheck,
       CloudFixityCheck,
-      DerivativeCheck
+      DerivativeCheck,
+      VideoCaptionCheck
     ]
   end
 

--- a/app/values/health_report/video_caption_check.rb
+++ b/app/values/health_report/video_caption_check.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+class HealthReport::VideoCaptionCheck
+  def self.for(resource)
+    new(resource: resource)
+  end
+
+  attr_reader :resource
+  def initialize(resource:)
+    @resource = resource
+  end
+
+  def valid?
+    if file_set?
+      resource.video?
+    else
+      video_members_count.positive?
+    end
+  end
+
+  def type
+    I18n.t("health_status.video_caption_check.type")
+  end
+
+  def status
+    @status ||=
+      if file_set?
+        file_set_status
+      elsif uncaptioned_members.length.positive?
+        :needs_attention
+      else
+        :healthy
+      end
+  end
+
+  def file_set_status
+    if resource.missing_captions?
+      :needs_attention
+    else
+      :healthy
+    end
+  end
+
+  def summary
+    if resource.respond_to?(:member_ids)
+      I18n.t("health_status.video_caption_check.summary.#{status}")
+    else
+      I18n.t("health_status.video_caption_check.summary.self.#{status}")
+    end
+  end
+
+  def query_service
+    ChangeSetPersister.default.query_service
+  end
+
+  def uncaptioned_members
+    @uncaptioned_members ||= query_service.custom_queries.find_uncaptioned_members(resource: resource)
+  end
+
+  def video_members_count
+    @video_members_count ||= query_service.custom_queries.find_video_members(resource: resource, count: true)
+  end
+
+  def file_set?
+    resource.is_a?(FileSet)
+  end
+end

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -432,7 +432,9 @@ Rails.application.config.to_prepare do
     MosaicFileSetQuery,
     FindPersistedMemberIds,
     FindNeverPreservedChildIds,
-    FindDeepErroredFileSets
+    FindDeepErroredFileSets,
+    FindUncaptionedMembers,
+    FindVideoMembers
   ].each do |query_handler|
     Valkyrie.config.metadata_adapter.query_service.custom_queries.register_query_handler(query_handler)
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -194,6 +194,14 @@ en:
         in_progress: "Derivatives are being processed. If this does not resolve itself contact DLS with a link to this resource via #digital-library."
         healthy: 'Derivatives are processed and healthy.'
         needs_attention: 'There was a problem generating derivatives. Contact DLS in #digital-library if you need assistance.'
+    video_caption_check:
+      type: 'Accessibility'
+      summary:
+        self:
+          healthy: 'Required Captions are present.'
+          needs_attention: 'The resource associated with this file will not be viewable until a caption file is attached to this FileSet.'
+        healthy: 'Required Captions are present.'
+        needs_attention: 'A video file attached to this resource is missing a caption file. This resource will not be viewable until one is added. Use the File Manager to identify and add missing captions.'
     local_fixity_check:
       type: 'Local Fixity'
       summary:

--- a/spec/factories/scanned_resource.rb
+++ b/spec/factories/scanned_resource.rb
@@ -51,6 +51,22 @@ FactoryBot.define do
       end
     end
 
+    factory :scanned_resource_with_silent_video do
+      files do
+        [
+          IngestableFile.new(
+            file_path: Rails.root.join("spec", "fixtures", "files", "city.mp4"),
+            mime_type: "video/mp4",
+            original_filename: "city.mp4",
+            use: Valkyrie::Vocab::PCDMUse.OriginalFile,
+            container_attributes: {
+              captions_required: false
+            }
+          )
+        ]
+      end
+    end
+
     factory :scanned_resource_with_video_and_captions do
       files do
         [

--- a/spec/queries/find_uncaptioned_members_spec.rb
+++ b/spec/queries/find_uncaptioned_members_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe FindUncaptionedMembers do
+  with_queue_adapter :inline
+  let(:query_service) { ChangeSetPersister.default.query_service }
+  it "returns all child members that are uncaptioned" do
+    resource = FactoryBot.create_for_repository(:scanned_resource_with_video)
+
+    uncaptioned_members = query_service.custom_queries.find_uncaptioned_members(resource: resource)
+
+    expect(uncaptioned_members.length).to eq 1
+  end
+  it "doesn't return child members that are captioned" do
+    resource = FactoryBot.create_for_repository(:scanned_resource_with_video_and_captions)
+
+    uncaptioned_members = query_service.custom_queries.find_uncaptioned_members(resource: resource)
+
+    expect(uncaptioned_members.length).to eq 0
+  end
+end

--- a/spec/queries/find_video_members_spec.rb
+++ b/spec/queries/find_video_members_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe FindVideoMembers do
+  with_queue_adapter :inline
+  let(:query_service) { ChangeSetPersister.default.query_service }
+  let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }
+  it "returns all child members that are videos" do
+    resource = FactoryBot.create_for_repository(:scanned_resource_with_video)
+
+    videos = query_service.custom_queries.find_video_members(resource: resource)
+
+    expect(videos.length).to eq 1
+  end
+
+  it "doesn't return children that aren't videos" do
+    resource = FactoryBot.create_for_repository(:scanned_resource, files: [file])
+
+    videos = query_service.custom_queries.find_video_members(resource: resource)
+
+    expect(videos.length).to eq 0
+  end
+
+  it "can return a count" do
+    resource = FactoryBot.create_for_repository(:scanned_resource_with_video)
+
+    videos_count = query_service.custom_queries.find_video_members(resource: resource, count: true)
+
+    expect(videos_count).to eq 1
+  end
+end

--- a/spec/values/health_report_spec.rb
+++ b/spec/values/health_report_spec.rb
@@ -303,6 +303,15 @@ RSpec.describe HealthReport do
 
           expect(report.status).to eq :needs_attention
         end
+        it "returns :healthy if the file set's marked as not requiring captions" do
+          stub_ezid
+
+          resource = FactoryBot.create_for_repository(:scanned_resource_with_silent_video, state: "complete")
+          report = described_class.for(resource)
+          expect(report.checks.length).to eq 4
+
+          expect(report.status).to eq :healthy
+        end
         it "returns :needs_attention for the file set" do
           stub_ezid
 


### PR DESCRIPTION
Closes #6192

![Screen Shot 2024-03-12 at 10 42 03 AM](https://github.com/pulibrary/figgy/assets/2806645/a5bfa11b-47b6-423d-8478-86e9b09dab04)


![Screen Shot 2024-03-12 at 10 42 11 AM](https://github.com/pulibrary/figgy/assets/2806645/fbb27b54-26f9-405b-9a38-820cfd31b8e1)

![Screen Shot 2024-03-12 at 10 44 41 AM](https://github.com/pulibrary/figgy/assets/2806645/630dd88c-71db-435d-98b7-8252a947730e)


I didn't add the links to attach a caption or the file manager because the links are right there, and frankly it was kinda hard. I would have had to have made the I18n accept an argument I think? And probably access path helpers from I18n?