### PR TITLE
Let errors pass through if file appender fails on create_node

### DIFF
--- a/app/jobs/cdl/pdf_ingest_job.rb
+++ b/app/jobs/cdl/pdf_ingest_job.rb
@@ -14,8 +14,9 @@ module CDL
       change_set = CDL::ResourceChangeSet.new(ScannedResource.new)
       change_set.validate(files: [ingestable_file], source_metadata_identifier: source_metadata_identifier, depositor: "cdl_auto_ingest", member_of_collection_ids: [collection_id].compact)
       change_set_persister.buffer_into_index do |buffered_change_set_persister|
-        output = buffered_change_set_persister.save(change_set: change_set)
-        raise "No PDF Found: #{file_name}" if output.member_ids.empty?
+        buffered_change_set_persister.save(change_set: change_set)
+      rescue FileAppender::FileUploadFailed
+        raise "No PDF Found: #{file_name}"
       end
       FileUtils.rm(file_path)
     end

--- a/app/services/file_appender.rb
+++ b/app/services/file_appender.rb
@@ -126,7 +126,7 @@ class FileAppender
       node.file_identifiers = node.file_identifiers + [stored_file.id]
       node
     rescue StandardError => error
-      # RRise the error, with extra info added to the message
+      # Raise the error, with extra info added to the message
       # We may end up with orphan files on disk, but it's better than
       # half-ingested resources
       message = "#{self.class}: Failed to append the new file #{original_filename} for #{node.id} to resource #{parent.id}: #{error}"

--- a/spec/controllers/collections_controller_spec.rb
+++ b/spec/controllers/collections_controller_spec.rb
@@ -168,9 +168,9 @@ RSpec.describe CollectionsController, type: :controller do
         expect(manifest_response[:manifests][0][:@id]).to eq "http://www.example.com/concern/scanned_resources/#{scanned_resource.id}/manifest"
       end
       it "doesn't run a query for every member of the collection" do
-        file = fixture_file_upload("files/example.tif", "image/tiff")
         collection = FactoryBot.create_for_repository(:collection)
         5.times do
+          file = fixture_file_upload("files/example.tif", "image/tiff")
           FactoryBot.create_for_repository(:scanned_resource, member_of_collection_ids: collection.id, files: [file])
         end
         metadata_adapter = Valkyrie::MetadataAdapter.find(:indexing_persister)

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -182,8 +182,8 @@ Princeton Only Image Count\nFoo,,,,,0,0,0,0\n"
 
     before do
       sign_in user
-      file = fixture_file_upload("files/example.tif", "image/tiff")
       5.times do
+        file = fixture_file_upload("files/example.tif", "image/tiff")
         FactoryBot.create_for_repository(:scanned_resource, member_of_collection_ids: collection.id, files: [file])
       end
     end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -6,13 +6,13 @@ describe Ability do
   include ActiveJob::TestHelper
   with_queue_adapter :test
   subject { described_class.new(current_user) }
-  let(:zip_file) { fixture_file_upload("files/vector/shapefile.zip", "application/zip") }
-  let(:zip_file_2) { fixture_file_upload("files/vector/shapefile.zip", "application/zip") }
-  let(:page_file) { fixture_file_upload("files/example.tif", "image/tiff") }
-  let(:page_file_2) { fixture_file_upload("files/example.tif", "image/tiff") }
-  let(:page_file_3) { fixture_file_upload("files/example.tif", "image/tiff") }
-  let(:audio_file) { fixture_file_upload("files/audio_file.wav", "audio/x-wav") }
-  let(:audio_file_2) { fixture_file_upload("files/audio_file.wav", "audio/x-wav") }
+  def zip_file = fixture_file_upload("files/vector/shapefile.zip", "application/zip")
+  def zip_file2 = fixture_file_upload("files/vector/shapefile.zip", "application/zip")
+  def page_file = fixture_file_upload("files/example.tif", "image/tiff")
+  def page_file2 = fixture_file_upload("files/example.tif", "image/tiff")
+  def page_file3 = fixture_file_upload("files/example.tif", "image/tiff")
+  def audio_file = fixture_file_upload("files/audio_file.wav", "audio/x-wav")
+  def audio_file2 = fixture_file_upload("files/audio_file.wav", "audio/x-wav")
 
   before do
     stub_ezid
@@ -30,7 +30,7 @@ describe Ability do
   end
 
   let(:no_public_download_open_scanned_resource) do
-    FactoryBot.create_for_repository(:complete_open_scanned_resource, user: creating_user, title: "Open", downloadable: "none", files: [page_file_3])
+    FactoryBot.create_for_repository(:complete_open_scanned_resource, user: creating_user, title: "Open", downloadable: "none", files: [page_file3])
   end
 
   let(:no_public_download_open_file) { no_public_download_open_scanned_resource.decorate.members.first }
