### PR TITLE
Update reindex_works

### DIFF
--- a/app/services/reindexer.rb
+++ b/app/services/reindexer.rb
@@ -36,7 +36,7 @@ class Reindexer
   end
 
   def reindex_works
-    reindex_all(except_models: excluded_models + ["FileSet", "PreservationObject"])
+    reindex_all(except_models: excluded_models + ["DeletionMarker"])
   end
 
   def wipe_records


### PR DESCRIPTION
it was only excluding models that were already excluded via
IndexingAdapter.no_index_models, making it no different from
reindex_all. Adding DeletionMarkers seemed to make sense since that's a
good chunk of objects that aren't works.
