### PR TITLE
Use with_rescue to retry SSLErrors during preservation audit

### DIFF
--- a/app/adapters/retrying_disk_adapter.rb
+++ b/app/adapters/retrying_disk_adapter.rb
@@ -7,18 +7,8 @@ class RetryingDiskAdapter
   end
 
   def upload(...)
-    with_rescue([Errno::EPIPE, Errno::EAGAIN, Errno::EIO, Errno::ECONNRESET], retries: 5) do
+    FiggyUtils.with_rescue([Errno::EPIPE, Errno::EAGAIN, Errno::EIO, Errno::ECONNRESET], retries: 5) do
       inner_storage_adapter.upload(...)
-    end
-  end
-
-  def with_rescue(exceptions, retries: 5)
-    try = 0
-    begin
-      yield try
-    rescue *exceptions => exc
-      try += 1
-      try <= retries ? retry : raise(exc)
     end
   end
 end

--- a/app/derivative_services/pdf_derivative_service.rb
+++ b/app/derivative_services/pdf_derivative_service.rb
@@ -107,7 +107,7 @@ class PDFDerivativeService
   end
 
   def generate_pdf_image(filename, location, page)
-    with_rescue([ZeroByteError], retries: 1) do
+    FiggyUtils.with_rescue([ZeroByteError], retries: 1) do
       convert_pdf_page(filename, location, page)
     end
   end
@@ -115,16 +115,6 @@ class PDFDerivativeService
   def convert_pdf_page(filename, location, page)
     `vips pdfload "#{filename}" #{location} --page #{page} --n 1 --access sequential`
     raise(ZeroByteError, "Failed to generate PDF derivative #{location} - page #{page}.") if File.size(location).zero?
-  end
-
-  def with_rescue(exceptions, retries: 5)
-    try = 0
-    begin
-      yield try
-    rescue *exceptions => exc
-      try += 1
-      try <= retries ? retry : raise(exc)
-    end
   end
 
   def build_file(page, file_path)

--- a/app/services/preserver/preservation_checker.rb
+++ b/app/services/preserver/preservation_checker.rb
@@ -47,7 +47,9 @@ class Preserver
 
       def preservation_file
         @preservation_file ||=
-          Valkyrie::StorageAdapter.find_by(id: preservation_node.file_identifiers.first)
+          FiggyUtils.with_rescue([OpenSSL::SSL::SSLError], retries: 5) do
+            Valkyrie::StorageAdapter.find_by(id: preservation_node.file_identifiers.first)
+          end
       end
 
       def preservation_node
@@ -88,7 +90,9 @@ class Preserver
 
       def preservation_file
         @preservation_file ||=
-          Valkyrie::StorageAdapter.find_by(id: preservation_node.file_identifiers.first)
+          FiggyUtils.with_rescue([OpenSSL::SSL::SSLError], retries: 5) do
+            Valkyrie::StorageAdapter.find_by(id: preservation_node.file_identifiers.first)
+          end
       end
 
       def preserved?

--- a/app/utils/figgy_utils.rb
+++ b/app/utils/figgy_utils.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class FiggyUtils
+  def self.with_rescue(exceptions, retries: 5)
+    try = 0
+    begin
+      yield try
+    rescue *exceptions => exc
+      try += 1
+      try <= retries ? retry : raise(exc)
+    end
+  end
+end


### PR DESCRIPTION
closes #6597
