### PR TITLE
Allow serials to render in UV by flattening manifests

### DIFF
--- a/app/controllers/scanned_maps_controller.rb
+++ b/app/controllers/scanned_maps_controller.rb
@@ -20,7 +20,7 @@ class ScannedMapsController < ScannedResourcesController
   end
 
   # Override to force v3 manifests
-  def cached_manifest(resource, auth_token_param)
+  def cached_manifest(resource, auth_token_param, _flatten = false)
     Rails.cache.fetch("#{ManifestKey.for(resource)}/#{auth_token_param}") do
       ManifestBuilderV3.new(resource, auth_token_param).build.to_json
     end

--- a/app/controllers/scanned_resources_controller.rb
+++ b/app/controllers/scanned_resources_controller.rb
@@ -39,19 +39,19 @@ class ScannedResourcesController < ResourcesController
     authorize! :manifest, @resource
     respond_to do |f|
       f.json do
-        render json: cached_manifest(@resource, auth_token_param)
+        render json: cached_manifest(@resource, auth_token_param, params[:flatten] == "true")
       end
     end
   end
 
-  def cached_manifest(resource, auth_token_param)
-    Rails.cache.fetch("#{ManifestKey.for(resource)}/#{auth_token_param}") do
+  def cached_manifest(resource, auth_token_param, flatten)
+    Rails.cache.fetch("#{ManifestKey.for(resource)}/#{flatten}/#{auth_token_param}") do
       builder_klass = if Wayfinder.for(resource).first_member.try(:av?)
                         ManifestBuilderV3
                       else
                         ManifestBuilder
                       end
-      builder_klass.new(resource, auth_token_param).build.to_json
+      builder_klass.new(resource, auth_token_param, nil, flatten).build.to_json
     end
   end
 

--- a/app/services/manifest_builder.rb
+++ b/app/services/manifest_builder.rb
@@ -4,8 +4,8 @@ class ManifestBuilder
 
   ##
   # @param [Resource] resource the Resource subject
-  def initialize(resource, auth_token = nil, current_ability = nil)
-    @resource = RootNode.for(resource, auth_token, current_ability)
+  def initialize(resource, auth_token = nil, current_ability = nil, flatten = false)
+    @resource = RootNode.for(resource, auth_token, current_ability, flatten)
   end
 
   ##
@@ -18,7 +18,7 @@ class ManifestBuilder
   ##
   # Presenter modeling the Resource subjects as root nodes
   class RootNode
-    def self.for(resource, auth_token = nil, current_ability = nil)
+    def self.for(resource, auth_token = nil, current_ability = nil, flatten = false)
       case resource
       when Collection
         case ChangeSet.for(resource)
@@ -28,15 +28,15 @@ class ManifestBuilder
           CollectionNode.new(resource, nil, current_ability)
         end
       when EphemeraProject
-        EphemeraProjectNode.new(resource)
+        EphemeraProjectNode.new(resource, nil, nil, flatten)
       when EphemeraFolder
-        EphemeraFolderNode.new(resource)
+        EphemeraFolderNode.new(resource, nil, nil, flatten)
       when IndexCollection
-        IndexCollectionNode.new(resource)
+        IndexCollectionNode.new(resource, nil, nil, flatten)
       when ScannedMap
-        ScannedMapNode.new(resource)
+        ScannedMapNode.new(resource, nil, nil, flatten)
       when Numismatics::Issue
-        Numismatics::IssueNode.new(resource)
+        Numismatics::IssueNode.new(resource, nil, nil, flatten)
       when Playlist
         ManifestBuilderV3::RootNode.for(resource, auth_token, current_ability)
       else
@@ -44,11 +44,12 @@ class ManifestBuilder
         when RecordingChangeSet
           ManifestBuilderV3::RootNode.for(resource, auth_token, current_ability)
         else
-          new(resource, auth_token)
+          new(resource, auth_token, nil, flatten)
         end
       end
     end
-    attr_reader :resource, :auth_token, :current_ability
+    attr_reader :resource, :auth_token, :current_ability, :flatten
+    attr_accessor :child_of
     delegate :query_service, to: :metadata_adapter
     delegate :decorate, :to_model, :id, to: :resource
 
@@ -58,10 +59,11 @@ class ManifestBuilder
 
     ##
     # @param [Resource] resource the Resource being modeled as the root
-    def initialize(resource, auth_token = nil, current_ability = nil)
+    def initialize(resource, auth_token = nil, current_ability = nil, flatten = false)
       @resource = resource
       @auth_token = auth_token
       @current_ability = current_ability
+      @flatten = flatten
     end
 
     ##
@@ -74,6 +76,10 @@ class ManifestBuilder
 
     def search_enabled?
       resource.try(:ocr_language).present?
+    end
+
+    def sammelband?
+      flatten == true
     end
 
     def description
@@ -93,7 +99,9 @@ class ManifestBuilder
     # @return [RootNode]
     def work_presenters
       @work_presenters ||= (members - leaf_nodes).map do |node|
