### PR TITLE
Add multi-language support to captions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -579,7 +579,8 @@ GEM
     irb (1.14.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    iso-639 (0.3.6)
+    iso-639 (0.3.8)
+      csv
     jaro_winkler (1.6.0)
     jbuilder (2.12.0)
       actionview (>= 5.0.0)

--- a/app/change_sets/caption_change_set.rb
+++ b/app/change_sets/caption_change_set.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class CaptionChangeSet < Valkyrie::ChangeSet
-  property :caption_language, multiple: false, type: Valkyrie::Types::String.optional, required: true
+  property :caption_language, multiple: true, type: Valkyrie::Types::Set, required: true
   property :change_set, required: true, default: "caption"
   property :original_language_caption, required: false, type: Dry::Types["params.bool"], default: false
   # VTT file uploaded from form.
@@ -9,13 +9,15 @@ class CaptionChangeSet < Valkyrie::ChangeSet
   validates :file, :caption_language, presence: true
 
   def caption_language=(value)
-    entry = ISO_639.find_by_code(value)
-    @fields["caption_language"] =
-      if entry
-        value
+    languages = value.reject(&:empty?).map do |code|
+      if ISO_639.find_by_code(code)
+        code
       else
         "und"
       end
+    end
+
+    @fields["caption_language"] = languages
   end
 
   def primary_terms

--- a/app/models/controlled_vocabulary.rb
+++ b/app/models/controlled_vocabulary.rb
@@ -277,12 +277,12 @@ class ControlledVocabulary
   class Language < ControlledVocabulary
     ControlledVocabulary.register(:language, self)
 
-    # Accesses all Terms mapped to ISO language codes
+    # Accesses all Terms mapped to ISO 639.2 language codes
     # @return [Array<Term>] the Term Objects modeling each language code
     def all(_scope = nil)
-      ISO_639::ISO_639_1.map(&:first).uniq.map do |value|
+      ISO_639::ISO_639_2.map(&:first).uniq.map do |value|
         find(value)
-      end
+      end.sort_by(&:label)
     end
 
     # Retrieve a Term with a specific ISO language code as a value

--- a/app/nested_resources/file_metadata.rb
+++ b/app/nested_resources/file_metadata.rb
@@ -33,7 +33,7 @@ class FileMetadata < Valkyrie::Resource
   attribute :page_count, Valkyrie::Types::Integer
 
   # Caption Metadata
-  attribute :caption_language, Valkyrie::Types::String.optional
+  attribute :caption_language, Valkyrie::Types::Set
   attribute :original_language_caption, Valkyrie::Types::Bool.optional
   attribute :change_set, Valkyrie::Types::String
 
@@ -139,7 +139,12 @@ class FileMetadata < Valkyrie::Resource
   end
 
   def caption_language_label
-    label = ControlledVocabulary.for(:language).label(caption_language)
+    label = if caption_language.count > 1
+              "Multilingual"
+            else
+              ControlledVocabulary.for(:language).label(caption_language&.first)
+            end
+
     return label unless original_language_caption
     "#{label} (Original)"
   end

--- a/app/services/bulk_ingest_service/bulk_file_path_converter.rb
+++ b/app/services/bulk_ingest_service/bulk_file_path_converter.rb
@@ -65,7 +65,7 @@ class BulkIngestService
     end
 
     def infer_language(vtt_path)
-      vtt_path.basename.sub_ext("").to_s.split("--")[-1]
+      [vtt_path.basename.sub_ext("").to_s.split("--")[-1]]
     end
 
     # @return [boolean] true if the second to last section of the filename

--- a/app/values/hls_manifest/primary.rb
+++ b/app/values/hls_manifest/primary.rb
@@ -36,7 +36,6 @@ class HlsManifest::Primary
         default: caption_metadata.original_language_caption,
         autoselect: true,
         characteristics: accessibility_characteristics,
-        language: caption_metadata.caption_language,
         uri: helper.download_path(file_set.id, caption_metadata.id, as: "stream", auth_token: auth_token, format: "m3u8")
       )
     end

--- a/app/values/hls_manifest/primary.rb
+++ b/app/values/hls_manifest/primary.rb
@@ -36,9 +36,17 @@ class HlsManifest::Primary
         default: caption_metadata.original_language_caption,
         autoselect: true,
         characteristics: accessibility_characteristics,
