### PR TITLE
WIP: Create PDF derivatives as "derivative partials" on a PDF FileSet.

### DIFF
--- a/app/derivative_services/pdf_derivative_service.rb
+++ b/app/derivative_services/pdf_derivative_service.rb
@@ -65,10 +65,10 @@ class PDFDerivativeService
   end
 
   # Delete the filesets that were generated from the pdf.
-  # TODO: Also cleanup the old versions if they're around.
+  # TODO: Also cleanup the old versions (derivatives of intermediate files) if they're around.
   def cleanup_derivatives
     deleted_file_metadata_identifiers = resource.derivative_partial_files.select(&:derivative_partial?).flat_map(&:file_identifiers)
-    change_set.file_metadata = change_set.file_metadata.reject(&:derivative_partial?)
+    change_set.validate(file_metadata: change_set.file_metadata.reject(&:derivative_partial?))
     buffered do
       @resource = change_set_persister.save(change_set: change_set)
     end

--- a/app/derivative_services/pdf_derivative_service.rb
+++ b/app/derivative_services/pdf_derivative_service.rb
@@ -65,6 +65,7 @@ class PDFDerivativeService
   end
 
   # Delete the filesets that were generated from the pdf.
+  # TODO: Also cleanup the old versions if they're around.
   def cleanup_derivatives
     deleted_file_metadata_identifiers = resource.derivative_partial_files.select(&:derivative_partial?).flat_map(&:file_identifiers)
     change_set.file_metadata = change_set.file_metadata.reject(&:derivative_partial?)

--- a/app/derivative_services/vips_derivative_service.rb
+++ b/app/derivative_services/vips_derivative_service.rb
@@ -16,6 +16,19 @@ class VipsDerivativeService
     end
   end
 
+  def self.save_tiff(vips_image, path)
+    vips_image.tiffsave(
+      path,
+      compression: :jpeg,
+      tile: true,
+      pyramid: true,
+      Q: 90,
+      tile_width: 1024,
+      tile_height: 1024,
+      strip: true
+    )
+  end
+
   class IoDecorator < SimpleDelegator
     attr_reader :original_filename, :content_type, :use, :upload_options
     def initialize(io, original_filename, content_type, use, upload_options: {})
@@ -81,16 +94,7 @@ class VipsDerivativeService
   end
 
   def run_derivatives
-    vips_image.tiffsave(
-      temporary_output.path.to_s,
-      compression: :jpeg,
-      tile: true,
-      pyramid: true,
-      Q: 90,
-      tile_width: 1024,
-      tile_height: 1024,
-      strip: true
-    )
+    self.class.save_tiff(vips_image, temporary_output.path.to_s)
     raise "Unable to store pyramidal TIFF for #{filename}!" unless File.exist?(temporary_output.path)
   end
 

--- a/app/models/concerns/blacklight_iiif_search/annotation_behavior.rb
+++ b/app/models/concerns/blacklight_iiif_search/annotation_behavior.rb
@@ -25,12 +25,12 @@ module BlacklightIiifSearch
     end
 
     def child_manifest_node
-      @child_manifest_node ||= ManifestBuilder::LeafNode.new(
+      @child_manifest_node ||= Array.wrap(ManifestBuilder::LeafNode.for(
         Valkyrie::MetadataAdapter.find(:index_solr).resource_factory.to_resource(
           object: document.to_h
         ),
         parent_manifest_node
-      )
+      )).first
     end
 
     ##

--- a/app/models/ingestable_file.rb
+++ b/app/models/ingestable_file.rb
@@ -23,6 +23,7 @@ class IngestableFile < Valkyrie::Resource
   #   `lae_storage` or `disk_via_copy` storage adapter, which is the case for the
   #   various bulk ingest jobs.
   attribute :copy_before_ingest, Valkyrie::Types::Bool
+  attribute :upload_options, Valkyrie::Types::Hash.optional
 
   def content_type
     mime_type

--- a/app/nested_resources/file_metadata.rb
+++ b/app/nested_resources/file_metadata.rb
@@ -31,6 +31,7 @@ class FileMetadata < Valkyrie::Resource
 
   # PDF Metadata
   attribute :page_count, Valkyrie::Types::Integer
+  attribute :page, Valkyrie::Types::Integer
 
   # Caption Metadata
   attribute :caption_language, Valkyrie::Types::Set

--- a/app/services/cdl/automatic_completer.rb
+++ b/app/services/cdl/automatic_completer.rb
@@ -68,8 +68,7 @@ module CDL
 
       def pages_match?
         first_member.mime_type.include?("application/pdf")
-        # The first member is the PDF itself, so do member_count - 1.
-        pdf_page_count == resource.member_ids.size - 1
+        pdf_page_count == first_member.derivative_partial_files.length
       end
 
       def manifest_generates?

