### PR TITLE
Improve MMS Report Performance

### DIFF
--- a/app/queries/all_mms_resources_query.rb
+++ b/app/queries/all_mms_resources_query.rb
@@ -15,7 +15,7 @@ class AllMmsResourcesQuery
     relation = orm_class.use_cursor
     relation = relation.exclude(internal_resource: [FileSet, PreservationObject, DeletionMarker, Event, EphemeraTerm].map(&:to_s))
     relation = relation.where(created_at: created_at) if created_at
-    relation = relation.where(Sequel.lit("metadata ->> 'source_metadata_identifier' ~ '99[0-9]+6421'"))
+    relation = relation.where(Sequel.lit("SUBSTRING(metadata->'source_metadata_identifier'->>0,1,2)='99'"))
     if fields
       relation.select(*fields)
     else

--- a/app/queries/all_mms_resources_query.rb
+++ b/app/queries/all_mms_resources_query.rb
@@ -11,13 +11,17 @@ class AllMmsResourcesQuery
     @query_service = query_service
   end
 
-  def all_mms_resources(created_at: nil)
+  def all_mms_resources(created_at: nil, fields: nil)
     relation = orm_class.use_cursor
     relation = relation.exclude(internal_resource: [FileSet, PreservationObject, DeletionMarker, Event, EphemeraTerm].map(&:to_s))
     relation = relation.where(created_at: created_at) if created_at
     relation = relation.where(Sequel.lit("metadata ->> 'source_metadata_identifier' ~ '99[0-9]+6421'"))
-    relation.map do |object|
-      resource_factory.to_resource(object: object)
+    if fields
+      relation.select(*fields)
+    else
+      relation.map do |object|
+        resource_factory.to_resource(object: object)
+      end
     end
   end
 

--- a/app/services/mms_report_generator.rb
+++ b/app/services/mms_report_generator.rb
@@ -15,6 +15,6 @@ class MmsReportGenerator
   private
 
     def mms_resources
-      ChangeSetPersister.default.query_service.custom_queries.all_mms_resources.map { |resource| ReportResource.new(resource) }
+      ChangeSetPersister.default.query_service.custom_queries.all_mms_resources(fields: ReportResource.resource_fields).map { |resource| ReportResource.new(resource) }
     end
 end

--- a/app/services/mms_report_generator/report_resource.rb
+++ b/app/services/mms_report_generator/report_resource.rb
@@ -1,28 +1,40 @@
 # frozen_string_literal: true
 class MmsReportGenerator::ReportResource
+  # Database fields we need to generate the fields for this report
+  def self.resource_fields
+    [
+      :id,
+      :internal_resource,
+      Sequel[:metadata].pg_jsonb["visibility"][0].as(:visibility),
+      Sequel[:metadata].pg_jsonb["portion_note"][0].as(:portion_note),
+      Sequel[:metadata].pg_jsonb["state"][0].as(:state),
+      Sequel[:metadata].pg_jsonb["source_metadata_identifier"][0].as(:source_metadata_identifier)
+    ]
+  end
+
   attr_reader :resource
   def initialize(resource)
     @resource = resource
   end
 
   def mms_id
-    resource.source_metadata_identifier.first
+    resource[:source_metadata_identifier]
   end
 
   def public_readable?
-    resource.decorate.public_readable_state?
+    resource[:state] == "complete" || resource[:state] == "flagged"
   end
 
   def to_hash
     {
       visibility: visibility,
-      portion_note: Array.wrap(resource.portion_note).first,
-      iiif_manifest_url: helper.manifest_url(resource)
+      portion_note: resource[:portion_note],
+      iiif_manifest_url: helper.manifest_url(resource[:internal_resource].constantize.new(id: resource[:id]))
     }
   end
 
   def visibility
