### PR TITLE
Refactor audio manifest builder spec for clarity

### DIFF
--- a/spec/services/manifest_builder/by_resource_type/manifest_builder_audio_resource_spec.rb
+++ b/spec/services/manifest_builder/by_resource_type/manifest_builder_audio_resource_spec.rb
@@ -38,6 +38,38 @@ RSpec.describe ManifestBuilder do
     before do
       stub_catalog(bib_id: "991234563506421")
     end
+
+    it "builds a presentation 3 manifest", run_real_characterization: true do
+      output = change_set_persister.save(change_set: change_set)
+      output.logical_structure = [
+        { label: "Logical", nodes: [{ proxy: output.member_ids.last }, { label: "Bla", nodes: [{ proxy: output.member_ids.first }] }] }
+      ]
+
+      change_set_persister.persister.save(resource: output)
+      output = manifest_builder.build
+      # pres 3 context is always an array
+      expect(output["@context"]).to include "http://iiif.io/api/presentation/3/context.json"
+      # logo is always an array
+      expect(output["logo"].first).to include("id" => "https://www.example.com/assets/pul_logo_icon-5333765252f2b86e34cd7c096c97e79495fe4656c5f787c5510a84ee6b67afd8.png")
+      # Logical structure should be able to have nested and un-nested members.
+      expect(output["structures"][0]["items"][0]["id"]).to include "#t="
+      expect(output["structures"][1]["items"][0]["items"][0]["id"]).to include "#t="
+      expect(output["behavior"]).to eq ["auto-advance"]
+      # downloading is blocked
+      expect(output["service"][0]).to eq({ "@context" => "http://universalviewer.io/context.json", "profile" => "http://universalviewer.io/ui-extensions-profile", "disableUI" => ["mediaDownload"] })
+    end
+
+    context "with no logical structure", run_real_characterization: true do
+      let(:logical_structure) { nil }
+      it "builds a presentation 3 manifest with a default table of contents" do
+        change_set_persister.save(change_set: change_set)
+        output = manifest_builder.build
+        # A default table of contents should display
+        expect(output["structures"][0]["items"][0]["id"]).to include "#t="
+        expect(output["structures"][0]["label"]["eng"]).to eq ["32101047382401_1_pm.wav"]
+      end
+    end
+
     context "when downloading is enabled" do
       let(:change_set) { ScannedResourceChangeSet.new(scanned_resource, files: [file], downloadable: "public") }
       it "doesn't block download" do
@@ -47,8 +79,97 @@ RSpec.describe ManifestBuilder do
         expect(output["service"]).to be_nil
       end
     end
+  end
 
