### PR TITLE
MMS Report for Catalog Synchronization

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require "csv"
 class ReportsController < ApplicationController
+  include TokenAuth
   def ephemera_data
     authorize! :show, Report
     if params[:project_id]

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -85,6 +85,16 @@ class ReportsController < ApplicationController
     end
   end
 
+  def mms_records
+    authorize! :show, :mms_report
+
+    respond_to do |format|
+      format.json do
+        render json: MmsReportGenerator.json_report
+      end
+    end
+  end
+
   private
 
     def resource_hash(resource)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -11,6 +11,8 @@ class Ability
     roles.each do |role|
       send "#{role}_permissions" if current_user.send "#{role}?"
     end
+
+    can :show, :mms_report if current_user.groups.include?("catalog_sync")
     cannot [:create, :update, :destroy], :all if Figgy.read_only_mode
     cannot [:create, :update, :destroy], :all if Figgy.index_read_only?
   end

--- a/app/services/mms_report_generator.rb
+++ b/app/services/mms_report_generator.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+class MmsReportGenerator
+  def self.json_report
+    new.records.to_json
+  end
+
+  def records
+    mms_resources.each_with_object({}) do |resource, hsh|
+      next unless resource.public_readable?
+      hsh[resource.mms_id] ||= []
+      hsh[resource.mms_id] << resource.to_hash
+    end
+  end
+
+  private
+
+    def mms_resources
+      ChangeSetPersister.default.query_service.custom_queries.all_mms_resources.map { |resource| ReportResource.new(resource) }
+    end
+end

--- a/app/services/mms_report_generator/report_resource.rb
+++ b/app/services/mms_report_generator/report_resource.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+class MmsReportGenerator::ReportResource
+  attr_reader :resource
+  def initialize(resource)
+    @resource = resource
+  end
+
+  def mms_id
+    resource.source_metadata_identifier.first
+  end
+
+  def public_readable?
+    resource.decorate.public_readable_state?
+  end
+
+  def to_hash
+    {
+      visibility: visibility,
+      portion_note: Array.wrap(resource.portion_note).first,
+      iiif_manifest_url: helper.manifest_url(resource)
+    }
+  end
+
+  def visibility
+    visibility_controlled_vocabulary = ControlledVocabulary.for(:visibility).find(resource.visibility.first)
+    {
+      value: visibility_controlled_vocabulary.value,
+      label: visibility_controlled_vocabulary.label,
+      definition: visibility_controlled_vocabulary.definition
+    }
+  end
+
+  def helper
+    @helper ||= ManifestBuilder::ManifestHelper.new
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -260,6 +260,7 @@ Rails.application.routes.draw do
   get "/reports/identifiers_to_reconcile", to: "reports#identifiers_to_reconcile", as: :identifiers_to_reconcile
   get "/reports/collection_item_and_image_count", to: "reports#collection_item_and_image_count", as: :collection_item_and_image_count
   get "/reports/dpul_success_dashboard", to: "reports#dpul_success_dashboard", as: :dpul_success_dashboard
+  get "/reports/mms_records", to: "reports#mms_records", as: :mms_records_report, defaults: { format: :json }
 
   get "bulk_ingest/:resource_type", to: "bulk_ingest#show", as: "bulk_ingest_show"
   post "bulk_ingest/:resource_type/bulk_ingest", to: "bulk_ingest#bulk_ingest", as: "bulk_ingest"

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -4,6 +4,20 @@ require "rails_helper"
 RSpec.describe ReportsController, type: :controller do
   let(:user) { FactoryBot.create(:admin) }
 
+  describe "GET #mms_records" do
+    before do
+      sign_in user
+    end
+
+    it "provides a JSON dump of all MMS-ID records" do
+      open_mms_record = FactoryBot.create(:complete_open_scanned_resource, source_metadata_identifier: "991234563506421")
+      private_mms_record = FactoryBot.create(:complete_private_scanned_resource, source_metadata_identifier: "991234563506421")
+      pending_mms_record = FactoryBot.create(:pending_scanned_resource, source_metadata_identifier: "991234563506421")
+      open_findingaids_record = FactoryBot.create(:complete_open_scanned_resource, source_metadata_identifier: "C1372_c47202-68234")
+      # WIP.
+    end
+  end
+
   describe "GET #ephemera_data" do
     let(:project) { FactoryBot.create_for_repository(:ephemera_project, member_ids: [box.id, boxless.id]) }
     let(:box) { FactoryBot.create_for_repository(:ephemera_box, member_ids: [folder.id]) }


### PR DESCRIPTION
Closes #6544

I made a couple changes to the specified format to support multiple resources per BibID and to provide some info about what the "visibility" value means to the devs using this. An example:

```json
{
"99125433518606421": [
    {
      "visibility": {
        "value": "open",
        "label": "open",
        "definition": "Open to the world. Anyone can view."
      },
      "portion_note": null,
      "iiif_manifest_url": "https://figgy-staging.princeton.edu/concern/raster_resources/9a3dd626-d169-49b4-b6eb-c21132d0bd32/manifest"
    }
  ],
  "9968666393506421": [
    {
      "visibility": {
        "value": "open",
        "label": "open",
        "definition": "Open to the world. Anyone can view."
      },
      "portion_note": null,
      "iiif_manifest_url": "https://figgy-staging.princeton.edu/concern/scanned_maps/4fbb471d-875f-486f-a867-12e70cf1501d/manifest"
    },
    {
      "visibility": {
        "value": "open",
        "label": "open",
        "definition": "Open to the world. Anyone can view."
      },
      "portion_note": null,
      "iiif_manifest_url": "https://figgy-staging.princeton.edu/concern/scanned_maps/2e0e6393-b928-486d-a9b1-ee91124cb212/manifest"
    },
    {
      "visibility": {
        "value": "open",
        "label": "open",
        "definition": "Open to the world. Anyone can view."
      },
      "portion_note": null,
      "iiif_manifest_url": "https://figgy-staging.princeton.edu/concern/scanned_maps/74943246-efe9-4747-94b3-943783cd03ae/manifest"
    }
  ]
}
```