### PR TITLE
Use standard storage adapter for geo resource thumbnails

### DIFF
--- a/app/derivative_services/raster_resource_derivative_service.rb
+++ b/app/derivative_services/raster_resource_derivative_service.rb
@@ -2,8 +2,6 @@
 class RasterResourceDerivativeService
   class Factory
     attr_reader :change_set_persister
-    delegate :metadata_adapter, :storage_adapter, to: :change_set_persister
-    delegate :query_service, to: :metadata_adapter
     def initialize(change_set_persister:)
       @change_set_persister = change_set_persister
     end
@@ -15,7 +13,7 @@ class RasterResourceDerivativeService
 
   attr_reader :id, :change_set_persister
   delegate :mime_type, to: :primary_file
-  delegate :query_service, to: :change_set_persister
+  delegate :query_service, :storage_adapter, to: :change_set_persister
   delegate :primary_file, to: :resource
   def initialize(id:, change_set_persister:)
     @id = id
@@ -159,10 +157,6 @@ class RasterResourceDerivativeService
       change_set_persister.buffer_into_index do |buffered_persister|
         buffered_persister.save(change_set: updated_change_set)
       end
-    end
-
-    def storage_adapter
-      @storage_adapter ||= Valkyrie::StorageAdapter.find(:geo_derivatives)
     end
 
     # Updates error message property on the original file.

--- a/app/derivative_services/vector_resource_derivative_service.rb
+++ b/app/derivative_services/vector_resource_derivative_service.rb
@@ -2,8 +2,6 @@
 class VectorResourceDerivativeService
   class Factory
     attr_reader :change_set_persister
-    delegate :metadata_adapter, :storage_adapter, to: :change_set_persister
-    delegate :query_service, to: :metadata_adapter
     def initialize(change_set_persister:)
       @change_set_persister = change_set_persister
     end
@@ -15,7 +13,7 @@ class VectorResourceDerivativeService
 
   attr_reader :id, :change_set_persister
   delegate :mime_type, to: :primary_file
-  delegate :query_service, to: :change_set_persister
+  delegate :query_service, :storage_adapter, to: :change_set_persister
   delegate :primary_file, to: :resource
   def initialize(id:, change_set_persister:)
     @id = id
@@ -158,10 +156,6 @@ class VectorResourceDerivativeService
       change_set_persister.buffer_into_index do |buffered_persister|
         buffered_persister.save(change_set: updated_change_set)
       end
-    end
-
-    def storage_adapter
-      @storage_adapter ||= Valkyrie::StorageAdapter.find(:geo_derivatives)
     end
 
     # Updates error message property on the original file.

--- a/config/config.yml
+++ b/config/config.yml
@@ -21,7 +21,6 @@ defaults: &defaults
   locations_url: https://bibdata.princeton.edu/locations/digital_locations.json
   derivative_path: <%= Rails.root.join("tmp", "derivatives") %>
   pyramidal_derivative_path: <%= Rails.root.join("tmp", "pyramidal_derivatives") %>
-  geo_derivative_path: <%= Rails.root.join("tmp", "geo_derivatives") %>
   stream_derivatives_path: <%= Rails.root.join("tmp", "stream_derivatives") %>
   repository_path: <%= Rails.root.join("tmp", "files") %>
   pyramidal_url: <%= ENV.fetch('PYRAMIDAL_URL', 'http://localhost:8182/iiif/2/') %>
@@ -250,7 +249,6 @@ test:
   repository_path: <%= Rails.root.join("tmp", "test_files#{ENV["TEST_ENV_NUMBER"]}") %>
   derivative_path: <%= Rails.root.join("tmp", "test_derivatives#{ENV["TEST_ENV_NUMBER"]}") %>
   pyramidal_derivative_path: <%= Rails.root.join("tmp", "test_pyramidal_derivatives#{ENV["TEST_ENV_NUMBER"]}") %>
-  geo_derivative_path: <%= Rails.root.join("tmp", "test_geo_derivatives#{ENV["TEST_ENV_NUMBER"]}") %>
   bag_path: <%= Rails.root.join("tmp", "test_bags#{ENV["TEST_ENV_NUMBER"]}") %>
   export_base: <%= Rails.root.join("tmp", "test_export#{ENV["TEST_ENV_NUMBER"]}") %>
   pudl_root: <%= Rails.root.join("spec", "fixtures", "test_pudl_root") %>
@@ -273,7 +271,6 @@ production:
   archivespace_url: <%= ENV["ASPACE_URL"] || "https://aspace.princeton.edu/staff/api" %>
   repository_path: "/opt/repository/files"
   derivative_path: "/opt/repository/derivatives"
-  geo_derivative_path: "/opt/repository/geo_derivatives"
   stream_derivatives_path: "/opt/repository/stream_derivatives"
   bag_path: <%= ENV["FIGGY_BAG_PATH"] || Rails.root.join("tmp", "bags") %>
   pudl_root: <%= ENV["FIGGY_PUDL_ROOT"]  %>
@@ -297,7 +294,6 @@ staging:
   derivative_path: "/opt/repository/derivatives"
   cloud_geo_bucket: "figgy-geo-staging"
   pyramidal_derivative_path: "/opt/repository/derivatives/pyramidals"
-  geo_derivative_path: "/opt/repository/geo_derivatives"
   stream_derivatives_path: "/opt/repository/stream_derivatives"
   bag_path: <%= ENV["FIGGY_BAG_PATH"] || Rails.root.join("tmp", "bags") %>
   pudl_root: <%= ENV["FIGGY_PUDL_ROOT"]  %>

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -157,17 +157,6 @@ Rails.application.config.to_prepare do
   # The file system in the server environment was overriding this, specifically for cases where files were saved to...
   # ...the IIIF image server network file share (libimages1) with a file access control octal value of 600 (globally-unreadable)
   # @see https://help.ubuntu.com/community/FilePermissions