-        RootNode.for(node)
+        RootNode.for(node).tap do |child_node|
+          child_node.child_of = self
+        end
       end
     end
 
@@ -110,9 +118,34 @@ class ManifestBuilder
     # Retrieves the presenter for each Range (sc:Range) instance
     # @return [TopStructure]
     def ranges
+      return sammelband_ranges if flatten
       logical_structure.map do |top_structure|
         TopStructure.new(top_structure, resource)
       end
+    end
+
+    def sammelband_ranges
+      [
+        TopStructure.new(
+          Structure.new(
+            label: "Logical",
+            nodes: work_presenters.map do |work_presenter|
+              StructureNode.new(
+                label: Array.wrap(work_presenter.to_s).first,
+                nodes: sammelband_work_structure(work_presenter)
+              )
+            end
+          ),
+          resource
+        )
+      ]
+    end
+
+    def sammelband_work_structure(work_presenter)
+      file_set = work_presenter.file_set_presenters.find { |x| x.resource.mime_type != ["application/pdf"] }
+      [
+        StructureNode.new(label: file_set.to_s, proxy: file_set.id)
+      ]
     end
 
     def collection?
@@ -123,7 +156,13 @@ class ManifestBuilder
     # Helper method for generating the URL to the resource manifest
     # @return [String]
     def manifest_url
-      helper.manifest_url(resource)
+      # We're a child resource being embedded - make sure our URL flattens.
+      # Don't flatten collections, they're used for DPUL indexing.
+      if child_of.present? && !child_of.try(:collection?)
+        "#{helper.manifest_url(resource)}?flatten=true"
+      else
+        helper.manifest_url(resource)
+      end
     end
 
     # Generate the IIIF Manifest metadata using the resource decorator

--- a/app/services/manifest_builder_v3.rb
+++ b/app/services/manifest_builder_v3.rb
@@ -3,7 +3,7 @@ class ManifestBuilderV3
   attr_reader :resource, :services
 
   # @param [Resource] resource the Resource subject
-  def initialize(resource, auth_token = nil, current_ability = nil)
+  def initialize(resource, auth_token = nil, current_ability = nil, _flatten = nil)
     @resource = RootNode.for(resource, auth_token, current_ability)
   end
 

--- a/spec/services/manifest_builder/by_resource_type/manifest_builder_collection_spec.rb
+++ b/spec/services/manifest_builder/by_resource_type/manifest_builder_collection_spec.rb
@@ -30,6 +30,8 @@ RSpec.describe ManifestBuilder do
       expect(output["metadata"]).not_to be_empty
       expect(output["metadata"].first).to include "label" => "Exhibit", "value" => [collection.decorate.slug]
       expect(output["manifests"].length).to eq 1
+      # It's important it doesn't flatten here, because we use this for DPUL
+      # indexing and that would break MVW manifest indexing.
       expect(output["manifests"][0]["@id"]).to eq "http://www.example.com/concern/scanned_resources/#{scanned_resource.id}/manifest"
       expect(output["viewingDirection"]).to eq nil
     end

--- a/spec/services/manifest_builder/by_resource_type/manifest_builder_mvw_spec.rb
+++ b/spec/services/manifest_builder/by_resource_type/manifest_builder_mvw_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ManifestBuilder do
     expect(output["thumbnail"]).to include "@id" => "http://www.example.com/image-service/#{child.member_ids.first.id}/full/!200,150/0/default.jpg"
 
     expect(output["manifests"].length).to eq 1
-    expect(output["manifests"][0]["@id"]).to eq "http://www.example.com/concern/scanned_resources/#{child.id}/manifest"
+    expect(output["manifests"][0]["@id"]).to eq "http://www.example.com/concern/scanned_resources/#{child.id}/manifest?flatten=true"
     expect(output["manifests"][0]["viewingHint"]).to be_nil
     expect(output["manifests"][0]["metadata"]).to be_nil
     expect(output["seeAlso"]).to include "@id" => "http://www.example.com/catalog/#{scanned_resource.id}.jsonld", "format" => "application/ld+json"

--- a/spec/services/manifest_builder/by_resource_type/manifest_builder_scanned_maps_spec.rb
+++ b/spec/services/manifest_builder/by_resource_type/manifest_builder_scanned_maps_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe ManifestBuilder do
       expect(output["@type"]).to eq "sc:Collection"
       expect(output["viewingHint"]).to eq "multi-part"
       expect(output["manifests"].length).to eq 1
-      expect(output["manifests"][0]["@id"]).to eq "http://www.example.com/concern/scanned_maps/#{volume1.id}/manifest"
+      expect(output["manifests"][0]["@id"]).to eq "http://www.example.com/concern/scanned_maps/#{volume1.id}/manifest?flatten=true"
       expect(output["manifests"][0]["viewingHint"]).to be_nil
       expect(output["manifests"][0]["metadata"]).to be_nil
     end


### PR DESCRIPTION
Manifests will now "flatten" (combine canvases and build a structure) if
they're navigated to via a multi-part collection, as the Universal
Viewer can't display collections of collections.

Work to support #6741
