### PR TITLE
ScannedMaps should not be start_canvases

### DIFF
--- a/app/services/manifest_builder/start_canvas_builder.rb
+++ b/app/services/manifest_builder/start_canvas_builder.rb
@@ -11,6 +11,7 @@ class ManifestBuilder
 
     def apply(manifest)
       return manifest unless start_canvas_id && file_set
+      return manifest unless file_set.is_a?(FileSet)
       manifest["startCanvas"] = path
       manifest
     end

--- a/spec/services/manifest_builder/by_resource_type/manifest_builder_scanned_maps_spec.rb
+++ b/spec/services/manifest_builder/by_resource_type/manifest_builder_scanned_maps_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ManifestBuilder do
   context "when given a nested scanned map set" do
     subject(:manifest_builder) { described_class.new(query_service.find_by(id: scanned_map.id)) }
     let(:scanned_map) do
-      FactoryBot.create_for_repository(:scanned_map, description: "Test Description", member_ids: child.id)
+      FactoryBot.create_for_repository(:scanned_map, description: "Test Description", member_ids: child.id, start_canvas: child.id)
     end
     let(:child) { FactoryBot.create_for_repository(:scanned_map, files: [file]) }
     it "builds a IIIF document" do

--- a/spec/services/manifest_builder/by_resource_type/manifest_builder_scanned_maps_spec.rb
+++ b/spec/services/manifest_builder/by_resource_type/manifest_builder_scanned_maps_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ManifestBuilder do
   context "when given a nested scanned map set" do
     subject(:manifest_builder) { described_class.new(query_service.find_by(id: scanned_map.id)) }
     let(:scanned_map) do
-      FactoryBot.create_for_repository(:scanned_map, description: "Test Description", member_ids: child.id, start_canvas: child.id)
+      FactoryBot.create_for_repository(:scanned_map, description: "Test Description", member_ids: child.id)
     end
     let(:child) { FactoryBot.create_for_repository(:scanned_map, files: [file]) }
     it "builds a IIIF document" do
@@ -48,6 +48,17 @@ RSpec.describe ManifestBuilder do
       expect(output["@type"]).to eq "sc:Manifest"
       expect(output["manifests"]).to eq nil
       expect(output["sequences"].first["canvases"].length).to eq 1
+    end
+    context "that mistakenly has a scanned map set as a start_canvas" do
+      let(:scanned_map) do
+        FactoryBot.create_for_repository(:scanned_map, description: "Test Description", member_ids: child.id, start_canvas: child.id)
+      end
+      it "builds a IIIF document" do
+        output = manifest_builder.build
+        expect(output).to be_kind_of Hash
+        expect(output["@type"]).to eq "sc:Manifest"
+        expect(output["sequences"].first["canvases"].length).to eq 1
+      end
     end
   end
 


### PR DESCRIPTION
If a scanned map gets set as a start canvas, don't try to render it as one.

Closes #6456 