### PR TITLE
Track Downloads through Universal Viewer

### DIFF
--- a/app/javascript/entrypoints/viewer.js
+++ b/app/javascript/entrypoints/viewer.js
@@ -1,6 +1,7 @@
 import UVManager from '@viewer/uv_manager'
 import 'leaflet/dist/leaflet.css'
 const UVManagerInstance = new UVManager()
+window.uv_instance = UVManagerInstance
 let timer = window.setInterval(() => {
   if (window.UV !== undefined) {
     UVManagerInstance.initialize()

--- a/app/javascript/viewer/uv_manager.js
+++ b/app/javascript/viewer/uv_manager.js
@@ -105,6 +105,7 @@ export default class UVManager {
   }
 
   createUV (graphqlData) {
+    this.remapWindowOpen()
     this.bindResizeUV()
     this.tabManager.onTabSelect(() => setTimeout(() => this.resizeUV(), 100))
     this.processTitle(graphqlData)
@@ -124,6 +125,16 @@ export default class UVManager {
     }, this.urlDataProvider)
     this.cdlTimer = new CDLTimer(this.figgyId)
     this.cdlTimer.initializeTimer()
+  }
+
+  // Universal Viewer uses window.open for download links, and we want to track
+  // those. We can remap window.open so we can do that.
+  remapWindowOpen () {
+    const cachedOpen = window.open
+    window.open = function (url, target, features) {
+      window.plausible('Download', { props: { url } })
+      cachedOpen(url, target, features)
+    }
   }
 
   createClover () {

--- a/app/views/layouts/viewer_layout.html.erb
+++ b/app/views/layouts/viewer_layout.html.erb
@@ -9,8 +9,9 @@
     <script type="text/javascript" src="/uv/lib/offline.js"></script>
     <script type="text/javascript" src="/uv/lib/offline.js"></script>
     <script type="text/javascript" src="/uv/helpers.js"></script>
-    <% if Rails.env.production? || Rails.env.staging? %>
-      <script defer file-types="jpg,jpeg,tiff,pdf" event-environment="<%= Rails.env.to_s %>" event-embed-host="<%= params[:embed_host] || "unknown" %>" data-domain="dpul.princeton.edu" src="https://plausible.io/js/script.file-downloads.outbound-links.pageview-props.js"></script>
+    <% if Rails.env.staging? || Rails.env.production? %>
+      <script defer event-environment="<%= Rails.env.to_s %>" event-embed-host="<%= params[:embed_host] || "unknown" %>" data-domain="dpul.princeton.edu" src="https://plausible.io/js/script.pageview-props.manual.js"></script>
+      <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
     <% end %>
   </head>
   <body>

--- a/app/views/layouts/viewer_layout.html.erb
+++ b/app/views/layouts/viewer_layout.html.erb
@@ -10,7 +10,7 @@
     <script type="text/javascript" src="/uv/lib/offline.js"></script>
     <script type="text/javascript" src="/uv/helpers.js"></script>
     <% if Rails.env.production? || Rails.env.staging? %>
-      <script defer file-types="jpg,jpeg,tiff,pdf" event-environment="<%= Rails.env.to_s %>" event-embed-host="<%= params[:embed_host] || "unknown" %>" data-domain="dpul.princeton.edu" src="https://plausible.io/js/script.file-downloads.pageview-props.js"></script>
+      <script defer file-types="jpg,jpeg,tiff,pdf" event-environment="<%= Rails.env.to_s %>" event-embed-host="<%= params[:embed_host] || "unknown" %>" data-domain="dpul.princeton.edu" src="https://plausible.io/js/script.file-downloads.outbound-links.pageview-props.js"></script>
     <% end %>
   </head>
   <body>

--- a/app/views/layouts/viewer_layout.html.erb
+++ b/app/views/layouts/viewer_layout.html.erb
@@ -9,6 +9,9 @@
     <script type="text/javascript" src="/uv/lib/offline.js"></script>
     <script type="text/javascript" src="/uv/lib/offline.js"></script>
     <script type="text/javascript" src="/uv/helpers.js"></script>
+    <% if Rails.env.production? || Rails.env.staging? %>
+      <script defer event-environment="<%= Rails.env.to_s %>" event-embed-host="<%= params[:embed_host] || "unknown" %>" data-domain="dpul.princeton.edu" src="https://plausible.io/js/script.file-downloads.pageview-props.js"></script>
+    <% end %>
   </head>
   <body>
     <%= yield %>

--- a/app/views/layouts/viewer_layout.html.erb
+++ b/app/views/layouts/viewer_layout.html.erb
@@ -10,7 +10,7 @@
     <script type="text/javascript" src="/uv/lib/offline.js"></script>
     <script type="text/javascript" src="/uv/helpers.js"></script>
     <% if Rails.env.production? || Rails.env.staging? %>
-      <script defer event-environment="<%= Rails.env.to_s %>" event-embed-host="<%= params[:embed_host] || "unknown" %>" data-domain="dpul.princeton.edu" src="https://plausible.io/js/script.file-downloads.pageview-props.js"></script>
+      <script defer file-types="jpg,jpeg,tiff,pdf" event-environment="<%= Rails.env.to_s %>" event-embed-host="<%= params[:embed_host] || "unknown" %>" data-domain="dpul.princeton.edu" src="https://plausible.io/js/script.file-downloads.pageview-props.js"></script>
     <% end %>
   </head>
   <body>


### PR DESCRIPTION
The download pane in Universal Viewer:

1. Doesn't fire any javascript events (so we can't bind to an event and send a custom event)
2. Doesn't count as an outbound link (https://plausible.io/docs/outbound-link-click-tracking doesn't work)
3. Doesn't count as a "File Download" (https://plausible.io/docs/file-downloads-tracking doesn't work)
4. DOES use `window.open` to open a link. (https://github.com/UniversalViewer/universalviewer/blob/main/src/content-handlers/iiif/extensions/uv-openseadragon-extension/DownloadDialogue.tsx#L431)

Thus we can fire a custom event by, if Universal Viewer is loaded, overriding `window.open` in the viewer. This also adds an "?embed_host" property that can be added to the iframe, and sends the environment it's sending as. This is done via the documentation at https://plausible.io/docs/custom-props/for-pageviews#2-add-your-custom-properties-to-your-plausible-snippet.

Finally, this uses `manual` for Plausible, which means it doesn't automatically track page views - I don't think we care how many people go to `/viewer`, just how many people interact with that viewer.

The documentation for sending a custom event with properties in Plausible is here: https://plausible.io/docs/custom-props/for-custom-events#2-using-the-manual-method

Closes #6376 
Closes #6377 

This will miss any downloads done from within Figgy. We could do that, but I'm not sure it's necessary - that's not a public interface our patrons will be accessing.