### PR TITLE
Replace characterization of tiffs with VIPS.

### DIFF
--- a/app/characterization_services/imagemagick_characterization_service.rb
+++ b/app/characterization_services/imagemagick_characterization_service.rb
@@ -53,20 +53,21 @@ class ImagemagickCharacterizationService
 
   def file_characterization_attributes
     {
-      width: image.width.to_s,
-      height: image.height.to_s,
-      mime_type: image.mime_type,
+      width: vips_image.width.to_s,
+      height: vips_image.height.to_s,
+      mime_type: mime_type,
       checksum: MultiChecksum.for(@file_object),
-      size: image.size,
+      size: File.size(filename),
       error_message: [] # Ensure any previous error messages are removed
     }
   end
 
-  # Retrieve the image handler from MiniMagick
-  # @return [MiniMagick::Image]
-  def image
-    # TODO: memoize this?
-    MiniMagick::Image.open(filename)
+  def mime_type
+    `file --b --mime-type #{Shellwords.escape(filename)}`.strip
+  end
+
+  def vips_image
+    Vips::Image.new_from_file(filename.to_s)
   end
 
   # Retrieve the Resource to which the FileSet is attached

--- a/app/characterization_services/imagemagick_characterization_service.rb
+++ b/app/characterization_services/imagemagick_characterization_service.rb
@@ -57,9 +57,13 @@ class ImagemagickCharacterizationService
       height: vips_image.height.to_s,
       mime_type: mime_type,
       checksum: MultiChecksum.for(@file_object),
-      size: File.size(filename),
+      size: file_size,
       error_message: [] # Ensure any previous error messages are removed
     }
+  end
+
+  def file_size
+    File.size(filename)
   end
 
   def mime_type

--- a/spec/characterization_services/imagemagick_characterization_service_spec.rb
+++ b/spec/characterization_services/imagemagick_characterization_service_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe ImagemagickCharacterizationService do
     let(:file) { fixture_file_upload("files/invalid.tif", "image/tiff") }
     let(:invalid_file_set) { book_members.first }
     it "adds an error message to the file set and raises an error" do
-      expect { described_class.new(file_set: invalid_file_set, persister: persister).characterize }.to raise_error(MiniMagick::Invalid)
+      expect { described_class.new(file_set: invalid_file_set, persister: persister).characterize }.to raise_error(Vips::Error)
       file_set = query_service.find_by(id: invalid_file_set.id)
       expect(file_set.file_metadata[0].width).to be_empty
       expect(file_set.file_metadata[0].error_message.first).to start_with "Error during characterization:"
@@ -103,7 +103,7 @@ RSpec.describe ImagemagickCharacterizationService do
     let(:file) { fixture_file_upload("files/empty.tif", "image/tiff") }
     let(:invalid_file_set) { book_members.first }
     it "adds an error message to the file set and raises an error" do
-      expect { described_class.new(file_set: invalid_file_set, persister: persister).characterize }.to raise_error(MiniMagick::Invalid)
+      expect { described_class.new(file_set: invalid_file_set, persister: persister).characterize }.to raise_error(Vips::Error)
       file_set = query_service.find_by(id: invalid_file_set.id)
       expect(file_set.file_metadata[0].width).to be_empty
       expect(file_set.file_metadata[0].error_message.first).to start_with "Error during characterization:"
@@ -114,11 +114,11 @@ RSpec.describe ImagemagickCharacterizationService do
     let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }
     let(:test_file_set) { book_members.first }
     it "removes any previous error messages" do
-      allow(MiniMagick::Image).to receive(:open).and_raise("Error")
+      allow(Vips::Image).to receive(:new_from_file).and_raise("Error")
       expect { described_class.new(file_set: test_file_set, persister: persister).characterize }.to raise_error(RuntimeError)
       file_set = query_service.find_by(id: test_file_set.id)
       expect(file_set.file_metadata[0].error_message.first).to start_with "Error during characterization:"
-      allow(MiniMagick::Image).to receive(:open).and_call_original
+      allow(Vips::Image).to receive(:new_from_file).and_call_original
       described_class.new(file_set: file_set, persister: persister).characterize
       file_set = query_service.find_by(id: test_file_set.id)
       expect(file_set.file_metadata[0].error_message).to be_empty

--- a/spec/derivative_services/image_derivative_service_spec.rb
+++ b/spec/derivative_services/image_derivative_service_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe ImageDerivativeService do
       thumbnail = reloaded.thumbnail_files.first
       expect(thumbnail).to be_present
       thumbnail_file = Valkyrie::StorageAdapter.find_by(id: thumbnail.file_identifiers.first)
-      image = MiniMagick::Image.open(thumbnail_file.disk_path)
+      image = Vips::Image.new_from_file(thumbnail_file.disk_path.to_s)
       expect(image.width).to eq 200
       expect(image.height).to eq 287
     end

--- a/spec/derivative_services/jp2_creator_spec.rb
+++ b/spec/derivative_services/jp2_creator_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe JP2Creator do
     end
   end
   context "jpeg source" do
-    it "creates a JP2" do
+    it "creates a JP2", run_real_characterization: true do
       file = fixture_file_upload("files/large-jpg-test.jpg", "image/jpeg")
       creator = described_class.new(filename: file.path.to_s)
       output = creator.generate
