### PR TITLE
Update readme for clarity and to reduce duplicate documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,67 +5,36 @@ A digital repository application in use at Princeton University Library for stor
 [![CircleCI](https://circleci.com/gh/pulibrary/figgy.svg?style=svg)](https://circleci.com/gh/pulibrary/figgy)
 [![Browserstack](./browserstack-logo.svg)](https://www.browserstack.com/)
 
-## Language Dependencies
+## Project Setup for Development and Test environments
 
-For asdf users `./bin/setup` will ensure that required languages are installed at the right versions. (See note on java, below)
+### One-time setup
 
-Otherwise consult `.tool-versions` for required languages and their current versions.
+Follow these steps the first time you clone this project to run in dev or test.
 
-### Java via ASDF on Mac
-You need to add the following line to your `~/.asdfrc` file:
+#### Install Language Dependencies
 
-```
-java_macos_integration_enable = yes
-```
+- We use asdf to manage language dependencies. If you don't have it installed do `brew install asdf`.
+- To support Java on Mac via asdf, add the following line to your `~/.asdfrc` file:
+    ```
+    java_macos_integration_enable = yes
+    ```
+- If your `~/.asdfrc` has this line you may need to remove it:
+    ```
+    legacy_version_file = yes
+    ```
+- After making these changes open a new terminal window for figgy.
+- Run `./bin/setup_asdf`. This script ensures all required plugins are installed and then installs all language dependencies specified in `.tool-versions`.
 
-And if you have this line you may need to remove it:
+#### Install Package Dependencies
 
-```
-legacy_version_file = yes
-```
-
-After making these changes open a new terminal window for figgy.
-
-## Package Dependencies
-
-The following dependencies will be installed via homebrew by `./bin/setup`:
-
-* [ImageMagick](https://www.imagemagick.org)
-* [GDAL](http://www.gdal.org/)
-* [Tesseract](https://github.com/tesseract-ocr/tesseract)
-    * Note that version 3.04 is on the servers but homebrew installs 4.1.1
-* [MediaInfo](https://mediaarea.net/en/MediaInfo)
-* [FFMpeg](http://www.ffmpeg.org/) (for AV derivatives)
-* [VIPS]
-* [OCRmyPDF](https://ocrmypdf.readthedocs.io/)
-* [cogeo-mosaic](https://github.com/developmentseed/cogeo-mosaic) for mosaic manifest generation
-* [tippecanoe](https://github.com/felt/tippecanoe) vector tileset generator
-
-Other dependencies:
-
-* Postgres (for OSX dev systems, install via homebrew)
-* [Redis](http://redis.io/)
-    * Start Redis with `redis-server` or if you're on certain Linuxes, you can do this via `sudo service redis-server start`.
-* [RabbitMQ](https://www.rabbitmq.com/) (Optional)
-    * Start with rabbitmq-server
-    * Used for publishing create/update/delete events for systems such as
-      [Pomegranate](https://github.com/pulibrary/pomegranate)
-
-## Initial Setup
-
-```sh
-git clone https://github.com/pulibrary/figgy.git
-cd figgy
-./bin/setup_asdf
-Follow setup notes for Mac M series processors if needed
-./bin/setup
-```
+- First follow package setup for Mac M series processors (below) if needed
+- Then run `./bin/setup` to ensure that required dependencies via homebrew, pip, bundler, and yarn.
 
 Remember you'll need to run `bundle install` and `yarn install` on an ongoing basis as dependencies are updated.
 
-### Setup Notes for Mac M Series Processors
+##### Package Setup for Mac M Series Processors
 
-Mapnik currently isn't supported by M1 processors, so `yarn install` above will
+Mapnik currently isn't supported by M-series processors, so `yarn install` above will
 fail. To get this working, do the following:
 
 1. $ arch -x86_64 /bin/zsh --login
@@ -85,24 +54,7 @@ fail. To get this working, do the following:
    export PGGSSENCMODE="disable"
 ```
 
-## Populate sidekiq-pro credentials from lastpass
-
-These steps are performed by `./bin/setup`; if that worked you don't have to do
-this separately.
-
-More information about lastpass-cli can be found here: https://lastpass.github.io/lastpass-cli/lpass.1.html
-```
-brew install lastpass-cli
-lpass login <email@email.com>
-bin/setup_credentials
-```
-
-## Setup server
-
-You can either run Solr/Postgres locally or spin them up in Docker containers
-with Lando.
-
-### Lando
+#### Install Lando
 
 Lando will automatically set up docker images for Solr and Postgres which match
 the versions we use in Production. The ports will not collide with any other
@@ -110,24 +62,26 @@ projects you're using Solr/Postgres for, and you can easily clean up with `lando
 destroy` or turn off all services with `lando poweroff`.
 
 1. Install Lando DMG from [[https://github.com/lando/lando/releases]]
-1. `bundle exec rake servers:start`
 
-1. For test:
-   - In a separate terminal: `bundle exec rspec`
-   - Run javascript tests: `yarn test`
-1. For development:
-   - In a separate terminal: `bundle exec foreman start`
-     - Or run services separately as shown in [[https://github.com/pulibrary/figgy/blob/main/Procfile]]
-   - Access Figgy at http://localhost:3000/
+### Every time setup
 
-### Feature Tests
+Follow these steps every time you start new work in this project in dev or test
+
+1. Run `bundle exec rake servers:start` to start lando services and set up database state.
+
+### Running tests
+
+- Run ruby test suite synchronously (takes a long time): `bundle exec rspec`
+- Run javascript test suite: `yarn test`
+
+##### Feature Tests
 
 If you want to watch feature tests run for debugging purposes, you can go to
 http://localhost:7900, use the password `secret`, and run tests like this:
 
 `RUN_IN_BROWSER=true bundle exec rspec spec/features`
 
-### Parallel Tests
+##### Parallel Tests
 
 If you'd like to run the test suite in parallel do the following:
 
@@ -140,13 +94,18 @@ listed separately for each parallel run, but final run time and coverage will be
 reported accurate, and the file that powers the --only-failures flag will be
 correctly generated.
 
-## Load sample development data
+### Development Environment
+
+- Run `bundle exec rails s` in a terminal window you can keep open
+- Access Figgy at http://localhost:3000/
+
+##### Load sample development data
 
 1. Log in to your development instance using your princeton credentials; this creates your user in figgy's db. If you only have user access and need admin access, run `bundle exec rake figgy:set_admin_user`
 1. Start sidekiq (see below)
 1. `rails db:seed` # pipe through `grep -v WARN` to ignore log warnings about the rabbitmq port
 
-## Background workers
+##### Background workers
 
 Some tasks are performed by background workers. To run a Sidekiq background worker process to execute
 background jobs that are queued:
@@ -155,7 +114,7 @@ background jobs that are queued:
 bundle exec sidekiq
 ```
 
-## Loading controlled vocabularies
+##### Loading controlled vocabularies
 
 To load the controlled vocabularies in `config/vocab/`:
   - `rake figgy:vocab:load CSV=config/vocab/iso639-1.csv NAME="LAE Languages"`
@@ -164,11 +123,11 @@ To load the controlled vocabularies in `config/vocab/`:
   - `rake figgy:vocab:load CSV=config/vocab/lae_genres.csv NAME="LAE Genres" LABEL=pul_label`
   - `rake figgy:vocab:load CSV=config/vocab/lae_subjects.csv NAME="LAE Subjects" CATEGORY=category`
 
-## Uploading files
+##### Uploading files
 
 By default, Figgy provides users with the ability to upload binaries from the local file system environment using the directory [https://github.com/pulibrary/figgy/tree/master/staged_files](/staged_files).  One may copy files into this directory for aiding in development, and may upload these files in this directory using the "File Manager" interface (exposed after saving a Work).
 
-## Preservation Configuration in Development
+##### Preservation Configuration in Development
 
 Figgy uses Google Cloud Storage buckets for providing support for preserving certain resources.  Please find further documentation outlining the configuration for Google Cloud service authentication and permissions management [here](https://github.com/pulibrary/figgy/blob/master/GOOGLE_CLOUD_STORAGE.md).
 
@@ -186,22 +145,21 @@ instead, do the following:
    will save to a bucket you can view at `https://console.cloud.google.com/storage/browser`
 4. Items only last in this bucket for 2 days, and aren't versioned.
 
-## Administering Figgy
-To put figgy in readonly mode, use the [ansible playbook](https://github.com/pulibrary/princeton_ansible/blob/master/playbooks/figgy_toggle_readonly.yml). Be mindful of the value of the `figgy_read_only_mode` variable when provisioning during readonly downtime. It defaults to false and could therefore turn off readonly mode prematurely if you don't override it.
+## Production tasks
 
-## Cloud Fixity Checking
+### Cloud Fixity Checking
 
 Documentation on setup for staging/production Fixity configuration can be found
 in [preservation_documentation.md](/docs/technical/preservation/google_pub_sub.md).
 
-### Deployment Steps
+#### Cloud Fixity Deployment Steps
 
 1. `gcloud components install beta`
 1. `gcloud auth login`
 1. `gcloud config set project pulibrary-figgy-storage-1`
 1. `cap [staging/production] deploy:google_cloud_function`
 
-## ArchivesSpace Synchronization and TiTiler functionality
+### ArchivesSpace Synchronization and TiTiler functionality
 
 Figgy will persist DAOs to ArchivesSpace on completion of finding aid resources.
 It also uses an s3 bucket to store geo derivatives and serve them via titiler
@@ -211,11 +169,11 @@ To set these up in development, do the following:
 1. `lpass login <email>`
 1. `bundle exec rake figgy:setup_keys`
 
-## Read-only Maintenance Windows
+### Read-only Maintenance Windows
 
 There are two types of read-only mode.
 
-### Read-only Mode
+##### Read-only Mode
 
 Read-only mode disables writing to the Postgres database. Use princeton_ansible to activate it:
 * change the `figgy_read_only_mode` value in the relevant group_vars file (example: https://github.com/pulibrary/princeton_ansible/blob/9ccaadf336ddac973c4c18e836d46d445f15d38f/group_vars/figgy/staging.yml#L30)
@@ -224,7 +182,7 @@ Read-only mode disables writing to the Postgres database. Use princeton_ansible 
 
 Known issue: In read-only mode users cannot download pdfs (unless they've been cached). See #2866
 
-### Index Read-Only
+##### Index Read-Only
 
 This disables writing to the Solr index, but allows writes to the Postgres
 database which don't get indexed, such as CDL charges or new user creation. This
@@ -251,7 +209,6 @@ docker buildx build --push --platform linux/arm64,linux/amd64 -t pulibrary/ci-fi
 docker push pulibrary/ci-figgy:{version}
 ```
 
-
 ## More
 Valkyrie Documentation:
 - For links to helpful valkyrie documentation and troubleshooting tips, visit the [Valkyrie wiki](https://github.com/samvera-labs/valkyrie/wiki).
@@ -260,3 +217,25 @@ Valkyrie Documentation:
 User documentation is maintained in Google Drive:
 - [Figgy_work > Demos and Documentation](https://drive.google.com/drive/u/2/folders/1--EaoC-9fCpJx2tW4ej0-SyNNbEBX4MX)
 - [Controlled Digital Lending workflow documentation](https://docs.google.com/document/d/1zX-V93TGy-2U2AF-cZb6GBrrz-J6onF1yo8UgMoSzes/edit#heading=h.up07nmqm707q)
+
+Links to dependencies used in Figgy:
+* [ImageMagick](https://www.imagemagick.org)
+* [GDAL](http://www.gdal.org/)
+* [Tesseract](https://github.com/tesseract-ocr/tesseract)
+    * Note that version 3.04 is on the servers but homebrew installs 4.1.1
+* [MediaInfo](https://mediaarea.net/en/MediaInfo)
+* [FFMpeg](http://www.ffmpeg.org/) (for AV derivatives)
+* [VIPS]
+* [OCRmyPDF](https://ocrmypdf.readthedocs.io/)
+* [cogeo-mosaic](https://github.com/developmentseed/cogeo-mosaic) for mosaic manifest generation
+* [tippecanoe](https://github.com/felt/tippecanoe) vector tileset generator
+
+Other dependencies:
+
+* Postgres - run in Lando (for OSX dev systems, install via homebrew)
+* [Redis](http://redis.io/) - run in Lando
+* [RabbitMQ](https://www.rabbitmq.com/) (Optional)
+    * Used for publishing create/update/delete events for systems such as
+      [DPUL](https://github.com/pulibrary/dpul)
+    * Start with rabbitmq-server
+

--- a/bin/setup_keys
+++ b/bin/setup_keys
@@ -1,8 +1,0 @@
-#!/usr/bin/env ruby
-def sidekiq_pro_credentials
-  content = `lpass show "Shared-ITIMS-Passwords/Sidekiq Pro Instructions"`
-  content = content.split("\n").find { |x| x.start_with?("BUNDLE_GEMS") }
-  content.split("=").last
-end
-
-`bundle config gems.contribsys.com #{sidekiq_pro_credentials}`


### PR DESCRIPTION
Several things were repeated, there was old content, and there was too
much detail in some places. Duplicate setup_keys script was removed. It
was probably moved to be called setup_credentials at some point to keep
it from being confusing given the setup_keys rake task.
