### PR TITLE
Use transparent background when generating geo thumbnails

### DIFF
--- a/app/derivative_services/geo_derivatives/processors/image.rb
+++ b/app/derivative_services/geo_derivatives/processors/image.rb
@@ -7,7 +7,7 @@ module GeoDerivatives
       included do
         # Uses imagemagick to resize an image and convert it to the output format.
         # Keeps the aspect ratio of the original image and adds padding to
-        # to the output image. The file extension is the output format.
+        # the output image. The file extension is the output format.
         # @param in_path [String] file input path
         # @param out_path [String] processor output file path.
         # @param options [Hash] creation options
@@ -21,7 +21,7 @@ module GeoDerivatives
           convert << "-extent"
           convert << size
           convert << "-background"
-          convert << "white"
+          convert << "none"
           convert << "-gravity"
           convert << "center"
           convert << out_path
@@ -50,7 +50,7 @@ module GeoDerivatives
           MiniMagick::Tool::Convert.new do |convert|
             convert << "-size"
             convert << options[:output_size].tr(" ", "x")
-            convert << "xc:white"
+            convert << "xc:none"
             convert << in_path
             convert << "-gravity"
             convert << "center"

--- a/app/derivative_services/raster_resource_derivative_service.rb
+++ b/app/derivative_services/raster_resource_derivative_service.rb
@@ -50,6 +50,16 @@ class RasterResourceDerivativeService
     generate_mosaic unless deleted_files.empty?
   end
 
+  # Deletes only the thumbnail file
+  def cleanup_thumbnail_derivatives
+    deleted_files = []
+    resource.file_metadata.select(&:thumbnail_file?).each do |file|
+      storage_adapter.delete(id: file.file_identifiers.first)
+      deleted_files << file.id
+    end
+    cleanup_derivative_metadata(derivatives: deleted_files)
+  end
+
   def create_derivatives
     run_derivatives
     create_local_derivatives
@@ -66,6 +76,21 @@ class RasterResourceDerivativeService
   ensure
     FileUtils.rmtree(temporary_working_directory) if Dir.exist?(temporary_working_directory)
     File.unlink(temporary_display_output.path) if File.exist?(temporary_display_output.path)
+    File.unlink(temporary_thumbnail_output.path) if File.exist?(temporary_thumbnail_output.path)
+  end
+
+  # Rebuilds only the thumbnail
+  def create_thumbnail_derivatives
+    run_thumbnail_derivatives
+    create_local_derivatives
+    update_error_message(message: nil) if primary_file.error_message.present?
+  rescue StandardError => error
+    change_set_persister.after_rollback.add do
+      update_error_message(message: error.message)
+    end
+    raise error
+  ensure
+    FileUtils.rmtree(temporary_working_directory) if Dir.exist?(temporary_working_directory)
     File.unlink(temporary_thumbnail_output.path) if File.exist?(temporary_thumbnail_output.path)
   end
 
@@ -120,6 +145,13 @@ class RasterResourceDerivativeService
   def run_derivatives
     GeoDerivatives::Runners::RasterDerivatives.create(
       filename, outputs: [instructions_for_cloud, instructions_for_thumbnail]
+    )
+  end
+
+  # generates only the thumbnail file
+  def run_thumbnail_derivatives
+    GeoDerivatives::Runners::RasterDerivatives.create(
+      filename, outputs: [instructions_for_thumbnail]
     )
   end
 

--- a/app/derivative_services/scanned_map_derivative_service.rb
+++ b/app/derivative_services/scanned_map_derivative_service.rb
@@ -55,6 +55,14 @@ class ScannedMapDerivativeService
     thumbnail_derivative_service.cleanup_derivatives if thumbnail_derivative_service.valid?
   end
 
+  def create_thumbnail_derivatives
+    thumbnail_derivative_service.create_derivatives if thumbnail_derivative_service.valid?
+  end
+
+  def cleanup_thumbnail_derivatives
+    thumbnail_derivative_service.cleanup_derivatives if thumbnail_derivative_service.valid?
+  end
+
   def thumbnail_derivative_service
     ThumbnailDerivativeService::Factory.new(change_set_persister: change_set_persister).new(id: id)
   end

--- a/app/derivative_services/vector_resource_derivative_service.rb
+++ b/app/derivative_services/vector_resource_derivative_service.rb
@@ -51,6 +51,15 @@ class VectorResourceDerivativeService
     cleanup_derivative_metadata(derivatives: deleted_files)
   end
 
+  def cleanup_thumbnail_derivatives
+    deleted_files = []
+    resource.file_metadata.select(&:thumbnail_file?).each do |file|
+      storage_adapter.delete(id: file.file_identifiers.first)
+      deleted_files << file.id
+    end
+    cleanup_derivative_metadata(derivatives: deleted_files)
+  end
+
   def create_derivatives
     run_derivatives
     create_local_derivatives
