### PR TITLE
Fix ephemera project casting marking titles as always having changed.

### DIFF
--- a/app/change_sets/ephemera_project_change_set.rb
+++ b/app/change_sets/ephemera_project_change_set.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class EphemeraProjectChangeSet < Valkyrie::ChangeSet
-  property :title, multiple: false
+  property :title, multiple: false, type: Valkyrie::Types::Set
   property :member_ids, multiple: true, required: false, type: Types::Strict::Array.of(Valkyrie::Types::ID)
   property :slug, multiple: false, required: true
   property :top_language, multiple: true, required: false

--- a/spec/features/ephemera_project_spec.rb
+++ b/spec/features/ephemera_project_spec.rb
@@ -9,7 +9,8 @@ RSpec.feature "Ephemera Project" do
   end
 
   scenario "editing a project", js: true do
-    project = FactoryBot.create_for_repository(:ephemera_project)
+    folder = FactoryBot.create_for_repository(:ephemera_folder)
+    project = FactoryBot.create_for_repository(:ephemera_project, member_ids: [folder.id])
     visit edit_ephemera_project_path(id: project.id)
 
     # edit fields
@@ -22,5 +23,11 @@ RSpec.feature "Ephemera Project" do
     # renders rich text editor for description
     element = find("trix-editor > div")
     expect(element.text).to eq project.description.first
+
+    click_button "Save"
+
+    expect(page).to have_link "Delete This Ephemera Project"
+    reloaded_folder = ChangeSetPersister.default.query_service.find_by(id: folder.id)
+    expect(reloaded_folder.updated_at).to eq folder.updated_at
   end
 end


### PR DESCRIPTION
We reindex children when collection titles are changed, this prevents the form from always thinking title changes.

Closes #6813