### PR TITLE
Update viewer logic to handle "unauthorized" redirects for CDL

### DIFF
--- a/app/javascript/test/viewer/uv_manager.spec.js
+++ b/app/javascript/test/viewer/uv_manager.spec.js
@@ -237,6 +237,44 @@ describe('UVManager', () => {
       expect(spy).not.toHaveBeenCalled()
     })
 
+    it('redirects to viewer auth if graph says unauthorized, for cdl acceptance', async () => {
+      document.body.innerHTML = initialHTML
+      mockJquery()
+      mockUvProvider()
+      stubQuery({
+        type: null,
+        content: null,
+        status: 'unauthorized',
+        mediaType: 'Image'
+      })
+
+      // Initialize
+      const uvManager = new UVManager()
+      const spy = vi.spyOn(uvManager, 'buildLeafletViewer')
+      await uvManager.initialize()
+      expect(window.location.assign).toHaveBeenCalledWith('/viewer/12345/auth')
+      expect(spy).not.toHaveBeenCalled()
+    })
+
+    it('does nothing if graph says forbidden', async () => {
+      document.body.innerHTML = initialHTML
+      mockJquery()
+      mockUvProvider()
+      stubQuery({
+        type: null,
+        content: null,
+        status: 'forbidden',
+        mediaType: 'Image'
+      })
+
+      // Initialize
+      const uvManager = new UVManager()
+      const spy = vi.spyOn(uvManager, 'buildLeafletViewer')
+      await uvManager.initialize()
+      expect(window.location.assign).not.toHaveBeenCalledWith('/viewer/12345/auth')
+      expect(spy).not.toHaveBeenCalled()
+    })
+
     it('falls back to a default viewer URI if not using a figgy manifest', async () => {
       document.body.innerHTML = initialHTML
       mockJquery()

--- a/app/javascript/viewer/uv_manager.js
+++ b/app/javascript/viewer/uv_manager.js
@@ -21,13 +21,15 @@ export default class UVManager {
   async loadViewer () {
     if (this.isFiggyManifest) {
       const result = await this.checkFiggyStatus()
-      if (result.embed.status === 'unauthenticated') {
+      if (result.embed.status === 'unauthenticated' || result.embed.status === 'unauthorized') {
         return window.location.assign('/viewer/' + this.figgyId + '/auth')
       } else if (result.embed.status === 'authorized') {
         this.displayNotice(result)
         this.renderViewer(result)
         await this.buildLeafletViewer(result)
       }
+      // The other possible state is "forbidden", which means there's no way
+      // they're able to view this resource, don't even try.
     } else {
       return this.createUV()
     }

--- a/app/services/embed.rb
+++ b/app/services/embed.rb
@@ -114,8 +114,14 @@ class Embed
         else
           "unauthenticated"
         end
-      else
+      elsif ability.can?(:discover, resource)
+        # If they can discover it, then it's probably a CDL resource - given
+        # some action they can get it
         "unauthorized"
+      else
+        # If they can't even discover it, there's nothing they can do. They're
+        # explicitly forbidden.
+        "forbidden"
       end
     end
 

--- a/spec/graphql/types/scanned_resource_type_spec.rb
+++ b/spec/graphql/types/scanned_resource_type_spec.rb
@@ -385,6 +385,19 @@ RSpec.describe Types::ScannedResourceType do
       let(:scanned_resource) do
         FactoryBot.create_for_repository(:complete_private_scanned_resource)
       end
+      let(:user) { FactoryBot.create(:user) }
+      context "and it's not a CDL resource" do
+        it "returns forbidden" do
+          expect(type.embed).to eq(
+            {
+              type: nil,
+              content: nil,
+              status: "forbidden",
+              media_type: nil
+            }
+          )
+        end
+      end
       context "and a permitted user is logged in" do
         let(:user) { FactoryBot.create(:admin) }
         it "returns an iframe and authorized" do


### PR DESCRIPTION
We accidentally broke CDL in
https://github.com/pulibrary/figgy/blob/e4162d20d99111cd64e574fd306982246a75354e/app/javascript/viewer/uv_manager.js#L23. We used to check manifest statuses and redirect if it was unauthorized, but not if it was "forbidden."

This PR adds a forbidden status to the embed code, which should get us back to parity.

Tested locally and this fixes the screen for CDL.

Closes #6418