### PR TITLE
Don't error when when record is in Solr but not in database

### DIFF
--- a/app/helpers/thumbnail_helper.rb
+++ b/app/helpers/thumbnail_helper.rb
@@ -24,9 +24,11 @@ module ThumbnailHelper
     document = document.try(:resource) || document.try(:model) || document
     value = send(figgy_thumbnail_method(document), document, image_options)
     value
-  rescue TypeError # This error is raised by the QueryService
+  rescue TypeError # Error raised by the QueryService in iiif_thumbnail_path
     Rails.logger.error("Unable to retrieve the resource with the ID #{document.id}")
     default_icon_fallback
+  rescue Valkyrie::Persistence::ObjectNotFoundError
+    Honeybadger.notify("Unable to retrieve the resource with the ID #{document.id} - probably a record in Solr but not in the database")
   end
 
   def geo_thumbnail?(document)

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -122,4 +122,21 @@ RSpec.feature "Scanned Resources" do
       expect(page).not_to have_css("#facet-parent_box_id_ssi-header")
     end
   end
+
+  describe "when a resource is in solr but not in the database" do
+    it "it renders the search results without erroring and notifies Honeybadger" do
+      allow(Honeybadger).to receive(:notify)
+      r1 = FactoryBot.create_for_repository(:scanned_resource, title: "test123")
+      r2 = FactoryBot.create_for_repository(:scanned_resource, title: "test456")
+      change_set_persister.save(change_set: ChangeSet.for(r1))
+      change_set_persister.save(change_set: ChangeSet.for(r2))
+      pg_adapter = Valkyrie::MetadataAdapter.find(:postgres)
+      pg_csp = ChangeSetPersister.new(metadata_adapter: pg_adapter, storage_adapter: Valkyrie.config.storage_adapter)
+      pg_csp.delete(change_set: ChangeSet.for(r2))
+
+      visit "/catalog?q="
+      expect(page).to have_content "test123"
+      expect(Honeybadger).to have_received(:notify).with("Unable to retrieve the resource with the ID #{r2.id} - probably a record in Solr but not in the database")
+    end
+  end
 end


### PR DESCRIPTION
Closes #7158

The ticket says to remove the document from the search results if it is not in the database, however this is a fairly rare event and I don't think the overhead (hitting Solr AND Figgy) for every query is worth it. This PR rescues the thumbnail helper error (source of the issue) and adds a helpful Honeybadger notice so we can fix the issue during the weekly stampede.