### PR TITLE
Fix raster derivative generation error in tile_path

### DIFF
--- a/app/values/tile_path.rb
+++ b/app/values/tile_path.rb
@@ -35,7 +35,7 @@ class TilePath
       if mosaic?
         resource.id.to_s.delete("-")
       else
-        fs = query_service.custom_queries.mosaic_file_sets_for(id: resource.id).first
+        fs = file_sets.first
         fm = fs.file_metadata.find { |m| m.cloud_uri.present? }
         fm.cloud_uri.gsub(/^.*\/\//, "").split("/")[-2].delete("-")
       end
@@ -46,8 +46,7 @@ class TilePath
     end
 
     def valid?
-      file_count = resource.decorate.try(:mosaic_file_count)
-      return false unless file_count&.positive?
+      return false unless file_sets.count.positive?
       true
     end
 
@@ -56,6 +55,10 @@ class TilePath
       # This tests if there are multiple child raster FileSets.
       return true if raster_file_sets && raster_file_sets.count > 1
       false
+    end
+
+    def file_sets
+      @file_sets ||= query_service.custom_queries.mosaic_file_sets_for(id: resource.id)
     end
 
     def query_service

--- a/spec/values/tile_path_spec.rb
+++ b/spec/values/tile_path_spec.rb
@@ -29,5 +29,14 @@ describe TilePath do
         expect(described_class.new(raster).tilejson).to eq "https://map-tiles-test.example.com/testgeo/cog/WebMercatorQuad/tilejson.json"
       end
     end
+
+    context "with a RasterSet with a GeoTiff FileSet without derivatives" do
+      it "returns a nil tilejson path" do
+        file_set = FactoryBot.create_for_repository(:geo_raster_file_set, service_targets: ["tiles"])
+        raster = FactoryBot.create_for_repository(:raster_resource, member_ids: [file_set.id])
+
+        expect(described_class.new(raster).tilejson).to be_nil
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes #6777

When regenerating derivates, the old derivatives are removed, but that triggers an event to recalculate the mosaic tile path on the parent. The tile_path generator chokes when it finds a FileSet with a `tiles` service but no derivatives.