### PR TITLE
Fix UV/Clover rendering.

### DIFF
--- a/spec/features/scanned_resource_spec.rb
+++ b/spec/features/scanned_resource_spec.rb
@@ -108,4 +108,18 @@ RSpec.feature "Scanned Resource" do
     expect(selene.visibility).to eq scanned_resource.visibility
     expect(selene.state).to eq scanned_resource.state
   end
+
+  context "when looking at a resource with derivatives" do
+    with_queue_adapter :inline
+    scenario "show page with a viewer", js: true, run_real_derivatives: true do
+      file = fixture_file_upload("files/example.tif", "image/tiff")
+      resource = FactoryBot.create_for_repository(:pending_scanned_resource, files: [file])
+
+      visit solr_document_path(id: resource.id)
+
+      within_frame(find(".uv-container > iframe")) do
+        expect(page).to have_selector("#uv #content .openseadragon-canvas")
+      end
+    end
+  end
 end

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -43,5 +43,18 @@ export default defineConfig({
         return { define: {  __VUE_PROD_DEVTOOLS__: true }  }
       },
     },
+    {
+      // Force openseadragon to not use requirejs, since when we load both Clover & UV
+      // (since UV is in uv.js), it complains.
+      name: 'openseadragon-disable-amd',
+      transform(code, id) {
+        if (id.includes('openseadragon') && code.includes("typeof define === 'function' && define.amd")) {
+          return code.replace(
+            "if (typeof define === 'function' && define.amd) {",
+            'if (false) {'
+          )
+        }
+      }
+    },
   ]
 })


### PR DESCRIPTION
What a mess. RequireJS was getting called in two different ways between
UV & Clover. Clover supports either way, so we can just replace the define.amd
branch of openseadragon and both load.
