### PR TITLE
Cleanup geo derivative working files

### DIFF
--- a/app/derivative_services/geo_derivatives/processors/base_geo_processor.rb
+++ b/app/derivative_services/geo_derivatives/processors/base_geo_processor.rb
@@ -51,7 +51,8 @@ module GeoDerivatives
           output_size: output_size,
           output_srid: output_srid,
           basename: basename,
-          id: id
+          id: id,
+          working_dir: working_dir
         }
       end
 
@@ -84,6 +85,12 @@ module GeoDerivatives
       # @return [String] fileset id
       def id
         directives.fetch(:id, nil)
+      end
+
+      # Gets the temporary working directory
+      # @return [String] working directory path
+      def working_dir
+        directives.fetch(:working_dir, nil)
       end
     end
   end

--- a/app/derivative_services/geo_derivatives/processors/raster/base.rb
+++ b/app/derivative_services/geo_derivatives/processors/raster/base.rb
@@ -36,6 +36,17 @@ module GeoDerivatives
         def self.reproject_raster(in_path, out_path, options)
           run_commands(in_path, out_path, reproject_queue, options)
         end
+
+        def encode_file(file_suffix, options)
+          temp_file_name = output_file(file_suffix, options[:working_dir])
+          self.class.encode(source_path, options, temp_file_name)
+          output_file_service.call(File.open(temp_file_name, "rb"), directives)
+          File.unlink(temp_file_name)
+        end
+
+        def output_file(file_suffix, working_dir)
+          Dir::Tmpname.create(["raster_derivative", ".#{file_suffix}"], working_dir) {}
+        end
       end
     end
   end

--- a/app/derivative_services/geo_derivatives/processors/vector/base.rb
+++ b/app/derivative_services/geo_derivatives/processors/vector/base.rb
@@ -50,6 +50,17 @@ module GeoDerivatives
         def self.cloud_vector(in_path, out_path, options)
           run_commands(in_path, out_path, cloud_queue, options)
         end
+
+        def encode_file(file_suffix, options)
+          temp_file_name = output_file(file_suffix, options[:working_dir])
+          self.class.encode(source_path, options, temp_file_name)
+          output_file_service.call(File.open(temp_file_name, "rb"), directives)
+          File.unlink(temp_file_name)
+        end
+
+        def output_file(file_suffix, working_dir)
+          Dir::Tmpname.create(["vector_derivative", ".#{file_suffix}"], working_dir) {}
+        end
       end
     end
   end

--- a/app/derivative_services/raster_resource_derivative_service.rb
+++ b/app/derivative_services/raster_resource_derivative_service.rb
@@ -129,11 +129,11 @@ class RasterResourceDerivativeService
   end
 
   def temporary_display_output
-    @temporary_display_output ||= Tempfile.new("raster_display", Hydra::Derivatives.temp_file_base)
+    @temporary_display_output ||= Tempfile.new("raster_display", temporary_working_directory)
   end
 
   def temporary_thumbnail_output
-    @temporary_thumbnail_output ||= Tempfile.new("raster_thumb", Hydra::Derivatives.temp_file_base)
+    @temporary_thumbnail_output ||= Tempfile.new("raster_thumb", temporary_working_directory)
   end
 
   def update_cloud_acl

--- a/app/derivative_services/raster_resource_derivative_service.rb
+++ b/app/derivative_services/raster_resource_derivative_service.rb
@@ -30,7 +30,7 @@ class RasterResourceDerivativeService
 
   def build_cloud_file
     IngestableFile.new(file_path: temporary_display_output.path, mime_type: "image/tiff; gdal-format=GTiff", original_filename: "display_raster.tif", use: use_cloud_derivative,
-                       copy_before_ingest: false)
+                       copy_before_ingest: true)
   end
 
   def build_thumbnail_file

--- a/app/derivative_services/vector_resource_derivative_service.rb
+++ b/app/derivative_services/vector_resource_derivative_service.rb
@@ -127,11 +127,11 @@ class VectorResourceDerivativeService
   end
 
   def temporary_cloud_output
-    @temporary_cloud_output ||= Tempfile.new("vector_cloud", Hydra::Derivatives.temp_file_base)
+    @temporary_cloud_output ||= Tempfile.new("vector_cloud", temporary_working_directory)
   end
 
   def temporary_thumbnail_output
-    @temporary_thumbnail_output ||= Tempfile.new("vector_thumb", Hydra::Derivatives.temp_file_base)
+    @temporary_thumbnail_output ||= Tempfile.new("vector_thumb", temporary_working_directory)
   end
 
   def update_cloud_acl

--- a/app/derivative_services/vector_resource_derivative_service.rb
+++ b/app/derivative_services/vector_resource_derivative_service.rb
@@ -63,6 +63,10 @@ class VectorResourceDerivativeService
       update_error_message(message: error.message)
     end
     raise error
+  ensure
+    FileUtils.rmtree(temporary_working_directory) if Dir.exist?(temporary_working_directory)
+    File.unlink(temporary_cloud_output.path) if File.exist?(temporary_cloud_output.path)
+    File.unlink(temporary_thumbnail_output.path) if File.exist?(temporary_thumbnail_output.path)
   end
 
   def cloud_storage_adapter