+        language: caption_language(caption_metadata),
         uri: helper.download_path(file_set.id, caption_metadata.id, as: "stream", auth_token: auth_token, format: "m3u8")
       )
     end
+  end
+
+  def caption_language(caption_metadata)
+    iso_codes = caption_metadata.caption_language
+
+    return iso_codes.first if iso_codes.count == 1
+    nil
   end
 
   # Says via HLS that the subtitles should be treated as captions in HLS.

--- a/app/views/records/edit_fields/_caption_language.html.erb
+++ b/app/views/records/edit_fields/_caption_language.html.erb
@@ -5,5 +5,5 @@
               value_method: :value,
               hint: "One caption must exist in the original language of the audio",
               include_blank: true,
-              input_html: { class: 'form-control' },
+              input_html: { multiple: true, class: 'form-control' },
               required: f.object.required?(key) %>

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -168,13 +168,16 @@ RSpec.describe DownloadsController do
           expect(playlist.items[1].uri).to eq "/downloads/#{file_set.id}/file/#{caption_metadata.id}/stream.m3u8"
           expect(playlist.items[1].characteristics).to eq "public.accessibility.describes-spoken-dialog,public.accessibility.describes-music-and-sound"
           expect(playlist.items[1].name).to eq "English (Original)"
+          expect(playlist.items[1].language).to eq "eng"
           expect(playlist.items[1].default).to be true
           expect(playlist.items[2].characteristics).to eq "public.accessibility.describes-spoken-dialog,public.accessibility.describes-music-and-sound"
           expect(playlist.items[2].name).to eq "Undetermined"
           expect(playlist.items[2].default).to be false
+          expect(playlist.items[2].language).to eq "und"
           expect(playlist.items[3].characteristics).to eq "public.accessibility.describes-spoken-dialog,public.accessibility.describes-music-and-sound"
           expect(playlist.items[3].name).to eq "Multilingual"
           expect(playlist.items[3].default).to be false
+          expect(playlist.items[3].language).to be_nil
         end
       end
 

--- a/spec/controllers/downloads_controller_spec.rb
+++ b/spec/controllers/downloads_controller_spec.rb
@@ -162,18 +162,19 @@ RSpec.describe DownloadsController do
 
           expect(response).to be_successful
           playlist = M3u8::Playlist.read(response.body)
-          expect(playlist.items.length).to eq 3
+          expect(playlist.items.length).to eq 4
           expect(playlist.items[0].uri).to eq "/downloads/#{file_set.id}/file/#{file_metadata.id}.m3u8"
           expect(playlist.items[0].subtitles).to eq "subs"
           expect(playlist.items[1].uri).to eq "/downloads/#{file_set.id}/file/#{caption_metadata.id}/stream.m3u8"
-          expect(playlist.items[1].language).to eq "eng"
           expect(playlist.items[1].characteristics).to eq "public.accessibility.describes-spoken-dialog,public.accessibility.describes-music-and-sound"
           expect(playlist.items[1].name).to eq "English (Original)"
           expect(playlist.items[1].default).to be true
-          expect(playlist.items[2].language).to eq "und"
           expect(playlist.items[2].characteristics).to eq "public.accessibility.describes-spoken-dialog,public.accessibility.describes-music-and-sound"
           expect(playlist.items[2].name).to eq "Undetermined"
           expect(playlist.items[2].default).to be false
+          expect(playlist.items[3].characteristics).to eq "public.accessibility.describes-spoken-dialog,public.accessibility.describes-music-and-sound"
+          expect(playlist.items[3].name).to eq "Multilingual"
+          expect(playlist.items[3].default).to be false
         end
       end
 

--- a/spec/controllers/file_metadata_controller_spec.rb
+++ b/spec/controllers/file_metadata_controller_spec.rb
@@ -24,13 +24,13 @@ RSpec.describe FileMetadataController do
       it "deletes the FileMetadata and cleans the file from the repository" do
         resource = FactoryBot.create_for_repository(:scanned_resource_with_video_and_captions)
         file_set = Wayfinder.for(resource).file_sets.first
