### PR TITLE
DAOs should always be created.

### DIFF
--- a/app/services/dao_updater.rb
+++ b/app/services/dao_updater.rb
@@ -9,7 +9,6 @@ class DaoUpdater
 
   def update!
     return unless decorated_resource.public_readable_state?
-    return if decorated_resource.private_visibility?
 
     # Assign digital object to Archival Object.
     link_digital_object
@@ -74,11 +73,11 @@ class DaoUpdater
       "jsonmodel_type" => "digital_object_component",
       "digital_object_id" => change_set.id.to_s,
       "title" => embed.link_label,
-      "publish" => true,
+      "publish" => !decorated_resource.private_visibility?,
       "file_versions" => [
         embed.to_dao.merge(
           {
-            "publish" => true,
+            "publish" => !decorated_resource.private_visibility?,
             "jsonmodel_type" => "file_version"
           }
         )

--- a/spec/services/dao_updater_spec.rb
+++ b/spec/services/dao_updater_spec.rb
@@ -16,19 +16,6 @@ RSpec.describe DaoUpdater do
         updater.update!
       end
     end
-    context "when the resource is private" do
-      it "does nothing" do
-        resource = FactoryBot.create_for_repository(:complete_private_scanned_resource)
-        change_set_persister = instance_double(ChangeSetPersister)
-
-        updater = described_class.new(change_set: ChangeSet.for(resource), change_set_persister: change_set_persister)
-
-        # We haven't stubbed ASpace, so webmock will error if it tries to do
-        # something.
-        updater.update!
-      end
-    end
-
     context "when no resource is found in ASpace and it's a collection ID" do
       it "doesn't notify honeybadger" do
         stub_aspace_login


### PR DESCRIPTION
This marks the Figgy DAOs as unpublished.

Closes #6512