### PR TITLE
Don't force ssl

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: ENV.fetch("APPLICATION_HOST", "localhost"), protocol: ENV.fetch("APPLICATION_HOST_PROTOCOL", "http") }
   config.action_mailer.perform_caching = false
   config.action_controller.action_on_unpermitted_parameters = false
-  config.force_ssl = true
+  config.force_ssl = false
   config.action_dispatch.x_sendfile_header = "X-Accel-Redirect"
   config.active_storage.service = :local
   config.cache_store = :mem_cache_store, "figgy-web-prod1.princeton.edu"


### PR DESCRIPTION
We're seeing issues with Datadog related to SSL redirects. We do not need to set this in the application, as the load balancer does this for us.