### PR TITLE
Move more video flags to video files only

### DIFF
--- a/app/derivative_services/av_derivative_service.rb
+++ b/app/derivative_services/av_derivative_service.rb
@@ -71,7 +71,11 @@ class AvDerivativeService
 
   def type_specific_flags
     if resource.video?
-      ["-c:v", "libx264"] # encode video with H.264
+      [
+        "-c:v", "libx264", # encode video with H.264
+        "-vf", "format=yuv420p", # needed for Firefox. See: https://trac.ffmpeg.org/wiki/Encode/H.264#Encodingfordumbplayers
+        "-crf", "20" # video quality from 0-51
+      ] # encode video with H.264
     else
       # Audio sometimes has cover art - just ignore it.
       [
@@ -91,8 +95,6 @@ class AvDerivativeService
                      "-hls_time", "10", # segments are 10s in length
                      *type_specific_flags,
                      "-preset", "slow", # slow encoding for better compression
-                     "-crf", "20", # video quality from 0-51
-                     "-vf", "format=yuv420p", # needed for Firefox. See: https://trac.ffmpeg.org/wiki/Encode/H.264#Encodingfordumbplayers
                      "-movflags", "+faststart", # good option for web video
                      "-c:a", "aac", # encode audio with AAC
                      "-b:a", "160k", # audio bitrate


### PR DESCRIPTION
Some of the HLS files were becoming corrupt, but only sometimes?

Work towards #7008 