### PR TITLE
Clarify sidekiq-pro credentials setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,16 @@ Other dependencies:
     * Used for publishing create/update/delete events for systems such as
       [Pomegranate](https://github.com/pulibrary/pomegranate)
 
-## Automatically pull vault password from lastpass
+## Populate sidekiq-pro credentials from lastpass
 
-These steps are performed by `./bin/setup`.
+These steps are performed by `./bin/setup`; if that worked you don't have to do
+this separately.
 
 More information about lastpass-cli can be found here: https://lastpass.github.io/lastpass-cli/lpass.1.html
 ```
 brew install lastpass-cli
 lpass login <email@email.com>
+bin/setup_credentials
 ```
 
 ## Initial Setup

--- a/bin/setup
+++ b/bin/setup
@@ -15,7 +15,7 @@ brew install --cask lando
 echo "Enter lastpass username:" 
 read USERNAME
 lpass login $USERNAME
-./bin/setup_keys
+./bin/setup_credentials
 bundle install
 yarn install
 

--- a/bin/setup_credentials
+++ b/bin/setup_credentials
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+def sidekiq_pro_credentials
+  content = `lpass show "Shared-ITIMS-Passwords/Sidekiq Pro Instructions"`
+  content = content.split("\n").find { |x| x.start_with?("BUNDLE_GEMS") }
+  content.split("=").last
+end
+
+`bundle config gems.contribsys.com #{sidekiq_pro_credentials}`


### PR DESCRIPTION
There's a rake task called setup_keys which does unrelated stuff. It's confusing to also have `bin/setup_keys` 