-    it "builds a manifest for an ArchivalMediaBag ingested Recording", run_real_characterization: true, run_real_derivatives: true do
+  context "when given a multi-volume recording", run_real_characterization: true, run_real_derivatives: true do
+    subject(:manifest_builder) { described_class.new(scanned_resource) }
+
+    let(:file1) { fixture_file_upload("av/la_c0652_2017_05_bag/data/32101047382401_1_pm.wav", "") }
+    let(:file2) { fixture_file_upload("av/la_c0652_2017_05_bag/data/32101047382401_1_pm.wav", "") }
+    let(:volume1) { FactoryBot.create_for_repository(:scanned_resource, files: [file1]) }
+    let(:volume2) { FactoryBot.create_for_repository(:scanned_resource, files: [file2]) }
+    let(:scanned_resource) do
+      sr = FactoryBot.create_for_repository(:recording)
+      cs = ScannedResourceChangeSet.new(sr)
+      cs.validate(member_ids: [volume1.id, volume2.id])
+      change_set_persister.save(change_set: cs)
+    end
+    let(:output) { manifest_builder.build }
+
+    it "generates the Ranges for the audio FileSets" do
+      expect(output).to be_kind_of Hash
+      expect(output["@context"]).to include "http://iiif.io/api/presentation/3/context.json"
+      expect(output["type"]).to eq "Manifest"
+      expect(output["items"].length).to eq 2
+
+      first_canvas = output["items"].first
+      expect(first_canvas).to include "label" => { "eng" => ["32101047382401_1_pm.wav"] }
+
+      last_canvas = output["items"].last
+      expect(last_canvas).to include "label" => { "eng" => ["32101047382401_1_pm.wav"] }
+
+      expect(output).to include "structures"
+      ranges = output["structures"]
+      expect(ranges.length).to eq 2
+
+      expect(ranges.first["items"].length).to eq 1
+      expect(ranges.first["items"].first).to include "label" => { "eng" => ["32101047382401_1_pm.wav"] }
+      child_ranges = ranges.first["items"]
+      expect(child_ranges.length).to eq 1
+      expect(child_ranges.first).to include "items"
+      range_canvases = child_ranges.first["items"]
+      expect(range_canvases.length).to eq 1
+      expect(range_canvases.first).to include "label" => [{ "eng" => ["32101047382401_1_pm.wav"] }]
+
+      expect(ranges.last["items"].length).to eq 1
+      expect(ranges.last["items"].first).to include "label" => { "eng" => ["32101047382401_1_pm.wav"] }
+      child_ranges = ranges.last["items"]
+      expect(child_ranges.length).to eq 1
+      expect(child_ranges.first).to include "items"
+      range_canvases = child_ranges.first["items"]
+      expect(range_canvases.length).to eq 1
+      expect(range_canvases.first).to include "label" => [{ "eng" => ["32101047382401_1_pm.wav"] }]
+    end
+  end
+
+  context "when given a multi-volume recording with thumbnails", run_real_characterization: true, run_real_derivatives: true do
+    subject(:manifest_builder) { described_class.new(scanned_resource) }
+
+    let(:audio_file1) { fixture_file_upload("av/la_c0652_2017_05_bag/data/32101047382401_1_pm.wav", "") }
+    let(:image_file1) { fixture_file_upload("files/example.tif") }
+    let(:audio_file2) { fixture_file_upload("av/la_c0652_2017_05_bag/data/32101047382401_1_pm.wav", "") }
+    let(:image_file2) { fixture_file_upload("files/example.tif") }
+    let(:volume1) { FactoryBot.create_for_repository(:scanned_resource, files: [audio_file1, image_file1]) }
+    let(:volume2) { FactoryBot.create_for_repository(:scanned_resource, files: [audio_file2, image_file2]) }
+    let(:scanned_resource) do
+      sr = FactoryBot.create_for_repository(:recording)
+      cs = ScannedResourceChangeSet.new(sr)
+      cs.validate(member_ids: [volume1.id, volume2.id])
+      change_set_persister.save(change_set: cs)
+    end
+    let(:output) { manifest_builder.build }
+
+    it "generates the posterCanvas for the Manifest" do
+      expect(output).to be_kind_of Hash
+      expect(output["@context"]).to include "http://iiif.io/api/presentation/3/context.json"
+      expect(output["type"]).to eq "Manifest"
+      expect(output["items"].length).to eq 2
+      first_item = output["items"].first
+      expect(first_item).to include "label" => { "eng" => ["32101047382401_1_pm.wav"] }
+
+      expect(output).to include("posterCanvas")
+      poster_canvas = output["posterCanvas"]
+      pages = poster_canvas["items"]
+      expect(pages.length).to eq(1)
+      annotations = pages.first["items"]
+      expect(annotations.length).to eq(1)
+      body = annotations.last["body"]
+      expect(body["type"]).to eq("Image")
+    end
+  end
+
+  context "when given a recording ingested from an ArchivalMediaBag" do
+    it "builds a manifest", run_real_characterization: true, run_real_derivatives: true do
       bag_path = Rails.root.join("spec", "fixtures", "av", "la_c0652_2017_05_bag")
       user = User.first
       stub_findingaid(pulfa_id: "C0652")
@@ -73,151 +194,34 @@ RSpec.describe ManifestBuilder do
                                               "width" => 120,
                                               "type" => "Image")
     end
+  end
 
-    context "when given a multi-volume recording", run_real_characterization: true, run_real_derivatives: true do
-      subject(:manifest_builder) { described_class.new(scanned_resource) }
+  context "when given an ArchivalMediaCollection", run_real_characterization: true, run_real_derivatives: true do
+    let(:collection) { FactoryBot.create_for_repository(:archival_media_collection) }
+    let(:collection_members) { collection.decorate.members }
+    let(:recording) { collection_members.first.decorate.members.first }
+    let(:manifest_builder) { described_class.new(collection) }
+    let(:output) { manifest_builder.build }
 
