### PR TITLE
Remove Date Facet

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem "bagit", "~> 0.6"
 # Pin to prevent passenger error
 gem "base64", "0.3.0"
 gem "blacklight", "~> 7.42"
-gem "blacklight_range_limit", "8.5.0"
 gem "bootsnap", require: false
 gem "bootstrap", "~> 4.0"
 gem "bootstrap_form", "~> 4.5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,10 +255,6 @@ GEM
       blacklight (> 6.0, < 9)
       cancancan (>= 1.8)
       deprecation (~> 1.0)
-    blacklight_range_limit (8.5.0)
-      blacklight (>= 7.25.2, < 9)
-      deprecation
-      view_component (>= 2.54, < 4)
     bootsnap (1.25.0)
       msgpack (~> 1.5)
     bootstrap (4.6.2.1)
@@ -1224,7 +1220,6 @@ DEPENDENCIES
   bcrypt_pbkdf
   benchmark-ips
   blacklight (~> 7.42)
-  blacklight_range_limit (= 8.5.0)
   bootsnap
   bootstrap (~> 4.0)
   bootstrap_form (~> 4.5.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -33,5 +33,4 @@
 //= require nestedSortable/jquery.mjs.nestedSortable
 //= require bootstrap_select_dropdown
 //= require cocoon
-//= require blacklight_range_limit
 //= require_tree .

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,4 @@
 /*
- *= require blacklight_range_limit
  *= require normalize-rails
  *= require jquery-ui/datepicker
  *= require jquery-ui/slider

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,5 +1,4 @@
 class CatalogController < ApplicationController
-  include BlacklightRangeLimit::ControllerOverride
   # @note If you're looking for the JSON-LD generation code, please see the
   #   LinkedData module in `app/models/concerns/linked_data.rb`. It gets
   #   registered here through `SolrDocument.use_extension`.

--- a/app/controllers/search_history_controller.rb
+++ b/app/controllers/search_history_controller.rb
@@ -1,5 +1,3 @@
 class SearchHistoryController < ApplicationController
   include Blacklight::SearchHistory
-
-  helper RangeLimitHelper
 end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -1,6 +1,5 @@
 class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
-  include BlacklightRangeLimit::RangeLimitBuilder
 
   # Add a filter query to restrict the search to documents the current user has access to
   include Hydra::AccessControlsEnforcement

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 Rails.application.routes.draw do
   mount HealthMonitor::Engine, at: "/"
   concern :searchable, Blacklight::Routes::Searchable.new
-  concern :range_searchable, BlacklightRangeLimit::Routes::RangeSearchable.new
   concern :exportable, Blacklight::Routes::Exportable.new
 
   if Rails.env.development?
@@ -45,7 +44,6 @@ Rails.application.routes.draw do
 
   resource :catalog, only: [], as: "catalog", path: "/catalog", controller: "catalog" do
     concerns :searchable
-    concerns :range_searchable
   end
 
   # Keep this below the concerns :searchable or catalog controller will try to


### PR DESCRIPTION
In the last 6 months nobody's clicked it, and it's kind of an odd facet
for a workflow application anyways. Removing this means we can get rid
of a large dependency that doesn't update much and maybe unblock
updating view_component.

<img width="652" height="528" alt="Screenshot 2026-08-31 at 1 22 49 PM" src="https://github.com/user-attachments/assets/78b17651-4c27-42c1-80e2-c946db46968b" />
