### PR TITLE
Move pdf spec to its own shared spec.

### DIFF
--- a/app/controllers/ephemera_folders_controller.rb
+++ b/app/controllers/ephemera_folders_controller.rb
@@ -77,10 +77,6 @@ class EphemeraFoldersController < ResourcesController
     redirect_to download_path(redirect_path_args)
   end
 
-  def storage_adapter
-    Valkyrie.config.storage_adapter
-  end
-
   def auth_token_param
     params[:auth_token]
   end

--- a/app/controllers/numismatics/coins_controller.rb
+++ b/app/controllers/numismatics/coins_controller.rb
@@ -89,10 +89,6 @@ module Numismatics
       @selected_issue = numismatic_issue&.id.to_s
     end
 
-    def storage_adapter
-      Valkyrie.config.storage_adapter
-    end
-
     def after_create_success(obj, _change_set)
       if params[:commit] == "Save and Duplicate Metadata"
         redirect_to new_numismatics_coin_path(parent_id: resource_params[:append_id], create_another: obj.id.to_s), notice: "Coin #{obj.coin_number} Saved, Creating Another..."

--- a/spec/controllers/ephemera_folders_controller_spec.rb
+++ b/spec/controllers/ephemera_folders_controller_spec.rb
@@ -472,10 +472,8 @@ RSpec.describe EphemeraFoldersController, type: :controller do
     end
   end
 
-  describe "pdf" do
-    let(:resource) { FactoryBot.create_for_repository(:ephemera_folder, member_ids: [file_set.id]) }
-    let(:file_set) { FactoryBot.create_for_repository(:file_set, file_metadata: file_meta) }
-    let(:file_meta) { FileMetadata.new(mime_type: "image/tiff", use: Valkyrie::Vocab::PCDMUse.OriginalFile) }
+  describe "#pdf" do
+    let(:factory) { :ephemera_folder }
 
     it_behaves_like "a Pdfable"
   end

--- a/spec/controllers/ephemera_folders_controller_spec.rb
+++ b/spec/controllers/ephemera_folders_controller_spec.rb
@@ -472,47 +472,13 @@ RSpec.describe EphemeraFoldersController, type: :controller do
     end
   end
 
-  # rubocop:disable RSpec/InstanceVariable
   describe "pdf" do
-    let(:user) { FactoryBot.create(:admin) }
     let(:resource) { FactoryBot.create_for_repository(:ephemera_folder, member_ids: [file_set.id]) }
     let(:file_set) { FactoryBot.create_for_repository(:file_set, file_metadata: file_meta) }
     let(:file_meta) { FileMetadata.new(mime_type: "image/tiff", use: Valkyrie::Vocab::PCDMUse.OriginalFile) }
 
-    # TODO: figure out why pdf generation works in development but fails in test, and remove this stubbing and
-    # the unneeded tests below
-    let(:storage_adapter) { Valkyrie::StorageAdapter.find(:disk_via_copy) }
-    let(:pdf_file) do
-      file = fixture_file_upload("files/example.tif", "application/pdf")
-      node = FileMetadata.for(file: file).new(id: SecureRandom.uuid)
-      stored_file = storage_adapter.upload(resource: node, file: file, original_filename: "tmp.pdf")
-      node.file_identifiers = stored_file.id
-      node
-    end
-    let(:pdf_generator) { double }
-
-    before do
-      allow(PDFGenerator).to receive(:new).and_return(pdf_generator)
-      allow(pdf_generator).to receive(:render).and_return(pdf_file)
-    end
-
-    it "generates a pdf, attaches it to the folder, and redirects the user to download it" do
-      get :pdf, params: { id: resource.id.to_s }
-      reloaded = adapter.query_service.find_by(id: resource.id)
-      expect(response).to redirect_to Rails.application.routes.url_helpers.download_path(resource_id: resource.id.to_s, id: reloaded.pdf_file.id.to_s)
-
-      expect(reloaded.file_metadata).not_to be_blank
-      expect(reloaded.pdf_file).not_to be_blank
-    end
+    it_behaves_like "a Pdfable"
   end
