### PR TITLE
Instead of Plausible events, send messages to iframe parent window

### DIFF
--- a/app/javascript/test/setup.js
+++ b/app/javascript/test/setup.js
@@ -3,6 +3,10 @@ import _ from 'lodash'
 vi.unmock('lodash')
 _.debounce = vi.fn((fn) => fn);
 
+// Stub HTMLCanvasElement.prototype.getContext used in OpenSeaDragon
+// to prevent "Not implemented" errors during tests.
+HTMLCanvasElement.prototype.getContext = vi.fn()
+
 // jsdom doesn't let you mock window.location anymore, so replace that
 // implementation for all tests so we can mock it. Solution found here:
 // https://www.benmvp.com/blog/mocking-window-location-methods-jest-jsdom/

--- a/app/javascript/test/viewer/uv_manager.spec.js
+++ b/app/javascript/test/viewer/uv_manager.spec.js
@@ -112,6 +112,10 @@ describe('UVManager', () => {
     window.parent.postMessage = vi.fn()
   }
 
+  function mockWindowOpen() {
+    window.open = vi.fn()
+  }
+
   beforeEach(() => {
     vi.clearAllMocks()
   })
@@ -148,6 +152,7 @@ describe('UVManager', () => {
       mockUvProvider()
       mockManifests(200)
       mockPostMessage()
+      mockWindowOpen()
       stubQuery({
         type: 'html',
         content: "<iframe src='https://figgy.princeton.edu/viewer#?manifest=https://figgy.princeton.edu/concern/scanned_resources/78e15d09-3a79-4057-b358-4fde3d884bbb/manifest'></iframe>",

--- a/app/javascript/test/viewer/uv_manager.spec.js
+++ b/app/javascript/test/viewer/uv_manager.spec.js
@@ -112,6 +112,10 @@ describe('UVManager', () => {
     window.plausible = vi.fn()
   }
 
+  function mockPostMessage() {
+    window.parent.postMessage = vi.fn()
+  }
+
   beforeEach(() => {
     vi.clearAllMocks()
   })
@@ -169,12 +173,12 @@ describe('UVManager', () => {
       expect(window.plausible).toHaveBeenCalledWith('Download', { props: { url: 'http://example.com' } })
     })
 
-    it('sends an event to Plausible when the Universal Viewer container is clicked', async () => {
+    it('sends an event message when the Universal Viewer container is clicked', async () => {
       document.body.innerHTML = initialHTML
       mockJquery()
       mockUvProvider()
       mockManifests(200)
-      mockPlausible()
+      mockPostMessage()
       stubQuery({
         type: 'html',
         content: "<iframe src='https://figgy.princeton.edu/viewer#?manifest=https://figgy.princeton.edu/concern/scanned_resources/78e15d09-3a79-4057-b358-4fde3d884bbb/manifest'></iframe>",
@@ -190,8 +194,13 @@ describe('UVManager', () => {
       const uvManager = new UVManager()
       await uvManager.initialize()
       document.getElementById('uv').click()
-      // This triggers a Plausible custom event.
-      expect(window.plausible).toHaveBeenCalledWith('UniversalViewer Click')
+      // This triggers an event message
+      const data = {
+        x: 0,
+        y: 0,
+        target: "<div id=\"uv\" class=\"uv\"></div>"
+      }
+      expect(window.parent.postMessage).toHaveBeenCalledWith({event: "universal-viewer-click", data: data}, "*")
     })
 
     it('passes on an auth token to graphql', async () => {

--- a/app/javascript/test/viewer/uv_manager.spec.js
+++ b/app/javascript/test/viewer/uv_manager.spec.js
@@ -108,10 +108,6 @@ describe('UVManager', () => {
     )
   }
 
-  function mockPlausible () {
-    window.plausible = vi.fn()
-  }
-
   function mockPostMessage() {
     window.parent.postMessage = vi.fn()
   }
@@ -126,7 +122,6 @@ describe('UVManager', () => {
       mockJquery()
       mockUvProvider()
       mockManifests(200)
-      mockPlausible()
       stubQuery({
         type: 'html',
         content: "<iframe src='https://figgy.princeton.edu/viewer#?manifest=https://figgy.princeton.edu/concern/scanned_resources/78e15d09-3a79-4057-b358-4fde3d884bbb/manifest'></iframe>",
@@ -147,12 +142,12 @@ describe('UVManager', () => {
       expect(leafletSpy).not.toHaveBeenCalled()
     })
 
-    it('sends an event to Plausible when downloading something', async () => {
+    it('sends an event message when downloading something', async () => {
       document.body.innerHTML = initialHTML
       mockJquery()
       mockUvProvider()
       mockManifests(200)
-      mockPlausible()
+      mockPostMessage()
       stubQuery({
         type: 'html',
         content: "<iframe src='https://figgy.princeton.edu/viewer#?manifest=https://figgy.princeton.edu/concern/scanned_resources/78e15d09-3a79-4057-b358-4fde3d884bbb/manifest'></iframe>",
@@ -169,8 +164,12 @@ describe('UVManager', () => {
       await uvManager.initialize()
       // window.open is how UV initializes a download.
       window.open('http://example.com')
-      // This triggers a Plausible custom event.
-      expect(window.plausible).toHaveBeenCalledWith('Download', { props: { url: 'http://example.com' } })
+
+      // This triggers an event message
+      const data = {
+        url: "http://example.com"
+      }
+      expect(window.parent.postMessage).toHaveBeenCalledWith({event: "universal-viewer-download", data: data}, "*")
     })
 
     it('sends an event message when the Universal Viewer container is clicked', async () => {

--- a/app/javascript/viewer/uv_manager.js
+++ b/app/javascript/viewer/uv_manager.js
@@ -147,9 +147,18 @@ export default class UVManager {
     uvElement.addEventListener(
       "click",
       (event) => {
-        /* … */
         uvElement.dispatchEvent(uvClick)
-        window.plausible('UniversalViewer Click')
+        const data = {
+          x: event.x,
+          y: event.y,
+          target: event.target.outerHTML
+        }
+        const message = {
+          event: "universal-viewer-click",
+          data: data
+        }
+
+        window.parent.postMessage(message, "*");
       },
       false,
     );

--- a/app/javascript/viewer/uv_manager.js
+++ b/app/javascript/viewer/uv_manager.js
@@ -135,7 +135,12 @@ export default class UVManager {
   remapWindowOpen () {
     const cachedOpen = window.open
     window.open = function (url, target, features) {
-      window.plausible('Download', { props: { url } })
+      const message = {
+        event: "universal-viewer-download",
+        data: { url: url }
+      }
+
+      window.parent.postMessage(message, "*");
       cachedOpen(url, target, features)
     }
   }

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -24,10 +24,10 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.18/dist/js/bootstrap-select.min.js"></script>
 
     <%= content_for(:head) %>
-    <%= render 'shared/analytics' if Rails.env.production? %>
+    <%= render 'shared/analytics' %>
   </head>
   <body class="<%= render_body_class %>">
-    <%= render 'shared/analytics_noscript' if Rails.env.production? %>
+    <%= render 'shared/analytics_noscript' %>
     <div class="lux">
     <nav id="skip-link" role="navigation" aria-label="<%= t('blacklight.skip_links.label') %>">
       <%= link_to t('blacklight.skip_links.search_field'), '#search_field', class: 'element-invisible element-focusable rounded-bottom py-2 px-3', data: { turbolinks: 'false' } %>

--- a/app/views/layouts/viewer_layout.html.erb
+++ b/app/views/layouts/viewer_layout.html.erb
@@ -9,11 +9,6 @@
     <script type="text/javascript" src="/uv/lib/offline.js"></script>
     <script type="text/javascript" src="/uv/lib/offline.js"></script>
     <script type="text/javascript" src="/uv/helpers.js"></script>
-    <%= render 'shared/analytics' if Rails.env.production? %>
-    <% if Rails.env.staging? || Rails.env.production? %>
-      <script defer event-environment="<%= Rails.env.to_s %>" event-embed-host="<%= params[:embed_host] || "unknown" %>" data-domain="dpul.princeton.edu" src="https://plausible.io/js/script.pageview-props.manual.js"></script>
-      <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
-    <% end %>
   </head>
   <body>
     <%= yield %>

--- a/app/views/shared/_analytics.html.erb
+++ b/app/views/shared/_analytics.html.erb
@@ -1,3 +1,9 @@
-<!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-TKVQSCRK');</script>
-<!-- End Google Tag Manager -->
+<% if Rails.env.production? %>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-TKVQSCRK');</script>
+  <!-- End Google Tag Manager -->
+<% elsif Rails.env.staging? %>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','GTM-P8WZGF7N');</script>
+  <!-- End Google Tag Manager -->
+<% end %>

--- a/app/views/shared/_analytics_noscript.html.erb
+++ b/app/views/shared/_analytics_noscript.html.erb
@@ -1,3 +1,9 @@
-<!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TKVQSCRK"
-                  height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<% if Rails.env.production? %>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TKVQSCRK" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<% elsif Rails.env.staging? %>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P8WZGF7N" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+<% end %>


### PR DESCRIPTION
Instead of Plausible events, send messages to iframe parent window that individual webapps can subscribe to and hook to analytics. This allows UV events to be logged per site.

Part of https://github.com/pulibrary/figgy/issues/7174

- **Send message to parent window on UV click**
- **Send message to parent window on download**
- **Silence uv_manager.spec errors**
- **Remove Plausible from Universal Viewer embed**
- **Add tag manager to staging**

Added figgy-staging to umami and tag manager and then added this code to the tag manager to subscribe to messages:

```
    // Listen for UniversalViewer event messages and track in umami
    window.addEventListener("message", function(event) {
      // Exit if message is not from a known origin
      var regex = /princeton\.edu/;
      if (!regex.test(event.origin)) {
        return;
      }

      var event_name = event.data.event;
      if (event_name == 'universal-viewer-click') {
        umami.track(event_name, event.data.data);
      } else if (event_name == 'universal-viewer-download') {
        umami.track(event_name, event.data.data);
      };
    });
```

Now UV click and download events are logged with Umami:
https://analytics-staging.lib.princeton.edu/websites/5ebe40c2-e7a8-453d-a934-96b14dfe0492/events

<img width="1358" height="1064" alt="image" src="https://github.com/user-attachments/assets/2d2c6b97-cdd8-4f07-98f0-05615388080c" />

<img width="1411" height="767" alt="image" src="https://github.com/user-attachments/assets/406b1337-a069-4293-b655-50f441b52018" />

If this PR is merged, we can then add that tag code to figgy-prod, finding aids, and dpul.