--- a/app/services/file_appender.rb
+++ b/app/services/file_appender.rb
@@ -155,7 +155,7 @@ class FileAppender
     # Extensions for primary_files that shouldn't be used as thumbnails.
     # @return [Array<String>] the file extensions
     def no_thumbnail_extensions
-      [".xml", ".pdf"]
+      [".xml"]
     end
 
     # Returns a thumbnail id for the parent and a array of file_sets.

--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -533,7 +533,7 @@ class ManifestBuilder
       if (Rails.env.development? && Figgy.config["pyramidals_bucket"].blank?) || Rails.env.test?
         RiiifHelper.new.base_url("#{resource.id}~#{file_metadata&.id || resource.pyramidal_derivative&.id}")
       else
-        PyramidalHelper.new.base_url(resource, file_metadata = nil)
+        PyramidalHelper.new.base_url(resource, file_metadata)
       end
     end
 

--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -391,7 +391,7 @@ class ManifestBuilder
   class LeafNode
     def self.for(resource, parent_node)
       # If it's a PDF we need to render every page.
-      if resource.mime_type.include?("application/pdf") && resource.derivative_partial_files.present?
+      if resource.mime_type&.include?("application/pdf") && resource.derivative_partial_files.present?
         resource.derivative_partial_files.map do |pdf_page|
           new(resource, parent_node, pdf_page)
         end

--- a/app/services/manifest_builder/canvas_builder.rb
+++ b/app/services/manifest_builder/canvas_builder.rb
@@ -9,7 +9,7 @@ class ManifestBuilder
     end
 
     def apply(sequence)
-      return sequence if record.resource.mime_type.include?("application/pdf")
+      return sequence if record.resource.mime_type.include?("application/pdf") && record.resource.derivative_partial_files.empty?
       super
     end
 

--- a/app/services/manifest_builder/media_sequence_builder.rb
+++ b/app/services/manifest_builder/media_sequence_builder.rb
@@ -10,7 +10,7 @@ class ManifestBuilder
     end
 
     def apply(manifest)
-      return manifest unless resource.leaf_nodes&.first&.mime_type == ["application/pdf"]
+      return manifest unless resource.leaf_nodes&.first&.mime_type == ["application/pdf"] && resource.leaf_nodes&.first&.derivative_partial_files&.empty?
       return manifest if pdf_node.primary_file.preservation_file?
       manifest["mediaSequences"] = [media_sequence]
       manifest

--- a/app/services/manifest_builder/start_canvas_builder.rb
+++ b/app/services/manifest_builder/start_canvas_builder.rb
@@ -20,7 +20,7 @@ class ManifestBuilder
 
       def path
         canvas_builder.new(
-          ManifestBuilder::LeafNode.new(file_set, resource),
+          Array.wrap(ManifestBuilder::LeafNode.for(file_set, resource)).first,
           resource
         ).path
       end

--- a/app/services/riiif_resolver.rb
+++ b/app/services/riiif_resolver.rb
@@ -3,10 +3,12 @@ class RiiifResolver < Riiif::AbstractFileSystemResolver
   attr_writer :input_types
   delegate :query_service, to: :metadata_adapter
 
-  def pattern(id)
-    raise ArgumentError, "Invalid characters in id `#{id}`" unless /^[\w\-:]+$/.match?(id)
+  def pattern(combined_id)
+    raise ArgumentError, "Invalid characters in id `#{combined_id}`" unless /^[\w\-:~]+$/.match?(combined_id)
+    id, file_metadata_id = combined_id.split("~")
     file_set = query_service.find_by(id: Valkyrie::ID.new(id))
-    file_metadata = file_set.derivative_files.find { |x| x.mime_type == ["image/tiff"] } || file_set.derivative_file
+    file_metadata = file_set.file_metadata.find { |x| x.id.to_s == file_metadata_id }
+    file_metadata ||= file_set.derivative_files.find { |x| x.mime_type == ["image/tiff"] } || file_set.derivative_file
     raise Valkyrie::Persistence::ObjectNotFoundError, id if file_metadata.nil?
     derivative_file = Valkyrie::StorageAdapter.find_by(id: file_metadata.file_identifiers.first)
     derivative_file.io.path

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -460,7 +460,7 @@ Rails.application.config.to_prepare do
   Valkyrie::Derivatives::DerivativeService.services << PDFDerivativeService::Factory.new(
     change_set_persister: ::ChangeSetPersister.new(
       metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister),
-      storage_adapter: Valkyrie::StorageAdapter.find(:disk)
+      storage_adapter: Valkyrie::StorageAdapter.find(:derivatives)
     )
   )
 