-  Valkyrie::StorageAdapter.register(
-    Valkyrie::Storage::Disk.new(
-      base_path: Figgy.config["geo_derivative_path"],
-      file_mover: lambda { |old_path, new_path|
-        FileUtils.mv(old_path, new_path)
-        FileUtils.chmod(0o644, new_path)
-      }
-    ),
-    :geo_derivatives
-  )
-
   if Figgy.config["aws_access_key_id"].present? && Figgy.config["cloud_geo_bucket"].present? && !Rails.env.test?
     Shrine.storages = (Shrine.storages || {}).merge(
       cloud_geo_storage: Shrine::Storage::S3.new(
@@ -349,7 +338,7 @@ Rails.application.config.to_prepare do
   Valkyrie::Derivatives::DerivativeService.services << VectorResourceDerivativeService::Factory.new(
     change_set_persister: ::ChangeSetPersister.new(
       metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister),
-      storage_adapter: Valkyrie::StorageAdapter.find(:geo_derivatives)
+      storage_adapter: Valkyrie::StorageAdapter.find(:derivatives)
     )
   )
 
@@ -357,13 +346,13 @@ Rails.application.config.to_prepare do
   Valkyrie::Derivatives::DerivativeService.services << RasterResourceDerivativeService::Factory.new(
     change_set_persister: ::ChangeSetPersister.new(
       metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister),
-      storage_adapter: Valkyrie::StorageAdapter.find(:geo_derivatives)
+      storage_adapter: Valkyrie::StorageAdapter.find(:derivatives)
     )
   )
   Valkyrie::Derivatives::DerivativeService.services << ExternalMetadataDerivativeService::Factory.new(
     change_set_persister: ::ChangeSetPersister.new(
       metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister),
-      storage_adapter: Valkyrie::StorageAdapter.find(:geo_derivatives)
+      storage_adapter: Valkyrie::StorageAdapter.find(:derivatives)
     )
   )
 

--- a/spec/derivative_services/raster_resource_derivative_service_spec.rb
+++ b/spec/derivative_services/raster_resource_derivative_service_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe RasterResourceDerivativeService do
   end
 
   context "with a valid geotiff" do
-    it "creates a thumbnail in the geo derivatives directory, and also stores to the cloud" do
+    it "creates a thumbnail in the derivatives directory, and also stores to the cloud" do
       cloud_file_service = instance_double(CloudFilePermissionsService)
       allow(CloudFilePermissionsService).to receive(:new).and_return(cloud_file_service)
       allow(cloud_file_service).to receive(:run)
@@ -52,7 +52,7 @@ RSpec.describe RasterResourceDerivativeService do
       cloud_raster_file = Valkyrie::StorageAdapter.find_by(id: cloud_raster_file_set.file_identifiers.first)
 
       expect(cloud_raster_file_set.use).to eq([Valkyrie::Vocab::PCDMUse.CloudDerivative])
-      expect(thumbnail_file.io.path).to start_with(Rails.root.join("tmp", Figgy.config["geo_derivative_path"]).to_s)
+      expect(thumbnail_file.io.path).to start_with(Rails.root.join("tmp", Figgy.config["derivative_path"]).to_s)
       expect(cloud_raster_file.io.path).to start_with(Rails.root.join("tmp", Figgy.config["test_cloud_geo_derivative_path"]).to_s)
       expect(cloud_file_service).to have_received(:run)
     end

--- a/spec/derivative_services/vector_resource_derivative_service_spec.rb
+++ b/spec/derivative_services/vector_resource_derivative_service_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe VectorResourceDerivativeService do
   end
 
   context "with a valid shapefile" do
-    it "creates a thumbnail in the geo derivatives directory and also stores to the cloud" do
+    it "creates a thumbnail in the derivatives directory and also stores to the cloud" do
       cloud_file_service = instance_double(CloudFilePermissionsService)
       allow(CloudFilePermissionsService).to receive(:new).and_return(cloud_file_service)
       allow(cloud_file_service).to receive(:run)
@@ -48,7 +48,7 @@ RSpec.describe VectorResourceDerivativeService do
       cloud_vector_file = Valkyrie::StorageAdapter.find_by(id: cloud_vector_file_set.file_identifiers.first)
 
       expect(cloud_vector_file_set.use).to eq([Valkyrie::Vocab::PCDMUse.CloudDerivative])
-      expect(thumbnail_file.io.path).to start_with(Rails.root.join("tmp", Figgy.config["geo_derivative_path"]).to_s)
+      expect(thumbnail_file.io.path).to start_with(Rails.root.join("tmp", Figgy.config["derivative_path"]).to_s)
       expect(cloud_vector_file.io.path).to start_with(Rails.root.join("tmp", Figgy.config["test_cloud_geo_derivative_path"]).to_s)
       expect(cloud_file_service).to have_received(:run)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,6 @@ RSpec.configure do |config|
   config.after(:suite) do
     break unless Rails.env.test?
     FileUtils.rm_rf(Figgy.config["derivative_path"])
-    FileUtils.rm_rf(Figgy.config["geo_derivative_path"])
     FileUtils.rm_rf(Figgy.config["repository_path"])
   end
 end


### PR DESCRIPTION
- Use standard storage adapter for geo resource thumbnails
- Remove geo_derivative storage adapter

Works towards #6312 