### PR TITLE
Improvements to make published_at migrator more resilient

### DIFF
--- a/app/services/migrations/add_published_at_migrator.rb
+++ b/app/services/migrations/add_published_at_migrator.rb
@@ -15,27 +15,42 @@ module Migrations
         resource_factory.to_resource(object: object)
       end
       resources.each do |resource|
-        decorator = resource.decorate
         next unless resource.respond_to?(:published_at)
+        decorator = resource.decorate
         next unless decorator.respond_to?(:published_state?) && decorator.published_state?
         change_set = ChangeSet.for(resource)
         next unless change_set.respond_to?(:published_at)
-        change_set.published_at = change_set.updated_at
+        change_set.resource.published_at = resource.updated_at
         change_set_persister.save(change_set: change_set)
+      rescue
+        next
       end
     end
 
     # Rather than make a query that's only used by this migration, just do one
     # inline here.
     def relation
-      orm_class.use_cursor
+      orm_class.use_cursor(skip_transaction: true)
                .exclude(internal_resource: [FileSet, PreservationObject, DeletionMarker, Event, EphemeraTerm].map(&:to_s))
                .where(Sequel.lit("metadata->'published_at' IS NULL"))
                .lazy
     end
 
     def change_set_persister
-      @change_set_persister ||= ChangeSetPersister.default
+      @change_set_persister ||= ::ChangeSetPersister::Basic.new(
+        metadata_adapter: Valkyrie::MetadataAdapter.find(:indexing_persister),
+        storage_adapter: Valkyrie.config.storage_adapter,
+        handlers: handlers
+      )
+    end
+
+    # Only use preservation handler for performance.
+    def handlers
+      {
+        after_save_commit: [
+          ChangeSetPersister::PreserveResource
+        ]
+      }
     end
   end
 end

--- a/spec/services/migrations/add_published_at_migrator_spec.rb
+++ b/spec/services/migrations/add_published_at_migrator_spec.rb
@@ -43,6 +43,15 @@ RSpec.describe Migrations::AddPublishedAtMigrator do
           end
         end
       end
+
+      context "when updating a resource raises an error" do
+        it "the migrator rescues and completes without error" do
+          FactoryBot.create_for_repository(:complete_scanned_resource, identifier: "123456")
+          allow(ChangeSet).to receive(:for).and_raise("Error")
+
+          expect { described_class.call }.not_to raise_error
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
- Rescues errors in while processing resources
- Only uses preservation handler for performance
- Uses `skip_transaction: true` with cursor so that commits to the database are made in a timely fashion. Otherwise, updates are not made until all 400,000+ records are processed and PreservationJobs are kicked off without access to the updated metadata.