### PR TITLE
Visibility warning for uncaptioned videos. 

### DIFF
--- a/app/decorators/valkyrie/resource_decorator.rb
+++ b/app/decorators/valkyrie/resource_decorator.rb
@@ -176,6 +176,7 @@ class Valkyrie::ResourceDecorator < ApplicationDecorator
   # Returns true if the resource has videos that need captions added to them. If
   # so, they're hidden no matter their state.
   def needs_captions?
+    return false unless persisted?
     query_service.custom_queries.find_uncaptioned_members(resource: model, count: true).positive?
   end
 

--- a/app/decorators/valkyrie/resource_decorator.rb
+++ b/app/decorators/valkyrie/resource_decorator.rb
@@ -45,7 +45,7 @@ class Valkyrie::ResourceDecorator < ApplicationDecorator
 
   def visibility
     Array(super).map do |visibility|
-      h.visibility_badge(visibility, public_readable_state?, embargoed?)
+      h.visibility_badge(visibility, public_readable_state?, embargoed?, needs_captions?)
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -119,8 +119,8 @@ module ApplicationHelper
   # @param [String] visibility value
   # @param [Boolean] whether the workflow state is publicly readable
   # @return [String]
-  def visibility_badge(value, public_readable_state = nil, embargoed = nil)
-    PermissionBadge.new(value, public_readable_state, embargoed).render
+  def visibility_badge(value, public_readable_state = nil, embargoed = nil, needs_captions = nil)
+    PermissionBadge.new(value, public_readable_state, embargoed, needs_captions).render
   end
 
   # Retrieve the authorization token from the request parameters

--- a/app/presenters/permission_badge.rb
+++ b/app/presenters/permission_badge.rb
@@ -7,10 +7,11 @@ class PermissionBadge
   # @param visibility [String] the current visibility
   # @param public_readable_state [Boolean] is the resource publically readable
   # @param embargoed [Boolean] is the resource embargoed
-  def initialize(visibility, public_readable_state = nil, embargoed = nil)
+  def initialize(visibility, public_readable_state = nil, embargoed = nil, needs_captions = nil)
     @visibility = visibility
     @public_readable_state = public_readable_state
     @embargoed = embargoed
+    @needs_captions = needs_captions
   end
 
   # Draws div tags with bootstrap labels representing the items visibility
@@ -42,6 +43,7 @@ class PermissionBadge
     # Generate a note of the final visibility, including both the visibility property and workflow state
     def computed_visibility
       return "embargoed" if @embargoed
+      return "needs_captions" if @needs_captions
       return "suppressed_workflow" unless @public_readable_state
       @visibility
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,9 @@ en:
     embargoed:
       class: "alert-warning"
       note_html: "Users will not be able to view this digital object on discovery sites because the resource is embargoed."
+    needs_captions:
+      class: "alert-danger"
+      note_html: "This resource will not be viewable until captions are provided for video files. Review the files in the File Manager."
   base:
     form_progress:
       requirements: 'Requirements'

--- a/spec/decorators/valkyrie/resource_decorator_spec.rb
+++ b/spec/decorators/valkyrie/resource_decorator_spec.rb
@@ -307,6 +307,15 @@ RSpec.describe Valkyrie::ResourceDecorator do
         expect(decorator.visibility.first).to have_selector("div.alert-warning", text: "Users will not be able to view this digital object on discovery sites because the resource is embargoed.")
       end
     end
+
+    context "complete video resource without captions" do
+      let(:resource) { FactoryBot.create_for_repository(:scanned_resource_with_video_and_captions) }
+      it "has a warning that the resource isn't viewable until captions are provided" do
+        expect(decorator.visibility.first).to have_selector(
+          "div.alert-warning", text: "This resource will not be viewable until captions are provided for video files. Review the files in the File Manager."
+        )
+      end
+    end
   end
   describe "#visibility_badge" do
     let(:resource) { FactoryBot.build(:complete_scanned_resource) }

--- a/spec/decorators/valkyrie/resource_decorator_spec.rb
+++ b/spec/decorators/valkyrie/resource_decorator_spec.rb
@@ -309,10 +309,10 @@ RSpec.describe Valkyrie::ResourceDecorator do
     end
 
     context "complete video resource without captions" do
-      let(:resource) { FactoryBot.create_for_repository(:scanned_resource_with_video_and_captions) }
+      let(:resource) { FactoryBot.create_for_repository(:scanned_resource_with_video) }
       it "has a warning that the resource isn't viewable until captions are provided" do
         expect(decorator.visibility.first).to have_selector(
-          "div.alert-warning", text: "This resource will not be viewable until captions are provided for video files. Review the files in the File Manager."
+          "div.alert-danger", text: "This resource will not be viewable until captions are provided for video files. Review the files in the File Manager."
         )
       end
     end


### PR DESCRIPTION
Closes https://github.com/pulibrary/figgy/issues/6183

![Screen Shot 2024-03-12 at 3 57 02 PM](https://github.com/pulibrary/figgy/assets/2806645/730558e9-cd9e-486b-b5e9-6a22e95d3aa9)

As an aside, this visibility logic wasn't very pleasant to work in, but I couldn't really think of how to clean it up.