### PR TITLE
ManifestBuilder should load a combined V3 manifest for MVW Recordings.

### DIFF
--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -40,7 +40,16 @@ class ManifestBuilder
       when Playlist
         ManifestBuilderV3::RootNode.for(resource, auth_token, current_ability)
       else
-        new(resource, auth_token)
+        case ChangeSet.for(resource)
+        when RecordingChangeSet
+          if ManifestBuilderV3::RootNode.multi_volume_recording?(resource)
+            ManifestBuilderV3::MultiVolumeRecordingNode.new(resource)
+          else
+            new(resource, auth_token)
+          end
+        else
+          new(resource, auth_token)
+        end
       end
     end
     attr_reader :resource, :auth_token, :current_ability

--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -42,11 +42,7 @@ class ManifestBuilder
       else
         case ChangeSet.for(resource)
         when RecordingChangeSet
-          if ManifestBuilderV3::RootNode.multi_volume_recording?(resource)
-            ManifestBuilderV3::MultiVolumeRecordingNode.new(resource)
-          else
-            new(resource, auth_token)
-          end
+          ManifestBuilderV3::RootNode.for(resource, auth_token, current_ability)
         else
           new(resource, auth_token)
         end

--- a/spec/controllers/scanned_resources_controller_spec.rb
+++ b/spec/controllers/scanned_resources_controller_spec.rb
@@ -74,6 +74,24 @@ RSpec.describe ScannedResourcesController, type: :controller do
         expect(json["@context"]).to include("http://iiif.io/api/presentation/3/context.json")
       end
     end
+    context "when given a mvw recording" do
+      it "renders a v3 manifest" do
+        stub_ezid
+        file1 = fixture_file_upload("av/la_c0652_2017_05_bag/data/32101047382401_1_pm.wav", "")
+        file2 = fixture_file_upload("av/la_c0652_2017_05_bag/data/32101047382401_1_pm.wav", "")
+        volume1 = FactoryBot.create_for_repository(:scanned_resource, files: [file1])
+        volume2 = FactoryBot.create_for_repository(:scanned_resource, files: [file2])
+        sr = FactoryBot.create_for_repository(:recording, state: "complete")
+        cs = ScannedResourceChangeSet.new(sr)
+        cs.validate(member_ids: [volume1.id, volume2.id])
+        resource = ChangeSetPersister.default.save(change_set: cs)
+
+        get :manifest, params: { id: resource.id, format: :json }
+        json = JSON.parse(response.body)
+
+        expect(json["@context"]).to include("http://iiif.io/api/presentation/3/context.json")
+      end
+    end
     context "when given a video" do
       it "renders a v3 manifest" do
         stub_ezid


### PR DESCRIPTION
This pathway got bypassed when we separated the rendering logic for V2/V3 manifests, similar to how Playlists broke.

Closes #6547