### PR TITLE
Fix generating vector thumbnails.

### DIFF
--- a/bin/mapnik_thumbnail
+++ b/bin/mapnik_thumbnail
@@ -6,6 +6,9 @@
 const fs = require('node:fs')
 const mapnik = require('@mapnik/mapnik')
 
+// Our templates use init rules, so set this.
+process.env.PROJ_USE_PROJ4_INIT_RULES = 'YES';
+
 mapnik.register_default_fonts()
 mapnik.register_default_input_plugins()
 

--- a/spec/derivative_services/vector_resource_derivative_service_spec.rb
+++ b/spec/derivative_services/vector_resource_derivative_service_spec.rb
@@ -49,6 +49,10 @@ RSpec.describe VectorResourceDerivativeService do
 
       expect(cloud_vector_file_set.use).to eq([::PcdmUse::CloudDerivative])
       expect(thumbnail_file.io.path).to start_with(Rails.root.join("tmp", Figgy.config["derivative_path"]).to_s)
+      image = Vips::Image.new_from_file(thumbnail_file.io.path)
+      # Generate the avg of the image bands to ensure it's the correct
+      # thumbnail. This is mostly white, but not -all- white.
+      expect(image.avg.round).to eq 250
       expect(cloud_vector_file.io.path).to start_with(Rails.root.join("tmp", Figgy.config["test_cloud_geo_derivative_path"]).to_s)
       expect(cloud_file_service).to have_received(:run)
     end


### PR DESCRIPTION
This has probably been broken ever since we updated mapnik and it
started using a new version of Proj. The problem was it'd just generate
a blank thumbnail happily, no errors.

Closes #6763 