### PR TITLE
Adding Creative Commons Public Domain Mark rights statement

### DIFF
--- a/config/authorities/rights_statement.yml
+++ b/config/authorities/rights_statement.yml
@@ -236,3 +236,14 @@
 
       You can copy, modify, distribute and perform the work, even for commercial
       purposes, all without asking permission.
+  - :value: https://creativecommons.org/publicdomain/mark/1.0/
+    :label: Public Domain Mark
+    :notable: true
+    :scopeNote: |
+      No Copyright
+    :definition: >-
+      This work has been identified as being free of known restrictions under copyright law,
+      including all related and neighboring rights.
+
+      You can copy, modify, distribute and perform the work, even for commercial purposes, all
+      without asking permission.


### PR DESCRIPTION
We are hosting content from the British Library, and they have requested that we use this rights statement. It is very similar to CC0, but differs in that it asserts the item is already in the public domain, as opposed to saying we are putting it in the public domain.