-      let(:file1) { fixture_file_upload("av/la_c0652_2017_05_bag/data/32101047382401_1_pm.wav", "") }
-      let(:file2) { fixture_file_upload("av/la_c0652_2017_05_bag/data/32101047382401_1_pm.wav", "") }
-      let(:volume1) { FactoryBot.create_for_repository(:scanned_resource, files: [file1]) }
-      let(:volume2) { FactoryBot.create_for_repository(:scanned_resource, files: [file2]) }
-      let(:scanned_resource) do
-        sr = FactoryBot.create_for_repository(:recording)
-        cs = ScannedResourceChangeSet.new(sr)
-        cs.validate(member_ids: [volume1.id, volume2.id])
-        change_set_persister.save(change_set: cs)
-      end
-      let(:output) { manifest_builder.build }
-
-      it "generates the Ranges for the audio FileSets" do
-        expect(output).to be_kind_of Hash
-        expect(output["@context"]).to include "http://iiif.io/api/presentation/3/context.json"
-        expect(output["type"]).to eq "Manifest"
-        expect(output["items"].length).to eq 2
-
-        first_canvas = output["items"].first
-        expect(first_canvas).to include "label" => { "eng" => ["32101047382401_1_pm.wav"] }
-
-        last_canvas = output["items"].last
-        expect(last_canvas).to include "label" => { "eng" => ["32101047382401_1_pm.wav"] }
-
-        expect(output).to include "structures"
-        ranges = output["structures"]
-        expect(ranges.length).to eq 2
-
-        expect(ranges.first["items"].length).to eq 1
-        expect(ranges.first["items"].first).to include "label" => { "eng" => ["32101047382401_1_pm.wav"] }
-        child_ranges = ranges.first["items"]
-        expect(child_ranges.length).to eq 1
-        expect(child_ranges.first).to include "items"
-        range_canvases = child_ranges.first["items"]
-        expect(range_canvases.length).to eq 1
-        expect(range_canvases.first).to include "label" => [{ "eng" => ["32101047382401_1_pm.wav"] }]
-
-        expect(ranges.last["items"].length).to eq 1
-        expect(ranges.last["items"].first).to include "label" => { "eng" => ["32101047382401_1_pm.wav"] }
-        child_ranges = ranges.last["items"]
-        expect(child_ranges.length).to eq 1
-        expect(child_ranges.first).to include "items"
-        range_canvases = child_ranges.first["items"]
-        expect(range_canvases.length).to eq 1
-        expect(range_canvases.first).to include "label" => [{ "eng" => ["32101047382401_1_pm.wav"] }]
-      end
+    before do
+      bag_path = Rails.root.join("spec", "fixtures", "av", "la_c0652_2017_05_bag")
+      user = User.first
+      stub_findingaid(pulfa_id: "C0652")
+      stub_findingaid(pulfa_id: "C0652_c0377")
+      IngestArchivalMediaBagJob.perform_now(collection_component: "C0652", bag_path: bag_path, user: user, member_of_collection_ids: [collection.id.to_s])
     end
 
