### PR TITLE
Add thumbnails to iiif manifest canvas elements

### DIFF
--- a/app/services/manifest_builder/canvas_builder.rb
+++ b/app/services/manifest_builder/canvas_builder.rb
@@ -5,6 +5,7 @@ class ManifestBuilder
       super
       canvas["local_identifier"] = record.local_identifier.first if record.try(:local_identifier).present?
       canvas["viewingHint"] = record.viewing_hint.first if record.try(:viewing_hint).present?
+      canvas["thumbnail"] = build_thumbnail_values
       rendering_builder.new(record).apply(canvas)
     end
 
@@ -16,5 +17,24 @@ class ManifestBuilder
     def rendering_builder
       ManifestBuilder::CanvasRenderingBuilder
     end
+
+    private
+
+      def build_thumbnail_values
+        {
+          "@id" => helper.manifest_image_thumbnail_path(record.resource),
+          "service" => {
+            "@context" => "http://iiif.io/api/image/2/context.json",
+            "@id" => helper.manifest_image_path(record.resource),
+            "profile" => "http://iiif.io/api/image/2/level2.json"
+          }
+        }
+      rescue
+        nil
+      end
+
+      def helper
+        @helper ||= ManifestHelper.new
+      end
   end
 end

--- a/app/services/manifest_builder_v3/canvas_builder.rb
+++ b/app/services/manifest_builder_v3/canvas_builder.rb
@@ -5,6 +5,7 @@ class ManifestBuilderV3
       super
       canvas["local_identifier"] = record.local_identifier.first if record.try(:local_identifier).present?
       canvas["viewingHint"] = record.viewing_hint.first if record.try(:viewing_hint).present?
+      canvas["thumbnail"] = build_thumbnail_values
       rendering_builder.new(record).apply(canvas)
       accompanying_canvas_builder.new(record).apply(canvas)
     end
@@ -26,5 +27,24 @@ class ManifestBuilderV3
       return record.structure.label if record.respond_to?(:structure)
       record.try(:label)
     end
+
+    private
+
+      def build_thumbnail_values
+        [
+          {
+            "id" => helper.manifest_image_thumbnail_path(record.resource),
+            "type" => "Image",
+            "format" => "image/jpeg",
+            "width" => 200
+          }
+        ]
+      rescue
+        nil
+      end
+
+      def helper
+        @helper ||= ManifestHelper.new
+      end
   end
 end

--- a/spec/services/manifest_builder/by_resource_type/manifest_builder_scanned_resource_spec.rb
+++ b/spec/services/manifest_builder/by_resource_type/manifest_builder_scanned_resource_spec.rb
@@ -113,6 +113,9 @@ RSpec.describe ManifestBuilder do
       expect(first_image["resource"]["@id"]).to eq "http://www.example.com/image-service/#{scanned_resource.member_ids.first}/full/1000,/0/default.jpg"
       expect(output["sequences"][0]["canvases"][0]["local_identifier"]).to eq "p79409x97p"
 
+      canvas_thumbnail = output["sequences"][0]["canvases"][0]["thumbnail"]
+      expect(canvas_thumbnail["@id"]).to eq "http://www.example.com/image-service/#{scanned_resource.member_ids.first}/full/!200,150/0/default.jpg"
+
       canvas_renderings = output["sequences"][0]["canvases"][0]["rendering"]
       expect(canvas_renderings.length).to eq 2
 

--- a/spec/services/manifest_builder_v3/by_resource_type/manifest_builder_v3_scanned_map_spec.rb
+++ b/spec/services/manifest_builder_v3/by_resource_type/manifest_builder_v3_scanned_map_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe ManifestBuilderV3 do
                                          viewing_direction: ["right-to-left"])
       end
 
-      before do
+      it "builds a IIIF Presentation 3 document" do
         stub_catalog(bib_id: "991234563506421")
         change_set = ScannedMapChangeSet.new(resource, files: [file])
         output = change_set_persister.save(change_set: change_set)
@@ -70,9 +70,7 @@ RSpec.describe ManifestBuilderV3 do
         change_set.validate(ocr_language: ocr_language)
         change_set.validate(logical_structure: logical_structure(file_set_id), start_canvas: file_set_id)
         change_set_persister.save(change_set: change_set)
-      end
 
-      it "builds a IIIF Presentation 3 document" do
         output = manifest_builder.build
         expect(output).to be_kind_of Hash
         expect(output["summary"]["eng"]).to eq ["Test Description"]
@@ -94,7 +92,7 @@ RSpec.describe ManifestBuilderV3 do
         # rendering
         expect(output["rendering"][0]["format"]).to eq "application/pdf"
 
-        # thumbnail
+        # manifest thumbnail
         expect(output["thumbnail"][0]["type"]).to eq "Image"
 
         # navPlace
@@ -103,6 +101,9 @@ RSpec.describe ManifestBuilderV3 do
         # No link for downloading original file because downloadable is set to `none`
         expect(output["items"][0]["rendering"].count).to eq 1
         expect(output["items"][0]["rendering"][0]["label"]["en"]).not_to eq ["Download the original file"]
+
+        # canvas thumbnail
+        expect(output["items"][0]["thumbnail"][0]["id"]).to eq "http://www.example.com/image-service/#{file_set_id}/full/!200,150/0/default.jpg"
 
         # Validate manifest
         expect(JSON::Validator.fully_validate(schema, output)).to be_empty


### PR DESCRIPTION
Closes #6868 
Works towards https://github.com/pulibrary/dpul-collections/issues/876

Improves rendering of thumbnails in clover viewer. Tested in staging and Clover renders with consistent thumbnail urls.

<img width="1949" height="915" alt="Screenshot 2025-10-23 at 12 29 08 PM" src="https://github.com/user-attachments/assets/10857fac-8c5e-4b90-b47f-332dca902131" />
