### PR TITLE
Try Devbox for Figgy Setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "bagit", "~> 0.4"
 # Pin to prevent passenger error
 gem "base64", "0.1.1"
 gem "blacklight", "~> 7.33"
-gem "blacklight_iiif_search", "~> 2.1.0"
+gem "blacklight_iiif_search", "~> 2.1.0", github: "pulibrary/blacklight_iiif_search", branch: "ffi_patch"
 gem "blacklight_range_limit"
 gem "bootsnap", require: false
 gem "bootstrap", "~> 4.0"
@@ -31,7 +31,7 @@ gem "dnsruby"
 gem "draper"
 gem "ezid-client", "1.9.4" # v1.9.0 introduces response errors in our tests/stubbing
 gem "faker"
-gem "ffi", "~> 1.16.0"
+gem "ffi", "~> 1.17.0"
 gem "filewatcher", "~> 1.0"
 gem "flutie"
 gem "font-awesome-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,16 @@ GIT
       devise
 
 GIT
+  remote: https://github.com/pulibrary/blacklight_iiif_search.git
+  revision: 0533d15ca417be0c9535fca7dd39326c9a47cc80
+  branch: ffi_patch
+  specs:
+    blacklight_iiif_search (2.1.0)
+      blacklight (~> 7.0)
+      iiif-presentation
+      rails (>= 6, < 7.3)
+
+GIT
   remote: https://github.com/pulibrary/mediainfo.git
   revision: 58f3e304f01009b459954b82d0675562106b1ac8
   branch: further_sanitize_track_names
@@ -257,11 +267,6 @@ GEM
       blacklight (> 6.0, < 8)
       cancancan (>= 1.8)
       deprecation (~> 1.0)
-    blacklight_iiif_search (2.1.0)
-      blacklight (~> 7.0)
-      ffi (~> 1.16.3)
-      iiif-presentation
-      rails (>= 6, < 7.3)
     blacklight_range_limit (8.5.0)
       blacklight (>= 7.25.2, < 9)
       deprecation
@@ -439,7 +444,9 @@ GEM
       net-http (>= 0.5.0)
     faraday-retry (2.2.1)
       faraday (~> 2.0)
-    ffi (1.16.3)
+    ffi (1.17.1-arm64-darwin)
+    ffi (1.17.1-x86_64-darwin)
+    ffi (1.17.1-x86_64-linux-gnu)
     filewatcher (1.1.1)
       optimist (~> 3.0)
     flutie (2.2.0)
@@ -1126,7 +1133,7 @@ DEPENDENCIES
   benchmark-ips
   bixby (~> 5.0)
   blacklight (~> 7.33)
-  blacklight_iiif_search (~> 2.1.0)
+  blacklight_iiif_search (~> 2.1.0)!
   blacklight_range_limit
   bootsnap
   bootstrap (~> 4.0)
@@ -1153,7 +1160,7 @@ DEPENDENCIES
   ezid-client (= 1.9.4)
   factory_bot_rails
   faker
-  ffi (~> 1.16.0)
+  ffi (~> 1.17.0)
   filewatcher (~> 1.0)
   flutie
   font-awesome-rails

--- a/README.md
+++ b/README.md
@@ -7,67 +7,22 @@ A digital repository application in use at Princeton University Library for stor
 
 ## Project Setup for Development and Test environments
 
