### PR TITLE
Updating link for Special Collections citation guidelines

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -112,7 +112,7 @@ en:
           label: "IIIF Manifest URL"
         rights_statement:
           boilerplate: |
-            Princeton University Library claims no copyright or license governing this digital resource. It is provided for free, on a non-commercial, open-access basis, for fair-use academic and research purposes only. Anyone who claims copyright over any part of these resources and feels that they should not be presented in this manner is invited to contact Princeton University Library, who will in turn consider such concerns and make every effort to respond appropriately. We request that users reproducing this resource cite it according to the guidelines described at <a href="https://library.princeton.edu/special-collections/policies/forms-citation">https://library.princeton.edu/special-collections/policies/forms-citation</a>.
+            Princeton University Library claims no copyright or license governing this digital resource. It is provided for free, on a non-commercial, open-access basis, for fair-use academic and research purposes only. Anyone who claims copyright over any part of these resources and feels that they should not be presented in this manner is invited to contact Princeton University Library, who will in turn consider such concerns and make every effort to respond appropriately. We request that users reproducing this resource cite it according to the guidelines described at <a href="https://library.princeton.edu/about/policies/special-collections-copyright-credit-and-citation-guidelines">https://library.princeton.edu/about/policies/special-collections-copyright-credit-and-citation-guidelines</a>.
         weight:
           label: "Weight (g)"
         size:

--- a/spec/services/pdf_generator_spec.rb
+++ b/spec/services/pdf_generator_spec.rb
@@ -306,7 +306,7 @@ RSpec.describe PDFGenerator do
           :scanned_resource,
           files: [file],
           source_metadata_identifier: "991234563506421",
-          holding_location: ControlledVocabulary.for(:holding_location).all.first.value
+          holding_location: ControlledVocabulary.for(:holding_location).all.find { |v| v.label == "Plasma Physics Library" }.value
         )
         file_set = Wayfinder.for(resource).file_sets.first
         stub_request(:any, "http://www.example.com/image-service/#{file_set.id}/full/200,/0/gray.jpg")
@@ -323,7 +323,7 @@ RSpec.describe PDFGenerator do
         # page.
         text = cover_page.text.tr("\n", " ")
         expect(text).to include("ppllib@princeton.edu")
-        expect(text).to include("Forrestal Campus Princeton, NJ 08544")
+        expect(text).to include("Plasma Physics Library")
         expect(text).to include("609-243-3565")
       end
     end


### PR DESCRIPTION
We noticed this change because a redirect was dropped in the website migration. So we should update to the current URL for the page and not use the old URL which depends on the redirect.