### PR TITLE
DAO Updater should only send a notice if the resource is a component.

### DIFF
--- a/app/services/dao_updater.rb
+++ b/app/services/dao_updater.rb
@@ -14,10 +14,10 @@ class DaoUpdater
     # Assign digital object to Archival Object.
     link_digital_object
   rescue Aspace::Client::ArchivalObjectNotFound
+    return unless change_set.source_metadata_identifier.include?("_")
     Honeybadger.notify(
       "DaoUpdater failed to update resource #{change_set.id} with source metadata identifier #{change_set.source_metadata_identifier} because the Archival Object could not be found. " \
-      "If the source metadata identifier looks like a collection-level component id (e.g. MC001), this error is expected (see #945). " \
-      "Otherwise if it looks like a component id it may need a dot instead of a dash or just be be a bad id. Contact the depositor or product owner. " \
+      "If the source metadata identifier looks like a component id it may need a dot instead of a dash or just be be a bad id. Contact the depositor or product owner. " \
       "Make sure they know that to get the DAO to generate they need to fix the id, then mark the item for takedown and mark it complete again. " \
       "If it looks like a bibid that's very unexpected -- ask on #figgy whether anyone recognizes what's going on."
     )

--- a/spec/services/dao_updater_spec.rb
+++ b/spec/services/dao_updater_spec.rb
@@ -29,6 +29,24 @@ RSpec.describe DaoUpdater do
       end
     end
 
+    context "when no resource is found in ASpace and it's a collection ID" do
+      it "doesn't notify honeybadger" do
+        stub_aspace_login
+
+        stub_findingaid(pulfa_id: "C0652")
+        stub_find_archival_object_not_found(component_id: "C0652")
+        allow(Honeybadger).to receive(:notify)
+
+        resource = FactoryBot.create_for_repository(:complete_open_scanned_resource, source_metadata_identifier: "C0652")
+        change_set_persister = instance_double(ChangeSetPersister)
+
+        updater = described_class.new(change_set: ChangeSet.for(resource), change_set_persister: change_set_persister)
+
+        updater.update!
+        expect(Honeybadger).not_to have_received(:notify)
+      end
+    end
+
     context "when no resource is found in aspace" do
       it "notifies honeybadger" do
         stub_aspace_login


### PR DESCRIPTION
Closes #6623