### PR TITLE
Fix Preservation

### DIFF
--- a/app/adapters/gcs_fake/storage.rb
+++ b/app/adapters/gcs_fake/storage.rb
@@ -7,9 +7,17 @@ class GcsFake::Storage < Valkyrie::Storage::Disk
     DecoratedFile.new(output)
   end
 
+  # We need an upload that does streams, since GCS copies streams.
+  def upload(file:, original_filename:, resource: nil, **_extra_arguments)
+    new_path = path_generator.generate(resource: resource, file: file, original_filename: original_filename)
+    FileUtils.mkdir_p(new_path.parent)
+    file_mover.call(file, new_path)
+    find_by(id: Valkyrie::ID.new("#{protocol}#{new_path}"))
+  end
+
   class DecoratedFile < SimpleDelegator
     def io
-      DecoratedIo.new(super, self)
+      @io ||= DecoratedIo.new(super, self)
     end
 
     class DecoratedIo < SimpleDelegator

--- a/app/services/preserver.rb
+++ b/app/services/preserver.rb
@@ -132,6 +132,7 @@ class Preserver
       local_checksum = metadata_node.checksum.first
       local_checksum_hex = [local_checksum.md5].pack("H*")
       local_md5_checksum = Base64.strict_encode64(local_checksum_hex)
+      temp_metadata_file.rewind
 
       uploaded_file = storage_adapter.upload(
         file: temp_metadata_file.io,

--- a/config/initializers/valkyrie.rb
+++ b/config/initializers/valkyrie.rb
@@ -133,7 +133,7 @@ Rails.application.config.to_prepare do
     Valkyrie::StorageAdapter.register(
       GcsFake::Storage.new(
         base_path: Figgy.config["disk_preservation_path"],
-        file_mover: FileUtils.method(:cp),
+        file_mover: FileUtils.method(:copy_stream),
         path_generator: Preserver::NestedStoragePath
       ),
       :google_cloud_storage

--- a/devbox.json
+++ b/devbox.json
@@ -7,7 +7,7 @@
     "FONTCONFIG_PATH":         "$PWD/.devbox/nix/profile/default/etc/fonts"
   },
   "packages": {
-    "ruby":   "3.2.6",
+    "ruby":   "3.4.8",
     "libffi": "latest",
     "vips": {
       "version": "latest",

--- a/devbox.lock
+++ b/devbox.lock
@@ -1672,68 +1672,68 @@
         }
       }
     },
-    "ruby@3.2.6": {
-      "last_modified": "2025-03-23T05:31:05Z",
+    "ruby@3.4.8": {
+      "last_modified": "2026-04-16T08:46:55Z",
       "plugin_version": "0.0.2",
-      "resolved": "github:NixOS/nixpkgs/dd613136ee91f67e5dba3f3f41ac99ae89c5406b#ruby_3_2",
+      "resolved": "github:NixOS/nixpkgs/b86751bc4085f48661017fa226dee99fab6c651b#ruby",
       "source": "devbox-search",
-      "version": "3.2.6",
+      "version": "3.4.8",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/6qrg0c52xj05njv9dn9s2sgrfpgkx2ja-ruby-3.2.6",
+              "path": "/nix/store/88sazm3fj9kabg4pxmnjc53cx0syp8fk-ruby-3.4.8",
               "default": true
             },
             {
               "name": "devdoc",
-              "path": "/nix/store/vkgkipfqm9baaki0y2hdhm5bwdjbq3g8-ruby-3.2.6-devdoc"
+              "path": "/nix/store/mk7a50jsk138apqrnlzc077cik8cr47m-ruby-3.4.8-devdoc"
             }
           ],
-          "store_path": "/nix/store/6qrg0c52xj05njv9dn9s2sgrfpgkx2ja-ruby-3.2.6"
+          "store_path": "/nix/store/88sazm3fj9kabg4pxmnjc53cx0syp8fk-ruby-3.4.8"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/f02zwccza8bw16f2izpl1mp7c7gk9a62-ruby-3.2.6",
+              "path": "/nix/store/rpcpk0lxd8iliza4nl9apsgrpsb2yk4d-ruby-3.4.8",
               "default": true
             },
             {
               "name": "devdoc",
-              "path": "/nix/store/qx6d9460b6hjaf89v0kva680z0wzdxir-ruby-3.2.6-devdoc"
+              "path": "/nix/store/9wnq7dd2yw2lbjs69y19lm08ranqa930-ruby-3.4.8-devdoc"
             }
           ],
-          "store_path": "/nix/store/f02zwccza8bw16f2izpl1mp7c7gk9a62-ruby-3.2.6"
+          "store_path": "/nix/store/rpcpk0lxd8iliza4nl9apsgrpsb2yk4d-ruby-3.4.8"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/bxlvw25ibqlqyckgdvwz51k5jc15gd9q-ruby-3.2.6",
+              "path": "/nix/store/gq0vdqfz16vf64ip8p749rmygxd7n3x1-ruby-3.4.8",
               "default": true
             },
             {
               "name": "devdoc",
-              "path": "/nix/store/bq8irvsvsy5c6iggy8g15qvv6mb04750-ruby-3.2.6-devdoc"
+              "path": "/nix/store/k3yn26wvgk4mfrd5nw4a23wnijd9hz6c-ruby-3.4.8-devdoc"
             }
           ],
-          "store_path": "/nix/store/bxlvw25ibqlqyckgdvwz51k5jc15gd9q-ruby-3.2.6"
+          "store_path": "/nix/store/gq0vdqfz16vf64ip8p749rmygxd7n3x1-ruby-3.4.8"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/npxjgn860mgvfmh8zasrs78lq5sz5qyy-ruby-3.2.6",
+              "path": "/nix/store/s57rf37r1i38kpm3nlv4h8f8z2w2n80d-ruby-3.4.8",
               "default": true
             },
             {
               "name": "devdoc",
-              "path": "/nix/store/04pwnawqfa7dvb58hhi1jd3qipn2c9b8-ruby-3.2.6-devdoc"
+              "path": "/nix/store/4k6c15chplw6cicc6f3lgzmi7i4792j6-ruby-3.4.8-devdoc"
             }
           ],
-          "store_path": "/nix/store/npxjgn860mgvfmh8zasrs78lq5sz5qyy-ruby-3.2.6"
+          "store_path": "/nix/store/s57rf37r1i38kpm3nlv4h8f8z2w2n80d-ruby-3.4.8"
         }
       }
     },

--- a/spec/change_set_persisters/change_set_persister_spec.rb
+++ b/spec/change_set_persisters/change_set_persister_spec.rb
@@ -1407,6 +1407,7 @@ RSpec.describe ChangeSetPersister do
         output = change_set_persister.save(change_set: change_set)
         expect(Wayfinder.for(output).preservation_object.metadata_node.use).to eq [::PcdmUse::PreservedMetadata]
         expect(File.exist?(disk_preservation_path.join(resource.id.to_s, "#{resource.id}.json"))).to eq true
+        expect(File.read(disk_preservation_path.join(resource.id.to_s, "#{resource.id}.json"))).not_to eq ""
         expect(File.exist?(disk_preservation_path.join(resource.id.to_s, "data", resource.member_ids.first.to_s, "#{resource.member_ids.first}.json"))).to eq true
       end
     end


### PR DESCRIPTION
Rewind metadata stream before sending it to GCS.

GCS does resumable uploads now and was relying on streams to do that. The problem was we'd used up the stream to calculate the MD5, so there was nothing more to send.

Closes #7329