-        expect(file_set.captions.length).to eq 2
+        expect(file_set.captions.length).to eq 3
         caption = file_set.captions.first
 
         delete :destroy, params: { file_set_id: file_set.id, id: caption.id }
 
         resource = ChangeSetPersister.default.query_service.find_by(id: file_set.id)
-        expect(resource.captions.length).to eq 1
+        expect(resource.captions.length).to eq 2
         expect { Valkyrie::StorageAdapter.find_by(id: caption.file_identifiers.first) }.to raise_error Valkyrie::StorageAdapter::FileNotFound
       end
       it "fails to delete a FileMetadata that's not a caption" do

--- a/spec/controllers/file_metadata_controller_spec.rb
+++ b/spec/controllers/file_metadata_controller_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe FileMetadataController do
           file_metadata: {
             change_set: "Caption",
             file: nil,
-            caption_language: "eng"
+            caption_language: ["eng"]
           }
         }
 
@@ -105,7 +105,7 @@ RSpec.describe FileMetadataController do
           file_metadata: {
             change_set: "caption",
             file: fixture_file_upload("files/caption.vtt", "text/vtt"),
-            caption_language: "eng"
+            caption_language: ["eng"]
           }
         }
 

--- a/spec/factories/scanned_resource.rb
+++ b/spec/factories/scanned_resource.rb
@@ -83,7 +83,7 @@ FactoryBot.define do
                   original_filename: "caption.vtt",
                   use: ::PcdmUse::Caption,
                   node_attributes: {
-                    caption_language: "eng",
+                    caption_language: ["eng"],
                     original_language_caption: true
                   }
                 ),
@@ -93,7 +93,18 @@ FactoryBot.define do
                   original_filename: "caption.vtt",
                   use: ::PcdmUse::Caption,
                   node_attributes: {
-                    caption_language: "und",
+                    caption_language: ["und"],
+                    original_language_caption: false
+                  }
+                ),
+
+                IngestableFile.new(
+                  file_path: Rails.root.join("spec", "fixtures", "files", "caption.vtt"),
+                  mime_type: "text/vtt",
+                  original_filename: "caption.vtt",
+                  use: ::PcdmUse::Caption,
+                  node_attributes: {
+                    caption_language: ["zgh", "alg"],
                     original_language_caption: false
                   }
                 )

--- a/spec/models/controlled_vocabulary/language_spec.rb
+++ b/spec/models/controlled_vocabulary/language_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe ControlledVocabulary::Language do
   subject(:service) { described_class.new }
   describe "#all" do
     it "gets all the possible languages" do
-      expect(service.all.map(&:label).length).to eq 184
+      expect(service.all.map(&:label).length).to eq 487
     end
   end
 end

--- a/spec/services/bulk_ingest_service_spec.rb
+++ b/spec/services/bulk_ingest_service_spec.rb
@@ -324,7 +324,7 @@ RSpec.describe BulkIngestService do
         )
         vtt_file_metadata = file_set.captions.first
         expect(vtt_file_metadata.original_filename).to eq(["city--original-language--eng.vtt"])
-        expect(vtt_file_metadata.caption_language).to eq("eng")
+        expect(vtt_file_metadata.caption_language).to eq(["eng"])
         expect(vtt_file_metadata.original_language_caption).to eq(true)
       end
     end
@@ -358,9 +358,9 @@ RSpec.describe BulkIngestService do
         vtt_file_metadatas = file_set.captions
         original_vtt = vtt_file_metadatas.find { |fm| fm.original_filename == ["city--original-language--engg.vtt"] }
         spa_vtt = vtt_file_metadatas.find { |fm| fm.original_filename == ["city--spa.vtt"] }
-        expect(spa_vtt.caption_language).to eq("spa")
+        expect(spa_vtt.caption_language).to eq(["spa"])
         expect(spa_vtt.original_language_caption).to eq(false)
-        expect(original_vtt.caption_language).to eq("und")
+        expect(original_vtt.caption_language).to eq(["und"])
         expect(original_vtt.original_language_caption).to eq(true)
       end
     end


### PR DESCRIPTION
- Make caption language multi-valued
- Use ISO 639.2 codes to supply language list (increases the number of available languages)

Tested in Chrome, Firefox, and Safari.
