### PR TITLE
Root health.json errors rarely, filtered checks error if they fail.

### DIFF
--- a/config/initializers/health_monitor.rb
+++ b/config/initializers/health_monitor.rb
@@ -1,20 +1,42 @@
 # frozen_string_literal: true
 Rails.application.config.after_initialize do
+  # Adds a patch a check is always critical if it's filtered for, otherwise fall
+  # back to configured value.
+  class HealthMonitor::Providers::Base
+    def critical
+      return true if request && request.parameters["providers"].present?
+      configuration.critical
+    end
+  end
+
   HealthMonitor.configure do |config|
     config.cache
 
     config.add_custom_provider(CheckOverrides::Redis)
-    config.add_custom_provider(SolrStatus)
-    config.add_custom_provider(AspaceStatus)
-    config.add_custom_provider(RabbitMqStatus)
-    config.add_custom_provider(SmtpStatus)
-    config.add_custom_provider(FileWatcherStatus)
-    config.add_custom_provider(IngestMountStatus)
+    config.add_custom_provider(SolrStatus).configure do |provider_config|
+      provider_config.critical = false
+    end
+    config.add_custom_provider(AspaceStatus).configure do |provider_config|
+      provider_config.critical = false
+    end
+    config.add_custom_provider(RabbitMqStatus).configure do |provider_config|
+      provider_config.critical = false
+    end
+    config.add_custom_provider(SmtpStatus).configure do |provider_config|
+      provider_config.critical = false
+    end
+    config.add_custom_provider(FileWatcherStatus).configure do |provider_config|
+      provider_config.critical = false
+    end
+    config.add_custom_provider(IngestMountStatus).configure do |provider_config|
+      provider_config.critical = false
+    end
 
     # monitor all the queues for latency
     # The gem also comes with some additional default monitoring,
     # e.g. it ensures that there are running workers
     config.sidekiq.configure do |sidekiq_config|
+      sidekiq_config.critical = false
       sidekiq_config.latency = 5.days
       sidekiq_config.queue_size = 1_000_000
       sidekiq_config.maximum_amount_of_retries = 17

--- a/spec/requests/health_monitor_spec.rb
+++ b/spec/requests/health_monitor_spec.rb
@@ -11,9 +11,6 @@ RSpec.describe "Health Monitor", type: :request do
   describe "GET /health" do
     it "has a success response" do
       stub_aspace_login
-      allow(Net::SMTP).to receive(:new).and_return(instance_double(Net::SMTP, "open_timeout=": nil, start: true))
-      # stub the number of processes since sidekiq doesn't run in test
-      allow(Sidekiq::Stats).to receive(:new).and_return(instance_double(Sidekiq::Stats, processes_size: 1))
 
       get "/health.json"
 


### PR DESCRIPTION
This might be interesting for upstream, but I can't really imagine how they'd want it. I'll make an issue for discussion in their repo.

Closes #6533.