### PR TITLE
Stop using <details> for file browser, use <li>

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1181,6 +1181,7 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
+  arm64-darwin-21
   arm64-darwin-22
   x86_64-darwin-20
   x86_64-linux

--- a/app/javascript/components/file_browser/directory_picker.vue
+++ b/app/javascript/components/file_browser/directory_picker.vue
@@ -2,41 +2,37 @@
   <div>
     <ul :class="root ? 'tree' : ''">
       <li
-        v-for="child in startChildren"
+        v-for="child in expandableChildren"
         :key="child.path"
+        @click.stop="tryLoading(child)"
       >
-        <v-details
-          v-if="child.expandable"
-          v-model="child.expanded"
-          @change="tryLoading(child)"
+        <div
+          class="item-label"
+          :class="{ 'list-focus': isFocused(child) }"
         >
-          <summary
-            class="item-label"
-            :class="{ 'list-focus': isFocused(child) }"
+          <div class="expander">
+            <svg v-if="child.expanded"><polygon points="5,8 10,13 15,8" /></svg>
+            <svg v-else><polygon points="8,5 13,10 8,15" /></svg>
+          </div>
+          <div
+            class="icon"
           >
-            <div class="expander">
-              <svg v-if="child.expanded"><polygon points="5,8 10,13 15,8" /></svg>
-              <svg v-else><polygon points="8,5 13,10 8,15" /></svg>
-            </div>
-            <div
-              class="icon"
-            >
-              <svg viewBox="0 0 25 25"><path d="M11 5h13v17h-24v-20h8l3 3zm-10-2v18h22v-15h-12.414l-3-3h-6.586z" /></svg>
-            </div>
-            <span
-              @click="listFocused(child, $event)"
-            >
-              {{ child.label }}
-            </span>
-          </summary>
-          <DirectoryPicker
-            :start-children="child.children"
-            :root="false"
-            :list-focus="listFocus"
-            @listFocus="listFocused"
-            @loadChild="tryLoading"
-          />
-        </v-details>
+            <svg viewBox="0 0 25 25"><path d="M11 5h13v17h-24v-20h8l3 3zm-10-2v18h22v-15h-12.414l-3-3h-6.586z" /></svg>
+          </div>
+          <span
+            @click="listFocused(child, $event)"
+          >
+            {{ child.label }}
+          </span>
+        </div>
+        <DirectoryPicker
+          v-if="child.expandable && child.expanded"
+          :start-children="child.children"
+          :root="false"
+          :list-focus="listFocus"
+          @listFocus="listFocused"
+          @loadChild="tryLoading"
+        />
       </li>
     </ul>
   </div>
