### PR TITLE
Precompile to try to prevent zlib buffer error.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,8 @@ commands:
             curl -H "Content-type:application/octet-stream" --data-binary @solr_config.zip "http://solr:SolrRocks@127.0.0.1:8984/solr/admin/configs?action=UPLOAD&name=figgy"
             curl -H 'Content-type: application/json' http://solr:SolrRocks@127.0.0.1:8984/api/collections/  -d '{"name": "figgy-core-test", "config": "figgy", "numShards": 1}'
       - run: bundle exec rake db:migrate
+      - run: bundle exec rake assets:precompile
+
   post-test-steps:
     steps:
       - persist_to_workspace:


### PR DESCRIPTION
There keeps being a buffer error. It seems to be related to compiling assets for tests on demand, so maybe pre compiling will fix it