### PR TITLE
ServerUploadJob shouldn't raise an error when object not found.

### DIFF
--- a/app/jobs/server_upload_job.rb
+++ b/app/jobs/server_upload_job.rb
@@ -24,6 +24,8 @@ class ServerUploadJob < ApplicationJob
         end
       end
     end
+  rescue Valkyrie::Persistence::ObjectNotFoundError
+    false
   end
 
   # We have access to the files on disk, so copy them from their locations.

--- a/spec/jobs/server_upload_job_spec.rb
+++ b/spec/jobs/server_upload_job_spec.rb
@@ -3,6 +3,15 @@ require "rails_helper"
 
 RSpec.describe ServerUploadJob do
   with_queue_adapter :inline
+  context "when a resource is gone" do
+    it "returns false and doesn't error" do
+      pending_upload = PendingUpload.new(
+        id: SecureRandom.uuid,
+        storage_adapter_id: "disk://#{Figgy.config['ingest_folder_path']}/examples/bulk_ingest/991234563506421/vol1/color.tif"
+      )
+      expect { described_class.perform_now(SecureRandom.uuid, [pending_upload.id.to_s]) }.not_to raise_error
+    end
+  end
   context "when given a resource and pending upload IDs" do
     it "creates and appends them" do
       pending_upload = PendingUpload.new(


### PR DESCRIPTION
You can't upload into non-existent objects, and we see this every week at honeybadger.