@@ -40,12 +40,12 @@ describe Ability do
   end
 
   let(:private_scanned_resource) do
-    FactoryBot.create_for_repository(:complete_private_scanned_resource, title: "Private", user: creating_user, files: [page_file_2])
+    FactoryBot.create_for_repository(:complete_private_scanned_resource, title: "Private", user: creating_user, files: [page_file2])
   end
 
   let(:private_cdl_scanned_resource) do
     stub_catalog(bib_id: "991234563506421")
-    resource = FactoryBot.create_for_repository(:complete_private_scanned_resource, title: "Private", source_metadata_identifier: "991234563506421", user: creating_user, files: [page_file_2])
+    resource = FactoryBot.create_for_repository(:complete_private_scanned_resource, title: "Private", source_metadata_identifier: "991234563506421", user: creating_user, files: [page_file2])
     FactoryBot.create_for_repository(
       :resource_charge_list,
       resource_id: resource.id,
@@ -59,7 +59,7 @@ describe Ability do
 
   let(:private_cdl_mvw_scanned_resource) do
     stub_catalog(bib_id: "991234563506421")
-    volume = FactoryBot.create_for_repository(:complete_private_scanned_resource, files: [page_file_2])
+    volume = FactoryBot.create_for_repository(:complete_private_scanned_resource, files: [page_file2])
     mvw_resource = FactoryBot.create_for_repository(:complete_private_scanned_resource,
                                                     title: "Private",
                                                     source_metadata_identifier: "991234563506421",
@@ -79,7 +79,7 @@ describe Ability do
 
   let(:expired_private_cdl_scanned_resource) do
     stub_catalog(bib_id: "991234563506421")
-    resource = FactoryBot.create_for_repository(:complete_private_scanned_resource, title: "Private", source_metadata_identifier: "991234563506421", user: creating_user, files: [page_file_2])
+    resource = FactoryBot.create_for_repository(:complete_private_scanned_resource, title: "Private", source_metadata_identifier: "991234563506421", user: creating_user, files: [page_file2])
     FactoryBot.create_for_repository(
       :resource_charge_list,
       resource_id: resource.id,
@@ -171,7 +171,7 @@ describe Ability do
 
   let(:token_downloadable_audio_file) { complete_playlist.decorate.file_sets.first }
 
-  let(:file) { fixture_file_upload("files/example.tif") }
+  def file = fixture_file_upload("files/example.tif")
   let(:other_staff_scanned_resource) do
     FactoryBot.create_for_repository(:complete_scanned_resource, user: other_staff_user, identifier: ["ark:/99999/fk4445wg45"], files: [file])
   end
@@ -205,13 +205,13 @@ describe Ability do
     FactoryBot.create_for_repository(:collection, restricted_viewers: ["rando"])
   end
   let(:ineligible_restricted_viewer_scanned_resource) do
-    FactoryBot.create_for_repository(:reading_room_scanned_resource, files: [page_file_2], member_of_collection_ids: ineligible_restricted_viewer_collection.id)
+    FactoryBot.create_for_repository(:reading_room_scanned_resource, files: [page_file2], member_of_collection_ids: ineligible_restricted_viewer_collection.id)
   end
   let(:reading_room_collection_restricted_viewer_scanned_resource) do
-    FactoryBot.create_for_repository(:reading_room_scanned_resource, files: [page_file_2], member_of_collection_ids: [restricted_viewer_collection.id])
+    FactoryBot.create_for_repository(:reading_room_scanned_resource, files: [page_file2], member_of_collection_ids: [restricted_viewer_collection.id])
   end
   let(:reading_room_collection_restricted_viewer_scanned_resource_no_users) do
-    FactoryBot.create_for_repository(:reading_room_scanned_resource, files: [page_file_2], member_of_collection_ids: [restricted_viewer_collection_no_users.id])
+    FactoryBot.create_for_repository(:reading_room_scanned_resource, files: [page_file2], member_of_collection_ids: [restricted_viewer_collection_no_users.id])
   end
   let(:reading_room_collection_restricted_viewer_zip_file) do
     FactoryBot.create_for_repository(:reading_room_scanned_resource, files: [zip_file], member_of_collection_ids: [restricted_viewer_collection.id])
@@ -230,7 +230,7 @@ describe Ability do
     )
   end
   let(:reading_room_ineligible_collection_restricted_viewer_zip_file) do
-    FactoryBot.create_for_repository(:reading_room_scanned_resource, files: [zip_file_2], member_of_collection_ids: [ineligible_restricted_viewer_collection.id])
+    FactoryBot.create_for_repository(:reading_room_scanned_resource, files: [zip_file2], member_of_collection_ids: [ineligible_restricted_viewer_collection.id])
   end
   let(:reading_room_ineligible_zip_file) do
     Wayfinder.for(reading_room_ineligible_collection_restricted_viewer_zip_file).file_sets.first
@@ -248,7 +248,7 @@ describe Ability do
   let(:reading_room_collection_restricted_viewer_recording) do
     parent = FactoryBot.create_for_repository(:reading_room_scanned_resource, member_of_collection_ids: [restricted_viewer_collection.id])
     perform_enqueued_jobs do
-      FactoryBot.create_for_repository(:reading_room_scanned_resource, files: [audio_file_2], append_id: parent.id)
+      FactoryBot.create_for_repository(:reading_room_scanned_resource, files: [audio_file2], append_id: parent.id)
     end
   end
   let(:reading_room_audio_file) do
@@ -265,7 +265,7 @@ describe Ability do
     )
   end
   let(:private_collection_restricted_viewer_scanned_resource) do
-    FactoryBot.create_for_repository(:complete_private_scanned_resource, files: [page_file_2], member_of_collection_ids: restricted_viewer_collection.id)
+    FactoryBot.create_for_repository(:complete_private_scanned_resource, files: [page_file2], member_of_collection_ids: restricted_viewer_collection.id)
   end
 
   let(:ocr_request) { FactoryBot.create(:ocr_request) }

--- a/spec/services/cdl/automatic_completer_spec.rb
+++ b/spec/services/cdl/automatic_completer_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe CDL::AutomaticCompleter do
-  let(:file) { fixture_file_upload("files/sample.pdf", "application/pdf") }
+  def file = fixture_file_upload("files/sample.pdf", "application/pdf")
   let(:query_service) { Valkyrie.config.metadata_adapter.query_service }
   let(:change_set_persister) { ChangeSetPersister.default }
   describe ".run" do

--- a/spec/services/manifest_builder/by_resource_type/manifest_builder_scanned_resource_spec.rb
+++ b/spec/services/manifest_builder/by_resource_type/manifest_builder_scanned_resource_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe ManifestBuilder do
   let(:change_set_persister) { ChangeSetPersister.new(metadata_adapter: metadata_adapter, storage_adapter: Valkyrie.config.storage_adapter) }
   let(:metadata_adapter) { Valkyrie.config.metadata_adapter }
   let(:query_service) { metadata_adapter.query_service }
-  let(:file) { fixture_file_upload("files/abstract.tiff", "image/tiff") }
+  def file = fixture_file_upload("files/abstract.tiff", "image/tiff")
   let(:start_canvas) { nil }
 
   def logical_structure(file_set_id)
@@ -182,7 +182,7 @@ RSpec.describe ManifestBuilder do
       expect(output).to be_kind_of Hash
       expect(output["@type"]).to eq "sc:Manifest"
       expect(output["manifests"]).to eq nil
-      expect(output["sequences"].first["canvases"].length).to eq 1
+      expect(output["sequences"].first["canvases"].length).to eq 2
     end
   end
 

--- a/spec/services/manifest_builder_v3/by_resource_type/manifest_builder_v3_scanned_map_spec.rb
+++ b/spec/services/manifest_builder_v3/by_resource_type/manifest_builder_v3_scanned_map_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ManifestBuilderV3 do
   let(:change_set_persister) { ChangeSetPersister.new(metadata_adapter: metadata_adapter, storage_adapter: Valkyrie.config.storage_adapter) }
   let(:metadata_adapter) { Valkyrie.config.metadata_adapter }
   let(:query_service) { metadata_adapter.query_service }
-  let(:file) { fixture_file_upload("files/abstract.tiff", "image/tiff") }
+  def file = fixture_file_upload("files/abstract.tiff", "image/tiff")
 
   def logical_structure(file_set_id)
     [

--- a/spec/services/preserver_spec.rb
+++ b/spec/services/preserver_spec.rb
@@ -6,13 +6,14 @@ describe Preserver do
 
   subject(:preserver) { described_class.new(change_set: change_set, change_set_persister: change_set_persister, storage_adapter: storage_adapter) }
   let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }
+  let(:file2) { fixture_file_upload("files/example.tif", "image/tiff") }
   let(:resource) do
     FactoryBot.create_for_repository(:complete_scanned_resource,
                                      source_metadata_identifier: "991234563506421",
                                      files: [file])
   end
   let(:unpreserved_resource) do
-    FactoryBot.create_for_repository(:complete_scanned_resource, source_metadata_identifier: "991234563506421", files: [file])
+    FactoryBot.create_for_repository(:complete_scanned_resource, source_metadata_identifier: "991234563506421", files: [file2])
   end
   let(:preservation_objects) { Wayfinder.for(resource).preservation_objects }
   let(:preservation_object) { preservation_objects.first }


### PR DESCRIPTION
This will keep pdf derivative generation from only generating a portion
of the files, and keep resources from being created if not all files
were successfully attached.

It's a bigger mess to have things half-ingested and have to clean up
after.

refs #5964
