### PR TITLE
Generate Checksum for captions.

### DIFF
--- a/app/change_set_persisters/change_set_persister.rb
+++ b/app/change_set_persisters/change_set_persister.rb
@@ -54,7 +54,8 @@ class ChangeSetPersister
         PreserveResource,
         ReorganizeCollection,
         UpdateAspaceDao,
-        CleanupDeletedFiles
+        CleanupDeletedFiles,
+        Characterize
       ],
       after_update_commit: [
         ReindexCollectionMembers,
@@ -82,7 +83,6 @@ class ChangeSetPersister
         CleanupPreservation
       ],
       after_commit: [
-        Characterize,
         PublishMessage::Factory.new(operation: :create)
       ]
     }

--- a/app/jobs/generate_checksum_job.rb
+++ b/app/jobs/generate_checksum_job.rb
@@ -4,8 +4,11 @@ class GenerateChecksumJob < ApplicationJob
 
   def perform(file_set_id)
     file_set = query_service.find_by(id: Valkyrie::ID.new(file_set_id))
-    file_set.primary_file.checksum = file_set.primary_file.file_identifiers.map do |id|
-      MultiChecksum.for(Valkyrie::StorageAdapter.find_by(id: id))
+    file_set.preservation_targets.each do |target|
+      next if target.checksum.present?
+      target.checksum = target.file_identifiers.map do |id|
+        MultiChecksum.for(Valkyrie::StorageAdapter.find_by(id: id))
+      end
     end
     persister.save(resource: file_set)
   end

--- a/spec/change_set_persisters/change_set_persister_spec.rb
+++ b/spec/change_set_persisters/change_set_persister_spec.rb
@@ -1383,6 +1383,7 @@ RSpec.describe ChangeSetPersister do
 
         expect(File.exist?(disk_preservation_path.join(resource.id.to_s, "data", output.member_ids.first.to_s, "city-#{file_set.primary_file.id}.mp4"))).to eq true
         expect(File.exist?(disk_preservation_path.join(resource.id.to_s, "data", output.member_ids.first.to_s, "caption-#{file_set.captions.first.id}.vtt"))).to eq true
+        expect(file_set.captions.first.checksum).not_to be_blank
       end
     end
 


### PR DESCRIPTION
This should handle future preservation targets as well.

I moved Characterize to after_save_commit so we'd have access to `post_save_resource` in its handlers - I couldn't find a reason for it to not be there.

Closes #6276