### PR TITLE
Remove retries check on sidekiq monitor

### DIFF
--- a/config/initializers/health_monitor.rb
+++ b/config/initializers/health_monitor.rb
@@ -38,9 +38,7 @@ Rails.application.config.after_initialize do
     # e.g. it ensures that there are running workers
     config.sidekiq.configure do |sidekiq_config|
       sidekiq_config.critical = false
-      sidekiq_config.latency = 5.days
-      sidekiq_config.queue_size = 1_000_000
-      sidekiq_config.maximum_amount_of_retries = 17
+      sidekiq_config.add_queue_configuration("default", latency: 5.days, queue_size: 1_000_000)
       sidekiq_config.add_queue_configuration("high", latency: 5.days, queue_size: 1_000_000)
       sidekiq_config.add_queue_configuration("mailers", latency: 5.days, queue_size: 1_000_000)
       sidekiq_config.add_queue_configuration("low", latency: 5.days, queue_size: 1_000_000)

--- a/spec/requests/health_monitor_spec.rb
+++ b/spec/requests/health_monitor_spec.rb
@@ -81,7 +81,6 @@ RSpec.describe "Health Monitor", type: :request do
         "super_low" => hash_including(latency: 5.days, queue_size: 1_000_000),
         "realtime" => hash_including(latency: 30.seconds, queue_size: 100)
       )
-      expect(sidekiq_configuration.maximum_amount_of_retries).to match(17)
     end
 
     context "when there are files in the ocr in directory" do


### PR DESCRIPTION
We weren't acting on this alert, and we have other process in place for
the retries queue.

Also make configuration for "default" queue more explicit

closes #6558
