### PR TITLE
Add an auto-generated banner_image_id property

### DIFF
--- a/app/change_set_persisters/change_set_persister.rb
+++ b/app/change_set_persisters/change_set_persister.rb
@@ -37,7 +37,8 @@ class ChangeSetPersister
         CreateProxyFileSets,
         ApplyAuthToken,
         CacheParentId,
-        UpdateCloudFilePermissions
+        UpdateCloudFilePermissions,
+        ApplyBannerImageId
       ],
       after_save: [
         UpdateAuthToken,

--- a/app/change_set_persisters/change_set_persister/apply_banner_image_id.rb
+++ b/app/change_set_persisters/change_set_persister/apply_banner_image_id.rb
@@ -1,0 +1,41 @@
+class ChangeSetPersister
+  class ApplyBannerImageId
+    attr_reader :change_set_persister, :change_set
+    delegate :query_service, :persister, to: :change_set_persister
+    def initialize(change_set_persister:, change_set:, post_save_resource: nil)
+      @change_set = change_set
+      @change_set_persister = change_set_persister
+    end
+
+    def run
+      return unless change_set.respond_to?(:banner_image_id)
+      return unless change_set.changed?(:banner_image_url)
+      change_set.validate(banner_image_id: banner_image_id)
+      change_set.sync
+      change_set
+    end
+
+    private
+
+      def banner_image_id
+        return nil unless change_set.banner_image_url
+        return nil unless change_set.banner_image_url.include?(Figgy.config["pyramidal_url"])
+        id = extract_id_from_url(change_set.banner_image_url)
+        file_set = query_service.custom_queries.find_by_property(property: :file_metadata, model: FileSet, value: { id: Valkyrie::ID.new(id.to_s) }).first
+        return nil unless file_set
+        Wayfinder.for(file_set).parent.id.to_s
+      end
+
+      def extract_id_from_url(url)
+        # Get the url path components as an array
+        path = url.gsub(Figgy.config["pyramidal_url"], "").split("/")
+        # Decode the iiif id and get the figgy file id. Example:
+        #   20%2F2b%2Ff5%2F202bf5e644d14b78a8183ea9219c5d4e%2Fintermediate_file ->
+        #   20/2b/f5/202bf5e644d14b78a8183ea9219c5d4e/intermediate_file ->
+        #   202bf5e644d14b78a8183ea9219c5d4e
+        id = URI.decode_www_form_component(path[0]).split("/")[3]
+        # Convert string back into a UUID
+        id.gsub(/\A(.{8})(.{4})(.{4})(.{4})(.{12})\z/, '\1-\2-\3-\4-\5')
+      end
+  end
+end

--- a/app/change_set_persisters/change_set_persister/apply_banner_image_id.rb
+++ b/app/change_set_persisters/change_set_persister/apply_banner_image_id.rb
@@ -27,13 +27,15 @@ class ChangeSetPersister
       end
 
       def extract_id_from_url(url)
+        # Ensure the url is fully decoded (no escaped slashes)
+        decoded = URI.decode_www_form_component(url)
+
         # Get the url path components as an array
-        path = url.gsub(Figgy.config["pyramidal_url"], "").split("/")
-        # Decode the iiif id and get the figgy file id. Example:
-        #   20%2F2b%2Ff5%2F202bf5e644d14b78a8183ea9219c5d4e%2Fintermediate_file ->
-        #   20/2b/f5/202bf5e644d14b78a8183ea9219c5d4e/intermediate_file ->
-        #   202bf5e644d14b78a8183ea9219c5d4e
-        id = URI.decode_www_form_component(path[0]).split("/")[3]
+        path = decoded.gsub(Figgy.config["pyramidal_url"], "").split("/").reject(&:empty?)
+
+        # Figgy image id is the fourth component of the path
+        id = path[3]
+
         # Convert string back into a UUID
         id.gsub(/\A(.{8})(.{4})(.{4})(.{4})(.{12})\z/, '\1-\2-\3-\4-\5')
       end

--- a/app/change_sets/collection_change_set.rb
+++ b/app/change_sets/collection_change_set.rb
@@ -7,6 +7,7 @@ class CollectionChangeSet < ChangeSet
   property :source_metadata_identifier, required: true, multiple: false
   property :tagline, multiple: false, required: false
   property :banner_image_url, multiple: false, required: false
+  property :banner_image_id, multiple: false, required: false
   property :description, multiple: false, required: false
   property :visibility, multiple: false, required: false
   property :owners, multiple: true, required: false

--- a/app/change_sets/ephemera_project_change_set.rb
+++ b/app/change_sets/ephemera_project_change_set.rb
@@ -8,6 +8,7 @@ class EphemeraProjectChangeSet < Valkyrie::ChangeSet
   property :description, multiple: false, required: false
   property :publish, multiple: false, required: false, type: Valkyrie::Types::Bool
   property :banner_image_url, multiple: false, required: false
+  property :banner_image_id, multiple: false, required: false
 
   validates :title, :slug, presence: true
 

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -11,6 +11,7 @@ class Collection < Resource
   attribute :publish, Valkyrie::Types::Bool.optional
   attribute :tagline, Valkyrie::Types::String.optional
   attribute :banner_image_url, Valkyrie::Types::String.optional
+  attribute :banner_image_id, Valkyrie::Types::String.optional
 
   def thumbnail_id; end
 

--- a/app/models/ephemera_project.rb
+++ b/app/models/ephemera_project.rb
@@ -9,6 +9,7 @@ class EphemeraProject < Resource
   attribute :description, Valkyrie::Types::Set
   attribute :publish, Valkyrie::Types::Bool.optional
   attribute :banner_image_url, Valkyrie::Types::String.optional
+  attribute :banner_image_id, Valkyrie::Types::String.optional
 
   def logical_structure
     []

--- a/spec/change_set_persisters/change_set_persister/apply_banner_image_id_spec.rb
+++ b/spec/change_set_persisters/change_set_persister/apply_banner_image_id_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.describe ChangeSetPersister::ApplyBannerImageId do
+  let(:change_set_persister) { ChangeSetPersister.default }
+  let(:collection) { FactoryBot.build(:collection) }
+  let(:change_set) { ChangeSet.for(collection) }
+
+  context "with a banner_image_url that points to a real file in figgy" do
+    with_queue_adapter :inline
+    it "sets banner_image_id to the id of the parent resource" do
+      file = fixture_file_upload("files/example.tif", "image/tiff")
+      resource = FactoryBot.create_for_repository(:scanned_resource, files: [file])
+      file_set = Wayfinder.for(resource).file_sets.first
+      iiif_image_path = ManifestBuilder::PyramidalHelper.new.base_url(file_set)
+
+      change_set.validate(banner_image_url: "#{iiif_image_path}/642,2316,3854,2569/full/0/default.jpg")
+      output = change_set_persister.save(change_set: change_set)
+      expect(output.banner_image_id).to eq resource.id.to_s
+    end
+  end
+
+  context "with a banner_image_url that points to a file that is no longer in figgy" do
+    it "sets banner_image_id to nil" do
+      output = change_set_persister.save(change_set: change_set)
+      expect(output.banner_image_id).to be_nil
+    end
+  end
+
+  context "with a banner_image_url that points to a resource outside figgy" do
+    it "sets banner_image_id to nil" do
+      change_set.validate(banner_image_url: "https://example.com/iiif/testitem/642,2316,3854,2569/full/0/default.jpg")
+      output = change_set_persister.save(change_set: change_set)
+      expect(output.banner_image_id).to be_nil
+    end
+  end
+
+  context "with an empty banner_image_url" do
+    it "sets banner_image_id to nil" do
+      change_set.validate(banner_image_url: nil)
+      output = change_set_persister.save(change_set: change_set)
+      expect(output.banner_image_id).to be_nil
+    end
+  end
+end

--- a/spec/change_sets/ephemera_project_change_set_spec.rb
+++ b/spec/change_sets/ephemera_project_change_set_spec.rb
@@ -34,6 +34,13 @@ RSpec.describe EphemeraProjectChangeSet do
     end
   end
 
+  describe "#banner_image_id" do
+    it "is single-valued and not required" do
+      expect(change_set.multiple?(:banner_image_id)).to eq false
+      expect(change_set.required?(:banner_image_id)).to eq false
+    end
+  end
+
   describe "#language_options" do
     let(:resource) { FactoryBot.create_for_repository(:ephemera_project, member_ids: [ephemera_field.id]) }
     let(:ephemera_field) { FactoryBot.create_for_repository(:ephemera_field, member_of_vocabulary_id: [ephemera_vocabulary.id]) }

--- a/spec/factories/collection.rb
+++ b/spec/factories/collection.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     visibility { "open" }
     read_groups { "public" }
     tagline { "the coolest stuff we could find on this topic" }
-    banner_image_url { "https://iiif-cloud.princeton.edu/iiif/2/60%2Fb5%2Fe5%2F60b5e5365600450db52dbe4d7f92b8cc%2Fintermediate_file/642,2316,3854,2569/full/0/default.jpg" }
+    banner_image_url { "http://localhost:8182/pyramidals/iiif/2/te%2Fst%2Fe5%2Fteste5365600450db52dbe4d7f92b8cc%2Fintermediate_file/642,2316,3854,2569/full/0/default.jpg" }
     to_create do |instance|
       Valkyrie.config.metadata_adapter.persister.save(resource: instance)
     end

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature "Collection" do
     # Submit the form
     click_button "Save"
     # Expect the banner_image_url to be the same
-    expect(page).to have_css 'li.rendered_banner_image > img[src="https://iiif-cloud.princeton.edu/iiif/2/60%2Fb5%2Fe5%2F60b5e5365600450db52dbe4d7f92b8cc%2Fintermediate_file/642,2316,3854,2569/full/0/default.jpg"]'
+    expect(page).to have_css 'li.rendered_banner_image > img[src="http://localhost:8182/pyramidals/iiif/2/te%2Fst%2Fe5%2Fteste5365600450db52dbe4d7f92b8cc%2Fintermediate_file/642,2316,3854,2569/full/0/default.jpg"]'
   end
 
   context "viewing a collection" do

--- a/spec/models/ephemera_project_spec.rb
+++ b/spec/models/ephemera_project_spec.rb
@@ -23,4 +23,8 @@ RSpec.describe EphemeraProject do
     project.banner_image_url = "https://iiif-cloud.princeton.edu/iiif/2/60%2Fb5%2Fe5%2F60b5e5365600450db52dbe4d7f92b8cc%2Fintermediate_file/full/!200,150/0/default.jpg"
     expect(project.banner_image_url).to start_with "https"
   end
+  it "has a banner_image_id" do
+    project.banner_image_id = "60b5e536-5600-450d-b52d-be4d7f92b8cc"
+    expect(project.banner_image_id).to eq "60b5e536-5600-450d-b52d-be4d7f92b8cc"
+  end
 end


### PR DESCRIPTION
Closes #7173

- Adds banner_image_id to Collection and EphemeraProject
- Adds a change set persister to calculate the figgy id of banner image parent resource