--- a/spec/controllers/bulk_ingest_controller_spec.rb
+++ b/spec/controllers/bulk_ingest_controller_spec.rb
@@ -316,13 +316,12 @@ RSpec.describe BulkIngestController do
       reloaded1 = query_service.find_by(id: folder1.id)
       reloaded2 = query_service.find_by(id: folder2.id)
 
-      # 6 files, 2 extras get made because the PDF generates two derivatives and
-      # attaches them.
-      expect(reloaded1.member_ids.length).to eq 8
+      # 6 files
+      expect(reloaded1.member_ids.length).to eq 6
       expect(reloaded2.member_ids.length).to eq 2
 
       file_sets = query_service.find_members(resource: reloaded1)
-      expect(file_sets.flat_map(&:mime_type).to_a).to eq ["image/tiff", "audio/mpeg", "audio/x-wav", "video/mp4", "image/tiff", "application/pdf", "image/tiff", "image/tiff"]
+      expect(file_sets.flat_map(&:mime_type).to_a).to eq ["image/tiff", "audio/mpeg", "audio/x-wav", "video/mp4", "image/tiff", "application/pdf"]
 
       file_sets = query_service.find_members(resource: reloaded2)
       expect(file_sets.flat_map(&:title).to_a).to eq ["1", "2"]

--- a/spec/services/cdl/automatic_completer_spec.rb
+++ b/spec/services/cdl/automatic_completer_spec.rb
@@ -48,7 +48,8 @@ RSpec.describe CDL::AutomaticCompleter do
         described_class.run
 
         resource = query_service.find_by(id: resource.id)
-        expect(resource.member_ids.length).to eq 3
+        expect(resource.member_ids.length).to eq 1
+        expect(Wayfinder.for(resource).members.first.derivative_partial_files.length).to eq 2
         expect(resource.state).to eq ["complete"]
         expect(ActionMailer::Base.deliveries.size).to eq 1
         mail = ActionMailer::Base.deliveries.first

--- a/spec/services/manifest_builder/by_resource_type/manifest_builder_scanned_resource_spec.rb
+++ b/spec/services/manifest_builder/by_resource_type/manifest_builder_scanned_resource_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe ManifestBuilder do
     end
   end
 
-  context "when given a PDF ScannedResource", run_real_characterization: true do
+  context "when given a PDF ScannedResource", run_real_derivatives: true, run_real_characterization: true do
     let(:file) { fixture_file_upload("files/sample.pdf", "application/pdf") }
     let(:change_set) { ScannedResourceChangeSet.new(scanned_resource, files: [file]) }
     before do
@@ -231,6 +231,7 @@ RSpec.describe ManifestBuilder do
       expect(output["mediaSequences"]).to be_nil
       canvases = output["sequences"].first["canvases"]
       expect(canvases.length).to eq 2
+      expect(canvases[0]["label"]).to eq "00000001"
     end
   end
 

--- a/spec/services/manifest_builder_v3/canvas_builder_spec.rb
+++ b/spec/services/manifest_builder_v3/canvas_builder_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ManifestBuilderV3::CanvasBuilder do
   let(:root_node) { ManifestBuilderV3::RootNode.new(scanned_resource) }
   let(:builder) do
     described_class.new(
-      ManifestBuilderV3::LeafNode.new(record, root_node),
+      ManifestBuilderV3::LeafNode.for(record, root_node),
       root_node,
       iiif_canvas_factory: ManifestBuilderV3::ManifestServiceLocator.iiif_canvas_factory,
       content_builder: ManifestBuilderV3::ManifestServiceLocator.content_builder,

--- a/spec/services/manifest_builder_v3/canvas_builder_spec.rb
+++ b/spec/services/manifest_builder_v3/canvas_builder_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ManifestBuilderV3::CanvasBuilder do
   let(:root_node) { ManifestBuilderV3::RootNode.new(scanned_resource) }
   let(:builder) do
     described_class.new(
-      ManifestBuilderV3::LeafNode.for(record, root_node),
+      ManifestBuilderV3::LeafNode.new(record, root_node),
       root_node,
       iiif_canvas_factory: ManifestBuilderV3::ManifestServiceLocator.iiif_canvas_factory,
       content_builder: ManifestBuilderV3::ManifestServiceLocator.content_builder,


### PR DESCRIPTION
This would:

1. Allow for multiple PDFs in a resource.
2. Prevent folks from adding structure (which is super fragile and would be lost on recreating derivatives) to PDFs.
3. This seems to speed up PDF derivative generation quite a lot - I think because it goes directly from the PDF to pyramidal tiffs with no need for characterization or more derivative jobs.

Current challenges:

1. How to keep this backwards compatible
2. How to still allow for per-page OCR.
4. How should the structure manager work here? Put all canvases from that file set in the node you put it in?