@@ -65,6 +74,21 @@ class VectorResourceDerivativeService
   ensure
     FileUtils.rmtree(temporary_working_directory) if Dir.exist?(temporary_working_directory)
     File.unlink(temporary_cloud_output.path) if File.exist?(temporary_cloud_output.path)
+    File.unlink(temporary_thumbnail_output.path) if File.exist?(temporary_thumbnail_output.path)
+  end
+
+  # Rebuilds the thumbnail only
+  def create_thumbnail_derivatives
+    run_thumbnail_derivatives
+    create_local_derivatives
+    update_error_message(message: nil) if primary_file.error_message.present?
+  rescue StandardError => error
+    change_set_persister.after_rollback.add do
+      update_error_message(message: error.message)
+    end
+    raise error
+  ensure
+    FileUtils.rmtree(temporary_working_directory) if Dir.exist?(temporary_working_directory)
     File.unlink(temporary_thumbnail_output.path) if File.exist?(temporary_thumbnail_output.path)
   end
 
@@ -118,6 +142,12 @@ class VectorResourceDerivativeService
   def run_derivatives
     GeoDerivatives::Runners::VectorDerivatives.create(
       filename, outputs: [instructions_for_cloud, instructions_for_thumbnail]
+    )
+  end
+
+  def run_thumbnail_derivatives
+    GeoDerivatives::Runners::VectorDerivatives.create(
+      filename, outputs: [instructions_for_thumbnail]
     )
   end
 

--- a/app/jobs/regenerate_derivatives_job.rb
+++ b/app/jobs/regenerate_derivatives_job.rb
@@ -1,11 +1,18 @@
 class RegenerateDerivativesJob < ApplicationJob
   delegate :query_service, to: :metadata_adapter
 
-  def perform(file_set_id)
+  def perform(file_set_id, thumbnail_only: false)
     file_set = query_service.find_by(id: Valkyrie::ID.new(file_set_id))
     messenger.derivatives_deleted(file_set)
-    Valkyrie::Derivatives::DerivativeService.for(id: file_set.id).cleanup_derivatives
-    Valkyrie::Derivatives::DerivativeService.for(id: file_set.id).create_derivatives
+    if thumbnail_only
+      # Only certain derivative services support regenerating thumbnails
+      return unless derivative_service_for(file_set).respond_to?(:create_thumbnail_derivatives)
+      derivative_service_for(file_set).cleanup_thumbnail_derivatives
+      derivative_service_for(file_set).create_thumbnail_derivatives
+    else
+      derivative_service_for(file_set).cleanup_derivatives
+      derivative_service_for(file_set).create_derivatives
+    end
     # fetch it again; it's out of date after derivatives are saved
     file_set = query_service.find_by(id: Valkyrie::ID.new(file_set_id))
     file_set.processing_status = "processed"
@@ -26,4 +33,10 @@ class RegenerateDerivativesJob < ApplicationJob
   def change_set_persister
     ChangeSetPersister.default
   end
+
+  private
+
+    def derivative_service_for(file_set)
+      Valkyrie::Derivatives::DerivativeService.for(id: file_set.id)
+    end
 end

--- a/config/mapnik.xml
+++ b/config/mapnik.xml
@@ -1,4 +1,4 @@
-<Map background-color="white" srs="+init=epsg:4326" >
+<Map background-color="#00000000" srs="+init=epsg:4326" >
   <Style name="features" filter-mode="first">
     <Rule>
       <MaxScaleDenominator>12500</MaxScaleDenominator>

--- a/spec/derivative_services/raster_resource_derivative_service_spec.rb
+++ b/spec/derivative_services/raster_resource_derivative_service_spec.rb
@@ -68,6 +68,37 @@ RSpec.describe RasterResourceDerivativeService do
       # Ensure that temporary files and directories are cleaned up
       expect(Dir.empty?(temp_dir)).to be true
     end
+
+    it "can regenerate the thumbnail without rebuilding other derivatives" do
+      cloud_file_service = instance_double(CloudFilePermissionsService, run: nil)
+      allow(CloudFilePermissionsService).to receive(:new).and_return(cloud_file_service)
+
+      resource = query_service.find_by(id: valid_resource.id)
+      original_cloud_file = resource.file_metadata.find(&:cloud_derivative?)
+      original_thumbnail = resource.file_metadata.find(&:thumbnail_file?)
+
+      derivative_service.new(id: valid_resource.id).cleanup_thumbnail_derivatives
+      derivative_service.new(id: valid_resource.id).create_thumbnail_derivatives
+
+      reloaded = query_service.find_by(id: valid_resource.id)
+      new_thumbnail = reloaded.file_metadata.find(&:thumbnail_file?)
+
+      expect(reloaded.file_metadata.find(&:cloud_derivative?).id).to eq original_cloud_file.id
+      expect(new_thumbnail.id).not_to eq original_thumbnail.id
+      expect(Dir.empty?(temp_dir)).to be true
+    end
+
+    it "stores an error message on the file set when regenerating the thumbnail fails" do
+      valid_resource
+      allow(GeoDerivatives::Runners::RasterDerivatives).to receive(:create).and_raise("gdal failed")
+      service = derivative_service.new(id: valid_resource.id)
+
+      expect { service.create_thumbnail_derivatives }.to raise_error(RuntimeError, "gdal failed")
+
+      file_set = query_service.find_by(id: valid_resource.id)
+      expect(file_set.primary_file.error_message).to include(/gdal failed/)
+      expect(Dir.empty?(temp_dir)).to be true
+    end
   end
 
   context "with a geotiff with an unsafe filename" do