@@ -84,7 +88,8 @@ class VectorResourceDerivativeService
       id: prefixed_id,
       format: "pmtiles",
       srid: "EPSG:4326",
-      url: URI("file://#{temporary_cloud_output.path}")
+      url: URI("file://#{temporary_cloud_output.path}"),
+      working_dir: temporary_working_directory
     }
   end
 
@@ -95,7 +100,8 @@ class VectorResourceDerivativeService
       id: resource.id,
       format: "png",
       size: "200x150",
-      url: URI("file://#{temporary_thumbnail_output.path}")
+      url: URI("file://#{temporary_thumbnail_output.path}"),
+      working_dir: temporary_working_directory
     }
   end
 
@@ -116,12 +122,16 @@ class VectorResourceDerivativeService
     )
   end
 
+  def temporary_working_directory
+    @temporary_working_directory ||= Dir.mktmpdir("vector_working_dir", Hydra::Derivatives.temp_file_base)
+  end
+
   def temporary_cloud_output
-    @temporary_cloud_output ||= Tempfile.new
+    @temporary_cloud_output ||= Tempfile.new("vector_cloud", Hydra::Derivatives.temp_file_base)
   end
 
   def temporary_thumbnail_output
-    @temporary_thumbnail_output ||= Tempfile.new
+    @temporary_thumbnail_output ||= Tempfile.new("vector_thumb", Hydra::Derivatives.temp_file_base)
   end
 
   def update_cloud_acl

--- a/app/derivative_services/vector_resource_derivative_service.rb
+++ b/app/derivative_services/vector_resource_derivative_service.rb
@@ -30,7 +30,7 @@ class VectorResourceDerivativeService
 
   def build_cloud_file
     IngestableFile.new(file_path: temporary_cloud_output.path, mime_type: "application/vnd.pmtiles", original_filename: "display_vector.pmtiles", use: use_cloud_derivative,
-                       copy_before_ingest: false)
+                       copy_before_ingest: true)
   end
 
   def build_thumbnail_file

--- a/spec/derivative_services/raster_resource_derivative_service_spec.rb
+++ b/spec/derivative_services/raster_resource_derivative_service_spec.rb
@@ -40,6 +40,16 @@ RSpec.describe RasterResourceDerivativeService do
   end
 
   context "with a valid geotiff" do
+    let(:temp_dir) { Rails.root.join("tmp", "temp_dir") }
+
+    before do
+      Dir.mkdir(temp_dir) unless Dir.exist?(temp_dir)
+      allow(Hydra::Derivatives).to receive(:temp_file_base).and_return temp_dir
+    end
+
+    after do
+      FileUtils.rmtree(temp_dir)
+    end
     it "creates a thumbnail in the derivatives directory, and also stores to the cloud" do
       cloud_file_service = instance_double(CloudFilePermissionsService)
       allow(CloudFilePermissionsService).to receive(:new).and_return(cloud_file_service)
@@ -55,6 +65,9 @@ RSpec.describe RasterResourceDerivativeService do
       expect(thumbnail_file.io.path).to start_with(Rails.root.join("tmp", Figgy.config["derivative_path"]).to_s)
       expect(cloud_raster_file.io.path).to start_with(Rails.root.join("tmp", Figgy.config["test_cloud_geo_derivative_path"]).to_s)
       expect(cloud_file_service).to have_received(:run)
+
+      # Ensure that temporary files and directories are cleaned up
+      expect(Dir.empty?(temp_dir)).to be true
     end
   end
 

--- a/spec/derivative_services/vector_resource_derivative_service_spec.rb
+++ b/spec/derivative_services/vector_resource_derivative_service_spec.rb
@@ -36,6 +36,17 @@ RSpec.describe VectorResourceDerivativeService do
   end
 
   context "with a valid shapefile" do
+    let(:temp_dir) { Rails.root.join("tmp", "temp_dir") }
+
+    before do
+      Dir.mkdir(temp_dir) unless Dir.exist?(temp_dir)
+      allow(Hydra::Derivatives).to receive(:temp_file_base).and_return temp_dir
+    end
+
+    after do
+      FileUtils.rmtree(temp_dir)
+    end
+
     it "creates a thumbnail in the derivatives directory and also stores to the cloud" do
       cloud_file_service = instance_double(CloudFilePermissionsService)
       allow(CloudFilePermissionsService).to receive(:new).and_return(cloud_file_service)
@@ -55,6 +66,9 @@ RSpec.describe VectorResourceDerivativeService do
       expect(image.avg.round).to eq 250
       expect(cloud_vector_file.io.path).to start_with(Rails.root.join("tmp", Figgy.config["test_cloud_geo_derivative_path"]).to_s)
       expect(cloud_file_service).to have_received(:run)
+
+      # Ensure that temporary files and directories are cleaned up
+      expect(Dir.empty?(temp_dir)).to be true
     end
   end
 


### PR DESCRIPTION
Closes #6780

Ensures that vector and raster derivative generation does not leave files on the worker.

- Creates a temp directory for all output and intermediate steps.
- Ensures that temp files and folders are removed when processing is done or an error is encountered.