### PR TITLE
Fix large raster derivative generation

### DIFF
--- a/app/derivative_services/geo_derivatives/processors/gdal.rb
+++ b/app/derivative_services/geo_derivatives/processors/gdal.rb
@@ -5,16 +5,16 @@ module GeoDerivatives
 
       included do
         # Executes a gdal_translate command. Used to translate a raster
-        # format into a different format. Also used in generating thumbnails
-        # from vector data.
+        # format into a different format.
         # @param in_path [String] file input path
         # @param out_path [String] processor output file path
         # @param options [Hash] creation options
-        def self.translate(in_path, out_path, _options)
-          execute "gdal_translate -q -ot Byte -of GTiff -co TILED=YES -expand rgb -co COMPRESS=DEFLATE \"#{in_path}\" #{out_path}"
+        def self.translate(in_path, out_path, options)
+          outsize = "-outsize #{options[:output_size].split(' ').first} 0"
+          execute "gdal_translate -q -ot Byte -of GTiff -co TILED=YES #{outsize} -expand rgb -co COMPRESS=DEFLATE \"#{in_path}\" #{out_path}"
         rescue StandardError
           # Try without expanding rgb
-          execute "gdal_translate -q -ot Byte -of GTiff -co TILED=YES -co COMPRESS=DEFLATE \"#{in_path}\" #{out_path}"
+          execute "gdal_translate -q -ot Byte -of GTiff -co TILED=YES #{outsize} -co COMPRESS=DEFLATE \"#{in_path}\" #{out_path}"
         end
 
         # Executes a gdalwarp command. Used to transform a raster

--- a/app/derivative_services/geo_derivatives/processors/gdal.rb
+++ b/app/derivative_services/geo_derivatives/processors/gdal.rb
@@ -18,13 +18,15 @@ module GeoDerivatives
         end
 
         # Executes a gdalwarp command. Used to transform a raster
-        # from one projection into another.
+        # from one projection into another. Intermediate is tiled and LZW-compressed
+        # to keep working-directory disk usage manageable for large rasters.
         # @param in_path [String] file input path
         # @param out_path [String] processor output file path
         # @param options [Hash] creation options
         def self.warp(in_path, out_path, options)
           execute "gdalwarp -q -t_srs #{options[:output_srid]} "\
-                  "\"#{in_path}\" #{out_path} -co COMPRESS=NONE"
+                  "\"#{in_path}\" #{out_path} "\
+                  "-co TILED=YES -co COMPRESS=LZW -co BIGTIFF=IF_SAFER"
         end
 
         # Executes a gdal_translate command. Used to compress
@@ -53,7 +55,8 @@ module GeoDerivatives
         # @param out_path [String] processor output file path
         # @param options [Hash] creation options
         def self.rgba(in_path, out_path, _options)
-          execute "gdal_translate -expand rgba \"#{in_path}\" #{out_path}"
+          execute "gdal_translate -expand rgba \"#{in_path}\" #{out_path} "\
+                  "-co TILED=YES -co COMPRESS=LZW -co BIGTIFF=IF_SAFER"
         end
 
         # Executes gdaladdo and gdal_translate commands. Used to add internal overviews

--- a/app/derivative_services/geo_derivatives/processors/gdal.rb
+++ b/app/derivative_services/geo_derivatives/processors/gdal.rb
@@ -59,19 +59,17 @@ module GeoDerivatives
                   "-co TILED=YES -co COMPRESS=LZW -co BIGTIFF=IF_SAFER"
         end
 
-        # Executes gdaladdo and gdal_translate commands. Used to add internal overviews
-        # and then compress a previously uncompressed raster.
-        # Output will be a Cloud Optimized GeoTIFF.
+        # Executes a single gdalwarp command that both reprojects and writes
+        # a Cloud Optimized GeoTIFF in one step. Combining the steps avoids
+        # writing a full-size warped intermediate to the working directory.
         # @param in_path [String] file input path
         # @param out_path [String] processor output file path
         # @param options [Hash] creation options
-        def self.cloud_optimized_geotiff(in_path, out_path, _options)
-          execute("gdal_translate -q -expand rgb \"#{in_path}\" #{out_path} -ot Byte -of COG "\
-                    "-a_nodata 256 -co COMPRESS=LZW -co TILING_SCHEME=GoogleMapsCompatible")
-        rescue StandardError
-          # Try without expanding rgb
-          execute("gdal_translate -q \"#{in_path}\" #{out_path} -ot Byte -of COG "\
-                    "-a_nodata 256 -co COMPRESS=LZW -co TILING_SCHEME=GoogleMapsCompatible")
+        def self.warp_to_cog(in_path, out_path, options)
+          execute "gdalwarp -q -t_srs #{options[:output_srid]} "\
+                  "\"#{in_path}\" #{out_path} -of COG -ot Byte "\
+                  "-co COMPRESS=LZW -co BLOCKSIZE=256 "\
+                  "-co TILING_SCHEME=GoogleMapsCompatible"
         end
 
         # Executes a gdal_rasterize command. Used to rasterize vector

