### PR TITLE
Support /uv.html for the viewer

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -299,6 +299,9 @@ Rails.application.routes.draw do
     end
   end
 
+  # Universal Viewer generates this as an embed hard-coded, so fix it here.
+  get "/uv.html", to: "viewer#index"
+
   resources :cdl, controller: "cdl/cdl", only: [] do
     member do
       get :status, defaults: { format: :json }

--- a/spec/requests/viewer_config_spec.rb
+++ b/spec/requests/viewer_config_spec.rb
@@ -107,4 +107,12 @@ RSpec.describe "ViewerConfiguration requests", type: :request do
       end
     end
   end
+
+  describe "/uv.html" do
+    it "renders the viewer" do
+      get "/uv.html#manifest=bla"
+
+      expect(response.status).to eq 200
+    end
+  end
 end


### PR DESCRIPTION
This is hard-coded into UniversalViewer right now, and folks are trying
to embed our objects. That should be possible - core to the mission.

I tried to do a redirect at first, but the embed passes parameters as
an anchor tag, which is only readable from javascript. It's easier to
render the viewer from two routes.

Closes #6454