@@ -131,6 +162,25 @@ RSpec.describe RasterResourceDerivativeService do
       resource.original_file.error_message = ["it went poorly"]
       persister.save(resource: resource)
       derivative_service.new(id: resource.id).cleanup_derivatives
+
+      resource = query_service.find_by(id: valid_resource.id)
+      expect(resource.original_file.error_message).to be_empty
+    end
+  end
+
+  describe "#cleanup_thumbnail_derivatives" do
+    it "only deletes the thumbnail" do
+      derivative_service.new(id: valid_change_set.id).cleanup_thumbnail_derivatives
+      reloaded = query_service.find_by(id: valid_resource.id)
+      expect(reloaded.file_metadata.select(&:thumbnail_file?)).to be_empty
+      expect(reloaded.file_metadata.select(&:cloud_derivative?)).not_to be_empty
+    end
+
+    it "deletes the error_message" do
+      resource = query_service.find_by(id: valid_resource.id)
+      resource.original_file.error_message = ["it went poorly"]
+      persister.save(resource: resource)
+      derivative_service.new(id: resource.id).cleanup_thumbnail_derivatives
 
       resource = query_service.find_by(id: valid_resource.id)
       expect(resource.original_file.error_message).to be_empty

--- a/spec/derivative_services/scanned_map_derivative_service_spec.rb
+++ b/spec/derivative_services/scanned_map_derivative_service_spec.rb
@@ -68,6 +68,33 @@ RSpec.describe ScannedMapDerivativeService do
     end
   end
 
+  describe "#create_thumbnail_derivatives" do
+    it "regenerates the thumbnail without rebuilding other derivatives" do
+      resource = query_service.find_by(id: valid_resource.id)
+      original_pyramidal = resource.pyramidal_derivative
+      original_thumbnail = resource.file_metadata.find(&:thumbnail_file?)
+
+      derivative_service.new(id: valid_resource.id).cleanup_thumbnail_derivatives
+      derivative_service.new(id: valid_resource.id).create_thumbnail_derivatives
+
+      reloaded = query_service.find_by(id: valid_resource.id)
+      new_thumbnail = reloaded.file_metadata.find(&:thumbnail_file?)
+
+      expect(reloaded.pyramidal_derivative.id).to eq original_pyramidal.id
+      expect(new_thumbnail.id).not_to eq original_thumbnail.id
+      expect(reloaded.file_metadata.select(&:thumbnail_file?).count).to eq 1
+    end
+  end
+
+  describe "#cleanup_thumbnail_derivatives" do
+    it "only deletes the thumbnail" do
+      derivative_service.new(id: valid_change_set.id).cleanup_thumbnail_derivatives
+      reloaded = query_service.find_by(id: valid_resource.id)
+      expect(reloaded.file_metadata.select(&:thumbnail_file?)).to be_empty
+      expect(reloaded.pyramidal_derivative).not_to be_blank
+    end
+  end
+
   describe "#cleanup_derivatives" do
     it "deletes the attached fileset when the resource is deleted" do
       derivative_service.new(id: valid_change_set.id).cleanup_derivatives

--- a/spec/derivative_services/vector_resource_derivative_service_spec.rb
+++ b/spec/derivative_services/vector_resource_derivative_service_spec.rb
@@ -60,13 +60,52 @@ RSpec.describe VectorResourceDerivativeService do
       expect(cloud_vector_file_set.use).to eq([::PcdmUse::CloudDerivative])
       expect(thumbnail_file.io.path).to start_with(Rails.root.join("tmp", Figgy.config["derivative_path"]).to_s)
       image = Vips::Image.new_from_file(thumbnail_file.io.path)
-      # Generate the avg of the image bands to ensure it's the correct
-      # thumbnail. This is mostly white, but not -all- white.
-      expect(image.avg.round).to eq 250
       expect(cloud_vector_file.io.path).to start_with(Rails.root.join("tmp", Figgy.config["test_cloud_geo_derivative_path"]).to_s)
       expect(cloud_file_service).to have_received(:run)
 