@@ -62,6 +58,11 @@ export default {
   },
   data () {
     return {
+    }
+  },
+  computed: {
+    expandableChildren () {
+      return this.startChildren.filter((child) => child.expandable)
     }
   },
   methods: {
@@ -103,6 +104,11 @@ export default {
 .tree li{
   display      : block;
   position     : relative;
+  &.item-label {
+    display: flex;
+    align-items: center;
+    margin: 1px;
+  }
 }
 
 .tree ul{

--- a/app/javascript/components/file_browser/file_browser.vue
+++ b/app/javascript/components/file_browser/file_browser.vue
@@ -63,6 +63,9 @@ export default {
       if (child.loaded === false && child.loadChildrenPath) {
         this.loadChildren(child)
       }
+      if (child.expandable) {
+        child.expanded = !child.expanded
+      }
     },
     loadChildren (child) {
       return fetch(

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -16,11 +16,9 @@ import AjaxSelect from '@components/ajax-select.vue'
 import { setupAjaxSelect, setupCocoonLinks } from '@helpers/setup_ajax_select'
 import FileUploader from '@components/file-uploader.vue'
 import Initializer from '@figgy/figgy_boot'
-import VueDetails from 'vue-details'
 import LocalUploader from '@components/local_uploader.vue'
 
 Vue.use(system)
-Vue.component('v-details', VueDetails)
 
 // mount the filemanager app
 document.addEventListener('DOMContentLoaded', () => {

--- a/app/javascript/test/file_browser/directory_picker.spec.js
+++ b/app/javascript/test/file_browser/directory_picker.spec.js
@@ -4,116 +4,87 @@ import DirectoryPicker from '../../components/file_browser/directory_picker.vue'
 const startChildren = () => {
   return [
     {
-      'label': 'Dir1',
-      'path': '/Dir1',
-      'expanded': true,
-      'expandable': true,
-      'selected': false,
-      'selectable': false,
-      'loaded': true,
-      'children': [
+      label: 'Dir1',
+      path: '/Dir1',
+      expanded: true,
+      expandable: true,
+      selected: false,
+      selectable: false,
+      loaded: true,
+      children: [
         {
-          'label': 'Subdir1',
-          'path': '/Dir1/Subdir1',
-          'expanded': false,
-          'expandable': true,
-          'selected': false,
-          'selectable': true,
-          'loaded': true,
-          'children': [
+          label: 'Subdir1',
+          path: '/Dir1/Subdir1',
+          expanded: true,
+          expandable: true,
+          selected: false,
+          selectable: true,
+          loaded: true,
+          children: [
             {
-              'label': 'SubSubdir1',
-              'path': '/Dir1/Subdir1/SubSubdir1',
-              'loadChildrenPath': '/loaders/test',
-              'expanded': false,
-              'expandable': true,
-              'selected': false,
-              'selectable': false,
-              'loaded': false,
-              'children': []
+              label: 'SubSubdir1',
+              path: '/Dir1/Subdir1/SubSubdir1',
+              loadChildrenPath: '/loaders/test',
+              expanded: true,
+              expandable: true,
+              selected: false,
+              selectable: false,
+              loaded: false,
+              children: []
             },
             {
-              'label': 'SubSubdir2',
-              'path': '/Dir1/Subdir1/SubSubdir2',
-              'expanded': false,
-              'expandable': true,
-              'selected': false,
-              'selectable': false,
-              'loaded': true,
-              'children': []
+              label: 'SubSubdir2',
+              path: '/Dir1/Subdir1/SubSubdir2',
+              expanded: true,
+              expandable: true,
+              selected: false,
+              selectable: false,
+              loaded: true,
+              children: []
             }
           ]
         }
       ]
     },
     {
-      'label': 'Dir2',
-      'path': '/Dir2',
-      'expanded': false,
-      'expandable': true,
-      'selected': false,
-      'selectable': true,
-      'loaded': true,
-      'children': [
+      label: 'Dir2',
+      path: '/Dir2',
+      expanded: true,
+      expandable: true,
+      selected: false,
+      selectable: true,
+      loaded: true,
+      children: [
         {
-          'label': 'Subdir1',
-          'path': '/Dir2/Subdir1',
-          'expandable': true,
-          'expanded': false,
-          'selected': false,
-          'selectable': false,
-          'loaded': true,
-          'children': []
+          label: 'Subdir1',
+          path: '/Dir2/Subdir1',
+          expandable: true,
+          expanded: true,
+          selected: false,
+          selectable: false,
+          loaded: true,
+          children: []
         },
         {
-          'label': 'Subdir2',
-          'path': '/Dir2/Subdir2',
-          'expandable': true,
-          'expanded': false,
-          'selected': false,
-          'selectable': false,
-          'loaded': true,
-          'children': [
+          label: 'Subdir2',
+          path: '/Dir2/Subdir2',
+          expandable: true,
+          expanded: true,
+          selected: false,
+          selectable: false,
+          loaded: true,
+          children: [
             {
-              'label': 'File1.jpg',
-              'path': '/Dir2/Subdir2/File1.jpg',
-              'expandable': false,
-              'selectable': true
+              label: 'File1.jpg',
+              path: '/Dir2/Subdir2/File1.jpg',
+              expandable: false,
+              selectable: true
             }
           ]
         }
       ]
     }
   ]
-}
-
-function stubFailedChildLoad () {
-  global.fetch = vi.fn(() =>
-    Promise.resolve({
-      status: 404,
-      json: () => { throw Error('broken') }
-    })
-  )
-}
-function stubChildLoad () {
-  global.fetch = vi.fn(() =>
-    Promise.resolve({
-      status: 200,
-      json: () => Promise.resolve(
-        [
-          {
-            'label': 'SubSubSubdir1',
-            'path': '/Dir1/Subdir1/SubSubdir1/SubSubSubdir1',
-            'expanded': false,
-            'selected': false,
-            'selectable': false,
-            'loaded': true,
-            'children': []
-          }
-        ]
-      )
-    })
-  )
 }
 
 test('renders with a root that has the tree class', () => {
@@ -126,12 +97,12 @@ test('renders with a root that has the tree class', () => {
 test('renders a collapsible detail for every child hierarchy', () => {
   const wrapper = mount(DirectoryPicker, { propsData: { startChildren: startChildren() } })
 
-  expect(wrapper.findAll('details').length).toEqual(7)
+  expect(wrapper.findAll('.expander').length).toEqual(7)
 })
 
 test('clicking a label emits a list-focus event', async () => {
   const wrapper = mount(DirectoryPicker, { propsData: { startChildren: startChildren() } })
-  await wrapper.findAll('summary span').at(0).trigger('click')
+  await wrapper.findAll('.item-label span').at(0).trigger('click')
 
   expect(wrapper.emitted()).toHaveProperty('listFocus')
 })

--- a/app/javascript/test/file_browser/embedded_file_browser.spec.js
+++ b/app/javascript/test/file_browser/embedded_file_browser.spec.js
@@ -49,7 +49,7 @@ const startChildren = () => {
     {
       'label': 'Dir2',
       'path': '/Dir2',
-      'expanded': false,
+      'expanded': true,
       'expandable': true,
       'selected': false,
       'selectable': true,
@@ -69,7 +69,7 @@ const startChildren = () => {
           'label': 'Subdir2',
           'path': '/Dir2/Subdir2',
           'expandable': true,
-          'expanded': false,
+          'expanded': true,
           'selected': false,
           'selectable': false,
           'loaded': true,
@@ -99,7 +99,7 @@ test('populates a hidden input for files selected and fires a formId', async () 
   window.HTMLFormElement.prototype.submit = mockSubmit
   const wrapper = mount(EmbeddedFileBrowser, { propsData: { startTree: startChildren(), formId: 'test' } })
 
-  await wrapper.findAll('summary span').at(6).trigger('click')
+  await wrapper.findAll('.item-label span').at(4).trigger('click')
   await wrapper.get('li.file').trigger('click')
   await wrapper.findAll('li.file').at(1).trigger('click', { ctrlKey: true })
   await wrapper.get('.actions a').trigger('click')

--- a/app/javascript/test/file_browser/file_browser.spec.js
+++ b/app/javascript/test/file_browser/file_browser.spec.js
@@ -100,7 +100,7 @@ const startChildren = () => {
           'label': 'Subdir2',
           'path': '/Dir2/Subdir2',
           'expandable': true,
-          'expanded': false,
+          'expanded': true,
           'selected': false,
           'selectable': false,
           'loaded': true,
@@ -128,7 +128,7 @@ test('renders a directory picker pane', () => {
 test('propagates folderSelect event up', async () => {
   const wrapper = mount(FileBrowser, { propsData: { startTree: startChildren(), mode: 'directoryIngest' } })
 
-  await wrapper.findAll('summary span').at(1).trigger('click')
+  await wrapper.findAll('.item-label span').at(1).trigger('click')
   await wrapper.get('.actions a').trigger('click')
   expect(wrapper.emitted()).toHaveProperty('folderSelect')
   expect(wrapper.emitted().folderSelect[0]).toEqual([wrapper.vm.tree[0].children[0]])
@@ -137,7 +137,7 @@ test('propagates folderSelect event up', async () => {
 test('propagates filesSelect event up', async () => {
   const wrapper = mount(FileBrowser, { propsData: { startTree: startChildren(), mode: 'fileIngest' } })
 
-  await wrapper.findAll('summary span').at(6).trigger('click')
+  await wrapper.findAll('.item-label span').at(4).trigger('click')
   await wrapper.get('li.file').trigger('click')
   await wrapper.get('.actions a').trigger('click')
   expect(wrapper.emitted()).toHaveProperty('filesSelect')
@@ -147,22 +147,22 @@ test('propagates filesSelect event up', async () => {
 test('highlights a list-focused pane', async () => {
   const wrapper = mount(FileBrowser, { propsData: { startTree: startChildren(), mode: 'directoryIngest' } })
 
-  await wrapper.findAll('summary span').at(0).trigger('click')
+  await wrapper.findAll('.item-label span').at(0).trigger('click')
 
-  expect(wrapper.findAll('summary.list-focus').length).toEqual(1)
+  expect(wrapper.findAll('.item-label.list-focus').length).toEqual(1)
   expect(wrapper.vm.listFocus.path).toEqual('/Dir1')
 
-  await wrapper.findAll('summary span').at(1).trigger('click')
+  await wrapper.findAll('.item-label span').at(1).trigger('click')
   expect(wrapper.vm.listFocus.path).toEqual('/Dir1/Subdir1')
-  expect(wrapper.findAll('summary.list-focus').length).toEqual(1)
+  expect(wrapper.findAll('.item-label.list-focus').length).toEqual(1)
 })
 
 test('can dynamically load child nodes via loadChildrenPath', async () => {
   stubChildLoad()
   const wrapper = mount(FileBrowser, { propsData: { startTree: startChildren(), mode: 'directoryIngest' } })
 
-  await wrapper.findAll('details').at(1).trigger('toggle')
-  await wrapper.findAll('details').at(2).trigger('toggle')
+  await wrapper.findAll('.item-label').at(1).trigger('click')
+  await wrapper.findAll('.item-label').at(2).trigger('click')
   await flushPromises()
   expect(wrapper.vm.tree[0].children[0].children[0].children.length).toEqual(1)
 })
@@ -170,8 +170,8 @@ test('can dynamically load child nodes via loadChildrenPath', async () => {
 test('dynamically loads child nodes when list-focused', async () => {
   stubChildLoad()
   const wrapper = mount(FileBrowser, { propsData: { startTree: startChildren(), mode: 'directoryIngest' } })
-  await wrapper.findAll('details').at(1).trigger('toggle')
-  await wrapper.findAll('summary span').at(2).trigger('click')
+  await wrapper.findAll('.item-label').at(1).trigger('click')
+  await wrapper.findAll('.item-label span').at(2).trigger('click')
   await flushPromises()
   expect(wrapper.vm.tree[0].children[0].children[0].children.length).toEqual(1)
 })
@@ -179,8 +179,8 @@ test('dynamically loads child nodes when list-focused', async () => {
 test('handles bad data when loading', async () => {
   stubFailedChildLoad()
   const wrapper = mount(FileBrowser, { propsData: { startTree: startChildren(), mode: 'directoryIngest' } })
-  await wrapper.findAll('details').at(1).trigger('toggle')
-  await wrapper.findAll('details').at(2).trigger('toggle')
+  await wrapper.findAll('.item-label').at(1).trigger('click')
+  await wrapper.findAll('.item-label').at(2).trigger('click')
   await flushPromises()
   expect(wrapper.vm.tree[0].children[0].children[0].children.length).toEqual(0)
 })

--- a/app/javascript/test/file_browser/input_path_selector.spec.js
+++ b/app/javascript/test/file_browser/input_path_selector.spec.js
@@ -115,7 +115,7 @@ test('populates a target input', async () => {
 
   await wrapper.get('button').trigger('click')
   expect(wrapper.findAll('ul.tree').length).toEqual(1)
-  await wrapper.findAll('summary span').at(1).trigger('click')
+  await wrapper.findAll('.item-label span').at(1).trigger('click')
   await wrapper.get('.actions a').trigger('click')
   expect(wrapper.findAll('ul.tree').length).toEqual(0)
   expect(document.getElementById('test').value).toEqual('/bla/Dir1/Subdir1')
@@ -127,7 +127,7 @@ test('populates a summary field', async () => {
 
   await wrapper.get('button').trigger('click')
   expect(wrapper.findAll('ul.tree').length).toEqual(1)
-  await wrapper.findAll('summary span').at(1).trigger('click')
+  await wrapper.findAll('.item-label span').at(1).trigger('click')
   await wrapper.get('.actions a').trigger('click')
   expect(wrapper.findAll('ul.tree').length).toEqual(0)
   expect(document.getElementById('test').value).toEqual('Dir1/Subdir1')

--- a/app/javascript/test/setup.js
+++ b/app/javascript/test/setup.js
@@ -1,11 +1,9 @@
 import Vue from 'vue'
 import _ from 'lodash'
-import VueDetails from 'vue-details'
 import system from 'lux-design-system'
 
 Vue.use(system)
 Vue.config.productionTip = false
-Vue.component('v-details', VueDetails)
 vi.unmock('lodash')
 _.debounce = vi.fn((fn) => fn);
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "unfetch": "^4.0.1",
     "uppy": "^3.9.1",
     "vue": "^2.5.17",
-    "vue-details": "^1.1.0",
     "vue-loader": "^15.4.2",
     "vue-select": "^3.4.0",
     "vue-template-compiler": "^2.5.17",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7395,11 +7395,6 @@ vue-cookies@^1.7.4:
   resolved "https://registry.yarnpkg.com/vue-cookies/-/vue-cookies-1.8.3.tgz#0c7ce26d150f7ac50356ae17cb4ead1122013b82"
   integrity sha512-VBRsyRMVdahBgFfh389TMHPmDdr4URDJNMk4FKSCfuNITs7+jitBDhwyL4RJd3WUsfOYNNjPAkfbehyH9AFuoA==
 
-vue-details@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/vue-details/-/vue-details-1.1.0.tgz#b176bdc3c3637c905aa3993ee905e51d356d29d8"
-  integrity sha512-QkoDgfMlzdH21NXc8fyawh3bNn9bclYt5cbCaWZjTkJfhUXK2Hx1ElTXQnSGO5dz/pUrMlxDOBREq1bjuTT0KA==
-
 vue-eslint-parser@^9.4.2:
   version "9.4.2"
   resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-9.4.2.tgz#02ffcce82042b082292f2d1672514615f0d95b6d"


### PR DESCRIPTION
Closes #6372 

By managing `expanded` ourselves and rendering the tree based on that we can get rid of this dependency.