### PR TITLE
Wrap all of find_by in the Timeout.

### DIFF
--- a/app/adapters/fallback_disk_adapter.rb
+++ b/app/adapters/fallback_disk_adapter.rb
@@ -8,18 +8,18 @@ class FallbackDiskAdapter
   end
 
   def find_by(id:)
-    resource = primary_adapter.find_by(id: id)
     # Check to see if the file's readable, fallback if not.
     # If Tigerdata doesn't have a solid connection to the Isilon, this will
     # fail. If it takes a long time, Tigerdata's frozen up, fail generally and
     # don't fallback.
-    Timeout.timeout(1) do
+    Timeout.timeout(2) do
+      resource = primary_adapter.find_by(id: id)
       File.open(resource.disk_path, "rb") do |file|
         # Read just one byte.
         file.read(1)
       end
+      resource
     end
-    resource
   rescue Valkyrie::StorageAdapter::FileNotFound, Errno::EIO
     # This'll only work for disk adapters, but that's our use case.
     new_id = id.to_s.gsub(primary_adapter.base_path.to_s, fallback_adapter.base_path.to_s)


### PR DESCRIPTION
The disk adapter in Valkyrie opens the file to propagate errors, which
is still causing the lockout.

Fix of #6952 