### PR TITLE
Upgrade rspec graphql matchers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -153,7 +153,7 @@ group :test do
   gem "database_cleaner"
   gem "database_cleaner-sequel"
   gem "formulaic"
-  gem "rspec-graphql_matchers", "~> 1.3.1"
+  gem "rspec-graphql_matchers", "~> 1.4.0"
   gem "rspec_junit_formatter"
   gem "selenium-webdriver"
   gem "simplecov", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -355,7 +355,7 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    diff-lcs (1.5.1)
+    diff-lcs (1.6.2)
     digest-crc (0.6.5)
       rake (>= 12.0.0, < 14.0.0)
     disposable (0.6.3)
@@ -527,7 +527,7 @@ GEM
     graphiql-rails (1.4.10)
       railties
       sprockets-rails
-    graphql (1.13.23)
+    graphql (1.13.25)
       base64
     grpc (1.68.1-arm64-darwin)
       google-protobuf (>= 3.25, < 5.0)
@@ -897,19 +897,19 @@ GEM
     rsolr (2.6.0)
       builder (>= 2.1.2)
       faraday (>= 0.9, < 3, != 2.0.0)
-    rspec (3.13.0)
+    rspec (3.13.2)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.2)
+    rspec-core (3.13.6)
       rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.3)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-graphql_matchers (1.3.1)
-      graphql (>= 1.8, < 2.0)
+    rspec-graphql_matchers (1.4.0)
+      graphql (>= 1.10.12, < 2.0)
       rspec (~> 3.0)
-    rspec-mocks (3.13.2)
+    rspec-mocks (3.13.7)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-rails (7.1.0)
@@ -920,7 +920,7 @@ GEM
       rspec-expectations (~> 3.13)
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
-    rspec-support (3.13.2)
+    rspec-support (3.13.6)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (1.28.2)
@@ -1243,7 +1243,7 @@ DEPENDENCIES
   reform
   riiif
   rsolr
-  rspec-graphql_matchers (~> 1.3.1)
+  rspec-graphql_matchers (~> 1.4.0)
   rspec-rails
   rspec_junit_formatter
   ruby-prof


### PR DESCRIPTION
This removes a lot of large deprecation warnings that were coming from
the test suite