-    visibility_controlled_vocabulary = ControlledVocabulary.for(:visibility).find(resource.visibility.first)
+    visibility_controlled_vocabulary = ControlledVocabulary.for(:visibility).find(resource[:visibility])
     {
       value: visibility_controlled_vocabulary.value,
       label: visibility_controlled_vocabulary.label,

--- a/app/services/mms_report_generator/report_resource.rb
+++ b/app/services/mms_report_generator/report_resource.rb
@@ -2,14 +2,14 @@
 class MmsReportGenerator::ReportResource
   # Database fields we need to generate the fields for this report
   def self.resource_fields
-    [
-      :id,
-      :internal_resource,
-      Sequel[:metadata].pg_jsonb["visibility"][0].as(:visibility),
-      Sequel[:metadata].pg_jsonb["portion_note"][0].as(:portion_note),
-      Sequel[:metadata].pg_jsonb["state"][0].as(:state),
-      Sequel[:metadata].pg_jsonb["source_metadata_identifier"][0].as(:source_metadata_identifier)
-    ]
+    # [
+    #   :id,
+    #   :internal_resource,
+    #   Sequel[:metadata].pg_jsonb["visibility"][0].as(:visibility),
+    #   Sequel[:metadata].pg_jsonb["portion_note"][0].as(:portion_note),
+    #   Sequel[:metadata].pg_jsonb["state"][0].as(:state),
+    #   Sequel[:metadata].pg_jsonb["source_metadata_identifier"][0].as(:source_metadata_identifier)
+    # ]
   end
 
   attr_reader :resource
@@ -18,23 +18,25 @@ class MmsReportGenerator::ReportResource
   end
 
   def mms_id
-    resource[:source_metadata_identifier]
+    # resource[:source_metadata_identifier]
+    resource.source_metadata_identifier.first
   end
 
   def public_readable?
-    resource[:state] == "complete" || resource[:state] == "flagged"
+    # resource[:state] == "complete" || resource[:state] == "flagged"
+    resource.decorate.public_readable_state?
   end
 
   def to_hash
     {
       visibility: visibility,
-      portion_note: resource[:portion_note],
-      iiif_manifest_url: helper.manifest_url(resource[:internal_resource].constantize.new(id: resource[:id]))
+      portion_note: Array.wrap(resource.portion_note).first,
+      iiif_manifest_url: helper.manifest_url(resource)
     }
   end
 
   def visibility
-    visibility_controlled_vocabulary = ControlledVocabulary.for(:visibility).find(resource[:visibility])
+    visibility_controlled_vocabulary = ControlledVocabulary.for(:visibility).find(resource.visibility.first)
     {
       value: visibility_controlled_vocabulary.value,
       label: visibility_controlled_vocabulary.label,

--- a/app/services/mms_report_generator/report_resource.rb
+++ b/app/services/mms_report_generator/report_resource.rb
@@ -2,14 +2,14 @@
 class MmsReportGenerator::ReportResource
   # Database fields we need to generate the fields for this report
   def self.resource_fields
-    # [
-    #   :id,
-    #   :internal_resource,
-    #   Sequel[:metadata].pg_jsonb["visibility"][0].as(:visibility),
-    #   Sequel[:metadata].pg_jsonb["portion_note"][0].as(:portion_note),
-    #   Sequel[:metadata].pg_jsonb["state"][0].as(:state),
-    #   Sequel[:metadata].pg_jsonb["source_metadata_identifier"][0].as(:source_metadata_identifier)
-    # ]
+    [
+      :id,
+      :internal_resource,
+      Sequel[:metadata].pg_jsonb["visibility"][0].as(:visibility),
+      Sequel[:metadata].pg_jsonb["portion_note"][0].as(:portion_note),
+      Sequel[:metadata].pg_jsonb["state"][0].as(:state),
+      Sequel[:metadata].pg_jsonb["source_metadata_identifier"][0].as(:source_metadata_identifier)
+    ]
   end
 
   attr_reader :resource
@@ -18,25 +18,23 @@ class MmsReportGenerator::ReportResource
   end
 
   def mms_id
-    # resource[:source_metadata_identifier]
-    resource.source_metadata_identifier.first
+    resource[:source_metadata_identifier]
   end
 
   def public_readable?
-    # resource[:state] == "complete" || resource[:state] == "flagged"
-    resource.decorate.public_readable_state?
+    resource[:state] == "complete" || resource[:state] == "flagged"
   end
 
   def to_hash
     {
       visibility: visibility,
-      portion_note: Array.wrap(resource.portion_note).first,
-      iiif_manifest_url: helper.manifest_url(resource)
+      portion_note: resource[:portion_note],
+      iiif_manifest_url: helper.manifest_url(resource[:internal_resource].constantize.new(id: resource[:id]))
     }
   end
 
   def visibility
-    visibility_controlled_vocabulary = ControlledVocabulary.for(:visibility).find(resource.visibility.first)
+    visibility_controlled_vocabulary = ControlledVocabulary.for(:visibility).find(resource[:visibility])
     {
       value: visibility_controlled_vocabulary.value,
       label: visibility_controlled_vocabulary.label,

--- a/db/migrate/20250123183528_substring_mms_idx.rb
+++ b/db/migrate/20250123183528_substring_mms_idx.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+class SubstringMmsIdx < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+  def up
+    execute <<-SQL
+      CREATE INDEX CONCURRENTLY mms_id_substring_idx ON orm_resources (SUBSTRING(metadata->'source_metadata_identifier'->>0,1,2)) WHERE (("internal_resource" NOT IN ('FileSet', 'PreservationObject', 'DeletionMarker', 'Event', 'EphemeraTerm')))
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      DROP INDEX CONCURRENTLY mms_id_substring_idx
+    SQL
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -994,6 +994,13 @@ CREATE INDEX index_users_on_uid ON public.users USING btree (uid);
 
 
 --
+-- Name: mms_id_substring_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX mms_id_substring_idx ON public.orm_resources USING btree ("substring"(((metadata -> 'source_metadata_identifier'::text) ->> 0), 1, 2)) WHERE ((internal_resource)::text <> ALL ((ARRAY['FileSet'::character varying, 'PreservationObject'::character varying, 'DeletionMarker'::character varying, 'Event'::character varying, 'EphemeraTerm'::character varying])::text[]));
+
+
+--
 -- Name: orm_resources_first_accession_number_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1066,6 +1073,7 @@ ALTER TABLE ONLY public.active_storage_attachments
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250123183528'),
 ('20230802152303'),
 ('20230119155402'),
 ('20221214184110'),

--- a/spec/controllers/reports_controller_spec.rb
+++ b/spec/controllers/reports_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe ReportsController, type: :controller do
       json = JSON.parse(response.body)
 
       expect(json.length).to eq 2
-      expect(json.keys).to eq ["991234563506421", "9911606823506421"]
+      expect(json.keys).to contain_exactly "991234563506421", "9911606823506421"
       # Only one resource for this key.
       expect(json["9911606823506421"].first).to eq(
         {

--- a/spec/queries/all_mms_resources_query_spec.rb
+++ b/spec/queries/all_mms_resources_query_spec.rb
@@ -14,6 +14,25 @@ describe AllMmsResourcesQuery do
       expect(query.all_mms_resources.map(&:id).to_a).to eq [mms_resource.id]
     end
 
+    it "can just return fields" do
+      stub_catalog(bib_id: "9985434293506421")
+      stub_findingaid(pulfa_id: "AC044_c0003")
+      mms_resource = FactoryBot.create_for_repository(:scanned_resource, source_metadata_identifier: "9985434293506421")
+      _component_resource = FactoryBot.create_for_repository(:scanned_resource, source_metadata_identifier: "AC044_c0003")
+
+      result = query.all_mms_resources(fields: [:id, :internal_resource, Sequel[:metadata].pg_jsonb["visibility"][0].as(:visibility)])
+
+      expect(result.all).to eq(
+        [
+          {
+            id: mms_resource.id,
+            internal_resource: "ScannedResource",
+            visibility: "open"
+          }
+        ]
+      )
+    end
+
     it "can filter by created_at" do
       id1 = "9985434293506421"
       id2 = "9946093213506421"


### PR DESCRIPTION
Before this change, the MMS report developed for #6544 took about 20 minutes to generate.

By avoiding pulling all fields and not converting to resources, the report generates in ~ 15 minutes.

By using SUBSTRING, only checking for "99", and creating an index on that value the report generates in 7 minutes.

By doing both, the report generates in ~ 25 seconds.