+We use [devbox](https://www.jetify.com/docs/devbox/quickstart/) for set up.
+
 ### One-time setup
 
 Follow these steps the first time you clone this project to run in dev or test.
 
-#### Install Language Dependencies
+### Install Devbox
 
-- We use asdf to manage language dependencies. If you don't have it installed do `brew install asdf`.
-- To support Java on Mac via asdf, add the following line to your `~/.asdfrc` file:
-    ```
-    java_macos_integration_enable = yes
-    ```
-- If your `~/.asdfrc` has this line you may need to remove it:
-    ```
-    legacy_version_file = yes
-    ```
-- After making these changes open a new terminal window for figgy.
-- Run `./bin/setup_asdf`. This script ensures all required plugins are installed and then installs all language dependencies specified in `.tool-versions`.
-
-#### Install Package Dependencies
-
-- First follow package setup for Mac M series processors (below) if needed
-- Then run `./bin/setup` to ensure that required dependencies via homebrew, pip, bundler, and yarn.
-
-Remember you'll need to run `bundle install` and `yarn install` on an ongoing basis as dependencies are updated.
-
-##### Package Setup for Mac M Series Processors
-
-Mapnik currently isn't supported by M-series processors, so `yarn install` above will
-fail. To get this working, do the following:
-
-1. $ arch -x86_64 /bin/zsh --login
-1. you can validate that it's running the right architecture now by viewing the output of the `arch` command
-1. `asdf uninstall nodejs`
-1. `asdf uninstall yarn`
-1. `rm ~/.asdf/shims/yarn`
-1. `asdf install nodejs`
-1. `npm install -g yarn`
-1. `yarn install`
-1. open a new Terminal or otherwise go back to the arm64 arch.
-1. Add the following to `~/.zshrc` or `~/.zshrc.local`:
-```
-   # Fix issue with homebrew postgres and rails applications (Figgy in
-   particular).
-   # See: https://github.com/ged/ruby-pg/issues/538
-   export PGGSSENCMODE="disable"
-```
-
-#### Install Lando
-
-Lando will automatically set up docker images for Solr and Postgres which match
-the versions we use in Production. The ports will not collide with any other
-projects you're using Solr/Postgres for, and you can easily clean up with `lando
-destroy` or turn off all services with `lando poweroff`.
-
-1. Install Lando DMG from [[https://github.com/lando/lando/releases]]
+curl -fsSL https://get.jetify.com/devbox | bash
 
 ### Every time setup
 
 Follow these steps every time you start new work in this project in dev or test
 
-1. Run `bundle exec rake servers:start` to start lando services and set up database state.
+1. Run `devbox run setup` to set up your database and dependencies.
+1. Run `devbox shell` to get into a shell where you can run the below commands.
 
 ### Running tests
 
@@ -85,8 +40,6 @@ http://localhost:7900, use the password `secret`, and run tests like this:
 
 If you'd like to run the test suite in parallel do the following:
 
-1. `bundle exec rake servers:start`
-1. `PARALLEL_TEST_FIRST_IS_1=true RAILS_ENV=test rake parallel:setup` (Sets up suport database; only needed after db has been destroyed)
 1. `./bin/parallel_rspec_coverage`
 
 The output from the parallel runs will be interspersed, and the failures will be

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Follow these steps the first time you clone this project to run in dev or test.
 
 ### Install Devbox
 
-curl -fsSL https://get.jetify.com/devbox | bash
+`curl -fsSL https://get.jetify.com/devbox | bash`
 
 ### Every time setup
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ docker buildx build --push --platform linux/arm64,linux/amd64 -t pulibrary/ci-fi
 docker push pulibrary/ci-figgy:{version}
 ```
 
+## Adding packages to devbox
+
+If you need to add a package to Figgy, you can search https://www.nixhub.io/ or use `devbox search <packagename>` to see if it exists. Then add it with `devbox add <packagehere>`.
+
+If you want to test to make sure none of your local packages are conflicting with running tests, you can run `devbox shell --pure`
+
 ## More
 Valkyrie Documentation:
 - For links to helpful valkyrie documentation and troubleshooting tips, visit the [Valkyrie wiki](https://github.com/samvera-labs/valkyrie/wiki).

--- a/devbox.json
+++ b/devbox.json
@@ -13,7 +13,9 @@
     "lando_redis_conn_host":                "127.0.0.1",
     "lando_redis_conn_port":                "9553",
     "TMPDIR": "/private/tmp",
-    "DEVBOX_USE_VERSION":                   "0.13.7"
+    "DEVBOX_USE_VERSION":                   "0.13.7",
+    "LD_LIBRARY_PATH": "$PWD/.devbox/nix/profile/default/lib",
+    "FONTCONFIG_PATH": "$PWD/.devbox/nix/profile/default/etc/fonts"
   },
   "packages": {
     "ruby":   "3.2.6",
@@ -63,8 +65,6 @@
   },
   "shell": {
     "init_hook": [
-      "export LD_LIBRARY_PATH=$(pwd)/.devbox/nix/profile/default/lib",
-      "export FONTCONFIG_PATH=${DEVBOX_PACKAGES_DIR}/etc/fonts",
       ". $VENV_DIR/bin/activate",
       "pip install cogeo-mosaic > /dev/null"
     ],

--- a/devbox.json
+++ b/devbox.json
@@ -13,7 +13,6 @@
     "lando_redis_conn_host":                "127.0.0.1",
     "lando_redis_conn_port":                "9553",
     "TMPDIR": "/private/tmp",
-    "DEVBOX_USE_VERSION":                   "0.13.7",
     "LD_LIBRARY_PATH": "$PWD/.devbox/nix/profile/default/lib",
     "FONTCONFIG_PATH": "$PWD/.devbox/nix/profile/default/etc/fonts"
   },
@@ -65,7 +64,8 @@
   },
   "shell": {
     "init_hook": [
-      "if [[ -n $FISH_VERSION ]]; then . $VENV_DIR/bin/activate.fish; else . $VENV_DIR/bin/activate; fi",
+      "echo $FISH_VERSION",
+      "source $VENV_DIR/bin/activate || source $VENV_DIR/bin/activate.fish",
       "pip install cogeo-mosaic > /dev/null"
     ],
     "scripts": {

--- a/devbox.json
+++ b/devbox.json
@@ -38,7 +38,8 @@
     "python":       "3.9.1",
     "lastpass-cli": "latest",
     "tippecanoe":   "2.35.0",
-    "yarn":         "1.22.10"
+    "yarn":         "1.22.10",
+    "openjpeg":     "latest"
   },
   "shell": {
     "init_hook": [

--- a/devbox.json
+++ b/devbox.json
@@ -12,6 +12,7 @@
     "lando_figgy_devopment_solr_conn_port": "9552",
     "lando_redis_conn_host":                "127.0.0.1",
     "lando_redis_conn_port":                "9553",
+    "TMPDIR": "/private/tmp",
     "DEVBOX_USE_VERSION":                   "0.13.7"
   },
   "packages": {
@@ -57,7 +58,8 @@
     "qemu":           "latest",
     "jdk":            "8",
     "unzip":          "latest",
-    "zip":            "latest"
+    "zip":            "latest",
+    "lsof":           "latest"
   },
   "shell": {
     "init_hook": [

--- a/devbox.json
+++ b/devbox.json
@@ -56,7 +56,8 @@
     "podman-compose": "latest",
     "qemu":           "latest",
     "jdk":            "8",
-    "unzip":          "latest"
+    "unzip":          "latest",
+    "zip":            "latest"
   },
   "shell": {
     "init_hook": [

--- a/devbox.json
+++ b/devbox.json
@@ -72,7 +72,7 @@
       "setup": [
         "bundle install",
         "yarn install",
-        "podman machine init -v .:/mnt/app || true",
+        "podman machine init -m 8192 -v $HOME:/mnt/$HOME || true",
         "podman machine start || true",
         "devbox services up -b || true",
         "PARALLEL_TEST_FIRST_IS_1=true RAILS_ENV=test rake parallel:setup || true",

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.14.0/.schema/devbox.schema.json",
+  "env": {
+    "DEVBOX_COREPACK_ENABLED": "true"
+  },
+  "packages": {
+    "ruby":   "3.2.6",
+    "libffi": "latest",
+    "vips": {
+      "version": "latest",
+      "outputs": ["out", "dev", "bin"]
+    },
+    "poppler": {
+      "version": "latest",
+      "outputs": ["out", "dev"]
+    },
+    "fontconfig": {
+      "version": "latest",
+      "outputs": ["lib", "dev", "bin", "out"]
+    },
+    "imagemagick6": {
+      "version":        "latest",
+      "allow_insecure": ["imagemagick-6.9.13-10"]
+    },
+    "postgresql": {
+      "version": "15.7",
+      "outputs": ["lib", "out"]
+    },
+    "gdal":        "3.6.4",
+    "tesseract_4": "latest",
+    "mediainfo":   "latest",
+    "ffmpeg":      "4.4.2",
+    "ocrmypdf":    "latest",
+    "nodejs": {
+      "version": "22.11.0",
+      "outputs": ["out", "libv8"]
+    },
+    "python":       "3.9.1",
+    "lastpass-cli": "latest",
+    "tippecanoe":   "2.35.0",
+    "yarn":         "1.22.10"
+  },
+  "shell": {
+    "init_hook": [
+      "export LD_LIBRARY_PATH=$(pwd)/.devbox/nix/profile/default/lib",
+      "export FONTCONFIG_PATH=${DEVBOX_PACKAGES_DIR}/etc/fonts",
+      ". $VENV_DIR/bin/activate",
+      "pip install cogeo-mosaic > /dev/null"
+    ],
+    "scripts": {
+      "test": [
+        "echo \"Error: no test specified\" && exit 1"
+      ]
+    }
+  }
+}

--- a/devbox.json
+++ b/devbox.json
@@ -65,7 +65,7 @@
   },
   "shell": {
     "init_hook": [
-      ". $VENV_DIR/bin/activate",
+      "if [[ -n $FISH_VERSION ]]; then . $VENV_DIR/bin/activate.fish; else . $VENV_DIR/bin/activate; fi",
       "pip install cogeo-mosaic > /dev/null"
     ],
     "scripts": {

--- a/devbox.json
+++ b/devbox.json
@@ -1,7 +1,18 @@
 {
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.14.0/.schema/devbox.schema.json",
   "env": {
-    "DEVBOX_COREPACK_ENABLED": "true"
+    "DEVBOX_COREPACK_ENABLED":              "true",
+    "lando_figgy_database_conn_host":       "127.0.0.1",
+    "lando_figgy_database_conn_port":       "9550",
+    "lando_figgy_database_creds_user":      "postgres",
+    "lando_figgy_database_creds_password":  "password",
+    "lando_figgy_test_solr_conn_host":      "127.0.0.1",
+    "lando_figgy_test_solr_conn_port":      "9551",
+    "lando_figgy_devopment_solr_conn_host": "127.0.0.1",
+    "lando_figgy_devopment_solr_conn_port": "9552",
+    "lando_redis_conn_host":                "127.0.0.1",
+    "lando_redis_conn_port":                "9553",
+    "DEVBOX_USE_VERSION":                   "0.13.7"
   },
   "packages": {
     "ruby":   "3.2.6",
@@ -35,11 +46,17 @@
       "version": "22.11.0",
       "outputs": ["out", "libv8"]
     },
-    "python":       "3.9.1",
-    "lastpass-cli": "latest",
-    "tippecanoe":   "2.35.0",
-    "yarn":         "1.22.10",
-    "openjpeg":     "latest"
+    "python":         "3.9.1",
+    "lastpass-cli":   "latest",
+    "tippecanoe":     "2.35.0",
+    "yarn":           "1.22.10",
+    "openjpeg":       "latest",
+    "openssh":        "latest",
+    "podman":         "4.9.3",
+    "podman-compose": "latest",
+    "qemu":           "latest",
+    "jdk":            "8",
+    "unzip":          "latest"
   },
   "shell": {
     "init_hook": [
@@ -49,8 +66,17 @@
       "pip install cogeo-mosaic > /dev/null"
     ],
     "scripts": {
-      "test": [
-        "echo \"Error: no test specified\" && exit 1"
+      "setup": [
+        "bundle install",
+        "yarn install",
+        "podman machine init -v .:/mnt/app || true",
+        "podman machine start || true",
+        "devbox services up -b || true",
+        "PARALLEL_TEST_FIRST_IS_1=true RAILS_ENV=test rake parallel:setup || true",
+        "RAILS_ENV=test rake db:create || true",
+        "RAILS_ENV=test rake db:migrate || true",
+        "RAILS_ENV=development rake db:create || true",
+        "RAILS_ENV=development rake db:migrate || true"
       ]
     }
   }

--- a/devbox.lock
+++ b/devbox.lock
@@ -261,9 +261,6 @@
         }
       }
     },
-    "github:NixOS/nixpkgs/nixpkgs-unstable": {
-      "resolved": "github:NixOS/nixpkgs/b7ba7f9f45c5cd0d8625e9e217c28f8eb6a19a76?lastModified=1743568003&narHash=sha256-ZID5T65E8ruHqWRcdvZLsczWDOAWIE7om%2BvQOREwiX0%3D"
-    },
     "imagemagick6@latest": {
       "last_modified": "2025-03-23T05:31:05Z",
       "resolved": "github:NixOS/nixpkgs/dd613136ee91f67e5dba3f3f41ac99ae89c5406b#imagemagick6",
@@ -341,6 +338,50 @@
             }
           ],
           "store_path": "/nix/store/wcwgh67ksv9ix9kjxlkizsapy65g0hkv-imagemagick-6.9.13-10"
+        }
+      }
+    },
+    "jdk@8": {
+      "last_modified": "2025-03-26T18:47:43Z",
+      "resolved": "github:NixOS/nixpkgs/bd3bac8bfb542dbde7ffffb6987a1a1f9d41699f#jdk8",
+      "source": "devbox-search",
+      "version": "8u432-b06",
+      "systems": {
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/0011mfjrkdv6gn7fyr1l5zq7xi9c2y0z-openjdk-8u432-b06",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/nplci1834fdj01qila28f66f2ai23hi2-openjdk-8u432-b06-debug"
+            },
+            {
+              "name": "jre",
+              "path": "/nix/store/vyr9kbqv507481hn7nv1np0ymy58skj0-openjdk-8u432-b06-jre"
+            }
+          ],
+          "store_path": "/nix/store/0011mfjrkdv6gn7fyr1l5zq7xi9c2y0z-openjdk-8u432-b06"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/dbd512p01n9lr35m28166n203fh17xip-openjdk-8u432-b06",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/bxs2fdq0inv7p93wrd7k4g1q552v9z4d-openjdk-8u432-b06-debug"
+            },
+            {
+              "name": "jre",
+              "path": "/nix/store/fbqdrkxgiwk831q7d6885hfd3cg4gvdw-openjdk-8u432-b06-jre"
+            }
+          ],
+          "store_path": "/nix/store/dbd512p01n9lr35m28166n203fh17xip-openjdk-8u432-b06"
         }
       }
     },
@@ -687,6 +728,186 @@
         }
       }
     },
+    "openssh@latest": {
+      "last_modified": "2025-03-11T17:52:14Z",
+      "resolved": "github:NixOS/nixpkgs/0d534853a55b5d02a4ababa1d71921ce8f0aee4c#openssh",
+      "source": "devbox-search",
+      "version": "9.9p2",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/mandn8m6jf2icswsk0n1krygcc42cfza-openssh-9.9p2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/mandn8m6jf2icswsk0n1krygcc42cfza-openssh-9.9p2"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/7vhn5faj32m7axh364hxw7qajwiw41dp-openssh-9.9p2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/7vhn5faj32m7axh364hxw7qajwiw41dp-openssh-9.9p2"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/nsbkf9n7wkyqyzay8a3bns3bprq6fd2z-openssh-9.9p2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/nsbkf9n7wkyqyzay8a3bns3bprq6fd2z-openssh-9.9p2"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/3yvsilhzgd05jwj6xq7lfbqfaq7f79qj-openssh-9.9p2",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/3yvsilhzgd05jwj6xq7lfbqfaq7f79qj-openssh-9.9p2"
+        }
+      }
+    },
+    "podman-compose@latest": {
+      "last_modified": "2025-03-11T17:52:14Z",
+      "resolved": "github:NixOS/nixpkgs/0d534853a55b5d02a4ababa1d71921ce8f0aee4c#podman-compose",
+      "source": "devbox-search",
+      "version": "1.3.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/6mcpqhhyfvvyhhq35sks5mgiqb82grrl-podman-compose-1.3.0",
+              "default": true
+            },
+            {
+              "name": "dist",
+              "path": "/nix/store/jv4il1clqr07c5rcxiaj0daawwmhvhxs-podman-compose-1.3.0-dist"
+            }
+          ],
+          "store_path": "/nix/store/6mcpqhhyfvvyhhq35sks5mgiqb82grrl-podman-compose-1.3.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/mmlllxn305c4bd0sji4y5yzqqkxz1j4m-podman-compose-1.3.0",
+              "default": true
+            },
+            {
+              "name": "dist",
+              "path": "/nix/store/w0sb2zdf6nsbrlm2sbqkb8vg14188a2x-podman-compose-1.3.0-dist"
+            }
+          ],
+          "store_path": "/nix/store/mmlllxn305c4bd0sji4y5yzqqkxz1j4m-podman-compose-1.3.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/yszv9d1h9sv122ibshy0kx4alc2i9syk-podman-compose-1.3.0",
+              "default": true
+            },
+            {
+              "name": "dist",
+              "path": "/nix/store/ir51a4cyzvnrc020fryasqp8jmmp1jgx-podman-compose-1.3.0-dist"
+            }
+          ],
+          "store_path": "/nix/store/yszv9d1h9sv122ibshy0kx4alc2i9syk-podman-compose-1.3.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/6lrcach9x9mqwqdrkkrjajga9j60mhw4-podman-compose-1.3.0",
+              "default": true
+            },
+            {
+              "name": "dist",
+              "path": "/nix/store/jhx7jih9g0lsw53nr7jgjb7a9f4m4xml-podman-compose-1.3.0-dist"
+            }
+          ],
+          "store_path": "/nix/store/6lrcach9x9mqwqdrkkrjajga9j60mhw4-podman-compose-1.3.0"
+        }
+      }
+    },
+    "podman@4.9.3": {
+      "last_modified": "2024-04-02T02:53:36Z",
+      "resolved": "github:NixOS/nixpkgs/080a4a27f206d07724b88da096e27ef63401a504#podman",
+      "source": "devbox-search",
+      "version": "4.9.3",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/ljmgw6bq46f0xcgbnfdlc8xcvdkcy6xy-podman-4.9.3",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/ksx2y2g1hary46xnsk9xx2h9ipa927pj-podman-4.9.3-man",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/ljmgw6bq46f0xcgbnfdlc8xcvdkcy6xy-podman-4.9.3"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/p6h96x6gbzrx815slfc2vcmvg3wvmpvs-podman-4.9.3",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/h7lmpbz2n3sxk4yvbk84pw6qzg2xbjgk-podman-4.9.3-man",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/p6h96x6gbzrx815slfc2vcmvg3wvmpvs-podman-4.9.3"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/kafw88ibhxf213c8dg8mbxipijigg8bf-podman-4.9.3",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/4aiw3fwrnqyd2a9h6c2bd0n07j42nd11-podman-4.9.3-man",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/kafw88ibhxf213c8dg8mbxipijigg8bf-podman-4.9.3"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/g5cy6j5agdg14kdshrlvsfnhgrlp522z-podman-4.9.3",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/ccdlla5gfk4gd9rgsp71yk2sivd1j6q9-podman-4.9.3-man",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/g5cy6j5agdg14kdshrlvsfnhgrlp522z-podman-4.9.3"
+        }
+      }
+    },
     "poppler@latest": {
       "last_modified": "2025-03-11T17:52:14Z",
       "resolved": "github:NixOS/nixpkgs/0d534853a55b5d02a4ababa1d71921ce8f0aee4c#poppler",
@@ -917,6 +1138,82 @@
         }
       }
     },
+    "qemu@latest": {
+      "last_modified": "2025-03-11T17:52:14Z",
+      "resolved": "github:NixOS/nixpkgs/0d534853a55b5d02a4ababa1d71921ce8f0aee4c#qemu",
+      "source": "devbox-search",
+      "version": "9.2.2",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/gny77jv7zpn2ym3hx6jys405yfzmn05g-qemu-9.2.2",
+              "default": true
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/wfrk0vnr0bf9cii337pgybdb3c1ngwfi-qemu-9.2.2-doc"
+            }
+          ],
+          "store_path": "/nix/store/gny77jv7zpn2ym3hx6jys405yfzmn05g-qemu-9.2.2"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/hm320kir3jxsi60584ki9p1fikqzrsi4-qemu-9.2.2",
+              "default": true
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/0jfgwz8bfa3zawvjkmhh1k0ikp50xxlb-qemu-9.2.2-doc"
+            },
+            {
+              "name": "ga",
+              "path": "/nix/store/rgvgqshi1iq3430cba7zr8kddnpc8kgh-qemu-9.2.2-ga"
+            }
+          ],
+          "store_path": "/nix/store/hm320kir3jxsi60584ki9p1fikqzrsi4-qemu-9.2.2"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/sgzgalhdxif9hcw9f470h0v8g7cxg6vc-qemu-9.2.2",
+              "default": true
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/5092djlpbqlbs9i5az9w5qxzs4r7lg3h-qemu-9.2.2-doc"
+            }
+          ],
+          "store_path": "/nix/store/sgzgalhdxif9hcw9f470h0v8g7cxg6vc-qemu-9.2.2"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/0d3a8gzsrfp8hypvr5spq1vvj2sa14fh-qemu-9.2.2",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/4p9vrqhfp2xbgsr4hr6fanq432w3x2y2-qemu-9.2.2-debug"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/xg464cq2rfql02bpc3f3l45q2qwjxqxk-qemu-9.2.2-doc"
+            },
+            {
+              "name": "ga",
+              "path": "/nix/store/q21z3c51irq6if264i1dv9rp9sp3ccv6-qemu-9.2.2-ga"
+            }
+          ],
+          "store_path": "/nix/store/0d3a8gzsrfp8hypvr5spq1vvj2sa14fh-qemu-9.2.2"
+        }
+      }
+    },
     "ruby@3.2.6": {
       "last_modified": "2025-03-11T17:52:14Z",
       "plugin_version": "0.0.2",
@@ -1033,6 +1330,54 @@
             }
           ],
           "store_path": "/nix/store/5vxhv7867lkibnvhr7x3gwwx7zisky4k-tippecanoe-2.35.0"
+        }
+      }
+    },
+    "unzip@latest": {
+      "last_modified": "2025-03-11T17:52:14Z",
+      "resolved": "github:NixOS/nixpkgs/0d534853a55b5d02a4ababa1d71921ce8f0aee4c#unzip",
+      "source": "devbox-search",
+      "version": "6.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/zr6wmhcrkbkc7z4007f9fh8s3miq9npr-unzip-6.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/zr6wmhcrkbkc7z4007f9fh8s3miq9npr-unzip-6.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/lcrn9i1wnygvv6kvvxb0nxsjx2hiijqc-unzip-6.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/lcrn9i1wnygvv6kvvxb0nxsjx2hiijqc-unzip-6.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/nd34c407gp101l0z0jpdf3pm9p9702gf-unzip-6.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/nd34c407gp101l0z0jpdf3pm9p9702gf-unzip-6.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/9476npas7nxlj8j898jvvvjk7cciyw0c-unzip-6.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/9476npas7nxlj8j898jvvvjk7cciyw0c-unzip-6.0"
         }
       }
     },

--- a/devbox.lock
+++ b/devbox.lock
@@ -261,6 +261,9 @@
         }
       }
     },
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "resolved": "github:NixOS/nixpkgs/2bfc080955153be0be56724be6fa5477b4eefabb?lastModified=1743689281&narHash=sha256-y7Hg5lwWhEOgflEHRfzSH96BOt26LaYfrYWzZ%2BVoVdg%3D"
+    },
     "imagemagick6@latest": {
       "last_modified": "2025-03-23T05:31:05Z",
       "resolved": "github:NixOS/nixpkgs/dd613136ee91f67e5dba3f3f41ac99ae89c5406b#imagemagick6",

--- a/devbox.lock
+++ b/devbox.lock
@@ -261,6 +261,9 @@
         }
       }
     },
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "resolved": "github:NixOS/nixpkgs/384d1adab77a8d49172a3acc1d5c2f26d013a69a?lastModified=1743598831&narHash=sha256-e10M97wGA0dpFAFnp1D0dgk9BcgphvuUeksDpDXMZRA%3D"
+    },
     "imagemagick6@latest": {
       "last_modified": "2025-03-23T05:31:05Z",
       "resolved": "github:NixOS/nixpkgs/dd613136ee91f67e5dba3f3f41ac99ae89c5406b#imagemagick6",
@@ -1494,6 +1497,54 @@
       "resolved": "github:NixOS/nixpkgs/404cd360c2607bcfe8d05a7d5ae609d6605f7e22#yarn",
       "source": "devbox-search",
       "version": "1.22.10"
+    },
+    "zip@latest": {
+      "last_modified": "2025-03-11T17:52:14Z",
+      "resolved": "github:NixOS/nixpkgs/0d534853a55b5d02a4ababa1d71921ce8f0aee4c#zip",
+      "source": "devbox-search",
+      "version": "3.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/c7l9cizx40hsq3lrxxc08sfwy8ggnj47-zip-3.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/c7l9cizx40hsq3lrxxc08sfwy8ggnj47-zip-3.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/84damby6iyhxi9zwyav3apnzd7h04gj2-zip-3.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/84damby6iyhxi9zwyav3apnzd7h04gj2-zip-3.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/sgd6ms2yqwjwp3vdxfyj2nksv6yrm8vf-zip-3.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/sgd6ms2yqwjwp3vdxfyj2nksv6yrm8vf-zip-3.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/y2c2xz67ldvxh8d74vfq3716xmlz54nh-zip-3.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/y2c2xz67ldvxh8d74vfq3716xmlz54nh-zip-3.0"
+        }
+      }
     }
   }
 }

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,0 +1,1090 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "ffmpeg@4.4.2": {
+      "last_modified": "2023-01-13T10:34:48Z",
+      "resolved": "github:NixOS/nixpkgs/37b97ae3dd714de9a17923d004a2c5b5543dfa6d#ffmpeg",
+      "source": "devbox-search",
+      "version": "4.4.2",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/z5kxi32ibzxf13j3qy54lq8g773w93pq-ffmpeg-4.4.2-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/pn1bdhpy7ax4qkqix0x2gp63jmh2w212-ffmpeg-4.4.2-man",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/kp9nwifq6wiv0pynr8y1icm120c4prvf-ffmpeg-4.4.2-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/vhibfn0i87ijl96a3rkhksmqwjpcwhwv-ffmpeg-4.4.2-doc"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/gbvb5q24zqpcplpxigyxph457766avfh-ffmpeg-4.4.2"
+            }
+          ],
+          "store_path": "/nix/store/z5kxi32ibzxf13j3qy54lq8g773w93pq-ffmpeg-4.4.2-bin"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/7yax3c3j6gfk2pj94kpm75mh03mk2252-ffmpeg-4.4.2-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/63l6ir2kbf99jjri26q7gdad9ihahiml-ffmpeg-4.4.2-man",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/zxw72ajssicy3ms0bkn0jz4l2pjyx0lj-ffmpeg-4.4.2-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/p9pa8lzni882mnsig7rn3s82hf0kz7af-ffmpeg-4.4.2-doc"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/frbg8mdms15r7grhip431lwpw0cpcz84-ffmpeg-4.4.2"
+            }
+          ],
+          "store_path": "/nix/store/7yax3c3j6gfk2pj94kpm75mh03mk2252-ffmpeg-4.4.2-bin"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/qby6pjdqd9d9bn1ds2jnz7ki9k0xihkk-ffmpeg-4.4.2-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/x5rdhbbnjrn54bhxaayfi8cc8zdc8c4n-ffmpeg-4.4.2-man",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/a2bb9kvn7h167symxr1i1ja9sl8jrhrg-ffmpeg-4.4.2-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/rby8fra3j1dq45pqvh482ma6lg4nzkp8-ffmpeg-4.4.2-doc"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/vnn6vpp2nv7grqg71y7kwzpcxgx0rr5n-ffmpeg-4.4.2"
+            }
+          ],
+          "store_path": "/nix/store/qby6pjdqd9d9bn1ds2jnz7ki9k0xihkk-ffmpeg-4.4.2-bin"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/3capsq2a0rfkygj2dy8bjq7jv6jjwyij-ffmpeg-4.4.2-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/22xpw4jqxmjh1j1g7knspz363i2s7zi6-ffmpeg-4.4.2-man",
+              "default": true
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/ahrhq7wdlkpxrwsmdi05ni41nl7jg6db-ffmpeg-4.4.2-doc"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/63bnvk2x2n2bg33c6cjhryd77l99ajdh-ffmpeg-4.4.2"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/8hxhzf86w632qc3b951i5206vhkhrhsw-ffmpeg-4.4.2-dev"
+            }
+          ],
+          "store_path": "/nix/store/3capsq2a0rfkygj2dy8bjq7jv6jjwyij-ffmpeg-4.4.2-bin"
+        }
+      }
+    },
+    "fontconfig@latest": {
+      "last_modified": "2025-03-27T11:50:31Z",
+      "resolved": "github:NixOS/nixpkgs/6c5963357f3c1c840201eda129a99d455074db04#fontconfig",
+      "source": "devbox-search",
+      "version": "2.16.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/7ppsp5xrfc6iynrn6dzsbjy41v1nxn81-fontconfig-2.16.0-bin",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/xry9v32z1pwimjzjnf2vvdpy1vhxxc5n-fontconfig-2.16.0-dev"
+            },
+            {
+              "name": "lib",
+              "path": "/nix/store/773r44j6bdd1i6ljh19v5xj5h3dzsa4n-fontconfig-2.16.0-lib"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/fcg908c8a5sn7cqmq9sacipf2nyx82y7-fontconfig-2.16.0"
+            }
+          ],
+          "store_path": "/nix/store/7ppsp5xrfc6iynrn6dzsbjy41v1nxn81-fontconfig-2.16.0-bin"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/8sl3ndgqjakl4315fr0fkrbh9lz3g1c3-fontconfig-2.16.0-bin",
+              "default": true
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/wb0av496k01rw78dkx9x0yp6bqxkvcd9-fontconfig-2.16.0"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/1l8vn8ink4308bnr0mvqqpisp720glz2-fontconfig-2.16.0-dev"
+            },
+            {
+              "name": "lib",
+              "path": "/nix/store/npxggq6j1gfcwdiw0v02jszd885rlr3n-fontconfig-2.16.0-lib"
+            }
+          ],
+          "store_path": "/nix/store/8sl3ndgqjakl4315fr0fkrbh9lz3g1c3-fontconfig-2.16.0-bin"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/gvzc6xk8jcsdscsvapgwcwa2mrksrnn4-fontconfig-2.16.0-bin",
+              "default": true
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/9kpcc60a9v51clvhsi4rz475idq6hwhp-fontconfig-2.16.0"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/izb6bfjbypazz7w51yn9dpqhr3gdplls-fontconfig-2.16.0-dev"
+            },
+            {
+              "name": "lib",
+              "path": "/nix/store/w10mdnwbpvmkvdcv2ii0crmwmkfyqsv9-fontconfig-2.16.0-lib"
+            }
+          ],
+          "store_path": "/nix/store/gvzc6xk8jcsdscsvapgwcwa2mrksrnn4-fontconfig-2.16.0-bin"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/680v0c7qkdpvnqng1aa8vamwmk9llznh-fontconfig-2.16.0-bin",
+              "default": true
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/n4iqx5jwcsgzcb1wpia5kfclgamrwj6l-fontconfig-2.16.0"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/nziailpyy0d90vq5pi1kckbxzvjcg5ng-fontconfig-2.16.0-dev"
+            },
+            {
+              "name": "lib",
+              "path": "/nix/store/pqb8qbd3bq9r7vndbphavjgmvcd8zs66-fontconfig-2.16.0-lib"
+            }
+          ],
+          "store_path": "/nix/store/680v0c7qkdpvnqng1aa8vamwmk9llznh-fontconfig-2.16.0-bin"
+        }
+      }
+    },
+    "gdal@3.6.4": {
+      "last_modified": "2023-07-12T05:12:53Z",
+      "resolved": "github:NixOS/nixpkgs/bf57c599729771cd23054a18c0f3a391ae85e193#gdal",
+      "source": "devbox-search",
+      "version": "3.6.4",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/1k309vmb1m749a3qql2rprlw55pxr1pa-gdal-3.6.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/1k309vmb1m749a3qql2rprlw55pxr1pa-gdal-3.6.4"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/sv53wl3jd74byy6hlzsb9f4c4b8bklir-gdal-3.6.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/sv53wl3jd74byy6hlzsb9f4c4b8bklir-gdal-3.6.4"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/qh6kdka23hp0pbjfpqcalz8998n807zd-gdal-3.6.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/qh6kdka23hp0pbjfpqcalz8998n807zd-gdal-3.6.4"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/kp998c2m5mkqgz6hr5pjjjd2a07n4c16-gdal-3.6.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/kp998c2m5mkqgz6hr5pjjjd2a07n4c16-gdal-3.6.4"
+        }
+      }
+    },
+    "github:NixOS/nixpkgs/nixpkgs-unstable": {
+      "resolved": "github:NixOS/nixpkgs/b7ba7f9f45c5cd0d8625e9e217c28f8eb6a19a76?lastModified=1743568003&narHash=sha256-ZID5T65E8ruHqWRcdvZLsczWDOAWIE7om%2BvQOREwiX0%3D"
+    },
+    "imagemagick6@latest": {
+      "last_modified": "2025-03-23T05:31:05Z",
+      "resolved": "github:NixOS/nixpkgs/dd613136ee91f67e5dba3f3f41ac99ae89c5406b#imagemagick6",
+      "source": "devbox-search",
+      "version": "6.9.13-10",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/nixww5wwj334gzdm1lk1qcman2sp5a06-imagemagick-6.9.13-10",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/sdiyw3yp6bbf8p6fp21q7iwfq14pyb0p-imagemagick-6.9.13-10-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/c59ad0rs1jw0lz0dyma3g52hcglssfac-imagemagick-6.9.13-10-doc"
+            }
+          ],
+          "store_path": "/nix/store/nixww5wwj334gzdm1lk1qcman2sp5a06-imagemagick-6.9.13-10"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/1iaca9q1lp2m8hd156yvlvyd9sr8r7hp-imagemagick-6.9.13-10",
+              "default": true
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/12c3jy8syqq53l6pp9p2b3829mks0p8r-imagemagick-6.9.13-10-doc"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/njx3072416dh613i9ndxm128s49f5rip-imagemagick-6.9.13-10-dev"
+            }
+          ],
+          "store_path": "/nix/store/1iaca9q1lp2m8hd156yvlvyd9sr8r7hp-imagemagick-6.9.13-10"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/70vs151x6fy63smscjp37s6fgm630nhv-imagemagick-6.9.13-10",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/87bpa68i6rka8jp39xvvjb5gc808wwcw-imagemagick-6.9.13-10-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/svgnjbdzlb8yg3b5sck0d39r8b0xgc7q-imagemagick-6.9.13-10-doc"
+            }
+          ],
+          "store_path": "/nix/store/70vs151x6fy63smscjp37s6fgm630nhv-imagemagick-6.9.13-10"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/wcwgh67ksv9ix9kjxlkizsapy65g0hkv-imagemagick-6.9.13-10",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/x2h2ni1lg1038ws8s3rkl6hlxpv1r2s8-imagemagick-6.9.13-10-dev"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/vh4sgrx1ws40r339g47vc8fw1a6dzxsx-imagemagick-6.9.13-10-doc"
+            }
+          ],
+          "store_path": "/nix/store/wcwgh67ksv9ix9kjxlkizsapy65g0hkv-imagemagick-6.9.13-10"
+        }
+      }
+    },
+    "lastpass-cli@latest": {
+      "last_modified": "2025-03-11T17:52:14Z",
+      "resolved": "github:NixOS/nixpkgs/0d534853a55b5d02a4ababa1d71921ce8f0aee4c#lastpass-cli",
+      "source": "devbox-search",
+      "version": "1.6.1",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/rg68fpdx1vpdsxwmb5rcpdlhzw5ha65v-lastpass-cli-1.6.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/rg68fpdx1vpdsxwmb5rcpdlhzw5ha65v-lastpass-cli-1.6.1"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/3l3s2p58mb7qvanx0jrc4s5p22gs0zv1-lastpass-cli-1.6.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/3l3s2p58mb7qvanx0jrc4s5p22gs0zv1-lastpass-cli-1.6.1"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/6vcbdmacrl3lfkfwi4gxrkg223d8rp3k-lastpass-cli-1.6.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/6vcbdmacrl3lfkfwi4gxrkg223d8rp3k-lastpass-cli-1.6.1"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/4i45h3awf6ydkicdl81sbwc5kqfws6p1-lastpass-cli-1.6.1",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/4i45h3awf6ydkicdl81sbwc5kqfws6p1-lastpass-cli-1.6.1"
+        }
+      }
+    },
+    "libffi@latest": {
+      "last_modified": "2025-03-27T11:50:31Z",
+      "resolved": "github:NixOS/nixpkgs/6c5963357f3c1c840201eda129a99d455074db04#libffi",
+      "source": "devbox-search",
+      "version": "39",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/jgdagkhidk9frkd0rj2frgcd7ysnf6pk-libffi-39",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/qpwkyfrydgzqhbv9c0m6gvv2nsr32a2c-libffi-39-man",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/mfb4sn2l4plmx349cbhw3vq6sjcl89g8-libffi-39-dev"
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/kmn8ffn8r4a2lpgfyd8dhpbqnjsmyp5b-libffi-39-info"
+            }
+          ],
+          "store_path": "/nix/store/jgdagkhidk9frkd0rj2frgcd7ysnf6pk-libffi-39"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/nv95nwhqrabvchsl0yf59i197viagk63-libffi-39",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/akgcmsb1nhfj0r5w6l2nsjwl3q53j54d-libffi-39-man",
+              "default": true
+            },
+            {
+              "name": "info",
+              "path": "/nix/store/zx9d5c7dnp1189lcjx7l8ll2k04306lf-libffi-39-info"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/75ah7r94arw6ajb2q7v1h78d8wrvqf4w-libffi-39-dev"
+            }
+          ],
+          "store_path": "/nix/store/nv95nwhqrabvchsl0yf59i197viagk63-libffi-39"
+        }
+      }
+    },
+    "mediainfo@latest": {
+      "last_modified": "2025-03-26T18:47:43Z",
+      "resolved": "github:NixOS/nixpkgs/bd3bac8bfb542dbde7ffffb6987a1a1f9d41699f#mediainfo",
+      "source": "devbox-search",
+      "version": "24.12",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/98zcxdgai4k95kps3ac35djlc9ibvhfb-mediainfo-24.12",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/98zcxdgai4k95kps3ac35djlc9ibvhfb-mediainfo-24.12"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/zfz34q1a156528z2rfrqjvwznh09p3hm-mediainfo-24.12",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/zfz34q1a156528z2rfrqjvwznh09p3hm-mediainfo-24.12"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/cx6ffv8lginjhqcfz8p9akfw3s6450yh-mediainfo-24.12",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/cx6ffv8lginjhqcfz8p9akfw3s6450yh-mediainfo-24.12"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/94sfc3d3hrnjj0ffiyzk2iwj043965cx-mediainfo-24.12",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/94sfc3d3hrnjj0ffiyzk2iwj043965cx-mediainfo-24.12"
+        }
+      }
+    },
+    "nodejs@22.11.0": {
+      "last_modified": "2024-12-23T21:10:33Z",
+      "plugin_version": "0.0.2",
+      "resolved": "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#nodejs_22",
+      "source": "devbox-search",
+      "version": "22.11.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/9vkabbbbyfn8hv5l1r8fm59d27imq460-nodejs-22.11.0",
+              "default": true
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/m3rxxwm6jp95kjmh4rklqn0d76biz6wm-nodejs-22.11.0-libv8"
+            }
+          ],
+          "store_path": "/nix/store/9vkabbbbyfn8hv5l1r8fm59d27imq460-nodejs-22.11.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/z2lznj5fq0wagkhj7nkgmb5yr4gyv0ws-nodejs-22.11.0",
+              "default": true
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/0xiwppqyszilzy9cg71c26fxg5qcxh89-nodejs-22.11.0-libv8"
+            }
+          ],
+          "store_path": "/nix/store/z2lznj5fq0wagkhj7nkgmb5yr4gyv0ws-nodejs-22.11.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/s81s2z275wnjazk4ij3zvn6kslfa5ipf-nodejs-22.11.0",
+              "default": true
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/mm87n14lp5akdjlfwh1yg4l93zm8gv9h-nodejs-22.11.0-libv8"
+            }
+          ],
+          "store_path": "/nix/store/s81s2z275wnjazk4ij3zvn6kslfa5ipf-nodejs-22.11.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/fkyp1bm5gll9adnfcj92snyym524mdrj-nodejs-22.11.0",
+              "default": true
+            },
+            {
+              "name": "libv8",
+              "path": "/nix/store/fyaac3q8qn3zfxy72airfabm3dakmgf5-nodejs-22.11.0-libv8"
+            }
+          ],
+          "store_path": "/nix/store/fkyp1bm5gll9adnfcj92snyym524mdrj-nodejs-22.11.0"
+        }
+      }
+    },
+    "ocrmypdf@latest": {
+      "last_modified": "2025-03-23T05:31:05Z",
+      "resolved": "github:NixOS/nixpkgs/dd613136ee91f67e5dba3f3f41ac99ae89c5406b#ocrmypdf",
+      "source": "devbox-search",
+      "version": "16.10.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/6ifahqn3cqibm4bikp076v604ny4md0d-python3.12-ocrmypdf-16.10.0",
+              "default": true
+            },
+            {
+              "name": "dist",
+              "path": "/nix/store/ch370cay4cg02ylci54qj6j6n4wbif0z-python3.12-ocrmypdf-16.10.0-dist"
+            }
+          ],
+          "store_path": "/nix/store/6ifahqn3cqibm4bikp076v604ny4md0d-python3.12-ocrmypdf-16.10.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/3hzqiwn47fs4wx47fpagjjwikny4c9vn-python3.12-ocrmypdf-16.10.0",
+              "default": true
+            },
+            {
+              "name": "dist",
+              "path": "/nix/store/41r9ycck5v3vj8ihlv0jch2g6javqnqc-python3.12-ocrmypdf-16.10.0-dist"
+            }
+          ],
+          "store_path": "/nix/store/3hzqiwn47fs4wx47fpagjjwikny4c9vn-python3.12-ocrmypdf-16.10.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/5gdgv6v1crv3di8q7iinq3ykbppr6bnz-python3.12-ocrmypdf-16.10.0",
+              "default": true
+            },
+            {
+              "name": "dist",
+              "path": "/nix/store/p1csj2xidgd5kd2pm04wdi73ybwx6xr9-python3.12-ocrmypdf-16.10.0-dist"
+            }
+          ],
+          "store_path": "/nix/store/5gdgv6v1crv3di8q7iinq3ykbppr6bnz-python3.12-ocrmypdf-16.10.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/hx30qsd226by6v12jadrl3qd7dd4sab3-python3.12-ocrmypdf-16.10.0",
+              "default": true
+            },
+            {
+              "name": "dist",
+              "path": "/nix/store/1ipara5hv3i2p3vhc2f5ns7qkc3iarhv-python3.12-ocrmypdf-16.10.0-dist"
+            }
+          ],
+          "store_path": "/nix/store/hx30qsd226by6v12jadrl3qd7dd4sab3-python3.12-ocrmypdf-16.10.0"
+        }
+      }
+    },
+    "poppler@latest": {
+      "last_modified": "2025-03-11T17:52:14Z",
+      "resolved": "github:NixOS/nixpkgs/0d534853a55b5d02a4ababa1d71921ce8f0aee4c#poppler",
+      "source": "devbox-search",
+      "version": "24.02.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/v879dwdr82f62jqm3xij4phidk40v7yw-poppler-glib-24.02.0",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/bc92d317jg0dd998wiq81kpsj1r08qm5-poppler-glib-24.02.0-dev"
+            }
+          ],
+          "store_path": "/nix/store/v879dwdr82f62jqm3xij4phidk40v7yw-poppler-glib-24.02.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/49dzf9b9k8kv55xb1yk74w88klfmrb7j-poppler-glib-24.02.0",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/z497k5aln4v26zgk4zsi6qj5q50jy8md-poppler-glib-24.02.0-dev"
+            }
+          ],
+          "store_path": "/nix/store/49dzf9b9k8kv55xb1yk74w88klfmrb7j-poppler-glib-24.02.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/z6b2031pv340idga1wbzb4lb6444z2ic-poppler-glib-24.02.0",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/qqs4zfk257rwk9a54bij0crpx2l9p7kj-poppler-glib-24.02.0-dev"
+            }
+          ],
+          "store_path": "/nix/store/z6b2031pv340idga1wbzb4lb6444z2ic-poppler-glib-24.02.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/4q6zs17804y15g1rrxnxprvyssnhmfbp-poppler-glib-24.02.0",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/bhalym2m37a8b1j21bcwc4gakx5nw6kl-poppler-glib-24.02.0-dev"
+            }
+          ],
+          "store_path": "/nix/store/4q6zs17804y15g1rrxnxprvyssnhmfbp-poppler-glib-24.02.0"
+        }
+      }
+    },
+    "postgresql@15.7": {
+      "last_modified": "2024-08-10T20:11:49Z",
+      "plugin_version": "0.0.2",
+      "resolved": "github:NixOS/nixpkgs/e1d92cda6fd1bcec60e4938ce92fcee619eea793#postgresql",
+      "source": "devbox-search",
+      "version": "15.7",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/j063gkab0kj312p0r5wlwh8hhs3ivmmv-postgresql-15.7",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/83zyb6qnvn85ilfb4g03yr8zjnc4kw5c-postgresql-15.7-man",
+              "default": true
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/w98l40gkbw15cxjajs9wr9aaz1zqq8pv-postgresql-15.7-doc"
+            },
+            {
+              "name": "lib",
+              "path": "/nix/store/2lqmjj3nwingqsajwgwym4jjl1plqrxd-postgresql-15.7-lib"
+            }
+          ],
+          "store_path": "/nix/store/j063gkab0kj312p0r5wlwh8hhs3ivmmv-postgresql-15.7"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/bm08f8k2gyndfq1mszvdm07jnmwr6nlf-postgresql-15.7",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/yd6qvs38zm55271230hfn4j0rd4029ca-postgresql-15.7-man",
+              "default": true
+            },
+            {
+              "name": "lib",
+              "path": "/nix/store/fvs07mhcygpwy41jhw34kq7ghlcnv4nf-postgresql-15.7-lib"
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/m8kdahlx418v1x8pvbjja5zbl8ix4hff-postgresql-15.7-debug"
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/nw2ng4sh1vzih1rrfzlivd2c7ifh9zm2-postgresql-15.7-doc"
+            }
+          ],
+          "store_path": "/nix/store/bm08f8k2gyndfq1mszvdm07jnmwr6nlf-postgresql-15.7"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/q4h9xjc0804xkcb0l7kxmp8rbqadlpg9-postgresql-15.7",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/22xrk7r5c4bh12wnmh4xssd1xk06b96l-postgresql-15.7-man",
+              "default": true
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/4ynkh5cclgi0jcg42868z764irl32dx3-postgresql-15.7-doc"
+            },
+            {
+              "name": "lib",
+              "path": "/nix/store/4bqzgkyvzc7c7i955raibmaqabffsi4y-postgresql-15.7-lib"
+            }
+          ],
+          "store_path": "/nix/store/q4h9xjc0804xkcb0l7kxmp8rbqadlpg9-postgresql-15.7"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/8gr5ybhmdkafii5idcg57p66nk1qd6sf-postgresql-15.7",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/0j6lskwq3imd8gdwy5rz9sjmn3c41qbc-postgresql-15.7-man",
+              "default": true
+            },
+            {
+              "name": "doc",
+              "path": "/nix/store/01snq9n6ka7zkb4dp7k639mbb5p0v5qi-postgresql-15.7-doc"
+            },
+            {
+              "name": "lib",
+              "path": "/nix/store/9xj29q1wf5wazv63hn5dxlwsp8k3h5lc-postgresql-15.7-lib"
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/xw1fhj72fzrlkvapaf1spx19ixqm7394-postgresql-15.7-debug"
+            }
+          ],
+          "store_path": "/nix/store/8gr5ybhmdkafii5idcg57p66nk1qd6sf-postgresql-15.7"
+        }
+      }
+    },
+    "python@3.9.1": {
+      "last_modified": "2024-09-10T15:01:03Z",
+      "plugin_version": "0.0.4",
+      "resolved": "github:NixOS/nixpkgs/5ed627539ac84809c78b2dd6d26a5cebeb5ae269#python39",
+      "source": "devbox-search",
+      "version": "3.9.19",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/wd2dpfz08lxa6lc0kvh0mfm7gwfi1y3d-python3-3.9.19",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/wd2dpfz08lxa6lc0kvh0mfm7gwfi1y3d-python3-3.9.19"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/zxkwfbmr2vh899f4j6cg4b3fknpv472k-python3-3.9.19",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/gc3ccasnkghh02zyhqr9k084gbzf27s9-python3-3.9.19-debug"
+            }
+          ],
+          "store_path": "/nix/store/zxkwfbmr2vh899f4j6cg4b3fknpv472k-python3-3.9.19"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/3kf5ip2gv94bxvmrhxcnp2487xi8srks-python3-3.9.19",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/3kf5ip2gv94bxvmrhxcnp2487xi8srks-python3-3.9.19"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/bss97archbk49yly549q9l4kw3cm55j9-python3-3.9.19",
+              "default": true
+            },
+            {
+              "name": "debug",
+              "path": "/nix/store/52msb18vapln4kiz4dzccjrp5yf7dz5r-python3-3.9.19-debug"
+            }
+          ],
+          "store_path": "/nix/store/bss97archbk49yly549q9l4kw3cm55j9-python3-3.9.19"
+        }
+      }
+    },
+    "ruby@3.2.6": {
+      "last_modified": "2025-03-11T17:52:14Z",
+      "plugin_version": "0.0.2",
+      "resolved": "github:NixOS/nixpkgs/0d534853a55b5d02a4ababa1d71921ce8f0aee4c#ruby_3_2",
+      "source": "devbox-search",
+      "version": "3.2.6",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/4x0k33lv5rkx61hnmpqz4nviw2qx1bpq-ruby-3.2.6",
+              "default": true
+            },
+            {
+              "name": "devdoc",
+              "path": "/nix/store/5cbmb14w1nbqfhifzhr9vn0wgyh2388y-ruby-3.2.6-devdoc"
+            }
+          ],
+          "store_path": "/nix/store/4x0k33lv5rkx61hnmpqz4nviw2qx1bpq-ruby-3.2.6"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/f02zwccza8bw16f2izpl1mp7c7gk9a62-ruby-3.2.6",
+              "default": true
+            },
+            {
+              "name": "devdoc",
+              "path": "/nix/store/qx6d9460b6hjaf89v0kva680z0wzdxir-ruby-3.2.6-devdoc"
+            }
+          ],
+          "store_path": "/nix/store/f02zwccza8bw16f2izpl1mp7c7gk9a62-ruby-3.2.6"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/lycwi4mg3q25p8wciqbzvn02klmdw9am-ruby-3.2.6",
+              "default": true
+            },
+            {
+              "name": "devdoc",
+              "path": "/nix/store/pkbvzhikm3c04xwb9apgw9bdnb5bi3vz-ruby-3.2.6-devdoc"
+            }
+          ],
+          "store_path": "/nix/store/lycwi4mg3q25p8wciqbzvn02klmdw9am-ruby-3.2.6"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/npxjgn860mgvfmh8zasrs78lq5sz5qyy-ruby-3.2.6",
+              "default": true
+            },
+            {
+              "name": "devdoc",
+              "path": "/nix/store/04pwnawqfa7dvb58hhi1jd3qipn2c9b8-ruby-3.2.6-devdoc"
+            }
+          ],
+          "store_path": "/nix/store/npxjgn860mgvfmh8zasrs78lq5sz5qyy-ruby-3.2.6"
+        }
+      }
+    },
+    "tesseract_4@latest": {
+      "last_modified": "2022-02-16T12:07:04Z",
+      "resolved": "github:NixOS/nixpkgs/b66b39216b1fef2d8c33cc7a5c72d8da80b79970#tesseract_4",
+      "source": "devbox-search",
+      "version": "4.1.1"
+    },
+    "tippecanoe@2.35.0": {
+      "last_modified": "2023-11-17T14:14:56Z",
+      "resolved": "github:NixOS/nixpkgs/a71323f68d4377d12c04a5410e214495ec598d4c#tippecanoe",
+      "source": "devbox-search",
+      "version": "2.35.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/w31857b15bhlr15ksh22dbiamwmbbf5n-tippecanoe-2.35.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/w31857b15bhlr15ksh22dbiamwmbbf5n-tippecanoe-2.35.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/7jkrwymgvh2aqch3av4d64d42xmw5lkq-tippecanoe-2.35.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/7jkrwymgvh2aqch3av4d64d42xmw5lkq-tippecanoe-2.35.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/l9m7adx1zbafc66d74isam24nd1544gf-tippecanoe-2.35.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/l9m7adx1zbafc66d74isam24nd1544gf-tippecanoe-2.35.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/5vxhv7867lkibnvhr7x3gwwx7zisky4k-tippecanoe-2.35.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/5vxhv7867lkibnvhr7x3gwwx7zisky4k-tippecanoe-2.35.0"
+        }
+      }
+    },
+    "vips@latest": {
+      "last_modified": "2025-03-26T18:47:43Z",
+      "resolved": "github:NixOS/nixpkgs/bd3bac8bfb542dbde7ffffb6987a1a1f9d41699f#vips",
+      "source": "devbox-search",
+      "version": "8.16.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/s47bd9ak6r629zsn1m9d7bqf3vrhyhk9-vips-8.16.0-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/sgs5i69ks5lqdcx33zxvn7wmvd9p37pw-vips-8.16.0-man",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/qj3pvvd8sggjr769nfq96kj6i90mwky7-vips-8.16.0-dev"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/akw4b5qqwiq1x63y1gzfvrkk63ssfpbj-vips-8.16.0"
+            }
+          ],
+          "store_path": "/nix/store/s47bd9ak6r629zsn1m9d7bqf3vrhyhk9-vips-8.16.0-bin"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/n3zh5cg0hszp9x1a78x24iis364gnh95-vips-8.16.0-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/6zxf93fd09i1aq83anv33q4mas5xir18-vips-8.16.0-man",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/k8aghv8qb015dhznkzjgf31472s6q3wd-vips-8.16.0-dev"
+            },
+            {
+              "name": "devdoc",
+              "path": "/nix/store/zkbq5ljkj7b7az811k1cja805im3h7yf-vips-8.16.0-devdoc"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/jb5wlqy6k899mmc9dgynay9f8c2lrgdj-vips-8.16.0"
+            }
+          ],
+          "store_path": "/nix/store/n3zh5cg0hszp9x1a78x24iis364gnh95-vips-8.16.0-bin"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/0d35lzq3srlk58vc3d7vbg9sj3nsldm7-vips-8.16.0-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/1fik15f3jpqxhlzd8c717kzdw5ygykgk-vips-8.16.0-man",
+              "default": true
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/657p215vv8j7x4dc9xxak80rrllqay94-vips-8.16.0"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/19x2jhv380zmna5p5yn3bp5l1xrvjchq-vips-8.16.0-dev"
+            }
+          ],
+          "store_path": "/nix/store/0d35lzq3srlk58vc3d7vbg9sj3nsldm7-vips-8.16.0-bin"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "bin",
+              "path": "/nix/store/4xf1vw1myb0ddik9kz0bw7ly7apv74m5-vips-8.16.0-bin",
+              "default": true
+            },
+            {
+              "name": "man",
+              "path": "/nix/store/5bf6l2w9sw6w8q4vrdjvr044ji98lp0a-vips-8.16.0-man",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/1xdlpkb2zj8rxarkp3l1r6q0qsx0rs14-vips-8.16.0-dev"
+            },
+            {
+              "name": "devdoc",
+              "path": "/nix/store/gdh554s5jks59r5al06rhffa27ycg464-vips-8.16.0-devdoc"
+            },
+            {
+              "name": "out",
+              "path": "/nix/store/lfklzryj7dph9rliy4544bpplfqx1b1q-vips-8.16.0"
+            }
+          ],
+          "store_path": "/nix/store/4xf1vw1myb0ddik9kz0bw7ly7apv74m5-vips-8.16.0-bin"
+        }
+      }
+    },
+    "yarn@1.22.10": {
+      "last_modified": "2021-08-01T02:58:48Z",
+      "resolved": "github:NixOS/nixpkgs/404cd360c2607bcfe8d05a7d5ae609d6605f7e22#yarn",
+      "source": "devbox-search",
+      "version": "1.22.10"
+    }
+  }
+}

--- a/devbox.lock
+++ b/devbox.lock
@@ -623,6 +623,70 @@
         }
       }
     },
+    "openjpeg@latest": {
+      "last_modified": "2025-03-11T17:52:14Z",
+      "resolved": "github:NixOS/nixpkgs/0d534853a55b5d02a4ababa1d71921ce8f0aee4c#openjpeg",
+      "source": "devbox-search",
+      "version": "2.5.2",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/pjnfmihawikjjr65600ypaagrhn9v0fa-openjpeg-2.5.2",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/49qln8gjhx7mrk3jblby4yk2fb05hapm-openjpeg-2.5.2-dev"
+            }
+          ],
+          "store_path": "/nix/store/pjnfmihawikjjr65600ypaagrhn9v0fa-openjpeg-2.5.2"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/7ipj9lwzjg8k2kgl8pjsihqa4jzgklgm-openjpeg-2.5.2",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/9bdsrlwggfyx1jgkp03y6fg5l0vsy35z-openjpeg-2.5.2-dev"
+            }
+          ],
+          "store_path": "/nix/store/7ipj9lwzjg8k2kgl8pjsihqa4jzgklgm-openjpeg-2.5.2"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/46nyhh6xwdpnmas41h4kc2ph2v589ajl-openjpeg-2.5.2",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/vlcmsr50v9bgdzax2srmvpglbix67373-openjpeg-2.5.2-dev"
+            }
+          ],
+          "store_path": "/nix/store/46nyhh6xwdpnmas41h4kc2ph2v589ajl-openjpeg-2.5.2"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/l80xwb9p00mqpbpzvsfihqk8vzak7bnf-openjpeg-2.5.2",
+              "default": true
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/irjfriawqs7fsyr9va9116gyn1wa30sm-openjpeg-2.5.2-dev"
+            }
+          ],
+          "store_path": "/nix/store/l80xwb9p00mqpbpzvsfihqk8vzak7bnf-openjpeg-2.5.2"
+        }
+      }
+    },
     "poppler@latest": {
       "last_modified": "2025-03-11T17:52:14Z",
       "resolved": "github:NixOS/nixpkgs/0d534853a55b5d02a4ababa1d71921ce8f0aee4c#poppler",

--- a/devbox.lock
+++ b/devbox.lock
@@ -261,9 +261,6 @@
         }
       }
     },
-    "github:NixOS/nixpkgs/nixpkgs-unstable": {
-      "resolved": "github:NixOS/nixpkgs/384d1adab77a8d49172a3acc1d5c2f26d013a69a?lastModified=1743598831&narHash=sha256-e10M97wGA0dpFAFnp1D0dgk9BcgphvuUeksDpDXMZRA%3D"
-    },
     "imagemagick6@latest": {
       "last_modified": "2025-03-23T05:31:05Z",
       "resolved": "github:NixOS/nixpkgs/dd613136ee91f67e5dba3f3f41ac99ae89c5406b#imagemagick6",
@@ -487,6 +484,54 @@
             }
           ],
           "store_path": "/nix/store/nv95nwhqrabvchsl0yf59i197viagk63-libffi-39"
+        }
+      }
+    },
+    "lsof@latest": {
+      "last_modified": "2025-03-11T17:52:14Z",
+      "resolved": "github:NixOS/nixpkgs/0d534853a55b5d02a4ababa1d71921ce8f0aee4c#lsof",
+      "source": "devbox-search",
+      "version": "4.99.4",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/fs6sn66n4dv6gnagvf8lgcy6x0jjgijd-lsof-4.99.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/fs6sn66n4dv6gnagvf8lgcy6x0jjgijd-lsof-4.99.4"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/a0kvnds1g3jmz7bx1ldwbihbqlzzmlsj-lsof-4.99.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/a0kvnds1g3jmz7bx1ldwbihbqlzzmlsj-lsof-4.99.4"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/bqh7ipnb6cxi140h660h0v37s05d2kmm-lsof-4.99.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/bqh7ipnb6cxi140h660h0v37s05d2kmm-lsof-4.99.4"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/zqc3zaffcpgybm89jdkjgf5m7jk62lxq-lsof-4.99.4",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/zqc3zaffcpgybm89jdkjgf5m7jk62lxq-lsof-4.99.4"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -58,5 +58,6 @@
     "vite": "^5.2",
     "vite-plugin-ruby": "^5.0",
     "vitest": "^1.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -4,11 +4,11 @@ processes:
     shutdown:
       command: "podman stop figgy_db"
   test_solr:
-    command: "podman run -v /mnt/app/solr/config/:/figgy_core/conf --rm --name figgy_test_solr -p 9551:8983 solr:7 solr-precreate figgy-core-test /figgy_core"
+    command: "podman run -v /mnt/$(pwd)/solr/config/:/figgy_core/conf --rm --name figgy_test_solr -p 9551:8983 solr:7 solr-precreate figgy-core-test /figgy_core"
     shutdown:
       command: "podman stop figgy_test_solr"
   dev_solr:
-    command: "podman run -v /mnt/app/solr/config/:/figgy_core/conf --rm --name figgy_dev_solr -p 9552:8983 solr:7 solr-precreate figgy-core-dev /figgy_core"
+    command: "podman run -v /mnt/$(pwd)/solr/config/:/figgy_core/conf --rm --name figgy_dev_solr -p 9552:8983 solr:7 solr-precreate figgy-core-dev /figgy_core"
     shutdown:
       command: "podman stop figgy_dev_solr"
   redis:

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -1,0 +1,21 @@
+processes:
+  postgresql:
+    command: "podman run -e POSTGRES_PASSWORD=password --rm --name figgy_db -p 9550:5432 postgres:15"
+    shutdown:
+      command: "podman stop figgy_db"
+  test_solr:
+    command: "podman run -v /mnt/app/solr/config/:/figgy_core/conf --rm --name figgy_test_solr -p 9551:8983 solr:7 solr-precreate figgy-core-test /figgy_core"
+    shutdown:
+      command: "podman stop figgy_test_solr"
+  dev_solr:
+    command: "podman run -v /mnt/app/solr/config/:/figgy_core/conf --rm --name figgy_dev_solr -p 9552:8983 solr:7 solr-precreate figgy-core-dev /figgy_core"
+    shutdown:
+      command: "podman stop figgy_dev_solr"
+  redis:
+    command: "podman run --rm --name figgy_redis -p 9553:6379 redis"
+    shutdown:
+      command: "podman stop figgy_redis"
+  chrome:
+    command: "podman run -e START_XVFB=true -e SE_NODE_MAX_SESSIONS=20 -e SE_NODE_OVERRIDE_MAX_SESSIONS=true --rm --name figgy_chrome -p 4445:4444 -p 5900:5900 -p 7900:7900 -v /dev/shm:/dev/shm seleniarm/standalone-chromium:114.0"
+    shutdown:
+      command: "podman stop figgy_chrome"

--- a/spec/derivative_services/vips_derivative_service_spec.rb
+++ b/spec/derivative_services/vips_derivative_service_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe VipsDerivativeService do
 
       expect(derivative).to be_present
       derivative_file = Valkyrie::StorageAdapter.find_by(id: derivative.file_identifiers.first)
-      expect(Vips::Image.new_from_file(derivative_file.disk_path.to_s).height).to eq 144
+      expect(Vips::Image.magickload(derivative_file.disk_path.to_s).height).to eq 144
     end
     it "uploads it with the appropriate metadata" do
       allow(storage_adapter).to receive(:upload).and_call_original


### PR DESCRIPTION
This is the first time I've gotten Figgy's full suite to run without a bunch of fiddling in my environment in a long time.

Could someone try this out and see if it also works for them?

To set up you do this:

```
curl -fsSL https://get.jetify.com/devbox | bash
devbox run setup
devbox shell
./bin/parallel_rspec_coverage
```

There's no lando or anything, this installs `podman` and runs the containers as services when you setup.