--- a/app/derivative_services/geo_derivatives/processors/image.rb
+++ b/app/derivative_services/geo_derivatives/processors/image.rb
@@ -14,7 +14,7 @@ module GeoDerivatives
         # @option options [String] `:output_size` as "w h" or "wxh"
         def self.convert(in_path, out_path, options)
           size = options[:output_size].tr(" ", "x")
-          convert = MiniMagick::Tool::Convert.new(whiny: false)
+          convert = MiniMagick::Tool::Convert.new
           convert << in_path
           convert << "-resize"
           convert << size

--- a/app/derivative_services/geo_derivatives/processors/raster/base.rb
+++ b/app/derivative_services/geo_derivatives/processors/raster/base.rb
@@ -25,7 +25,7 @@ module GeoDerivatives
         # Set of commands to run to reproject the raster.
         # @return [Array] set of command name symbols
         def self.reproject_queue
-          [:rgb2pct, :rgba, :warp, :cloud_optimized_geotiff]
+          [:rgb2pct, :rgba, :warp_to_cog]
         end
 
         def self.encode_raster(in_path, out_path, options)

--- a/spec/derivative_services/geo_derivatives/processors/base_geo_processor_spec.rb
+++ b/spec/derivative_services/geo_derivatives/processors/base_geo_processor_spec.rb
@@ -63,8 +63,8 @@ RSpec.describe GeoDerivatives::Processors::BaseGeoProcessor do
     let(:options) { { output_size: "150 150", output_srid: "EPSG:4326" } }
 
     describe "#translate" do
-      it "executes a gdal_translate command" do
-        command = "gdal_translate -q -ot Byte -of GTiff -co TILED=YES -expand rgb -co COMPRESS=DEFLATE \"files/geo.tif\" output/geo.png"
+      it "executes a gdal_translate command, scaling the intermediate to the thumbnail width" do
+        command = "gdal_translate -q -ot Byte -of GTiff -co TILED=YES -outsize 150 0 -expand rgb -co COMPRESS=DEFLATE \"files/geo.tif\" output/geo.png"
         processor.class.translate(file_name, output_file, options)
         expect(processor.class).to have_received(:execute).with command
       end

--- a/spec/derivative_services/geo_derivatives/processors/base_geo_processor_spec.rb
+++ b/spec/derivative_services/geo_derivatives/processors/base_geo_processor_spec.rb
@@ -79,6 +79,17 @@ RSpec.describe GeoDerivatives::Processors::BaseGeoProcessor do
       end
     end
 
+    describe "#warp_to_cog" do
+      it "reprojects and writes a COG in a single gdalwarp command" do
+        command = "gdalwarp -q -t_srs EPSG:4326 \"files/geo.tif\" output/geo.png " \
+                  "-of COG -ot Byte " \
+                  "-co COMPRESS=LZW -co BLOCKSIZE=256 " \
+                  "-co TILING_SCHEME=GoogleMapsCompatible"
+        processor.class.warp_to_cog(file_name, output_file, options)
+        expect(processor.class).to have_received(:execute).with command
+      end
+    end
+
     describe "#compress" do
       it "returns a gdal_translate command with a compress option" do
         command = "gdal_translate -q -ot Byte -a_srs EPSG:4326 \"files/geo.tif\" output/geo.png -co COMPRESS=JPEG -co JPEG_QUALITY=90"

--- a/spec/derivative_services/geo_derivatives/processors/base_geo_processor_spec.rb
+++ b/spec/derivative_services/geo_derivatives/processors/base_geo_processor_spec.rb
@@ -71,8 +71,9 @@ RSpec.describe GeoDerivatives::Processors::BaseGeoProcessor do
     end
 
     describe "#warp" do
-      it "executes a reproject command" do
-        command = "gdalwarp -q -t_srs EPSG:4326 \"files/geo.tif\" output/geo.png -co COMPRESS=NONE"
+      it "executes a reproject command with a compressed intermediate" do
+        command = "gdalwarp -q -t_srs EPSG:4326 \"files/geo.tif\" output/geo.png " \
+                  "-co TILED=YES -co COMPRESS=LZW -co BIGTIFF=IF_SAFER"
         processor.class.warp(file_name, output_file, options)
         expect(processor.class).to have_received(:execute).with command
       end

--- a/spec/derivative_services/geo_derivatives/runners/raster_derivatives_spec.rb
+++ b/spec/derivative_services/geo_derivatives/runners/raster_derivatives_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe GeoDerivatives::Runners::RasterDerivatives do
           label: :display_raster,
           id: "file_set_id",
           format: "tif",
+          srid: "EPSG:3857",
           url: display_raster_uri
         },
         {


### PR DESCRIPTION
Closes #7142

- **Compress and tile intermediate raster images**
- **Add a gdal warp command that outputs in COG format**

Results of research:
1. Compressing and tiling any intermediate files should allow gdal to process it in smaller chunks.
2. Combining the gdal-warp command with the COG conversion command should reduce the amount of intermediate data on disk.