-
-  # TODO: remove this block when stubbing above has been removed
-  context "coverage for lines skipped because of stubbing" do
-    it "has a storage adapter" do
-      expect(@controller.storage_adapter).to be_a(Valkyrie::Storage::Disk)
-    end
-  end
-  # rubocop:enable RSpec/InstanceVariable
 
   context "when an admin" do
     let(:user) { FactoryBot.create(:admin) }

--- a/spec/controllers/numismatics/coins_controller_spec.rb
+++ b/spec/controllers/numismatics/coins_controller_spec.rb
@@ -174,10 +174,8 @@ RSpec.describe Numismatics::CoinsController, type: :controller do
     end
   end
 
-  describe "pdf" do
-    let(:resource) { FactoryBot.create_for_repository(:coin, member_ids: [file_set.id]) }
-    let(:file_set) { FactoryBot.create_for_repository(:file_set, file_metadata: file_metadata) }
-    let(:file_metadata) { FileMetadata.new(mime_type: "image/tiff", use: Valkyrie::Vocab::PCDMUse.OriginalFile) }
+  describe "#pdf" do
+    let(:factory) { :coin }
 
     it_behaves_like "a Pdfable"
   end

--- a/spec/controllers/numismatics/coins_controller_spec.rb
+++ b/spec/controllers/numismatics/coins_controller_spec.rb
@@ -174,43 +174,11 @@ RSpec.describe Numismatics::CoinsController, type: :controller do
     end
   end
 
-  # Copied from ephemera_folders_controller_spec.rb:434. Similarly the test will fail if the stubbing is not included.
   describe "pdf" do
     let(:resource) { FactoryBot.create_for_repository(:coin, member_ids: [file_set.id]) }
-    let(:user) { FactoryBot.create(:admin) }
     let(:file_set) { FactoryBot.create_for_repository(:file_set, file_metadata: file_metadata) }
     let(:file_metadata) { FileMetadata.new(mime_type: "image/tiff", use: Valkyrie::Vocab::PCDMUse.OriginalFile) }
-    let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
 
-    let(:storage_adapter) { Valkyrie::StorageAdapter.find(:disk_via_copy) }
-    let(:pdf_file) do
-      file = fixture_file_upload("files/example.tif", "application/pdf")
-      node = FileMetadata.for(file: file).new(id: SecureRandom.uuid)
-      stored_file = storage_adapter.upload(resource: node, file: file, original_filename: "tmp.pdf")
-      node.file_identifiers = stored_file.id
-      node
-    end
-    let(:pdf_generator) { double }
-
-    before do
-      allow(PDFGenerator).to receive(:new).and_return(pdf_generator)
-      allow(pdf_generator).to receive(:render).and_return(pdf_file)
-    end
-
-    it "generates a pdf, attaches it to the folder, and redirects the user to download it" do
-      get :pdf, params: { id: resource.id.to_s }
-      reloaded = adapter.query_service.find_by(id: resource.id)
-      expect(response).to redirect_to Rails.application.routes.url_helpers.download_path(resource_id: resource.id.to_s, id: reloaded.pdf_file.id.to_s)
-
-      expect(reloaded.file_metadata).not_to be_blank
-      expect(reloaded.pdf_file).not_to be_blank
-    end
-  end
-
-  # TODO: remove this block when stubbing above has been removed
-  context "coverage for lines skipped because of stubbing" do
-    it "has a storage adapter" do
-      expect(controller.storage_adapter).to be_a(Valkyrie::Storage::Disk)
-    end
+    it_behaves_like "a Pdfable"
   end
 end

--- a/spec/controllers/scanned_resources_controller_spec.rb
+++ b/spec/controllers/scanned_resources_controller_spec.rb
@@ -16,6 +16,13 @@ RSpec.describe ScannedResourcesController, type: :controller do
 
   it_behaves_like "a ResourcesController"
 
+  describe "#pdf" do
+    let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }
+    let(:resource) { FactoryBot.create_for_repository(:scanned_resource, files: [file]) }
+
+    it_behaves_like "a Pdfable"
+  end
+
   describe "manifest caching" do
     let(:memory_store) { ActiveSupport::Cache.lookup_store(:memory_store) }
     let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }

