### PR TITLE
Use google tag manager for Figgy.

### DIFF
--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -27,6 +27,7 @@
     <%= render 'shared/analytics' if Rails.env.production? %>
   </head>
   <body class="<%= render_body_class %>">
+    <%= render 'shared/analytics_noscript' if Rails.env.production? %>
     <div class="lux">
     <nav id="skip-link" role="navigation" aria-label="<%= t('blacklight.skip_links.label') %>">
       <%= link_to t('blacklight.skip_links.search_field'), '#search_field', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>

--- a/app/views/layouts/viewer_layout.html.erb
+++ b/app/views/layouts/viewer_layout.html.erb
@@ -9,6 +9,7 @@
     <script type="text/javascript" src="/uv/lib/offline.js"></script>
     <script type="text/javascript" src="/uv/lib/offline.js"></script>
     <script type="text/javascript" src="/uv/helpers.js"></script>
+    <%= render 'shared/analytics' if Rails.env.production? %>
     <% if Rails.env.staging? || Rails.env.production? %>
       <script defer event-environment="<%= Rails.env.to_s %>" event-embed-host="<%= params[:embed_host] || "unknown" %>" data-domain="dpul.princeton.edu" src="https://plausible.io/js/script.pageview-props.manual.js"></script>
       <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>

--- a/app/views/shared/_analytics.html.erb
+++ b/app/views/shared/_analytics.html.erb
@@ -1,9 +1,3 @@
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-2JF8QH5HFK"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-2JF8QH5HFK');
-</script>
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-TKVQSCRK');</script>
+<!-- End Google Tag Manager -->

--- a/app/views/shared/_analytics_noscript.html.erb
+++ b/app/views/shared/_analytics_noscript.html.erb
@@ -1,0 +1,3 @@
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TKVQSCRK"
+                  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>


### PR DESCRIPTION
This also adds local analytics for the viewer page - there's an
exception for the google tag in Google Tag Manager if it's on the viewer, so we maintain existing functionality.

Work towards pulibrary/dpul-collections#709
