### PR TITLE
Add an index for updated_at/id to support DC pagination.

### DIFF
--- a/db/migrate/20260603175418_add_updated_at_id_index.rb
+++ b/db/migrate/20260603175418_add_updated_at_id_index.rb
@@ -1,0 +1,7 @@
+class AddUpdatedAtIdIndex < ActiveRecord::Migration[7.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :orm_resources, [:updated_at, :id], algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -842,6 +842,13 @@ CREATE INDEX index_orm_resources_on_updated_at ON public.orm_resources USING btr
 
 
 --
+-- Name: index_orm_resources_on_updated_at_and_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_orm_resources_on_updated_at_and_id ON public.orm_resources USING btree (updated_at, id);
+
+
+--
 -- Name: index_preservation_audits_on_ids_from_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -992,6 +999,7 @@ ALTER TABLE ONLY public.active_storage_attachments
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260603175418'),
 ('20260109173200'),
 ('20251208215153'),
 ('20251204175843'),

--- a/devbox.json
+++ b/devbox.json
@@ -51,8 +51,8 @@
     "mediainfo": "latest",
     "ffmpeg": "8.0",
     "ocrmypdf": "latest",
-    "nodejs": {
-      "version": "22.11.0",
+    "nodejs-slim": {
+      "version": "24.15.0",
       "outputs": [
         "out",
         "libv8"

--- a/devbox.lock
+++ b/devbox.lock
@@ -715,68 +715,116 @@
         }
       }
     },
-    "nodejs@22.11.0": {
-      "last_modified": "2024-12-23T21:10:33Z",
+    "nodejs-slim@24.15.0": {
+      "last_modified": "2026-05-27T10:28:13Z",
       "plugin_version": "0.0.2",
-      "resolved": "github:NixOS/nixpkgs/de1864217bfa9b5845f465e771e0ecb48b30e02d#nodejs_22",
+      "resolved": "github:NixOS/nixpkgs/4100e830e085863741bc69b156ec4ccd53ab5be0#nodejs-slim",
       "source": "devbox-search",
-      "version": "22.11.0",
+      "version": "24.15.0",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/9vkabbbbyfn8hv5l1r8fm59d27imq460-nodejs-22.11.0",
+              "path": "/nix/store/4366l8b6kz1f2sxq6243rfs53grc73zz-nodejs-slim-24.15.0",
               "default": true
             },
             {
+              "name": "npm",
+              "path": "/nix/store/l5hp40l8wa03j18zbnfpbabvp5d4lw82-nodejs-slim-24.15.0-npm"
+            },
+            {
+              "name": "corepack",
+              "path": "/nix/store/q2cd2d4via0g4k92ffga65a0dsybm7na-nodejs-slim-24.15.0-corepack"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/0ab520bg0zaj03jj4dzwisdbqig5z4l6-nodejs-slim-24.15.0-dev"
+            },
+            {
               "name": "libv8",
-              "path": "/nix/store/m3rxxwm6jp95kjmh4rklqn0d76biz6wm-nodejs-22.11.0-libv8"
+              "path": "/nix/store/dw3i9zmh6p6p8h0ac5wc2rp2zqi22jl9-nodejs-slim-24.15.0-libv8"
             }
           ],
-          "store_path": "/nix/store/9vkabbbbyfn8hv5l1r8fm59d27imq460-nodejs-22.11.0"
+          "store_path": "/nix/store/4366l8b6kz1f2sxq6243rfs53grc73zz-nodejs-slim-24.15.0"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/z2lznj5fq0wagkhj7nkgmb5yr4gyv0ws-nodejs-22.11.0",
+              "path": "/nix/store/2qxdj2gxwckn22v4h78v1ijr4m6swfmj-nodejs-slim-24.15.0",
               "default": true
             },
             {
+              "name": "corepack",
+              "path": "/nix/store/mz4s7fqvq9z3p139wr33na0hwiw36yj9-nodejs-slim-24.15.0-corepack"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/vlzqwpsyb260jpavf47as6i7kn036kvi-nodejs-slim-24.15.0-dev"
+            },
+            {
               "name": "libv8",
-              "path": "/nix/store/0xiwppqyszilzy9cg71c26fxg5qcxh89-nodejs-22.11.0-libv8"
+              "path": "/nix/store/hcqiiv9l1y09pmp5kh4pac33y4d6rss2-nodejs-slim-24.15.0-libv8"
+            },
+            {
+              "name": "npm",
+              "path": "/nix/store/k6xvg2vn1dz0fqjc68c2jnzmbakdmdp6-nodejs-slim-24.15.0-npm"
             }
           ],
