### PR TITLE
Remove figgy-web-staging1 as deploy target

### DIFF
--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -7,7 +7,7 @@
 # server 'example.com', user: 'deploy', roles: %w{app db web}, my_property: :my_value
 # server 'example.com', user: 'deploy', roles: %w{app web}, other_property: :other_value
 # server 'db.example.com', user: 'deploy', roles: %w{db}
-server "figgy-web-staging1", user: "deploy", roles: %w[app db web worker]
+# server "figgy-web-staging1", user: "deploy", roles: %w[app db web worker]
 server "figgy-web-staging2", user: "deploy", roles: %w[app web worker]
 set :google_fixity_request_topic, "figgy-staging-fixity-request"
 set :google_service_account, "figgy-staging@pulibrary-figgy-storage-1.iam.gserviceaccount.com"


### PR DESCRIPTION
We can't deploy to figgy-web-staging1, pending
https://github.com/pulibrary/figgy/issues/6593

Remove it for now
