### PR TITLE
Adds UV click event listener and sends custom event to Plausible

### DIFF
--- a/app/javascript/test/viewer/uv_manager.spec.js
+++ b/app/javascript/test/viewer/uv_manager.spec.js
@@ -169,6 +169,31 @@ describe('UVManager', () => {
       expect(window.plausible).toHaveBeenCalledWith('Download', { props: { url: 'http://example.com' } })
     })
 
+    it('sends an event to Plausible when the Universal Viewer container is clicked', async () => {
+      document.body.innerHTML = initialHTML
+      mockJquery()
+      mockUvProvider()
+      mockManifests(200)
+      mockPlausible()
+      stubQuery({
+        type: 'html',
+        content: "<iframe src='https://figgy.princeton.edu/viewer#?manifest=https://figgy.princeton.edu/concern/scanned_resources/78e15d09-3a79-4057-b358-4fde3d884bbb/manifest'></iframe>",
+        status: 'authorized',
+        mediaType: 'Image'
+      },
+        null,
+        'Test Playlist',
+        'Playlist'
+      )
+
+      // Initialize
+      const uvManager = new UVManager()
+      await uvManager.initialize()
+      document.getElementById('uv').click()
+      // This triggers a Plausible custom event.
+      expect(window.plausible).toHaveBeenCalledWith('UniversalViewer Click')
+    })
+
     it('passes on an auth token to graphql', async () => {
       document.body.innerHTML = initialHTML
       mockJquery()

--- a/app/javascript/viewer/uv_manager.js
+++ b/app/javascript/viewer/uv_manager.js
@@ -125,6 +125,7 @@ export default class UVManager {
     }, this.urlDataProvider)
     this.cdlTimer = new CDLTimer(this.figgyId)
     this.cdlTimer.initializeTimer()
+    this.bindUvClick()
   }
 
   // Universal Viewer uses window.open for download links, and we want to track
@@ -135,6 +136,26 @@ export default class UVManager {
       window.plausible('Download', { props: { url } })
       cachedOpen(url, target, features)
     }
+  }
+
+  bindUvClick () {
+    const uvElement = document.getElementById('uv')
+    const uvClick = new Event("uv-click", { bubbles: true });
+
+    uvElement.addEventListener(
+      "click",
+      (event) => {
+        /* … */
+        uvElement.dispatchEvent(uvClick)
+        const cachedOpen = window.open
+        window.open = function (url, target, features) {
+          window.plausible('UV-click', { props: { url } })
+          cachedOpen(url, target, features)
+        }
+        console.log("UV clicked!")
+      },
+      false,
+    );
   }
 
   createClover () {

--- a/app/javascript/viewer/uv_manager.js
+++ b/app/javascript/viewer/uv_manager.js
@@ -140,19 +140,14 @@ export default class UVManager {
 
   bindUvClick () {
     const uvElement = document.getElementById('uv')
-    const uvClick = new Event("uv-click", { bubbles: true });
+    const uvClick = new Event("UniversalViewer Click", { bubbles: true });
 
     uvElement.addEventListener(
       "click",
       (event) => {
         /* … */
         uvElement.dispatchEvent(uvClick)
-        const cachedOpen = window.open
-        window.open = function (url, target, features) {
-          window.plausible('uv-click', { props: { url } })
-          cachedOpen(url, target, features)
-        }
-        console.log("UV clicked!")
+        window.plausible('UniversalViewer Click')
       },
       false,
     );

--- a/app/javascript/viewer/uv_manager.js
+++ b/app/javascript/viewer/uv_manager.js
@@ -149,7 +149,7 @@ export default class UVManager {
         uvElement.dispatchEvent(uvClick)
         const cachedOpen = window.open
         window.open = function (url, target, features) {
-          window.plausible('UV-click', { props: { url } })
+          window.plausible('uv-click', { props: { url } })
           cachedOpen(url, target, features)
         }
         console.log("UV clicked!")

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -22,7 +22,6 @@
     <script src="//cdn.jsdelivr.net/npm/clipboard@2.0.6/dist/clipboard.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.18/dist/css/bootstrap-select.min.css">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.18/dist/js/bootstrap-select.min.js"></script>
-    <script defer data-domain="figgy.princeton.edu" src="https://plausible.io/js/script.js"></script>
 
     <%= content_for(:head) %>
     <%= render 'shared/analytics' if Rails.env.production? %>

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -22,6 +22,7 @@
     <script src="//cdn.jsdelivr.net/npm/clipboard@2.0.6/dist/clipboard.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.18/dist/css/bootstrap-select.min.css">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.18/dist/js/bootstrap-select.min.js"></script>
+    <script defer data-domain="figgy.princeton.edu" src="https://plausible.io/js/script.js"></script>
 
     <%= content_for(:head) %>
     <%= render 'shared/analytics' if Rails.env.production? %>


### PR DESCRIPTION
This may be a naive approach, but it listens for a click event on the #uv element, logs it (for testing), and dispatches a `uv-click` event to Plausible. I am unsure of how to test this in Plausible to make sure it was received. 