### PR TITLE
PDF Resilience Attempts

### DIFF
--- a/app/derivative_services/pdf_derivative_service.rb
+++ b/app/derivative_services/pdf_derivative_service.rb
@@ -24,27 +24,36 @@ class PDFDerivativeService
   end
 
   def create_derivatives
-    update_pdf_use
-    tiffs = convert_pages
-    add_file_sets(tiffs)
-    update_error_message(message: nil) if target_file.error_message.present?
-  rescue StandardError => e
-    change_set_persister.after_rollback.add do
-      update_error_message(message: e.message)
+    buffered do
+      update_pdf_use
+      tiffs = convert_pages
+      add_file_sets(tiffs)
+      update_error_message(message: nil) if target_file.error_message.present?
+    rescue StandardError => e
+      change_set_persister.after_rollback.add do
+        update_error_message(message: e.message)
+      end
+      raise e
+    ensure
+      FileUtils.remove_entry(tmpdir, true) if File.exist?(tmpdir)
     end
-    raise e
-  ensure
-    FileUtils.remove_entry(tmpdir, true) if File.exist?(tmpdir)
+  end
+
+  def buffered
+    change_set_persister.buffer_into_index do |buffered_change_set_persister|
+      old_persister = change_set_persister
+      @change_set_persister = buffered_change_set_persister
+      yield
+      @change_set_persister = old_persister
+    end
   end
 
   def add_file_sets(files)
     resource = parent
-    change_set_persister.buffer_into_index do |buffered_change_set_persister|
-      files.each_slice(page_slice) do |file_slice|
-        change_set = ChangeSet.for(resource)
-        change_set.validate(files: file_slice)
-        resource = buffered_change_set_persister.save(change_set: change_set)
-      end
+    files.each_slice(page_slice) do |file_slice|
+      change_set = ChangeSet.for(resource)
+      change_set.validate(files: file_slice)
+      resource = change_set_persister.save(change_set: change_set)
     end
   end
 
@@ -89,10 +98,14 @@ class PDFDerivativeService
     pages = image.get_value("pdf-n_pages")
     files = Array.new(pages).lazy.each_with_index.map do |_, page|
       location = temporary_output(page).to_s
-      `vips pdfload "#{filename}" #{location} --page #{page} --n 1 --dpi 300 --access sequential`
+      generate_pdf_image(filename, location, page)
       build_file(page + 1, location)
     end
     files
+  end
+
+  def generate_pdf_image(filename, location, page)
+    `vips pdfload "#{filename}" #{location} --page #{page} --n 1 --dpi 300 --access sequential`
   end
 
   def build_file(page, file_path)

--- a/app/derivative_services/pdf_derivative_service.rb
+++ b/app/derivative_services/pdf_derivative_service.rb
@@ -113,7 +113,7 @@ class PDFDerivativeService
   end
 
   def convert_pdf_page(filename, location, page)
-    `vips pdfload "#{filename}" #{location} --page #{page} --n 1 --dpi 300 --access sequential`
+    `vips pdfload "#{filename}" #{location} --page #{page} --n 1 --access sequential`
     raise(ZeroByteError, "Failed to generate PDF derivative #{location} - page #{page}.") if File.size(location).zero?
   end
 

--- a/spec/derivative_services/pdf_derivative_service_spec.rb
+++ b/spec/derivative_services/pdf_derivative_service_spec.rb
@@ -67,7 +67,8 @@ RSpec.describe PDFDerivativeService do
         intermediate_file = intermediate_files.first.intermediate_file
         intermediate_disk_file = Valkyrie::StorageAdapter.find_by(id: intermediate_file.file_identifiers.first)
         vips_image = Vips::Image.new_from_file(intermediate_disk_file.disk_path.to_s)
-        expect(vips_image.width).to eq 2550
+        # Don't upscale.
+        expect(vips_image.width).to eq 612
 
         # Ensure the thumbnail is set to the first derivative.
         reloaded_resource = query_service.find_by(id: scanned_resource.id)


### PR DESCRIPTION
For PDF derivatives this does three things:

1. Ensure the whole resource rolls back appropriately if it fails to generate a derivative.
2. Retry if VIPS creates a zero byte file.
3. Uses the default DPI settings. 300 was resulting in 300 MB files PER PAGE for a PDF that was only 20 MB total.

Now it should only be able to make a zero byte file if the storage uploader somehow creates one when copying the file over.

Work towards #6436