### PR TITLE
Resolve graphql deprecations

### DIFF
--- a/spec/graphql/types/viewing_direction_enum_spec.rb
+++ b/spec/graphql/types/viewing_direction_enum_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe Types::ViewingDirectionEnum do
   subject(:enum) { described_class }
-  it "can convert to graphql" do
-    expect { enum.to_graphql }.not_to raise_error
+  it "contains the desired keys" do
+    expect(enum.values.keys).to contain_exactly("LEFTTORIGHT", "RIGHTTOLEFT", "TOPTOBOTTOM", "BOTTOMTOTOP")
   end
 end


### PR DESCRIPTION
- **Upgrade rspec graphql matchers gem**
- **Test the behavior of the viewingdirectionenum, not its private internals**

These changes remove large blocks of deprecation warning from the test suite