### PR TITLE
Add muxdelay 0 to ffmpeg HLS generation.

### DIFF
--- a/app/derivative_services/av_derivative_service.rb
+++ b/app/derivative_services/av_derivative_service.rb
@@ -71,7 +71,7 @@ class AvDerivativeService
 
   def generate_hls_derivatives(dir)
     _stdout, _stderr, status =
-      Open3.capture3("ffmpeg", "-y", "-i", file_object.disk_path.to_s, "-hls_list_size", "0", "-hls_time", "10", "-f", "hls", "-codec:a", "libmp3lame", dir.join("hls.m3u8").to_s)
+      Open3.capture3("ffmpeg", "-y", "-i", file_object.disk_path.to_s, "-hls_list_size", "0", "-hls_time", "10", "-f", "hls", "-codec:a", "libmp3lame", "-muxdelay", "0", dir.join("hls.m3u8").to_s)
     return unless status.success?
     change_set.files = Dir[dir.join("*.ts")].map do |file|
       build_file(file, filename: Pathname.new(file).basename, partial: true)

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe DownloadsController do
 
         get :show, params: { resource_id: file_set.id.to_s, id: file_node.id.to_s, auth_token: persisted_playlist.auth_token }
 
-        expect(response.content_length).to eq(5452)
+        expect(response.content_length).to eq(7332)
         expect(response.media_type).to eq("video/MP2T")
       end
     end


### PR DESCRIPTION
I very carefully crafted some subtitles for a demo video, uploaded them, and noticed subtitles were out of sync! According to https://stackoverflow.com/questions/61835223/ffmpeg-burnt-in-subtitles-out-of-sync-when-converting-to-hls ffmpeg adds a delay to AV when creating HLS - and sure enough, when I add this argument everything's in sync.