--- a/spec/controllers/scanned_resources_controller_spec.rb
+++ b/spec/controllers/scanned_resources_controller_spec.rb
@@ -17,8 +17,7 @@ RSpec.describe ScannedResourcesController, type: :controller do
   it_behaves_like "a ResourcesController"
 
   describe "#pdf" do
-    let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }
-    let(:resource) { FactoryBot.create_for_repository(:scanned_resource, files: [file]) }
+    let(:factory) { :scanned_resource }
 
     it_behaves_like "a Pdfable"
   end

--- a/spec/shared_specs.rb
+++ b/spec/shared_specs.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require_relative "shared_specs/controllers/base_resource_controller.rb"
+require_relative "shared_specs/controllers/concerns/pdfable.rb"
 require_relative "shared_specs/decorators/collection_decorator.rb"
 require_relative "shared_specs/models/linked_data/linked_resource.rb"
 require_relative "shared_specs/models/linked_data/resource/with_date_range.rb"

--- a/spec/shared_specs/controllers/base_resource_controller.rb
+++ b/spec/shared_specs/controllers/base_resource_controller.rb
@@ -382,22 +382,4 @@ RSpec.shared_examples "a ResourcesController" do |*flags|
       end
     end
   end
-
-  describe "#pdf" do
-    let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }
-    let(:resource) { FactoryBot.create_for_repository(factory, files: [file]) }
-    let(:file_set) { resource.member_ids.first }
-    before do
-      stub_request(:any, "http://www.example.com/image-service/#{file_set.id}/full/200,/0/gray.jpg")
-        .to_return(body: File.open(Rails.root.join("spec", "fixtures", "files", "derivatives", "grey-pdf.jpg")), status: 200)
-    end
-    it "generates a PDF, attaches it to the simple resource, and redirects to download for it" do
-      get :pdf, params: { id: resource.id.to_s }
-      reloaded = adapter.query_service.find_by(id: resource.id)
-
-      expect(reloaded.file_metadata).not_to be_blank
-      expect(reloaded.pdf_file).not_to be_blank
-      expect(response).to redirect_to Rails.application.routes.url_helpers.download_path(resource_id: resource.id.to_s, id: reloaded.pdf_file.id.to_s)
-    end
-  end
 end

--- a/spec/shared_specs/controllers/concerns/pdfable.rb
+++ b/spec/shared_specs/controllers/concerns/pdfable.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.shared_examples "a Pdfable" do
+  with_queue_adapter :inline
+  let(:user) { FactoryBot.create(:admin) }
+  let(:adapter) { Valkyrie::MetadataAdapter.find(:indexing_persister) }
+
+  before do
+    raise "resource must be set with `let(:resource)`" unless
+      defined? resource
+    sign_in user
+  end
+
+  let(:storage_adapter) { Valkyrie::StorageAdapter.find(:disk_via_copy) }
+  let(:pdf_file) do
+    file = fixture_file_upload("files/example.tif", "application/pdf")
+    node = FileMetadata.for(file: file).new(id: SecureRandom.uuid)
+    stored_file = storage_adapter.upload(resource: node, file: file, original_filename: "tmp.pdf")
+    node.file_identifiers = stored_file.id
+    node
+  end
+  let(:pdf_generator) { double }
+
+  before do
+    allow(PDFGenerator).to receive(:new).and_return(pdf_generator)
+    allow(pdf_generator).to receive(:render).and_return(pdf_file)
+  end
+
+  it "generates a pdf, attaches it to the folder, and redirects the user to download it" do
+    get :pdf, params: { id: resource.id.to_s }
+    reloaded = adapter.query_service.find_by(id: resource.id)
+    expect(response).to redirect_to Rails.application.routes.url_helpers.download_path(resource_id: resource.id.to_s, id: reloaded.pdf_file.id.to_s)
+
+    expect(reloaded.file_metadata).not_to be_blank
+    expect(reloaded.pdf_file).not_to be_blank
+  end
+end


### PR DESCRIPTION
- There were identical specs in ephemera folders controller, coins
  controller, and scanned resources controller specs. This will make
  them easier to change together
- The shared spec for ResourcesController had the pdf spec, but the
  ResourcesController does not implement that code, it's directly in the
  scanned resources controller itself, so it didn't make sense for the
  spec to be there.
- Set us up to move the pdf controller code to a concern

refs #6278