+
+      # Test that the thumbnail background is transparent
+      expect(image.has_alpha?).to be true
+      alpha = image.extract_band(3)
+      expect(alpha.getpoint(0, 0).first).to eq 0
+
+      # Test that not all pixels are transparent and that
+      # mapnik actually generated a thumbnail
+      expect(alpha.max).to be > 0
+
       # Ensure that temporary files and directories are cleaned up
+      expect(Dir.empty?(temp_dir)).to be true
+    end
+
+    it "can regenerate the thumbnail without rebuilding other derivatives" do
+      cloud_file_service = instance_double(CloudFilePermissionsService, run: nil)
+      allow(CloudFilePermissionsService).to receive(:new).and_return(cloud_file_service)
+
+      resource = query_service.find_by(id: valid_resource.id)
+      original_cloud_file = resource.file_metadata.find(&:cloud_derivative?)
+      original_thumbnail = resource.file_metadata.find(&:thumbnail_file?)
+
+      derivative_service.new(id: valid_resource.id).cleanup_thumbnail_derivatives
+      derivative_service.new(id: valid_resource.id).create_thumbnail_derivatives
+
+      reloaded = query_service.find_by(id: valid_resource.id)
+      new_thumbnail = reloaded.file_metadata.find(&:thumbnail_file?)
+
+      expect(reloaded.file_metadata.find(&:cloud_derivative?).id).to eq original_cloud_file.id
+      expect(new_thumbnail.id).not_to eq original_thumbnail.id
+      expect(File.exist?(Valkyrie::StorageAdapter.find_by(id: new_thumbnail.file_identifiers.first).io.path)).to be true
+      expect(Dir.empty?(temp_dir)).to be true
+    end
+
+    it "stores an error message on the file set when regenerating the thumbnail fails" do
+      valid_resource
+      allow(GeoDerivatives::Runners::VectorDerivatives).to receive(:create).and_raise("mapnik failed")
+      service = derivative_service.new(id: valid_resource.id)
+
+      expect { service.create_thumbnail_derivatives }.to raise_error(RuntimeError, "mapnik failed")
+
+      file_set = query_service.find_by(id: valid_resource.id)
+      expect(file_set.primary_file.error_message).to include(/mapnik failed/)
       expect(Dir.empty?(temp_dir)).to be true
     end
   end

--- a/spec/jobs/regenerate_derivatives_job_spec.rb
+++ b/spec/jobs/regenerate_derivatives_job_spec.rb
@@ -25,6 +25,42 @@ RSpec.describe RegenerateDerivativesJob do
       end
     end
 
+    context "when regenerating thumbnails only" do
+      let(:derivatives_service) { instance_double(VectorResourceDerivativeService) }
+      let(:file_set) { FactoryBot.create_for_repository(:file_set) }
+      let(:generator) { instance_double(EventGenerator, derivatives_deleted: nil, derivatives_created: nil) }
+
+      before do
+        allow(Valkyrie::Derivatives::DerivativeService).to receive(:for).with(id: file_set.id).and_return(derivatives_service)
+        allow(derivatives_service).to receive(:create_thumbnail_derivatives)
+        allow(derivatives_service).to receive(:cleanup_thumbnail_derivatives)
+        allow(EventGenerator).to receive(:new).and_return(generator)
+      end
+
+      it "regenerates the thumbnail" do
+        described_class.perform_now(file_set.id, thumbnail_only: true)
+        expect(derivatives_service).to have_received(:cleanup_thumbnail_derivatives)
+        expect(derivatives_service).to have_received(:create_thumbnail_derivatives)
+      end
+    end
+
+    context "when regenerating thumbnails only for a service which doesn't build thumbnails" do
+      let(:derivatives_service) { instance_double(Valkyrie::Derivatives::DerivativeService) }
+      let(:file_set) { FactoryBot.create_for_repository(:file_set) }
+
+      before do
+        allow(Valkyrie::Derivatives::DerivativeService).to receive(:for).with(id: file_set.id).and_return(derivatives_service)
+        allow(derivatives_service).to receive(:cleanup_derivatives)
+        allow(derivatives_service).to receive(:create_derivatives)
+      end
+
+      it "doesn't regenerate any derivatives" do
+        described_class.perform_now(file_set.id, thumbnail_only: true)
+        expect(derivatives_service).not_to have_received(:cleanup_derivatives)
+        expect(derivatives_service).not_to have_received(:create_derivatives)
+      end
+    end
+
     context "when a file set was 'in process'" do
       with_queue_adapter :inline
       let(:file) { fixture_file_upload("files/example.tif", "image/tiff") }


### PR DESCRIPTION
Closes #7342

- **Use transparent background when generating geo thumbnails**
- **Allow regeneration of thumbnails only on geo file sets**
