### PR TITLE
Use version of setuptools I found on figgy-staging

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -12,7 +12,7 @@ RUN sudo sh ./bin/ci_free_tds_install.sh
 RUN sudo sh ./bin/ci_openjpeg_install.sh
 RUN sudo sh ./bin/ci_vips_install.sh
 RUN sudo pip3 install pip -U \
-  && sudo pip3 install setuptools -U \
+  && sudo pip3 install "setuptools==68.1.2" \
   && sudo pip3 install -U numpy \
   && sudo pip3 install cogeo-mosaic
 RUN sudo rm -rf bin


### PR DESCRIPTION
same version is on prod.

closes #7077

This was tested on the new container, but that container won't be tagged as `ci` until it gets merged. If review is good, it's okay to merge over test failure.