### PR TITLE
Add a digital collections metadata panel

### DIFF
--- a/app/assets/stylesheets/components/show.scss
+++ b/app/assets/stylesheets/components/show.scss
@@ -3,7 +3,7 @@ body.blacklight-catalog-show #content {
   @extend .order-first;
 }
 
-.relationships, .attributes {
+.relationships, .attributes, .digital-collections-metadata {
   tbody th {
     width: 20%;
   }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -182,6 +182,7 @@ class CatalogController < ApplicationController
     config.show.partials += [:workflow_controls]
     config.show.partials += [:playlists]
     config.show.partials += [:vocabulary_nav]
+    config.show.partials += [:digital_collections]
     config.show.partials += [:members]
     config.show.partials += [:categories]
     config.show.partials += [:terms]

--- a/app/decorators/collection_decorator.rb
+++ b/app/decorators/collection_decorator.rb
@@ -1,7 +1,6 @@
 class CollectionDecorator < Valkyrie::ResourceDecorator
   delegate :members, :parents, :collections, :members_count, to: :wayfinder
-  display Schema::Common.attributes, :owners, :restricted_viewers, :rendered_manifest_url, :rendered_dpul_url, :rendered_banner_image
-
+  display Schema::Common.attributes, :owners, :restricted_viewers
   def title
     Array(super).first
   end
@@ -28,6 +27,23 @@ class CollectionDecorator < Valkyrie::ResourceDecorator
     end
   end
 
+  def digital_collections_attributes
+    rows = [
+      rendered_dc_url,
+      rendered_dpul_url,
+      rendered_manifest_url,
+      rendered_banner_image
+    ].compact.join("\n")
+
+    <<~HTML.html_safe
+      <table class="table digital-collections-metadata">
+        <tbody>
+          #{rows}
+        </tbody>
+      </table>
+    HTML
+  end
+
   private
 
     # Generate the Hash for the IIIF Manifest metadata exposing the slug as an "Exhibit" property
@@ -36,17 +52,42 @@ class CollectionDecorator < Valkyrie::ResourceDecorator
       { exhibit: slug }
     end
 
+    def rendered_dc_url
+      return unless publish
+      <<~HTML
+        <tr>
+          <th>Digital Collections URL</th>
+          <td class="rendered_dc_url">#{rendered_link("https://digital-collections.princeton.edu/collections/#{slug}")}</td>
+        </tr>
+      HTML
+    end
+
     def rendered_dpul_url
-      rendered_link("https://dpul.princeton.edu/#{slug}")
+      <<~HTML
+        <tr>
+          <th>DPUL URL</th>
+          <td class="rendered_dpul_url">#{rendered_link("https://dpul.princeton.edu/#{slug}")}</td>
+        </tr>
+      HTML
     end
 
     def rendered_manifest_url
-      rendered_link(helpers.manifest_collection_url(self))
+      <<~HTML
+        <tr>
+          <th>IIIF Manifest URL</th>
+          <td class="rendered_manifest_url">#{rendered_link(helpers.manifest_collection_url(self))}</td>
+        </tr>
+      HTML
     end
 
     def rendered_banner_image
       return if banner_image_url.blank?
-      "<img style=\"width: 100%;\" src=\"#{banner_image_url}\" />".html_safe
+      <<~HTML
+        <tr>
+          <th>Banner Image</th>
+          <td class="rendered_banner_image"><img style="width: 50%;" src="#{banner_image_url}" /></td>
+        </tr>
+      HTML
     end
 
     def rendered_link(url)

--- a/app/decorators/collection_decorator.rb
+++ b/app/decorators/collection_decorator.rb
@@ -1,4 +1,5 @@
 class CollectionDecorator < Valkyrie::ResourceDecorator
+  include DigitalCollectionsMetadata
   delegate :members, :parents, :collections, :members_count, to: :wayfinder
   display Schema::Common.attributes, :owners, :restricted_viewers
   def title
@@ -27,23 +28,6 @@ class CollectionDecorator < Valkyrie::ResourceDecorator
     end
   end
 
-  def digital_collections_attributes
-    rows = [
-      rendered_dc_url,
-      rendered_dpul_url,
-      rendered_manifest_url,
-      rendered_banner_image
-    ].compact.join("\n")
-
-    <<~HTML.html_safe
-      <table class="table digital-collections-metadata">
-        <tbody>
-          #{rows}
-        </tbody>
-      </table>
-    HTML
-  end
-
   private
 
     # Generate the Hash for the IIIF Manifest metadata exposing the slug as an "Exhibit" property
@@ -52,45 +36,14 @@ class CollectionDecorator < Valkyrie::ResourceDecorator
       { exhibit: slug }
     end
 
-    def rendered_dc_url
-      return unless publish
-      <<~HTML
-        <tr>
-          <th>Digital Collections URL</th>
-          <td class="rendered_dc_url">#{rendered_link("https://digital-collections.princeton.edu/collections/#{slug}")}</td>
-        </tr>
-      HTML
-    end
-
-    def rendered_dpul_url
-      <<~HTML
-        <tr>
-          <th>DPUL URL</th>
-          <td class="rendered_dpul_url">#{rendered_link("https://dpul.princeton.edu/#{slug}")}</td>
-        </tr>
-      HTML
-    end
-
-    def rendered_manifest_url
-      <<~HTML
-        <tr>
-          <th>IIIF Manifest URL</th>
-          <td class="rendered_manifest_url">#{rendered_link(helpers.manifest_collection_url(self))}</td>
-        </tr>
-      HTML
-    end
-
-    def rendered_banner_image
-      return if banner_image_url.blank?
-      <<~HTML
-        <tr>
-          <th>Banner Image</th>
-          <td class="rendered_banner_image"><img style="width: 50%;" src="#{banner_image_url}" /></td>
-        </tr>
-      HTML
-    end
-
-    def rendered_link(url)
-      "<a href=\"#{url}\">#{url}</a>".html_safe
+    # Rows to include in the digital collections metadata panel on the show
+    # page. Logic in DigitalCollectionsMetadata class.
+    def digital_collections_rows
+      [
+        rendered_dc_url,
+        rendered_dpul_url,
+        rendered_manifest_url,
+        rendered_banner_image
+      ]
     end
 end

--- a/app/decorators/digital_collections_metadata.rb
+++ b/app/decorators/digital_collections_metadata.rb
@@ -1,0 +1,51 @@
+module DigitalCollectionsMetadata
+  # Render digital collections metadata as a striped table.
+  def digital_collections_attributes
+    rows = digital_collections_rows.compact.join("\n")
+
+    <<~HTML.html_safe
+      <table class="table digital-collections-metadata">
+        <tbody>
+          #{rows}
+        </tbody>
+      </table>
+    HTML
+  end
+
+  private
+
+    def rendered_dc_url
+      return unless publish
+      digital_collections_row("Digital Collections URL", "rendered_dc_url",
+        rendered_link("https://digital-collections.princeton.edu/collections/#{slug}"))
+    end
+
+    def rendered_dpul_url
+      digital_collections_row("DPUL URL", "rendered_dpul_url",
+        rendered_link("https://dpul.princeton.edu/#{slug}"))
+    end
+
+    def rendered_manifest_url
+      digital_collections_row("IIIF Manifest URL", "rendered_manifest_url",
+        rendered_link(helpers.manifest_collection_url(self)))
+    end
+
+    def rendered_banner_image
+      return if banner_image_url.blank?
+      digital_collections_row("Banner Image", "rendered_banner_image",
+        "<img style=\"width: 50%;\" src=\"#{banner_image_url}\" />")
+    end
+
+    def digital_collections_row(label, css_class, value)
+      <<~HTML
+        <tr>
+          <th>#{label}</th>
+          <td class="#{css_class}">#{value}</td>
+        </tr>
+      HTML
+    end
+
+    def rendered_link(url)
+      "<a href=\"#{url}\">#{url}</a>"
+    end
+end

--- a/app/decorators/ephemera_project_decorator.rb
+++ b/app/decorators/ephemera_project_decorator.rb
@@ -1,4 +1,5 @@
 class EphemeraProjectDecorator < Valkyrie::ResourceDecorator
+  include DigitalCollectionsMetadata
   delegate :members, :query_service, :decorated_folders_with_genres, to: :wayfinder
 
   # TODO: Rename to decorated_ephemera_boxes
@@ -52,21 +53,6 @@ class EphemeraProjectDecorator < Valkyrie::ResourceDecorator
     super.merge iiif_manifest_exhibit
   end
 
-  def digital_collections_attributes
-    rows = [
-      rendered_dc_url,
-      rendered_banner_image
-    ].compact.join("\n")
-
-    <<~HTML.html_safe
-      <table class="table digital-collections-metadata">
-        <tbody>
-          #{rows}
-        </tbody>
-      </table>
-    HTML
-  end
-
   private
 
     # Generate the Hash for the IIIF Manifest metadata exposing the slug as an "Exhibit" property
@@ -75,27 +61,12 @@ class EphemeraProjectDecorator < Valkyrie::ResourceDecorator
       { exhibit: slug }
     end
 
-    def rendered_dc_url
-      return unless publish
-      <<~HTML
-        <tr>
-          <th>Digital Collections URL</th>
-          <td class="rendered_dc_url">#{rendered_link("https://digital-collections.princeton.edu/collections/#{slug}")}</td>
-        </tr>
-      HTML
-    end
-
-    def rendered_banner_image
-      return if banner_image_url.blank?
-      <<~HTML
-        <tr>
-          <th>Banner Image</th>
-          <td class="rendered_banner_image"><img style="width: 50%;" src="#{banner_image_url}" /></td>
-        </tr>
-      HTML
-    end
-
-    def rendered_link(url)
-      "<a href=\"#{url}\">#{url}</a>".html_safe
+    # Rows to include in the digital collections metadata panel on the show
+    # page. Logic in DigitalCollectionsMetadata class.
+    def digital_collections_rows
+      [
+        rendered_dc_url,
+        rendered_banner_image
+      ]
     end
 end

--- a/app/decorators/ephemera_project_decorator.rb
+++ b/app/decorators/ephemera_project_decorator.rb
@@ -1,5 +1,4 @@
 class EphemeraProjectDecorator < Valkyrie::ResourceDecorator
-  display :rendered_banner_image
   delegate :members, :query_service, :decorated_folders_with_genres, to: :wayfinder
 
   # TODO: Rename to decorated_ephemera_boxes
@@ -53,6 +52,21 @@ class EphemeraProjectDecorator < Valkyrie::ResourceDecorator
     super.merge iiif_manifest_exhibit
   end
 
+  def digital_collections_attributes
+    rows = [
+      rendered_dc_url,
+      rendered_banner_image
+    ].compact.join("\n")
+
+    <<~HTML.html_safe
+      <table class="table digital-collections-metadata">
+        <tbody>
+          #{rows}
+        </tbody>
+      </table>
+    HTML
+  end
+
   private
 
     # Generate the Hash for the IIIF Manifest metadata exposing the slug as an "Exhibit" property
@@ -61,8 +75,27 @@ class EphemeraProjectDecorator < Valkyrie::ResourceDecorator
       { exhibit: slug }
     end
 
+    def rendered_dc_url
+      return unless publish
+      <<~HTML
+        <tr>
+          <th>Digital Collections URL</th>
+          <td class="rendered_dc_url">#{rendered_link("https://digital-collections.princeton.edu/collections/#{slug}")}</td>
+        </tr>
+      HTML
+    end
+
     def rendered_banner_image
       return if banner_image_url.blank?
-      "<img style=\"width: 100%;\" src=\"#{banner_image_url}\" />".html_safe
+      <<~HTML
+        <tr>
+          <th>Banner Image</th>
+          <td class="rendered_banner_image"><img style="width: 50%;" src="#{banner_image_url}" /></td>
+        </tr>
+      HTML
+    end
+
+    def rendered_link(url)
+      "<a href=\"#{url}\">#{url}</a>".html_safe
     end
 end

--- a/app/decorators/ephemera_project_decorator.rb
+++ b/app/decorators/ephemera_project_decorator.rb
@@ -66,6 +66,7 @@ class EphemeraProjectDecorator < Valkyrie::ResourceDecorator
     def digital_collections_rows
       [
         rendered_dc_url,
+        rendered_dpul_url,
         rendered_banner_image
       ]
     end

--- a/app/views/catalog/_digital_collections_default.html.erb
+++ b/app/views/catalog/_digital_collections_default.html.erb
@@ -1,0 +1,15 @@
+<% if resource.is_a?(Collection) || resource.is_a?(EphemeraProject) %>
+  <div id="digital_collections" class="card digital-collections-affix">
+    <div class="card-header">
+      <h2 class="card-title">
+        Digital Collections
+      </h2>
+    </div>
+    <div id="digital_collections_collapse" class="card-body">
+      <% decorator = resource.decorate %>
+      <dl class="digital-collections-metadata">
+        <%= decorator.digital_collections_attributes %>
+      </dl>
+    </div>
+  </div>
+<% end %>

--- a/spec/decorators/collection_decorator_spec.rb
+++ b/spec/decorators/collection_decorator_spec.rb
@@ -23,9 +23,6 @@ RSpec.describe CollectionDecorator do
     it "displays the description" do
       expect(decorator.display_attributes[:description]).to eq ["test description"]
     end
-    it "displays the DPUL url" do
-      expect(decorator.display_attributes[:rendered_dpul_url]).to eq ["<a href=\"https://dpul.princeton.edu/test\">https://dpul.princeton.edu/test</a>"]
-    end
   end
 
   describe "#members_count" do

--- a/spec/features/collection_spec.rb
+++ b/spec/features/collection_spec.rb
@@ -36,23 +36,31 @@ RSpec.feature "Collection" do
     # Submit the form
     click_button "Save"
     # Expect the banner_image_url to be the same
-    expect(page).to have_css 'li.rendered_banner_image > img[src="https://iiif-cloud.princeton.edu/iiif/2/60%2Fb5%2Fe5%2F60b5e5365600450db52dbe4d7f92b8cc%2Fintermediate_file/642,2316,3854,2569/750,/0/default.jpg"]'
+    expect(page).to have_css 'td.rendered_banner_image > img[src="https://iiif-cloud.princeton.edu/iiif/2/60%2Fb5%2Fe5%2F60b5e5365600450db52dbe4d7f92b8cc%2Fintermediate_file/642,2316,3854,2569/750,/0/default.jpg"]'
   end
 
   context "viewing a collection" do
-    scenario "with a banner image url" do
-      collection = FactoryBot.create_for_repository(:collection)
+    scenario "when published with a banner image url" do
+      collection = FactoryBot.create_for_repository(:collection, publish: true)
       visit solr_document_path(id: collection.id)
-      expect(page).to have_text "Rendered Banner Image"
-      expect(page).to have_css "li.rendered_banner_image > img"
+      expect(page).to have_text "Banner Image"
+      expect(page).to have_css "td.rendered_banner_image > img"
+      expect(page).to have_text "Digital Collections URL"
+      expect(page).to have_css "td.rendered_dc_url > a[href=\"https://digital-collections.princeton.edu/collections/test\"]"
+      expect(page).to have_text "DPUL URL"
+      expect(page).to have_css "td.rendered_dpul_url > a[href=\"https://dpul.princeton.edu/test\"]"
+      expect(page).to have_text "IIIF Manifest URL"
+      expect(page).to have_link href: /collections\/.*\/manifest/\
     end
 
-    scenario "without a banner image url" do
-      collection = FactoryBot.create_for_repository(:collection, banner_image_url: nil)
+    scenario "when unpublished and without a banner image url" do
+      collection = FactoryBot.create_for_repository(:collection, banner_image_url: nil, publish: false)
       visit solr_document_path(id: collection.id)
 
-      expect(page).not_to have_text "Rendered Banner Image"
-      expect(page).not_to have_css "li.rendered_banner_image > img"
+      expect(page).not_to have_text "Banner Image"
+      expect(page).not_to have_css "td.rendered_banner_image > img"
+      expect(page).not_to have_text "Digital Collections URL"
+      expect(page).not_to have_css "td.rendered_dc_url > a[href=\"https://digital-collections.princeton.edu/collections/test\"]"
     end
 
     scenario "with a highlighted item" do

--- a/spec/features/ephemera_project_spec.rb
+++ b/spec/features/ephemera_project_spec.rb
@@ -47,6 +47,8 @@ RSpec.feature "Ephemera Project" do
       expect(page).to have_css "td.rendered_banner_image > img"
       expect(page).to have_text "Digital Collections URL"
       expect(page).to have_css "td.rendered_dc_url > a[href=\"https://digital-collections.princeton.edu/collections/test_project-1234\"]"
+      expect(page).to have_text "DPUL URL"
+      expect(page).to have_css "td.rendered_dpul_url > a[href=\"https://dpul.princeton.edu/test_project-1234\"]"
     end
 
     scenario "when unpublished and without a banner image url" do

--- a/spec/features/ephemera_project_spec.rb
+++ b/spec/features/ephemera_project_spec.rb
@@ -34,24 +34,30 @@ RSpec.feature "Ephemera Project" do
 
     expect(page).to have_link "Delete This Ephemera Project"
     # Expect the banner_image_url to be the same
-    expect(page).to have_css "li.rendered_banner_image > img[src=\"#{project.banner_image_url}\"]"
+    expect(page).to have_css "td.rendered_banner_image > img[src=\"#{project.banner_image_url}\"]"
     reloaded_folder = ChangeSetPersister.default.query_service.find_by(id: folder.id)
     expect(reloaded_folder.updated_at).to eq folder.updated_at
   end
 
   context "viewing a project" do
-    scenario "with a banner image url" do
-      project = FactoryBot.create_for_repository(:ephemera_project)
+    scenario "when published with a banner image url" do
+      project = FactoryBot.create_for_repository(:ephemera_project, publish: true)
       visit solr_document_path(id: project.id)
-      expect(page).to have_text "Rendered Banner Image"
-      expect(page).to have_css "li.rendered_banner_image > img"
+      expect(page).to have_text "Banner Image"
+      expect(page).to have_css "td.rendered_banner_image > img"
+      expect(page).to have_text "Digital Collections URL"
+      expect(page).to have_css "td.rendered_dc_url > a[href=\"https://digital-collections.princeton.edu/collections/test_project-1234\"]"
     end
-    scenario "without a banner image url" do
-      project = FactoryBot.create_for_repository(:ephemera_project, banner_image_url: nil)
+
+    scenario "when unpublished and without a banner image url" do
+      project = FactoryBot.create_for_repository(:ephemera_project, banner_image_url: nil, publish: false)
       visit solr_document_path(id: project.id)
-      expect(page).not_to have_text "Rendered Banner Image"
-      expect(page).not_to have_css "li.rendered_banner_image > img"
+      expect(page).not_to have_text "Banner Image"
+      expect(page).not_to have_css "td.rendered_banner_image > img"
+      expect(page).not_to have_text "Digital Collections URL"
+      expect(page).not_to have_css "td.rendered_dc_url > a[href=\"https://digital-collections.princeton.edu/collections/test_project-1234\"]"
     end
+
     scenario "with a highlighted item" do
       folder = FactoryBot.create_for_repository(:ephemera_folder, title: "Featured Folder", featurable: "0")
       project = FactoryBot.create_for_repository(:ephemera_project, member_ids: [folder.id])


### PR DESCRIPTION
Closes #7209

- **Add a digital collections metadata panel**
- **Refactor with DigitalCollectionsMetadata class**

<img width="907" height="1049" alt="image" src="https://github.com/user-attachments/assets/487f9f8f-1d35-4b1f-a1e8-0988c53a08d2" />
