### PR TITLE
Add validation for Selene ingest path

### DIFF
--- a/app/controllers/scanned_resources_controller.rb
+++ b/app/controllers/scanned_resources_controller.rb
@@ -2,6 +2,7 @@
 class ScannedResourcesController < ResourcesController
   self.resource_class = ScannedResource
   self.change_set_persister = ChangeSetPersister.default
+  before_action :validate_selene_ingest_path, only: [:create]
 
   include Pdfable
 
@@ -9,6 +10,14 @@ class ScannedResourcesController < ResourcesController
     super
     handle_save_and_ingest(obj)
     handle_upload_selene_files(obj)
+  end
+
+  def validate_selene_ingest_path
+    return if params[:ingest_path].blank?
+    base = Pathname.new(Figgy.config["ingest_folder_path"])
+    ingest_path = base.join(params[:ingest_path])
+    return if SelenePathValidator.validate(ingest_path)
+    redirect_back(fallback_location: root_path, notice: "Selene file structure invalid")
   end
 
   def handle_save_and_ingest(obj)

--- a/app/services/file_browser_disk_provider.rb
+++ b/app/services/file_browser_disk_provider.rb
@@ -109,17 +109,7 @@ end
 
 class SeleneEntry < Entry
   def selectable?
-    selene_structure.none?(&:nil?)
-  end
-
-  def selene_structure
-    [
-      file_path.children.find { |c| c.basename.to_s == "Selene_Output" },
-      file_path.children.find { |c| c.basename.to_s.match(/1\.(tif|TIF)/) },
-      file_path.children.find { |c| c.basename.to_s.match(/2\.(tif|TIF)/) },
-      file_path.children.find { |c| c.basename.to_s.match(/3\.(tif|TIF)/) },
-      file_path.children.find { |c| c.basename.to_s.match(/4\.(tif|TIF)/) }
-    ]
+    SelenePathValidator.validate(file_path)
   end
 
   def directory_json

--- a/app/validators/selene_path_validator.rb
+++ b/app/validators/selene_path_validator.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+class SelenePathValidator
+  def self.validate(path)
+    new(path).validate
+  end
+
+  attr_reader :path
+  # @param path [Pathname] Full path to the selene directory
+  def initialize(path)
+    @path = path
+  end
+
+  def validate
+    selene_structure.none?(&:nil?)
+  end
+
+  private
+
+    def selene_structure
+      [
+        depthmap_tfw,
+        path.children.find { |c| c.basename.to_s.match(/1\.(tif|TIF)/) },
+        path.children.find { |c| c.basename.to_s.match(/2\.(tif|TIF)/) },
+        path.children.find { |c| c.basename.to_s.match(/3\.(tif|TIF)/) },
+        path.children.find { |c| c.basename.to_s.match(/4\.(tif|TIF)/) }
+      ]
+    end
+
+    def depthmap_tfw
+      output_dir = path.children.find { |c| c.basename.to_s == "Selene_Output" }
+      return nil unless output_dir
+      output_dir.children.find { |c| c.basename.to_s == "depthmap_m1.tfw" }
+    end
+end

--- a/spec/controllers/scanned_resources_controller_spec.rb
+++ b/spec/controllers/scanned_resources_controller_spec.rb
@@ -301,6 +301,26 @@ RSpec.describe ScannedResourcesController, type: :controller do
           expect(file_set.original_file.mime_type).to eq ["image/tiff"]
         end
       end
+
+      context "when creating a new Selene Resource with a path without the correct selene structure" do
+        it "does not create a new resource and redirects with a flash notice" do
+          post :create, params: {
+            scanned_resource: {
+              change_set: "selene_resource",
+              title: "Selene"
+            },
+            ingest_path: "studio_new/DPUL"
+          }
+
+          expect(response).to be_redirect
+          expect(response.location).not_to start_with "http://test.host/catalog/"
+          expect(flash[:notice]).to eq("Selene file structure invalid")
+
+          query_service = ChangeSetPersister.default.query_service
+          resources = query_service.find_all_of_model(model: ScannedResource)
+          expect(resources.count).to eq 0
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Closes #6948


Note: A standard validator on the ChangeSet doesn't work with virtual properties, so the validation here is done in the controller before `create`.