### PR TITLE
I6355 structure manager labels

### DIFF
--- a/app/javascript/components/Tree.vue
+++ b/app/javascript/components/Tree.vue
@@ -53,18 +53,10 @@
                 v-model="structureData.label"
                 type="text"
                 class="folder-label-input"
-                @keyup.enter="saveLabel(id)"
+                @keyup="saveLabel(id)"
+                @keydown.enter="hideLabelInput()"
+                @blur="hideLabelInput()"
               >
-            </div>
-            <div class="folder-edit">
-              <lux-input-button
-                class="save-label"
-                type="button"
-                variation="icon"
-                size="small"
-                icon="approved"
-                @button-clicked="saveLabel(id)"
-              />
             </div>
           </template>
           <template v-else>
@@ -295,6 +287,8 @@ export default {
         }
       }
       store.commit('SAVE_LABEL', structure)
+    },
+    hideLabelInput: function () {
       this.editedFieldId = null
     },
     updateFolderLabel: function (array, selectedFolder) {

--- a/spec/features/struct_manager_spec.rb
+++ b/spec/features/struct_manager_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature "Structure Manager", js: true do
     page.all("button.toggle-edit")[1].click
     expect(page).to have_css "input.folder-label-input"
     find("input.folder-label-input").set("Chapter Foo")
-    find("button.save-label").click
+    page.send_keys [:enter]
     expect(page).to have_css("div.folder-label", text: "Chapter Foo")
 
     # test cut of gallery item
@@ -48,7 +48,7 @@ RSpec.feature "Structure Manager", js: true do
     find("button.lux-menu-item", text: "Paste (Ctrl-v)").click
     expect(page).to have_css ".lux-structManager .file"
 
-    # test create new folder with ctrl-n
+    # test create new folder with ctrl-/
     find("div.folder-label", match: :first).click
     expect(page).not_to have_css("div.folder-label", text: "Untitled")
     page.send_keys [:control, "/"]


### PR DESCRIPTION
This fixes #6355. One suggestion is to autofocus label edits when folder is created. This is beyond the scope of the ticket but could also be added here.