### PR TITLE
Ensure simple resources do not raise error when migrating published_at

### DIFF
--- a/app/services/migrations/add_published_at_migrator.rb
+++ b/app/services/migrations/add_published_at_migrator.rb
@@ -18,8 +18,8 @@ module Migrations
         decorator = resource.decorate
         next unless resource.respond_to?(:published_at)
         next unless decorator.respond_to?(:published_state?) && decorator.published_state?
-
         change_set = ChangeSet.for(resource)
+        next unless change_set.respond_to?(:published_at)
         change_set.published_at = change_set.updated_at
         change_set_persister.save(change_set: change_set)
       end

--- a/spec/services/migrations/add_published_at_migrator_spec.rb
+++ b/spec/services/migrations/add_published_at_migrator_spec.rb
@@ -33,6 +33,16 @@ RSpec.describe Migrations::AddPublishedAtMigrator do
           end
         end
       end
+
+      context "when given resources that do not have a published_at value" do
+        it "does not error" do
+          FactoryBot.create_for_repository(:simple_resource, state: "complete")
+          FactoryBot.create_for_repository(:complete_vector_resource)
+          FactoryBot.create_for_repository(:complete_raster_resource)
+
+          described_class.call
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Simple resource change sets raise exceptions in the AddPublishedAtMigrator.

This ensures they are properly skipped.