### PR TITLE
Make OCR language a multi-valued field.

### DIFF
--- a/app/views/records/edit_fields/_ocr_language.html.erb
+++ b/app/views/records/edit_fields/_ocr_language.html.erb
@@ -5,5 +5,5 @@
               value_method: :value,
               hint: "Set this field to trigger OCR generation",
               include_blank: true,
-              input_html: { class: 'form-control' },
+              input_html: { class: 'form-control', multiple: f.object.multiple?(key) },
               required: f.object.required?(key) %>

--- a/spec/shared_specs/controllers/base_resource_controller.rb
+++ b/spec/shared_specs/controllers/base_resource_controller.rb
@@ -41,7 +41,7 @@ RSpec.shared_examples "a ResourcesController" do |*flags|
         expect(response.body).to have_select "Rights Statement", name: "#{model_name}[rights_statement]", options: [""] + ControlledVocabulary.for(:rights_statement).all.map(&:label)
         expect(response.body).to have_select "PDF Type", name: "#{model_name}[pdf_type]", options: ["Color PDF", "Grayscale PDF", "Bitonal PDF", "No PDF"]
         languages = Tesseract.languages
-        expect(response.body).to have_select "OCR Language", name: "#{model_name}[ocr_language]", options: languages.values + [""]
+        expect(response.body).to have_select "OCR Language", name: "#{model_name}[ocr_language][]", options: languages.values + [""]
         expect(response.body).to have_checked_field "Open"
         expect(response.body).to have_button "Save"
       end

--- a/spec/views/records/edit_fields/_ocr_language.html.erb_spec.rb
+++ b/spec/views/records/edit_fields/_ocr_language.html.erb_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "records/edit_fields/_ocr_language.html.erb" do
+  def simple_form_helper_for(change_set)
+    form = nil
+    view.simple_form_for(change_set) do |f|
+      form = f
+    end
+    form
+  end
+
+  it "renders a collection on ocr language" do
+    resource = ChangeSet.for(FactoryBot.build(:scanned_resource))
+    render partial: "records/edit_fields/ocr_language", locals: { f: simple_form_helper_for(resource), key: :ocr_language }
+
+    expect(rendered).to have_select("OCR Language")
+    expect(rendered).to have_selector "#scanned_resource_ocr_language[multiple=multiple]"
+  end
+end


### PR DESCRIPTION
Done on a whim, on a user request, and because it's been bothering me for a long time that our OCR generators all handle this but we can't put it in the form.