### PR TITLE
Don't memoize the binary file checksum in preserver

### DIFF
--- a/app/services/preserver.rb
+++ b/app/services/preserver.rb
@@ -61,7 +61,7 @@ class Preserver
     end
 
     def calculate_checksum(file_metadata)
-      @calculated_checksum ||= MultiChecksum.for(Valkyrie::StorageAdapter.find_by(id: file_metadata.file_identifiers.first))
+      MultiChecksum.for(Valkyrie::StorageAdapter.find_by(id: file_metadata.file_identifiers.first))
     end
 
     # Creates the binary name for a preserved copy of a file by setting the

--- a/spec/factories/scanned_resource.rb
+++ b/spec/factories/scanned_resource.rb
@@ -87,7 +87,7 @@ FactoryBot.define do
                   }
                 ),
                 IngestableFile.new(
-                  file_path: Rails.root.join("spec", "fixtures", "files", "caption.vtt"),
+                  file_path: Rails.root.join("spec", "fixtures", "files", "caption_und.vtt"),
                   mime_type: "text/vtt",
                   original_filename: "caption.vtt",
                   use: ::PcdmUse::Caption,
@@ -98,7 +98,7 @@ FactoryBot.define do
                 ),
 
                 IngestableFile.new(
-                  file_path: Rails.root.join("spec", "fixtures", "files", "caption.vtt"),
+                  file_path: Rails.root.join("spec", "fixtures", "files", "caption_zgh_alg.vtt"),
                   mime_type: "text/vtt",
                   original_filename: "caption.vtt",
                   use: ::PcdmUse::Caption,

--- a/spec/fixtures/files/caption_und.vtt
+++ b/spec/fixtures/files/caption_und.vtt
@@ -1,0 +1,4 @@
+WEBVTT
+
+00:00.000 --> 00:03.000
+Test Caption, undetermined language

--- a/spec/fixtures/files/caption_zgh_alg.vtt
+++ b/spec/fixtures/files/caption_zgh_alg.vtt
@@ -1,0 +1,4 @@
+WEBVTT
+
+00:00.000 --> 00:03.000
+Test Caption, languages: zgh, alg


### PR DESCRIPTION
It needs to be recalculated for each binary file that's preserved

closes #7053