### PR TITLE
Use FlatGeobuff as an intermediate vector format

### DIFF
--- a/app/derivative_services/geo_derivatives/processors/ogr.rb
+++ b/app/derivative_services/geo_derivatives/processors/ogr.rb
@@ -13,7 +13,7 @@ module GeoDerivatives
         def self.reproject(in_path, out_path, options)
           execute "env OGR_ENABLE_PARTIAL_REPROJECTION=YES env SHAPE_ENCODING= ogr2ogr -q "\
                   "-nln #{options[:id]} -f 'ESRI Shapefile' -t_srs #{options[:output_srid]} "\
-                  "-preserve_fid '#{out_path}' '#{in_path}'"
+                  "-skipfailures -preserve_fid '#{out_path}' '#{in_path}'"
         end
 
         # Executes a ogr2ogr command. Used to reproject a
@@ -23,11 +23,8 @@ module GeoDerivatives
         # @param out_path [String] processor output file path
         def self.cloud_reproject(in_path, out_path, options)
           execute "env OGR_ENABLE_PARTIAL_REPROJECTION=YES env ogr2ogr -q "\
-                  "-nln #{options[:id]} -f GeoJSON -t_srs EPSG:4326 "\
-                  "-preserve_fid '#{out_path}.tmp' '#{in_path}'"
-
-          # Fix any encoding issues in the geojson file
-          execute "iconv -f ISO-8859-1 -t utf-8 #{out_path}.tmp > #{out_path}"
+                  "-nln #{options[:id]} -f FlatGeobuf -t_srs EPSG:4326 "\
+                  "-skipfailures -preserve_fid '#{out_path}.fgb' '#{in_path}'"
         end
       end
     end

--- a/app/derivative_services/geo_derivatives/processors/tippecanoe.rb
+++ b/app/derivative_services/geo_derivatives/processors/tippecanoe.rb
@@ -15,7 +15,7 @@ module GeoDerivatives
         rescue
           # Try without guessing max zoom. Some datasets only have one feature.
           execute "tippecanoe --force --maximum-tile-features=10000 --no-tile-size-limit " \
-            "--coalesce-densest-as-needed --extend-zooms-if-still-dropping -o #{out_path} #{in_path}"
+            "--coalesce-densest-as-needed --extend-zooms-if-still-dropping -o #{out_path} #{in_path}.fgb"
         end
       end
     end

--- a/spec/derivative_services/vector_resource_derivative_service_spec.rb
+++ b/spec/derivative_services/vector_resource_derivative_service_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe VectorResourceDerivativeService do
     it "stores an error message on the fileset" do
       expect { valid_resource }.to raise_error(RuntimeError)
       file_set = query_service.find_all_of_model(model: FileSet).first
-      expect(file_set.original_file.error_message).to include(/ogr2ogr/)
+      expect(file_set.original_file.error_message).to include(/Unable to execute command/)
     end
   end
 


### PR DESCRIPTION
Closes #6857 

By using FlatGeobuff instead of GeoJSON as an intermediate format when generating a pmtiles, the processing time for a large dataset goes from days (or, in the example below, never) to 30 minutes.

https://figgy-staging.princeton.edu/catalog/e04e0300-6260-4cdf-b924-c8902d53dd10

Flatgeobuff performance benefits:
https://flatgeobuf.org/#performance