-    context "when given a multi-volume recording with thumbnails", run_real_characterization: true, run_real_derivatives: true do
-      subject(:manifest_builder) { described_class.new(scanned_resource) }
-
-      let(:audio_file1) { fixture_file_upload("av/la_c0652_2017_05_bag/data/32101047382401_1_pm.wav", "") }
-      let(:image_file1) { fixture_file_upload("files/example.tif") }
-      let(:audio_file2) { fixture_file_upload("av/la_c0652_2017_05_bag/data/32101047382401_1_pm.wav", "") }
-      let(:image_file2) { fixture_file_upload("files/example.tif") }
-      let(:volume1) { FactoryBot.create_for_repository(:scanned_resource, files: [audio_file1, image_file1]) }
-      let(:volume2) { FactoryBot.create_for_repository(:scanned_resource, files: [audio_file2, image_file2]) }
-      let(:scanned_resource) do
-        sr = FactoryBot.create_for_repository(:recording)
-        cs = ScannedResourceChangeSet.new(sr)
-        cs.validate(member_ids: [volume1.id, volume2.id])
-        change_set_persister.save(change_set: cs)
-      end
-      let(:output) { manifest_builder.build }
-
-      it "generates the posterCanvas for the Manifest" do
-        expect(output).to be_kind_of Hash
-        expect(output["@context"]).to include "http://iiif.io/api/presentation/3/context.json"
-        expect(output["type"]).to eq "Manifest"
-        expect(output["items"].length).to eq 2
-        first_item = output["items"].first
-        expect(first_item).to include "label" => { "eng" => ["32101047382401_1_pm.wav"] }
-
-        expect(output).to include("posterCanvas")
-        poster_canvas = output["posterCanvas"]
-        pages = poster_canvas["items"]
-        expect(pages.length).to eq(1)
-        annotations = pages.first["items"]
-        expect(annotations.length).to eq(1)
-        body = annotations.last["body"]
-        expect(body["type"]).to eq("Image")
-      end
-    end
-
-    context "when given an ArchivalMediaCollection", run_real_characterization: true, run_real_derivatives: true do
-      let(:collection) { FactoryBot.create_for_repository(:archival_media_collection) }
-      let(:collection_members) { collection.decorate.members }
-      let(:recording) { collection_members.first.decorate.members.first }
-      let(:manifest_builder) { described_class.new(collection) }
-      let(:output) { manifest_builder.build }
-
-      before do
-        bag_path = Rails.root.join("spec", "fixtures", "av", "la_c0652_2017_05_bag")
-        user = User.first
-        stub_findingaid(pulfa_id: "C0652")
-        stub_findingaid(pulfa_id: "C0652_c0377")
-        IngestArchivalMediaBagJob.perform_now(collection_component: "C0652", bag_path: bag_path, user: user, member_of_collection_ids: [collection.id.to_s])
-      end
-
-      it "builds a presentation 3 manifest with recordings as separate canvases" do
-        expect(output).to be_kind_of Hash
-        expect(output["@context"]).to include "http://iiif.io/api/presentation/3/context.json"
-        expect(output["type"]).to eq "Manifest"
-        expect(output["items"].length).to eq 2
-        expect(output["items"].first).to include "label" => { "eng" => ["32101047382401_1"] }
-        expect(output["items"].last).to include "label" => { "eng" => ["32101047382401_2"] }
-
-        expect(output["structures"].length).to eq 2
-        expect(output["structures"].first).to include "label" => { "eng" => ["32101047382401_1"] }
-        expect(output["structures"].last).to include "label" => { "eng" => ["32101047382401_2"] }
-      end
-    end
-
-    it "builds a presentation 3 manifest", run_real_characterization: true do
-      output = change_set_persister.save(change_set: change_set)
-      output.logical_structure = [
-        { label: "Logical", nodes: [{ proxy: output.member_ids.last }, { label: "Bla", nodes: [{ proxy: output.member_ids.first }] }] }
-      ]
-
-      change_set_persister.persister.save(resource: output)
-      output = manifest_builder.build
-      # pres 3 context is always an array
+    it "builds a presentation 3 manifest with recordings as separate canvases" do
+      expect(output).to be_kind_of Hash
       expect(output["@context"]).to include "http://iiif.io/api/presentation/3/context.json"
-      # logo is always an array
-      expect(output["logo"].first).to include("id" => "https://www.example.com/assets/pul_logo_icon-5333765252f2b86e34cd7c096c97e79495fe4656c5f787c5510a84ee6b67afd8.png")
-      # Logical structure should be able to have nested and un-nested members.
-      expect(output["structures"][0]["items"][0]["id"]).to include "#t="
-      expect(output["structures"][1]["items"][0]["items"][0]["id"]).to include "#t="
-      expect(output["behavior"]).to eq ["auto-advance"]
-      # downloading is blocked
-      expect(output["service"][0]).to eq({ "@context" => "http://universalviewer.io/context.json", "profile" => "http://universalviewer.io/ui-extensions-profile", "disableUI" => ["mediaDownload"] })
-    end
-    context "with no logical structure", run_real_characterization: true do
-      let(:logical_structure) { nil }
-      it "builds a presentation 3 manifest with a default table of contents" do
-        change_set_persister.save(change_set: change_set)
-        output = manifest_builder.build
-        # A default table of contents should display
-        expect(output["structures"][0]["items"][0]["id"]).to include "#t="
-        expect(output["structures"][0]["label"]["eng"]).to eq ["32101047382401_1_pm.wav"]
-      end
+      expect(output["type"]).to eq "Manifest"
+      expect(output["items"].length).to eq 2
+      expect(output["items"].first).to include "label" => { "eng" => ["32101047382401_1"] }
+      expect(output["items"].last).to include "label" => { "eng" => ["32101047382401_2"] }
+
+      expect(output["structures"].length).to eq 2
+      expect(output["structures"].first).to include "label" => { "eng" => ["32101047382401_1"] }
+      expect(output["structures"].last).to include "label" => { "eng" => ["32101047382401_2"] }
     end
   end
 end


### PR DESCRIPTION
Just moves the specs around / changes the nesting.

refs #5747