@@ -31,7 +31,7 @@ RSpec.describe JP2Creator do
     end
   end
   context "png source" do
-    it "creates a JP2" do
+    it "creates a JP2", run_real_characterization: true do
       file = fixture_file_upload("files/abstract.png", "image/png")
       creator = described_class.new(filename: file.path.to_s)
       output = creator.generate

--- a/spec/derivative_services/thumbnail_derivative_service_spec.rb
+++ b/spec/derivative_services/thumbnail_derivative_service_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe ThumbnailDerivativeService do
       thumbnail = reloaded.thumbnail_files.first
       expect(thumbnail).to be_present
       thumbnail_file = Valkyrie::StorageAdapter.find_by(id: thumbnail.file_identifiers.first)
-      image = MiniMagick::Image.open(thumbnail_file.disk_path)
+      image = Vips::Image.new_from_file(thumbnail_file.disk_path.to_s)
       expect(image.width).to eq 200
       expect(image.height).to eq 287
     end
@@ -88,7 +88,7 @@ RSpec.describe ThumbnailDerivativeService do
       thumbnail = reloaded.thumbnail_files.first
       expect(thumbnail).to be_present
       thumbnail_file = Valkyrie::StorageAdapter.find_by(id: thumbnail.file_identifiers.first)
-      image = MiniMagick::Image.open(thumbnail_file.disk_path)
+      image = Vips::Image.new_from_file(thumbnail_file.disk_path.to_s)
       expect(image.width).to eq 200
       expect(image.height).to eq 287
     end

--- a/spec/derivative_services/vips_derivative_service_spec.rb
+++ b/spec/derivative_services/vips_derivative_service_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe VipsDerivativeService do
   end
 
   context "tiff source larger than reduction threshold", run_real_derivatives: true do
-    it "resizes it by half" do
+    it "resizes it by half", run_real_characterization: true do
       stub_const("VipsDerivativeService::REDUCTION_THRESHOLD", 1)
       derivative_service.new(id: valid_change_set.id).create_derivatives
 
@@ -162,9 +162,9 @@ RSpec.describe VipsDerivativeService do
 
       expect(derivative).to be_present
       derivative_file = Valkyrie::StorageAdapter.find_by(id: derivative.file_identifiers.first)
-      expect(Vips::Image.new_from_file(derivative_file.disk_path.to_s).height).to eq 144
+      expect(Vips::Image.magickload(derivative_file.disk_path.to_s).height).to eq 144
     end
-    it "uploads it with the appropriate metadata" do
+    it "uploads it with the appropriate metadata", run_real_characterization: true do
       allow(storage_adapter).to receive(:upload).and_call_original
       stub_const("VipsDerivativeService::REDUCTION_THRESHOLD", 1)
       derivative_service.new(id: valid_change_set.id).create_derivatives

--- a/spec/jobs/characterization_job_spec.rb
+++ b/spec/jobs/characterization_job_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CharacterizationJob do
         book_members = query_service.find_members(resource: book)
         invalid_file_set = book_members.first
 
-        expect { described_class.perform_now(invalid_file_set.id) }.to raise_error(MiniMagick::Invalid)
+        expect { described_class.perform_now(invalid_file_set.id) }.to raise_error(Vips::Error)
         file_set = query_service.find_by(id: invalid_file_set.id)
         expect(file_set.file_metadata[0].error_message.first).to start_with "Error during characterization:"
       end

--- a/spec/jobs/recharacterize_job_spec.rb
+++ b/spec/jobs/recharacterize_job_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe RecharacterizeJob do
         book_members = query_service.find_members(resource: book)
         invalid_file_set = book_members.first
 
-        expect { described_class.perform_now(invalid_file_set.id) }.to raise_error(MiniMagick::Invalid)
+        expect { described_class.perform_now(invalid_file_set.id) }.to raise_error(Vips::Error)
         file_set = query_service.find_by(id: invalid_file_set.id)
         expect(file_set.file_metadata[0].error_message.first).to start_with "Error during characterization:"
       end

--- a/spec/support/stub_tika.rb
+++ b/spec/support/stub_tika.rb
@@ -18,10 +18,10 @@ RSpec.configure do |config|
     unless ex.metadata[:run_real_characterization]
       ruby_mock = instance_double(RubyTikaApp, to_json: tika_output)
       allow(RubyTikaApp).to receive(:new).and_return(ruby_mock)
-      allow_any_instance_of(MiniMagick::Image).to receive(:width).and_return(200)
-      allow_any_instance_of(MiniMagick::Image).to receive(:height).and_return(287)
-      allow_any_instance_of(MiniMagick::Image).to receive(:mime_type).and_return("image/tiff")
-      allow_any_instance_of(MiniMagick::Image).to receive(:size).and_return("196882B")
+      allow_any_instance_of(Vips::Image).to receive(:width).and_return(200)
+      allow_any_instance_of(Vips::Image).to receive(:height).and_return(287)
+      allow_any_instance_of(ImagemagickCharacterizationService).to receive(:mime_type).and_return("image/tiff")
+      allow_any_instance_of(ImagemagickCharacterizationService).to receive(:file_size).and_return("196882B")
     end
   end
 end


### PR DESCRIPTION
ImageMagick 7 characterizes better than 6, but Debian's having a rough time getting IM 7 into their repo. Instead, let's just use VIPS!

Closes #6669