### PR TITLE
Renovate should pin versions.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,7 @@
     "enabled": true
   },
   "minimumReleaseAge": "14 days",
+  "rangeStrategy": "pin",
   "packageRules": [
     {
       "matchDatasources": [
@@ -29,7 +30,7 @@
       "matchManagers": [
         "bundler"
       ],
-      "rangeStrategy": "update-lockfile"
+      "rangeStrategy": "pin"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
This'll be annoying at first and we might be able to revert it later
when bundler's set up to enforce the range limit, but for now this'll
get us moving.