-          "store_path": "/nix/store/z2lznj5fq0wagkhj7nkgmb5yr4gyv0ws-nodejs-22.11.0"
+          "store_path": "/nix/store/2qxdj2gxwckn22v4h78v1ijr4m6swfmj-nodejs-slim-24.15.0"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/s81s2z275wnjazk4ij3zvn6kslfa5ipf-nodejs-22.11.0",
+              "path": "/nix/store/jni6dbiv7ihywbp70zix5g8nx9akmcn3-nodejs-slim-24.15.0",
               "default": true
             },
             {
+              "name": "corepack",
+              "path": "/nix/store/jqllggkxmq013iwqypzpjyagfs7vzbg4-nodejs-slim-24.15.0-corepack"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/klwycgrys2lshbs820p46i38jjsb71fw-nodejs-slim-24.15.0-dev"
+            },
+            {
               "name": "libv8",
-              "path": "/nix/store/mm87n14lp5akdjlfwh1yg4l93zm8gv9h-nodejs-22.11.0-libv8"
+              "path": "/nix/store/s9nivn4my67zx06l44q7sl1yrzbda7f4-nodejs-slim-24.15.0-libv8"
+            },
+            {
+              "name": "npm",
+              "path": "/nix/store/sdf3j9ni3x1j6vns4hb1yrf75pi41xp9-nodejs-slim-24.15.0-npm"
             }
           ],
-          "store_path": "/nix/store/s81s2z275wnjazk4ij3zvn6kslfa5ipf-nodejs-22.11.0"
+          "store_path": "/nix/store/jni6dbiv7ihywbp70zix5g8nx9akmcn3-nodejs-slim-24.15.0"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/fkyp1bm5gll9adnfcj92snyym524mdrj-nodejs-22.11.0",
+              "path": "/nix/store/q1r7qkrnbhakljr4j228v2yi2874jkl9-nodejs-slim-24.15.0",
               "default": true
             },
             {
+              "name": "corepack",
+              "path": "/nix/store/6plsadgnfakc13sjwcqjskb672pws2yw-nodejs-slim-24.15.0-corepack"
+            },
+            {
+              "name": "dev",
+              "path": "/nix/store/g92zwc10l4clznizbwncdpa3lsfg9a99-nodejs-slim-24.15.0-dev"
+            },
+            {
               "name": "libv8",
-              "path": "/nix/store/fyaac3q8qn3zfxy72airfabm3dakmgf5-nodejs-22.11.0-libv8"
+              "path": "/nix/store/4czajckssv9nzxxki1ivb6x6wshqcx46-nodejs-slim-24.15.0-libv8"
+            },
+            {
+              "name": "npm",
+              "path": "/nix/store/mm1a1wnphf568znv8jsz1gf4476yjhzm-nodejs-slim-24.15.0-npm"
             }
           ],
-          "store_path": "/nix/store/fkyp1bm5gll9adnfcj92snyym524mdrj-nodejs-22.11.0"
+          "store_path": "/nix/store/q1r7qkrnbhakljr4j228v2yi2874jkl9-nodejs-slim-24.15.0"
         }
       }
     },


### PR DESCRIPTION
Our HydrationConsumer pages ordered by updated_at/id, but we don't have an index for that combination so it runs pretty slow. This should speed it up.

This also updates NodeJS as far as I could get it right now in devbox.

Closes #7178 

This drops the query to 15ms in staging.