### PR TITLE
Add sidekiq to health monitor

### DIFF
--- a/config/initializers/health_monitor.rb
+++ b/config/initializers/health_monitor.rb
@@ -10,6 +10,18 @@ Rails.application.config.after_initialize do
     config.add_custom_provider(SmtpStatus)
     config.add_custom_provider(FileWatcherStatus)
 
+    # monitor all the queues for latency
+    # The gem also comes with some additional default monitoring, including
+    # number of retries on a job (max 20) and ensuring there are running workers
+    config.sidekiq.configure do |sidekiq_config|
+      sidekiq_config.latency = 5.days
+      sidekiq_config.queue_size = 1_000_000
+      sidekiq_config.add_queue_configuration("high", latency: 5.days, queue_size: 1_000_000)
+      sidekiq_config.add_queue_configuration("low", latency: 5.days, queue_size: 1_000_000)
+      sidekiq_config.add_queue_configuration("super_low", latency: 5.days, queue_size: 1_000_000)
+      sidekiq_config.add_queue_configuration("retry", latency: 5.days, queue_size: 1_000_000)
+    end
+
     # Make this health check available at /health
     config.path = :health
 

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe "Health Check", type: :request do
         ocr_in_path = Figgy.config["ocr_in_path"]
         FileUtils.touch("#{ocr_in_path}/file1.pdf", mtime: thirteen_hours_ago)
 
-        get "/health.json"
+        get "/health.json?providers[]=filewatcherstatus"
 
         expect(response).not_to be_successful
         expect(response.status).to eq 503
@@ -94,7 +94,7 @@ RSpec.describe "Health Check", type: :request do
         ocr_in_path = Figgy.config["ocr_in_path"]
         FileUtils.touch("#{ocr_in_path}/file1.pdf")
 
-        get "/health.json"
+        get "/health.json?providers[]=filewatcherstatus"
 
         expect(response).to be_successful
       end

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -50,6 +50,19 @@ RSpec.describe "Health Check", type: :request do
       expect(rabbit_response["message"]).not_to be_blank
     end
 
+    it "is configured to monitor all desired Sidekiq queues" do
+      sidekiq_configuration = HealthMonitor.configuration.providers.find { |provider| provider.name == "Sidekiq" }.configuration
+
+      # test that all the queues are checked, and the configuration of each
+      expect(sidekiq_configuration.queues).to match(
+        "high" => hash_including(latency: 5.days, queue_size: 1_000_000),
+        "default" => hash_including(latency: 5.days, queue_size: 1_000_000),
+        "low" => hash_including(latency: 5.days, queue_size: 1_000_000),
+        "super_low" => hash_including(latency: 5.days, queue_size: 1_000_000),
+        "retry" => hash_including(latency: 5.days, queue_size: 1_000_000)
+      )
+    end
+
     context "when there are files in the ocr in directory" do
       before do
         stub_aspace_login
@@ -83,6 +96,5 @@ RSpec.describe "Health Check", type: :request do
 
         expect(response).to be_successful
       end
-    end
   end
 end

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -12,6 +12,8 @@ RSpec.describe "Health Check", type: :request do
     it "has a health check" do
       stub_aspace_login
       allow(Net::SMTP).to receive(:new).and_return(instance_double(Net::SMTP, "open_timeout=": nil, start: true))
+      # stub the number of processes since sidekiq doesn't run in test
+      allow(Sidekiq::Stats).to receive(:new).and_return(instance_double(Sidekiq::Stats, processes_size: 1))
 
       get "/health.json"
 
@@ -96,5 +98,6 @@ RSpec.describe "Health Check", type: :request do
 
         expect(response).to be_successful
       end
+    end
   end
 end


### PR DESCRIPTION
advances #6287

This monitor will fail if any job in the retry queue has 20 or more retries. There is not a way in the sidekiq api to check retry latency because it's not a queue; it's a set. We had determined that 5 days would probably be around 17 retries, but it's not configurable in the underlying gem.