### PR TITLE
Updates the paste hotkey from Ctrl-v to Ctrl-.

### DIFF
--- a/app/javascript/components/StructManagerToolbar.vue
+++ b/app/javascript/components/StructManagerToolbar.vue
@@ -12,7 +12,7 @@
         {name: 'Delete Folder (Ctrl-d)', component: 'FolderDelete', disabled: rootNodeSelected},
         {name: 'Undo Cut (Ctrl-z)', component: 'UndoCut', disabled: !isCutDisabled()},
         {name: 'Cut (Ctrl-x)', component: 'Cut', disabled: isCutDisabled()},
-        {name: 'Paste (Ctrl-v)', component: 'Paste', disabled: isPasteDisabled()},
+        {name: 'Paste (Ctrl-.)', component: 'Paste', disabled: isPasteDisabled()},
         {name: 'Zoom on Selected (Ctrl-o)', component: 'Zoom', disabled: isZoomDisabled()}
       ]"
       @menu-item-clicked="menuSelection($event)"
@@ -120,7 +120,7 @@ export default {
         e.preventDefault()
         this.cutSelected()
       }
-      if (e.key === 'v' && (e.ctrlKey || e.metaKey)) {
+      if (e.key === '.' && (e.ctrlKey || e.metaKey)) {
         e.preventDefault()
         this.paste()
       }
@@ -226,7 +226,7 @@ export default {
         case 'Cut (Ctrl-x)':
           this.cutSelected()
           break
-        case 'Paste (Ctrl-v)':
+        case 'Paste (Ctrl-.)':
           this.paste()
           break
         case 'Zoom on Selected (Ctrl-o)':

--- a/spec/features/struct_manager_spec.rb
+++ b/spec/features/struct_manager_spec.rb
@@ -43,9 +43,10 @@ RSpec.feature "Structure Manager", js: true do
     expect(page).to have_css ".lux-card-disabled"
 
     # test paste of gallery item into a tree structure folder
+    # the hotkey for paste is a period (.) to avoid hotkey collisions with Windows Ctrl-V
     find("div.folder-label", text: "Chapter Foo").click
     find("button.lux-dropdown-button").click
-    find("button.lux-menu-item", text: "Paste (Ctrl-v)").click
+    find("button.lux-menu-item", text: "Paste (Ctrl-.)").click
     expect(page).to have_css ".lux-structManager .file"
 
     # test create new folder with ctrl-n

--- a/spec/features/struct_manager_spec.rb
+++ b/spec/features/struct_manager_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature "Structure Manager", js: true do
     find("button.lux-menu-item", text: "Paste (Ctrl-.)").click
     expect(page).to have_css ".lux-structManager .file"
 
-    # test create new folder with ctrl-n
+    # test create new folder with ctrl-/
     find("div.folder-label", match: :first).click
     expect(page).not_to have_css("div.folder-label", text: "Untitled")
     page.send_keys [:control, "/"]
@@ -64,7 +64,7 @@ RSpec.feature "Structure Manager", js: true do
 
     # test paste of a cut folder into another folder using keyboard commands
     find("div.folder-label", text: "Untitled").click
-    page.send_keys [:control, "v"]
+    page.send_keys [:control, "."]
     first_node = find("ul.lux-tree-sub", match: :first)
     expect(first_node).to have_css(".folder-label", text: "Untitled")
 


### PR DESCRIPTION
There was no need to change the Ctrl-x hotkey since the hotkey collision issue on Windows was pasting text from the clipboard, not cutting or copying.